### PR TITLE
Don't show position for expressions/dynamics

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
@@ -723,11 +723,13 @@ void TextSettingsModel::updateIsLineSpacingAvailable()
 
 void TextSettingsModel::updateIsPositionAvailable()
 {
-    bool available = true;
+    bool available = false;
     for (EngravingItem* item : m_elementList) {
         if (item->isTextLineBase()) {
             available = false;
             break;
+        } else if (!item->hasVoiceAssignmentProperties()) {
+            available = true;
         }
     }
 


### PR DESCRIPTION
Resolves: #32046

Items with voice assignment properties (expressions, dynamics) use `Pid::DIRECTION`, provided elsewhere in properties.