### PR TITLE
Optimize layout termination in ScorePageViewLayout and ScoreVerticalV…

### DIFF
--- a/src/engraving/rendering/score/scorepageviewlayout.cpp
+++ b/src/engraving/rendering/score/scorepageviewlayout.cpp
@@ -176,10 +176,10 @@ void ScorePageViewLayout::layoutPageView(Score* score, LayoutContext& ctx, const
     prepareScore(score, ctx);
 
     //! NOTE Reset pass need anyway
-//#ifdef MUE_ENABLE_ENGRAVING_LD_PASSES
+    // #ifdef MUE_ENABLE_ENGRAVING_LD_PASSES
     PassResetLayoutData resetPass;
     resetPass.run(score, ctx);
-//#endif
+    // #endif
 
 #ifdef MUE_ENABLE_ENGRAVING_LD_PASSES
     if (ctx.state().isLayoutAll()) {
@@ -223,7 +223,12 @@ void ScorePageViewLayout::doLayout(LayoutContext& ctx)
         //    c) this page ends with the same measure as the previous layout
         //    pageOldMeasure will be last measure from previous layout if range was completed on or before this page
         //    it will be nullptr if this page was never laid out or if we collected a system for next page
-    } while (state.curSystem() && !(state.rangeDone() && lmb == state.pageOldMeasure()));
+    } while (state.curSystem()
+             && !(state.rangeDone() && lmb == state.pageOldMeasure()
+                  && state.page() && !state.page()->systems().empty()
+                  && !state.page()->systems().front()->measures().empty()
+                  && state.page()->systems().front()->measures().back()->tick()
+                  > state.endTick()));
     // && page->system(0)->measures().back()->tick() > endTick // FIXME: perhaps the first measure was meant? Or last system?
 }
 

--- a/src/engraving/rendering/score/scoreverticalviewlayout.cpp
+++ b/src/engraving/rendering/score/scoreverticalviewlayout.cpp
@@ -177,7 +177,12 @@ void ScoreVerticalViewLayout::doLayout(LayoutContext& ctx)
         //    c) this page ends with the same measure as the previous layout
         //    pageOldMeasure will be last measure from previous layout if range was completed on or before this page
         //    it will be nullptr if this page was never laid out or if we collected a system for next page
-    } while (ctx.state().curSystem() && !(ctx.state().rangeDone() && lmb == ctx.state().pageOldMeasure()));
+    } while (ctx.state().curSystem()
+             && !(ctx.state().rangeDone() && lmb == ctx.state().pageOldMeasure()
+                  && ctx.state().page() && !ctx.state().page()->systems().empty()
+                  && !ctx.state().page()->systems().front()->measures().empty()
+                  && ctx.state().page()->systems().front()->measures().back()->tick()
+                  > ctx.state().endTick()));
     // && page->system(0)->measures().back()->tick() > endTick // FIXME: perhaps the first measure was meant? Or last system?
 
     if (!ctx.state().curSystem()) {


### PR DESCRIPTION
## Description
This PR enables an optimization in the layout engine that allows the layout loop to terminate earlier when the edited range has been fully processed and the subsequent pages are stable. 

Previously, a FIXME comment suggested checking if the current page starts after the `endTick` of the layout context. This PR implements that check, ensuring we don't continue iterating through pages that are guaranteed to be unaffected by the changes.

The following condition was added to the loop termination logic in both `ScorePageViewLayout::doLayout` and `ScoreVerticalViewLayout::doLayout`:

```cpp
&& state.page()->systems().front()->measures().back()->tick() > state.endTick()