### PR TITLE
Fix #32068: String tunings drag & drop

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -170,8 +170,6 @@ bool ChordRest::acceptDrop(EditData& data) const
     case ElementType::TREMOLOBAR:
     case ElementType::HARP_DIAGRAM:
         return true;
-    case  ElementType::STRING_TUNINGS:
-        return measure()->canAddStringTunings(staffIdx());
     case ElementType::ACTION_ICON: {
         switch (toActionIcon(e)->actionType()) {
         case ActionIconType::BEAM_AUTO:
@@ -343,14 +341,6 @@ EngravingItem* ChordRest::drop(EditData& data)
                 toHarpPedalDiagram(e)->setPedalState(prevDiagram->getPedalState());
             }
         }
-        score()->undoAddElement(e);
-        return e;
-    }
-    case ElementType::STRING_TUNINGS:
-    {
-        Staff* st = staff()->isPrimaryStaff() ? staff() : staff()->primaryStaff();
-        e->setParent(segment());
-        e->setTrack(staff2track(st->idx()));
         score()->undoAddElement(e);
         return e;
     }


### PR DESCRIPTION
Resolves: #32068

String tunings are handled by `prepareDropMeasureAnchorElement` in `NotationInteraction`. Removing the logic from `Measure::acceptDrop` in 427f6d6b164eb130654f6186c4350f08e044b5ea means that we never set a target measure for the drop. The changes in this PR revert to what we had before this commit (with a couple tweaks).

Curious to hear your thoughts too @XiaoMigros if you get a chance - copy/pasting string tunings still appears to work as expected after these changes.