### PR TITLE
[4.7.0] Fix mixer hang when loading score with custom soundfonts

### DIFF
--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -195,53 +195,56 @@ void EngineRpcController::init()
         };
 
         AudioResourceType resourceType = params.in.resourceMeta.type;
+
         // Not Fluid
         if (resourceType != AudioResourceType::FluidSoundfont) {
             addTrackAndSendResponce(msg, seqId, trackName, playbackData, params);
+            return;
         }
+
         // Fluid
-        else {
-            std::string sfname = params.in.resourceMeta.attributeVal(synth::SOUNDFONT_NAME_ATTRIBUTE).toStdString();
-            if (sfname.empty()) {
-                sfname = params.in.resourceMeta.id;
-            }
+        std::string sfname = params.in.resourceMeta.attributeVal(synth::SOUNDFONT_NAME_ATTRIBUTE).toStdString();
+        if (sfname.empty()) {
+            sfname = params.in.resourceMeta.id;
+        }
 
-            if (soundFontRepository()->isSoundFontLoaded(sfname)) {
-                addTrackAndSendResponce(msg, seqId, trackName, playbackData, params);
-            }
-            // Waiting for SF to load
-            else {
-                LOGI() << "Waiting for SF to load, trackName: " << trackName << ", SF name: " << sfname;
-                m_pendingTracks[sfname].emplace_back(PendingTrack { msg, seqId, trackName, playbackData, params });
+        if (soundFontRepository()->isSoundFontLoaded(sfname)) {
+            addTrackAndSendResponce(msg, seqId, trackName, playbackData, params);
+        }
+        // Waiting for SF to load
+        else if (soundFontRepository()->isLoadingSoundFonts()) {
+            LOGI() << "Waiting for SF to load, trackName: " << trackName << ", SF name: " << sfname;
+            m_pendingTracks[sfname].emplace_back(PendingTrack { msg, seqId, trackName, playbackData, params });
 
-                //! NOTE We subscribe for the first track for which a soundfont is not found.
-                //! When the notification is triggered, processing will be called for all tracks.
-                if (!m_soundFontsChangedSubscribed) {
-                    m_soundFontsChangedSubscribed = true;
-                    soundFontRepository()->soundFontsChanged().onNotify(this,
-                                                                        [this, addTrackAndSendResponce]() {
-                        std::vector<std::string> toRemove;
-                        for (auto& p : m_pendingTracks) {
-                            const std::string& sfname = p.first;
-                            if (soundFontRepository()->isSoundFontLoaded(sfname)) {
-                                for (const PendingTrack& t : p.second) {
-                                    addTrackAndSendResponce(t.msg, t.seqId, t.trackName, t.playbackData, t.params);
-                                }
-                                toRemove.push_back(sfname);
+            //! NOTE We subscribe for the first track for which a soundfont is not found.
+            //! When the notification is triggered, processing will be called for all tracks.
+            if (!m_soundFontsChangedSubscribed) {
+                m_soundFontsChangedSubscribed = true;
+                soundFontRepository()->soundFontsChanged().onNotify(this,
+                                                                    [this, addTrackAndSendResponce]() {
+                    std::vector<std::string> toRemove;
+                    for (auto& p : m_pendingTracks) {
+                        const std::string& sfname = p.first;
+                        if (soundFontRepository()->isSoundFontLoaded(sfname)) {
+                            for (const PendingTrack& t : p.second) {
+                                addTrackAndSendResponce(t.msg, t.seqId, t.trackName, t.playbackData, t.params);
                             }
+                            toRemove.push_back(sfname);
                         }
+                    }
 
-                        for (const std::string& sf : toRemove) {
-                            m_pendingTracks.erase(sf);
-                        }
+                    for (const std::string& sf : toRemove) {
+                        m_pendingTracks.erase(sf);
+                    }
 
-                        if (m_pendingTracks.empty()) {
-                            soundFontRepository()->soundFontsChanged().disconnect(this);
-                            m_soundFontsChangedSubscribed = false;
-                        }
-                    });
-                }
+                    if (m_pendingTracks.empty()) {
+                        soundFontRepository()->soundFontsChanged().disconnect(this);
+                        m_soundFontsChangedSubscribed = false;
+                    }
+                });
             }
+        } else { // Attempt to add it anyway (most likely fallback will be used)
+            addTrackAndSendResponce(msg, seqId, trackName, playbackData, params);
         }
     });
 

--- a/src/framework/audio/engine/internal/synthesizers/soundfontrepository.h
+++ b/src/framework/audio/engine/internal/synthesizers/soundfontrepository.h
@@ -19,32 +19,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_AUDIO_SOUNDFONTREPOSITORY_H
-#define MUSE_AUDIO_SOUNDFONTREPOSITORY_H
 
-#include "../../isoundfontrepository.h"
+#pragma once
+
+#include "audio/engine/isoundfontrepository.h"
 
 namespace muse::audio::synth {
 class SoundFontRepository : public ISoundFontRepository
 {
 public:
-    SoundFontRepository() = default;
-
     void loadSoundFonts(const std::vector<SoundFontUri>& uris) override;
     void addSoundFont(const SoundFontUri& uri) override;
     void addSoundFontData(const SoundFontUri& uri, const ByteArray& data) override;
 
     bool isSoundFontLoaded(const std::string& name) const override;
+    bool isLoadingSoundFonts() const override;
+
     const SoundFontsMap& soundFonts() const override;
     async::Notification soundFontsChanged() const override;
 
 private:
-
     void doAddSoundFont(const SoundFontUri& uri, const SoundFontsMap* cache = nullptr, std::function<void()> onFinished = nullptr);
 
     SoundFontsMap m_soundFonts;
     async::Notification m_soundFontsChanged;
+
+    size_t m_loadingSoundFontCount = 0;
 };
 }
-
-#endif // MUSE_AUDIO_SOUNDFONTREPOSITORY_H

--- a/src/framework/audio/engine/isoundfontrepository.h
+++ b/src/framework/audio/engine/isoundfontrepository.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_AUDIO_ISOUNDFONTREPOSITORY_H
-#define MUSE_AUDIO_ISOUNDFONTREPOSITORY_H
+
+#pragma once
 
 #include "modularity/imoduleinterface.h"
 
@@ -41,9 +41,9 @@ public:
     virtual void addSoundFontData(const SoundFontUri& uri, const ByteArray& data) = 0;
 
     virtual bool isSoundFontLoaded(const std::string& name) const = 0;
+    virtual bool isLoadingSoundFonts() const = 0;
+
     virtual const SoundFontsMap& soundFonts() const = 0;
     virtual async::Notification soundFontsChanged() const = 0;
 };
 }
-
-#endif // MUSE_AUDIO_ISOUNDFONTREPOSITORY_H


### PR DESCRIPTION
Very similar bug: https://github.com/musescore/MuseScore/issues/30966

To reproduce: open a score that uses a soundfont that is not installed on your system -> mixer hangs