### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/importexport/tabledit/internal/importtef.cpp
+++ b/src/importexport/tabledit/internal/importtef.cpp
@@ -568,12 +568,12 @@ void TablEdit::createRepeats()
     ReadingList readingList;
     readingList.calculate(tefMeasures.size(), tefReadingList);
     for (size_t i = 0; i < tefMeasures.size(); ++i) {
-        Measure* m { score->crMeasure(i) };
+        Measure* m { score->crMeasure(static_cast<int>(i)) };
         m->setRepeatStart(readingList.status().at(i).repeatStart);
         m->setRepeatEnd(readingList.status().at(i).repeatEnd);
     }
     if (readingList.status().back().barlineEnd) {
-        Measure* m { score->crMeasure(tefMeasures.size() - 1) };
+        Measure* m { score->crMeasure(static_cast<int>(tefMeasures.size()) - 1) };
         m->setEndBarLineType(BarLineType::END, 0);
     }
 }

--- a/src/importexport/tabledit/internal/readinglist.cpp
+++ b/src/importexport/tabledit/internal/readinglist.cpp
@@ -122,7 +122,7 @@ void ReadingList::analyze()
             m_status[m_list.at(itemsUsed - 1).last].repeatEnd = true;
             if (itemsUsed > 2) {
                 // check interaction with alternative endings
-                m_status[m_list.at(itemsUsed - 1).last].ending = itemsUsed;
+                m_status[m_list.at(itemsUsed - 1).last].ending = static_cast<int>(itemsUsed);
             }
             m_list.erase(m_list.begin(), m_list.begin() + itemsUsed);
             continue;


### PR DESCRIPTION
* reg.: 'nMeasures': unreferenced parameter (4100)
* reg.: 'argument': conversion from 'size_t' to 'int', possible loss of data
  and: '=': conversion from 'size_t' to 'int', possible loss of data (C4267)