### PR TITLE
Fix #31976: Text edit deactivates on paste

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5350,32 +5350,7 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
 
     bool succeeded = true;
     if (isTextEditingStarted()) {
-        const QMimeData* mimeData = QApplication::clipboard()->mimeData();
-        if (mimeData->hasFormat(TextEditData::mimeRichTextFormat)) {
-            const QString txt = QString::fromUtf8(mimeData->data(TextEditData::mimeRichTextFormat));
-            toTextBase(m_editData.element)->paste(m_editData, txt);
-        } else {
-            QString clipboardText = mimeData->text();
-            QString textForPaste = clipboardText;
-            if ((!clipboardText.startsWith('<') || !clipboardText.contains('>')) && m_editData.element->isLyrics()) {
-                textForPaste = extractSyllable(clipboardText);
-            }
-
-            toTextBase(m_editData.element)->paste(m_editData, textForPaste);
-
-            if (!textForPaste.isEmpty() && m_editData.element->isLyrics()) {
-                if (textForPaste.endsWith('-')) {
-                    navigateToNextSyllable();
-                } else if (textForPaste.endsWith('_')) {
-                    addMelisma();
-                } else {
-                    navigateToLyrics(false, false, false);
-                }
-
-                QString textForNextPaste = clipboardText.remove(0, clipboardText.indexOf(textForPaste) + textForPaste.size());
-                QGuiApplication::clipboard()->setText(textForNextPaste);
-            }
-        }
+        pasteIntoTextEdit();
     } else {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
         QMimeDataAdapter ma(mimeData);
@@ -5394,6 +5369,39 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
     }
 
     checkAndShowError();
+}
+
+void NotationInteraction::pasteIntoTextEdit()
+{
+    const QMimeData* mimeData = QApplication::clipboard()->mimeData();
+    if (mimeData->hasFormat(TextEditData::mimeRichTextFormat)) {
+        const QString txt = QString::fromUtf8(mimeData->data(TextEditData::mimeRichTextFormat));
+        toTextBase(m_editData.element)->paste(m_editData, txt);
+        return;
+    }
+
+    QString clipboardText = mimeData->text();
+    QString textForPaste = clipboardText;
+    if ((!clipboardText.startsWith('<') || !clipboardText.contains('>')) && m_editData.element->isLyrics()) {
+        textForPaste = extractSyllable(clipboardText);
+    }
+
+    toTextBase(m_editData.element)->paste(m_editData, textForPaste);
+
+    if (textForPaste.isEmpty() || !m_editData.element->isLyrics()) {
+        return;
+    }
+
+    if (textForPaste.endsWith('-')) {
+        navigateToNextSyllable();
+    } else if (textForPaste.endsWith('_')) {
+        addMelisma();
+    } else {
+        navigateToLyrics(false, false, false);
+    }
+
+    const QString textForNextPaste = clipboardText.remove(0, clipboardText.indexOf(textForPaste) + textForPaste.size());
+    QGuiApplication::clipboard()->setText(textForNextPaste);
 }
 
 void NotationInteraction::swapSelection()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5355,9 +5355,8 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
         QMimeDataAdapter ma(mimeData);
         succeeded = score()->cmdPaste(&ma, nullptr, scale);
+        m_editData.element = nullptr;
     }
-
-    m_editData.element = nullptr;
 
     if (succeeded) {
         apply();

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -405,6 +405,7 @@ private:
 
     void startEditText(mu::engraving::TextBase* text);
     bool needEndTextEdit() const;
+    void pasteIntoTextEdit();
 
     mu::engraving::Page* point2page(const muse::PointF& p, bool useNearestPage = false) const;
     std::vector<EngravingItem*> elementsAt(const muse::PointF& p) const;


### PR DESCRIPTION
Resolves: #31976

The problem here is that `isTextEditingStarted`, `drawTextEditMode`, and other methods rely on `m_editData.element` after paste, which is being nullified in `pasteSelection`. This was introduced in b203a8e7b8ce8f78095ef528b35aa64e25d6c264 because our paste logic could result in a dangling pointer to `m_editData.element`. Dangling is not possible, however, in the case where we paste into a text edit so, as @krasko78 points out in the linked issue, we don't need to nullify in this case.

I have encountered a few similar issues with `m_editData` over the years and I do wonder whether we can make it a little more robust going forward (perhaps starting with some accessor methods, etc)...

This PR also introduces a helper to address some deep nesting.