### PR TITLE
Fix quarter tone bend on TAB

### DIFF
--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -319,6 +319,10 @@ AccidentalType Accidental::centOffset2Subtype(double centOffset)
 
 AccidentalType Accidental::value2MicrotonalSubtype(AccidentalVal val, int quarterOff)
 {
+    if (quarterOff == 0) {
+        return value2subtype(val);
+    }
+
     if (quarterOff < -1 || quarterOff > 1) {
         // TODO: more general implementation
         return value2subtype(val);
@@ -374,6 +378,14 @@ AccidentalType Accidental::name2subtype(const AsciiStringView& tag)
 void Accidental::setSubtype(const AsciiStringView& tag)
 {
     setAccidentalType(name2subtype(tag));
+}
+
+void Accidental::setAccidentalType(AccidentalType t)
+{
+    m_accidentalType = t;
+    if (note()) {
+        note()->setCentOffset(Accidental::subtype2centOffset(t));
+    }
 }
 
 void Accidental::computeMag()

--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -306,6 +306,35 @@ double Accidental::subtype2centOffset(AccidentalType st)
     return ACC_LIST[int(st)].centOffset;
 }
 
+AccidentalType Accidental::centOffset2Subtype(double centOffset)
+{
+    for (int i = 0; i < static_cast<int>(AccidentalType::END); ++i) {
+        if (muse::RealIsEqual(ACC_LIST[i].centOffset, centOffset)) {
+            return static_cast<AccidentalType>(i);
+        }
+    }
+
+    return AccidentalType::NONE;
+}
+
+AccidentalType Accidental::value2MicrotonalSubtype(AccidentalVal val, QuarterOffset quarterOff)
+{
+    switch (val) {
+    case AccidentalVal::NATURAL:
+        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP_ARROW_DOWN : AccidentalType::FLAT_ARROW_UP;
+    case AccidentalVal::FLAT:
+        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::FLAT_ARROW_UP : AccidentalType::FLAT_ARROW_DOWN;
+    case AccidentalVal::SHARP:
+        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP_ARROW_UP : AccidentalType::SHARP_ARROW_DOWN;
+    case AccidentalVal::FLAT2:
+        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::FLAT2_ARROW_UP : AccidentalType::FLAT2_ARROW_DOWN;
+    case AccidentalVal::SHARP2:
+        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP2_ARROW_UP : AccidentalType::SHARP2_ARROW_DOWN;
+    default:
+        return value2subtype(val);
+    }
+}
+
 int Accidental::line() const
 {
     Note* n = note();

--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -317,19 +317,24 @@ AccidentalType Accidental::centOffset2Subtype(double centOffset)
     return AccidentalType::NONE;
 }
 
-AccidentalType Accidental::value2MicrotonalSubtype(AccidentalVal val, QuarterOffset quarterOff)
+AccidentalType Accidental::value2MicrotonalSubtype(AccidentalVal val, int quarterOff)
 {
+    if (quarterOff < -1 || quarterOff > 1) {
+        // TODO: more general implementation
+        return value2subtype(val);
+    }
+
     switch (val) {
     case AccidentalVal::NATURAL:
-        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP_ARROW_DOWN : AccidentalType::FLAT_ARROW_UP;
+        return quarterOff == 1 ? AccidentalType::SHARP_ARROW_DOWN : AccidentalType::FLAT_ARROW_UP;
     case AccidentalVal::FLAT:
-        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::FLAT_ARROW_UP : AccidentalType::FLAT_ARROW_DOWN;
+        return quarterOff == 1 ? AccidentalType::FLAT_ARROW_UP : AccidentalType::FLAT_ARROW_DOWN;
     case AccidentalVal::SHARP:
-        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP_ARROW_UP : AccidentalType::SHARP_ARROW_DOWN;
+        return quarterOff == 1 ? AccidentalType::SHARP_ARROW_UP : AccidentalType::SHARP_ARROW_DOWN;
     case AccidentalVal::FLAT2:
-        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::FLAT2_ARROW_UP : AccidentalType::FLAT2_ARROW_DOWN;
+        return quarterOff == 1 ? AccidentalType::FLAT2_ARROW_UP : AccidentalType::FLAT2_ARROW_DOWN;
     case AccidentalVal::SHARP2:
-        return quarterOff == QuarterOffset::QUARTER_SHARP ? AccidentalType::SHARP2_ARROW_UP : AccidentalType::SHARP2_ARROW_DOWN;
+        return quarterOff == 1 ? AccidentalType::SHARP2_ARROW_UP : AccidentalType::SHARP2_ARROW_DOWN;
     default:
         return value2subtype(val);
     }

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -272,7 +272,7 @@ public:
     static SymId subtype2symbol(AccidentalType);
     static AsciiStringView subtype2name(AccidentalType);
     static AccidentalType value2subtype(AccidentalVal);
-    static AccidentalType value2MicrotonalSubtype(AccidentalVal val, QuarterOffset quarterOff);
+    static AccidentalType value2MicrotonalSubtype(AccidentalVal val, int quarterOff);
     static AccidentalType name2subtype(const AsciiStringView&);
     static bool isMicrotonal(AccidentalType t) { return t > AccidentalType::FLAT3; }
     static double subtype2centOffset(AccidentalType);

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -243,7 +243,7 @@ public:
     void setSubtype(const AsciiStringView& s);
     int subtype() const override { return (int)m_accidentalType; }
 
-    void setAccidentalType(AccidentalType t) { m_accidentalType = t; }
+    void setAccidentalType(AccidentalType t);
     AccidentalType accidentalType() const { return m_accidentalType; }
 
     void setRole(AccidentalRole r) { m_role = r; }

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -272,9 +272,11 @@ public:
     static SymId subtype2symbol(AccidentalType);
     static AsciiStringView subtype2name(AccidentalType);
     static AccidentalType value2subtype(AccidentalVal);
+    static AccidentalType value2MicrotonalSubtype(AccidentalVal val, QuarterOffset quarterOff);
     static AccidentalType name2subtype(const AsciiStringView&);
     static bool isMicrotonal(AccidentalType t) { return t > AccidentalType::FLAT3; }
     static double subtype2centOffset(AccidentalType);
+    static AccidentalType centOffset2Subtype(double centOffset);
 
     int stackingOrder() const { return ldata()->stackingNumber + m_stackingOrderOffset; }
 

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -134,18 +134,17 @@ void GuitarBend::changeBendAmount(int endBendAmount, int startBendAmount)
 
     // All other bends: set bend amount by transposing end note appropriately
     int pitch = endBendAmount / 2 + startNoteOfChain()->pitch();
-    QuarterOffset quarterOff = endBendAmount % 2 == 1 ? QuarterOffset::QUARTER_SHARP
-                               : endBendAmount % 2 == -1 ? QuarterOffset::QUARTER_FLAT : QuarterOffset::NONE;
-    if (pitch == startNote()->pitch() && quarterOff == QuarterOffset::QUARTER_SHARP) {
+    int quarterOff = endBendAmount % 2;
+    if (pitch == startNote()->pitch() && quarterOff == 1) {
         // Because a flat second is more readable than a sharp unison
         pitch += 1;
-        quarterOff = QuarterOffset::QUARTER_FLAT;
+        quarterOff = -1;
     }
 
     setEndNotePitch(pitch, quarterOff);
 }
 
-void GuitarBend::setEndNotePitch(int pitch, QuarterOffset quarterOff)
+void GuitarBend::setEndNotePitch(int pitch, int quarterToneOffset)
 {
     Note* note = endNote();
     IF_ASSERT_FAILED(note) {
@@ -180,12 +179,12 @@ void GuitarBend::setEndNotePitch(int pitch, QuarterOffset quarterOff)
 
     if (linkedNoteOnNotationStaff) {
         // Manage microtonal by setting appropriate microtonal accidentals, which will propagate to TAB staff too
-        AccidentalType accidentalType = Accidental::value2MicrotonalSubtype(tpc2alter(targetTpc1), quarterOff);
+        AccidentalType accidentalType = Accidental::value2MicrotonalSubtype(tpc2alter(targetTpc1), quarterToneOffset);
         linkedNoteOnNotationStaff->updateLine();
         score()->changeAccidental(linkedNoteOnNotationStaff, accidentalType);
     } else {
         // Accidental logic doesn't work on TAB, so set cents offset directly
-        note->undoChangeProperty(Pid::CENT_OFFSET, int(quarterOff) * 50.0);
+        note->undoChangeProperty(Pid::CENT_OFFSET, quarterToneOffset * 50.0);
     }
 
     computeBendAmount();

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -489,13 +489,8 @@ void GuitarBend::computeBendAmount()
 
     int pitchDiffInQuarterTones = 2 * (endPitch - startPitch);
 
-    Accidental* startAcc = startN->accidental();
-    Accidental* endAcc = endN->accidental();
-    int startCentsOff = startAcc ? Accidental::subtype2centOffset(startAcc->accidentalType()) : 0;
-    int endCentsOff = endAcc ? Accidental::subtype2centOffset(endAcc->accidentalType()) : 0;
-
-    int startOffInQuarterTones = round(double(startCentsOff) / 50);
-    int endOffInQuarterTones = round(double(endCentsOff) / 50);
+    int startOffInQuarterTones = round(startN->centOffset() / 50);
+    int endOffInQuarterTones = round(endN->centOffset() / 50);
 
     pitchDiffInQuarterTones += endOffInQuarterTones - startOffInQuarterTones;
 

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -180,39 +180,7 @@ void GuitarBend::setEndNotePitch(int pitch, QuarterOffset quarterOff)
 
     if (linkedNoteOnNotationStaff) {
         // Manage microtonal by setting appropriate microtonal accidentals, which will propagate to TAB staff too
-        AccidentalType accidentalType = Accidental::value2subtype(tpc2alter(targetTpc1));
-        if (quarterOff == QuarterOffset::QUARTER_SHARP) {
-            switch (accidentalType) {
-            case AccidentalType::NONE:
-            case AccidentalType::NATURAL:
-                accidentalType = AccidentalType::SHARP_ARROW_DOWN;
-                break;
-            case AccidentalType::FLAT:
-                accidentalType = AccidentalType::FLAT_ARROW_UP;
-                break;
-            case AccidentalType::SHARP:
-                accidentalType = AccidentalType::SHARP_ARROW_UP;
-                break;
-            default:
-                break;
-            }
-        } else if (quarterOff == QuarterOffset::QUARTER_FLAT) {
-            switch (accidentalType) {
-            case AccidentalType::NONE:
-            case AccidentalType::NATURAL:
-                accidentalType = AccidentalType::FLAT_ARROW_UP;
-                break;
-            case AccidentalType::FLAT:
-                accidentalType = AccidentalType::FLAT_ARROW_DOWN;
-                break;
-            case AccidentalType::SHARP:
-                accidentalType = AccidentalType::SHARP_ARROW_DOWN;
-                break;
-            default:
-                break;
-            }
-        }
-
+        AccidentalType accidentalType = Accidental::value2MicrotonalSubtype(tpc2alter(targetTpc1), quarterOff);
         linkedNoteOnNotationStaff->updateLine();
         score()->changeAccidental(linkedNoteOnNotationStaff, accidentalType);
     } else {

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -45,8 +45,8 @@ enum class GuitarBendShowHoldLine : unsigned char {
     HIDE,
 };
 
-enum class QuarterOffset : unsigned char {
-    QUARTER_FLAT,
+enum class QuarterOffset {
+    QUARTER_FLAT = -1,
     NONE,
     QUARTER_SHARP
 };

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -78,7 +78,7 @@ public:
 
     Note* endNote() const;
     void changeBendAmount(int bendAmount, int startBendAmount);
-    void setEndNotePitch(int pitch, QuarterOffset quarterOff = QuarterOffset::NONE);
+    void setEndNotePitch(int pitch, int quarterToneOffset);
 
     bool isReleaseBend() const;
     bool isFullRelease() const;

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -45,12 +45,6 @@ enum class GuitarBendShowHoldLine : unsigned char {
     HIDE,
 };
 
-enum class QuarterOffset {
-    QUARTER_FLAT = -1,
-    NONE,
-    QUARTER_SHARP
-};
-
 enum class ActionIconType : signed char;
 
 class GuitarBend final : public SLine

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2135,7 +2135,12 @@ void Note::updateAccidental(AccidentalState* as)
 {
     int absLine = absStep(tpc(), epitch());
 
-    if (!muse::RealIsNull(m_centOffset)) {
+    // Ensure m_centOffset and microtonal accidental match (they can mismatch when switching from TAB)
+    if (muse::RealIsNull(m_centOffset)) {
+        if (m_accidental && Accidental::isMicrotonal(m_accidental->accidentalType())) {
+            score()->undoRemoveElement(m_accidental);
+        }
+    } else {
         if (m_accidental) {
             bool correct = muse::RealIsEqual(Accidental::subtype2centOffset(m_accidental->accidentalType()), m_centOffset);
             if (!correct) {

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1289,6 +1289,7 @@ void Note::add(EngravingItem* e)
     break;
     case ElementType::ACCIDENTAL:
         m_accidental = toAccidental(e);
+        m_centOffset = Accidental::subtype2centOffset(toAccidental(e)->accidentalType());
         break;
     case ElementType::TEXTLINE:
     case ElementType::NOTELINE:
@@ -1354,6 +1355,7 @@ void Note::remove(EngravingItem* e)
 
     case ElementType::ACCIDENTAL:
         m_accidental = 0;
+        m_centOffset = 0;
         break;
 
     case ElementType::TEXTLINE:

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2137,7 +2137,7 @@ void Note::updateAccidental(AccidentalState* as)
 
     // Ensure m_centOffset and microtonal accidental match (they can mismatch when switching from TAB)
     if (muse::RealIsNull(m_centOffset)) {
-        if (m_accidental && Accidental::isMicrotonal(m_accidental->accidentalType())) {
+        if (m_accidental && !muse::RealIsNull(Accidental::subtype2centOffset(m_accidental->accidentalType()))) {
             score()->undoRemoveElement(m_accidental);
         }
     } else {

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2134,6 +2134,19 @@ void Note::updateAccidental(AccidentalState* as)
 {
     int absLine = absStep(tpc(), epitch());
 
+    if (!muse::RealIsNull(m_centOffset)) {
+        if (m_accidental) {
+            bool correct = muse::RealIsEqual(Accidental::subtype2centOffset(m_accidental->accidentalType()), m_centOffset);
+            if (!correct) {
+                m_accidental->undoChangeProperty(Pid::ACCIDENTAL_TYPE, static_cast<int>(Accidental::centOffset2Subtype(m_centOffset)));
+            }
+        } else {
+            AccidentalType accType = Accidental::value2MicrotonalSubtype(tpc2alter(tpc()), static_cast<QuarterOffset>(m_centOffset / 50));
+            updateLine();
+            score()->changeAccidental(this, accType);
+        }
+    }
+
     // don't touch accidentals that don't concern tpc such as
     // quarter tones
     if (!(m_accidental && Accidental::isMicrotonal(m_accidental->accidentalType()))) {

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -605,6 +605,7 @@ Note::Note(const Note& n, bool link)
     m_ghost             = n.m_ghost;
     m_deadNote          = n.m_deadNote;
     m_pitch             = n.m_pitch;
+    m_centOffset        = n.m_centOffset;
     m_tpc[0]            = n.m_tpc[0];
     m_tpc[1]            = n.m_tpc[1];
     m_dotsHidden        = n.m_dotsHidden;

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2995,6 +2995,8 @@ PropertyValue Note::getProperty(Pid propertyId) const
     switch (propertyId) {
     case Pid::PITCH:
         return pitch();
+    case Pid::CENT_OFFSET:
+        return centOffset();
     case Pid::TPC1:
         return m_tpc[0];
     case Pid::TPC2:
@@ -3059,6 +3061,9 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::PITCH:
         setPitch(v.toInt());
         score()->setPlaylistDirty();
+        break;
+    case Pid::CENT_OFFSET:
+        setCentOffset(v.toDouble());
         break;
     case Pid::TPC1:
         m_tpc[0] = v.toInt();
@@ -3176,6 +3181,8 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
 PropertyValue Note::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::CENT_OFFSET:
+        return 0.0;
     case Pid::GHOST:
     case Pid::DEAD:
     case Pid::SMALL:

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2141,7 +2141,7 @@ void Note::updateAccidental(AccidentalState* as)
                 m_accidental->undoChangeProperty(Pid::ACCIDENTAL_TYPE, static_cast<int>(Accidental::centOffset2Subtype(m_centOffset)));
             }
         } else {
-            AccidentalType accType = Accidental::value2MicrotonalSubtype(tpc2alter(tpc()), static_cast<QuarterOffset>(m_centOffset / 50));
+            AccidentalType accType = Accidental::value2MicrotonalSubtype(tpc2alter(tpc()), quarterToneOffset());
             updateLine();
             score()->changeAccidental(this, accType);
         }
@@ -2648,11 +2648,7 @@ int Note::playingOctave() const
 
 double Note::playingTuning() const
 {
-    if (!m_accidental) {
-        return m_tuning;
-    }
-
-    return m_tuning + Accidental::subtype2centOffset(m_accidental->accidentalType());
+    return m_tuning + m_centOffset;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -199,6 +199,7 @@ public:
 
     double centOffset() const { return m_centOffset; }
     void setCentOffset(double v) { m_centOffset = v; }
+    int quarterToneOffset() const { return std::round(m_centOffset / 50); }
 
     int ottaveCapoFret() const;
     int linkedOttavaPitchOffset() const;

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -196,6 +196,10 @@ public:
     void setPitch(int val, bool notifyAboutChanged = true);
     void setPitch(int pitch, int tpc1, int tpc2);
     int pitch() const { return m_pitch; }
+
+    double centOffset() const { return m_centOffset; }
+    void setCentOffset(double v) { m_centOffset = v; }
+
     int ottaveCapoFret() const;
     int linkedOttavaPitchOffset() const;
     int ppitch() const;             // playback pitch
@@ -528,6 +532,7 @@ private:
     int m_string = -1;
     mutable int m_tpc[2] = { Tpc::TPC_INVALID, Tpc::TPC_INVALID };   // tonal pitch class  (concert/transposing)
     mutable int m_pitch = 0;      // Note pitch as midi value (0 - 127).
+    mutable double m_centOffset = 0.0; // Pitch offset in cents (100 cents = 1 semitone)
 
     int m_userVelocity = 0;     // velocity user offset in percent, or absolute velocity for this note
     int m_fixedLine = 0;        // fixed line number if _fixed == true

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -71,6 +71,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::KEYSIG_MODE,                         P_TYPE::KEY_MODE,                  PropertyGroup::APPEARANCE, false, "keysig_mode",                     QT_TRANSLATE_NOOP("engraving/propertyName", "key signature mode") },
     { Pid::SLUR_STYLE_TYPE,                     P_TYPE::SLUR_STYLE_TYPE,           PropertyGroup::APPEARANCE, false, "lineType",                        QT_TRANSLATE_NOOP("engraving/propertyName", "line type") },
     { Pid::PITCH,                               P_TYPE::INT,                       PropertyGroup::NONE,       true,  "pitch",                           QT_TRANSLATE_NOOP("engraving/propertyName", "pitch") },
+    { Pid::CENT_OFFSET,                         P_TYPE::REAL,                      PropertyGroup::NONE,       true,  "centOffset",                      QT_TRANSLATE_NOOP("engraving/propertyName", "cent offset") },
 
     { Pid::TPC1,                                P_TYPE::INT,                       PropertyGroup::NONE,       true,  "tpc",                             QT_TRANSLATE_NOOP("engraving/propertyName", "tonal pitch class") },
     { Pid::TPC2,                                P_TYPE::INT,                       PropertyGroup::NONE,       true,  "tpc2",                            QT_TRANSLATE_NOOP("engraving/propertyName", "transposed tonal pitch class") },

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -83,6 +83,7 @@ enum class Pid : short {
     KEYSIG_MODE,
     SLUR_STYLE_TYPE,
     PITCH,
+    CENT_OFFSET,
 
     TPC1,
     TPC2,

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3303,6 +3303,7 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
 
     if (tag == "pitch") {
         n->setPitch(clampPitch(e.readInt()), false);
+    } else if (TRead::readProperty(n, tag, e, ctx, Pid::CENT_OFFSET)) {
     } else if (tag == "tpc") {
         int tpc = e.readInt();
         n->setTpc1(tpc);

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2370,7 +2370,7 @@ void TWrite::write(const Note* item, XmlWriter& xml, WriteContext& ctx)
         }
         xml.endElement();
     }
-    for (Pid id : { Pid::PITCH, Pid::TPC1, Pid::TPC2, Pid::SMALL, Pid::MIRROR_HEAD, Pid::DOT_POSITION,
+    for (Pid id : { Pid::PITCH, Pid::CENT_OFFSET, Pid::TPC1, Pid::TPC2, Pid::SMALL, Pid::MIRROR_HEAD, Pid::DOT_POSITION,
                     Pid::HEAD_SCHEME, Pid::HEAD_GROUP, Pid::USER_VELOCITY, Pid::PLAY, Pid::TUNING, Pid::FRET, Pid::STRING,
                     Pid::GHOST, Pid::DEAD, Pid::HEAD_TYPE, Pid::FIXED, Pid::FIXED_LINE }) {
         writeProperty(item, xml, id);

--- a/src/engraving/tests/compat114_data/accidentals-ref.mscx
+++ b/src/engraving/tests/compat114_data/accidentals-ref.mscx
@@ -170,6 +170,7 @@
                 <eid>Z_Z</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-44</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -184,6 +185,7 @@
                 <eid>c_c</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -198,6 +200,7 @@
                 <eid>f_f</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -217,6 +220,7 @@
                 <eid>j_j</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -259,6 +263,7 @@
                 <eid>s_s</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -282,6 +287,7 @@
                 <eid>x_x</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -296,6 +302,7 @@
                 <eid>0_0</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>56</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -310,6 +317,7 @@
                 <eid>3_3</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -324,6 +332,7 @@
                 <eid>6_6</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -343,6 +352,7 @@
                 <eid>+_+</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -371,6 +381,7 @@
                 <eid>EB_EB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -385,6 +396,7 @@
                 <eid>HB_HB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -418,6 +430,7 @@
                 <eid>OB_OB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -432,6 +445,7 @@
                 <eid>RB_RB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -469,6 +483,7 @@
                 <eid>ZB_ZB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>33</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -483,6 +498,7 @@
                 <eid>cB_cB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-67</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -583,6 +599,7 @@
                 <eid>xB_xB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-44</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -598,6 +615,7 @@
                 <eid>0B_0B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -613,6 +631,7 @@
                 <eid>3B_3B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -633,6 +652,7 @@
                 <eid>7B_7B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -678,6 +698,7 @@
                 <eid>EC_EC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -702,6 +723,7 @@
                 <eid>JC_JC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -717,6 +739,7 @@
                 <eid>MC_MC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>56</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -732,6 +755,7 @@
                 <eid>PC_PC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -747,6 +771,7 @@
                 <eid>SC_SC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -767,6 +792,7 @@
                 <eid>WC_WC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -797,6 +823,7 @@
                 <eid>cC_cC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -812,6 +839,7 @@
                 <eid>fC_fC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -847,6 +875,7 @@
                 <eid>mC_mC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -862,6 +891,7 @@
                 <eid>pC_pC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -897,6 +927,7 @@
                 <eid>wC_wC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>33</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -912,6 +943,7 @@
                 <eid>zC_zC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-67</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>

--- a/src/engraving/tests/compat206_data/accidentals-ref.mscx
+++ b/src/engraving/tests/compat206_data/accidentals-ref.mscx
@@ -162,6 +162,7 @@
                 <eid>X_X</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-44</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -176,6 +177,7 @@
                 <eid>a_a</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -190,6 +192,7 @@
                 <eid>d_d</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -213,6 +216,7 @@
                 <eid>i_i</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -227,6 +231,7 @@
                 <eid>l_l</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -241,6 +246,7 @@
                 <eid>o_o</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -255,6 +261,7 @@
                 <eid>r_r</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>56</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -274,6 +281,7 @@
                 <eid>v_v</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -288,6 +296,7 @@
                 <eid>y_y</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -302,6 +311,7 @@
                 <eid>1_1</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -316,6 +326,7 @@
                 <eid>4_4</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -335,6 +346,7 @@
                 <eid>8_8</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -349,6 +361,7 @@
                 <eid>/_/</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -363,6 +376,7 @@
                 <eid>CB_CB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -377,6 +391,7 @@
                 <eid>FB_FB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>33</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -400,6 +415,7 @@
                 <eid>KB_KB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-67</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -523,6 +539,7 @@
                 <eid>kB_kB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-44</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -538,6 +555,7 @@
                 <eid>nB_nB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -553,6 +571,7 @@
                 <eid>qB_qB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -577,6 +596,7 @@
                 <eid>vB_vB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -592,6 +612,7 @@
                 <eid>yB_yB</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -607,6 +628,7 @@
                 <eid>1B_1B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>89</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -622,6 +644,7 @@
                 <eid>4B_4B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>56</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -642,6 +665,7 @@
                 <eid>8B_8B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -657,6 +681,7 @@
                 <eid>/B_/B</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -672,6 +697,7 @@
                 <eid>CC_CC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -687,6 +713,7 @@
                 <eid>FC_FC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -707,6 +734,7 @@
                 <eid>JC_JC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-150</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -722,6 +750,7 @@
                 <eid>MC_MC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -737,6 +766,7 @@
                 <eid>PC_PC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-50</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -752,6 +782,7 @@
                 <eid>SC_SC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>33</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>
@@ -776,6 +807,7 @@
                 <eid>XC_XC</eid>
                 </Accidental>
               <pitch>72</pitch>
+              <centOffset>-67</centOffset>
               <tpc>14</tpc>
               </Note>
             </Chord>

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -1008,6 +1008,12 @@ enum class AccidentalVal : signed char {
     MAX     = SHARP3
 };
 
+enum class QuarterOffset : signed char {
+    QUARTER_FLAT = -1,
+    NONE,
+    QUARTER_SHARP
+};
+
 // Positions of naturals in key sig. changes
 enum class KeySigNatural : char {
     NONE   = 0,      // no naturals, except for change to CMaj/Amin

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -1008,12 +1008,6 @@ enum class AccidentalVal : signed char {
     MAX     = SHARP3
 };
 
-enum class QuarterOffset : signed char {
-    QUARTER_FLAT = -1,
-    NONE,
-    QUARTER_SHARP
-};
-
 // Positions of naturals in key sig. changes
 enum class KeySigNatural : char {
     NONE   = 0,      // no naturals, except for change to CMaj/Amin

--- a/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
@@ -112,7 +112,7 @@ static void createPreBends(const BendDataContext& bendDataCtx, mu::engraving::Sc
                 const int pitch = noteBendData.quarterTones / 2;
                 note->setPitch(note->pitch() + pitch);
                 note->setTpcFromPitch();
-                QuarterOffset quarterOff = noteBendData.quarterTones % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
+                int quarterOff = noteBendData.quarterTones % 2;
                 bend->setEndNotePitch(note->pitch(), quarterOff);
                 Note* startNote = bend->startNote();
                 if (!startNote) {
@@ -220,7 +220,7 @@ static void createGraceAfterBends(const BendDataContext& bendDataCtx, mu::engrav
                         break;
                     }
 
-                    QuarterOffset quarterOff = noteData.quarterTones % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
+                    int quarterOff = noteData.quarterTones % 2;
                     bend->setEndNotePitch(bend->startNoteOfChain()->pitch() + noteData.quarterTones / 2, quarterOff);
                     bend->setStartTimeFactor(noteData.startFactor);
                     bend->setEndTimeFactor(noteData.endFactor);
@@ -275,7 +275,7 @@ static void createTiedNotesBends(const BendDataContext& bendDataCtx, mu::engravi
                     continue;
                 }
 
-                QuarterOffset quarterOff = noteInfo.quarterTones % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
+                int quarterOff = noteInfo.quarterTones % 2;
                 bend->setEndNotePitch(bend->startNoteOfChain()->pitch() + noteInfo.quarterTones / 2, quarterOff);
                 bend->setStartTimeFactor(noteInfo.startFactor);
                 bend->setEndTimeFactor(noteInfo.endFactor);

--- a/src/importexport/guitarpro/internal/guitarbendimport/splitchord/benddataprocessorsplitchord.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/splitchord/benddataprocessorsplitchord.cpp
@@ -200,7 +200,7 @@ static void createSplitDurationBendsForChord(const BendDataContextSplitChord& be
             return;
         }
 
-        QuarterOffset quarterOff = bendNoteData.quarterTones % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
+        int quarterOff = bendNoteData.quarterTones % 2;
         bend->setEndNotePitch(bend->startNoteOfChain()->pitch() + pitch, quarterOff);
         bend->setStartTimeFactor(bendNoteData.startFactor);
         bend->setEndTimeFactor(bendNoteData.endFactor);

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_release-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_release-gp.mscx
@@ -277,6 +277,7 @@
                 <eid>e_e</eid>
                 </Accidental>
               <pitch>62</pitch>
+              <centOffset>50</centOffset>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>1</string>
@@ -366,6 +367,7 @@
                 <eid>o_o</eid>
                 </Accidental>
               <pitch>65</pitch>
+              <centOffset>50</centOffset>
               <tpc>13</tpc>
               <fret>6</fret>
               <string>1</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp.mscx
@@ -169,6 +169,7 @@
                 <eid>S_S</eid>
                 </Accidental>
               <pitch>64</pitch>
+              <centOffset>50</centOffset>
               <tpc>18</tpc>
               <fret>1</fret>
               <string>1</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp5.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp5.mscx
@@ -181,6 +181,7 @@
                 <eid>V_V</eid>
                 </Accidental>
               <pitch>64</pitch>
+              <centOffset>50</centOffset>
               <tpc>18</tpc>
               <fret>1</fret>
               <string>1</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_bend-gp.mscx
@@ -228,6 +228,7 @@
                 <eid>Y_Y</eid>
                 </Accidental>
               <pitch>65</pitch>
+              <centOffset>50</centOffset>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>1</string>
@@ -363,6 +364,7 @@
                 <eid>m_m</eid>
                 </Accidental>
               <pitch>64</pitch>
+              <centOffset>50</centOffset>
               <tpc>18</tpc>
               <fret>11</fret>
               <string>1</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/simple_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/simple_bend-gp.mscx
@@ -231,6 +231,7 @@
                 <eid>b_b</eid>
                 </Accidental>
               <pitch>62</pitch>
+              <centOffset>50</centOffset>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>1</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_tied-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_tied-gp.mscx
@@ -139,6 +139,7 @@
                 <eid>R_R</eid>
                 </Accidental>
               <pitch>69</pitch>
+              <centOffset>-50</centOffset>
               <tpc>17</tpc>
               <fret>14</fret>
               <string>2</string>
@@ -246,6 +247,7 @@
                 <eid>d_d</eid>
                 </Accidental>
               <pitch>69</pitch>
+              <centOffset>-50</centOffset>
               <tpc>17</tpc>
               <fret>14</fret>
               <string>2</string>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bends_release_or_hold-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bends_release_or_hold-gp.mscx
@@ -308,7 +308,7 @@
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
-              <fret>9</fret>
+              <fret>8</fret>
               <string>2</string>
               <Spanner type="GuitarBend">
                 <prev>
@@ -341,12 +341,8 @@
             <noStem>1</noStem>
             <Note>
               <eid>k_k</eid>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>l_l</eid>
-                </Accidental>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
               <fret>9</fret>
               <string>2</string>
               <Spanner type="GuitarBend">
@@ -354,7 +350,7 @@
                   <guitarBendType>2</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>m_m</eid>
+                  <eid>l_l</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -371,7 +367,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>n_n</eid>
+              <eid>m_m</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <fret>10</fret>
@@ -381,7 +377,7 @@
                   <guitarBendType>2</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>o_o</eid>
+                  <eid>n_n</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -399,14 +395,14 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>p_p</eid>
+            <eid>o_o</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>q_q</eid>
+              <eid>p_p</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>r_r</eid>
+                <eid>q_q</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -417,7 +413,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                  <eid>s_s</eid>
+                  <eid>r_r</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -435,7 +431,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>t_t</eid>
+              <eid>s_s</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -446,7 +442,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                  <eid>u_u</eid>
+                  <eid>t_t</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -475,21 +471,21 @@
               </NoteParenGroup>
             </Chord>
           <BarLine>
-            <eid>v_v</eid>
+            <eid>u_u</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>w_w</eid>
+        <eid>v_v</eid>
         <voice>
           <Chord>
-            <eid>x_x</eid>
+            <eid>w_w</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>y_y</eid>
+              <eid>x_x</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>z_z</eid>
+                <eid>y_y</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -500,7 +496,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.633333</bendEndTimeFactor>
-                  <eid>0_0</eid>
+                  <eid>z_z</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -511,7 +507,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>1_1</eid>
+              <eid>0_0</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -521,7 +517,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>2_2</eid>
+                  <eid>1_1</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -533,14 +529,14 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>3_3</eid>
+            <eid>2_2</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>4_4</eid>
+              <eid>3_3</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>5_5</eid>
+                <eid>4_4</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -555,7 +551,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>6_6</eid>
+              <eid>5_5</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -581,13 +577,13 @@
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>7_7</eid>
+            <eid>6_6</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>8_8</eid>
+              <eid>7_7</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>9_9</eid>
+                <eid>8_8</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -598,7 +594,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.633333</bendEndTimeFactor>
-                  <eid>+_+</eid>
+                  <eid>9_9</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -609,7 +605,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>/_/</eid>
+              <eid>+_+</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -619,7 +615,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>AB_AB</eid>
+                  <eid>/_/</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -631,17 +627,17 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>BB_BB</eid>
+            <eid>AB_AB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>CB_CB</eid>
+              <eid>BB_BB</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalFlat</subtype>
-                <eid>DB_DB</eid>
+                <eid>CB_CB</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -655,7 +651,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>EB_EB</eid>
+              <eid>DB_DB</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -669,14 +665,14 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>FB_FB</eid>
+            <eid>EB_EB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>GB_GB</eid>
+              <eid>FB_FB</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>HB_HB</eid>
+                <eid>GB_GB</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -687,7 +683,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>IB_IB</eid>
+                  <eid>HB_HB</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>
@@ -705,7 +701,7 @@
                 </Spanner>
               </Note>
             <Note>
-              <eid>JB_JB</eid>
+              <eid>IB_IB</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -716,7 +712,7 @@
                   <guitarBendType>0</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                  <eid>KB_KB</eid>
+                  <eid>JB_JB</eid>
                   <anchor>3</anchor>
                   </GuitarBend>
                 <next>


### PR DESCRIPTION
Resolves: #31109 

UPDATE. Microtonal bends work based on microtonal accidentals. If there is at least one notation staff, the information about accidentals propagates to TAB staff too. But if there isn't, TAB staves don't support any accidental logic, therefore microtonal bends don't work. This PR adds the "cent offset" information to notes themselves (as opposed to just inferring it from the accidental) which is anyway a necessary step to support microtonal music in future.