### PR TITLE
Use commit `f471206335392ff52f49dbb61284cd527c594672` of `mnxdom`.

### DIFF
--- a/src/importexport/mnx/CMakeLists.txt
+++ b/src/importexport/mnx/CMakeLists.txt
@@ -12,7 +12,7 @@ set(mnxdom_BUILD_TESTING OFF CACHE BOOL "Do not build tests for mnx")
 FetchContent_Declare(
     mnxdom
     GIT_REPOSITORY https://github.com/rpatters1/mnxdom.git
-    GIT_TAG        bb5661363303de0bcabc2ae45325f9f66b2ff190
+    GIT_TAG        f471206335392ff52f49dbb61284cd527c594672
 )
 
 FetchContent_MakeAvailable(mnxdom)


### PR DESCRIPTION
Resolve an issue reported on Discord that MuseScore would not build on Visual Studio 2026 after #31924 was merged. This was due to the boilerplate macros in [`mnxdom`](https://github.com/rpatters1/mnxdom) using C++20 macro extensions `__VA_OPT__` and empty variadic arguments. VS2026 is apparently much stricter about enforcing C++17 compliance.
 
<!-- Add a short description of and motivation for the changes here -->

This push request changes the commit number pulled by the MuseScore build to pull a revised version of `musxdom` with simplified boilerplate macros. The revised `mnxdom` also includes another small variable name change that suppresses a warning and some comments refactoring.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
(Current tests verify that the change does not affect them)
