### PR TITLE
Add "Play on Pass" system, implemented for ottavas.

### DIFF
--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -109,6 +109,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::GHOST,                               P_TYPE::BOOL,                      PropertyGroup::APPEARANCE, true,  "ghost",                           QT_TRANSLATE_NOOP("engraving/propertyName", "ghost") },
     { Pid::DEAD,                                P_TYPE::BOOL,                      PropertyGroup::APPEARANCE, true,  "dead",                            QT_TRANSLATE_NOOP("engraving/propertyName", "dead") },
     { Pid::PLAY,                                P_TYPE::BOOL,                      PropertyGroup::NONE,       false, "play",                            QT_TRANSLATE_NOOP("engraving/propertyName", "played") },
+    { Pid::PLAY_ON_PASSES,                      P_TYPE::INT_VEC,                   PropertyGroup::APPEARANCE, false, "playOnPasses",                    QT_TRANSLATE_NOOP("engraving/propertyName", "play on passes") },
     { Pid::TIMESIG_NOMINAL,                     P_TYPE::FRACTION,                  PropertyGroup::APPEARANCE, false, "timesigNominal",                  QT_TRANSLATE_NOOP("engraving/propertyName", "nominal time signature") },
     { Pid::TIMESIG_ACTUAL,                      P_TYPE::FRACTION,                  PropertyGroup::APPEARANCE, true,  "timesigActual",                   QT_TRANSLATE_NOOP("engraving/propertyName", "actual time signature") },
     { Pid::NUMBER_TYPE,                         P_TYPE::INT,                       PropertyGroup::APPEARANCE, false, "numberType",                      QT_TRANSLATE_NOOP("engraving/propertyName", "number type") },

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -120,6 +120,7 @@ enum class Pid : short {
     GHOST,
     DEAD,
     PLAY,
+    PLAY_ON_PASSES,
     TIMESIG_NOMINAL,
 
     TIMESIG_ACTUAL,

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -424,6 +424,7 @@ Spanner::Spanner(const Spanner& s)
     : EngravingItem(s)
 {
     m_playSpanner  = s.m_playSpanner;
+    m_playOnPasses = s.m_playOnPasses;
     m_anchor       = s.m_anchor;
     m_startElement = s.m_startElement;
     m_endElement   = s.m_endElement;
@@ -605,6 +606,8 @@ PropertyValue Spanner::getProperty(Pid propertyId) const
     switch (propertyId) {
     case Pid::PLAY:
         return m_playSpanner;
+    case Pid::PLAY_ON_PASSES:
+        return m_playOnPasses;
     case Pid::SPANNER_TICK:
         return m_tick;
     case Pid::SPANNER_TICKS:
@@ -638,6 +641,9 @@ bool Spanner::setProperty(Pid propertyId, const PropertyValue& v)
     switch (propertyId) {
     case Pid::PLAY:
         setPlaySpanner(v.toBool());
+        break;
+    case Pid::PLAY_ON_PASSES:
+        setPlayOnPasses(v.value<std::vector<int> >());
         break;
     case Pid::SPANNER_TICK:
         triggerLayout();           // spanner may have moved to another system
@@ -696,6 +702,8 @@ PropertyValue Spanner::propertyDefault(Pid propertyId) const
     switch (propertyId) {
     case Pid::PLAY:
         return true;
+    case Pid::PLAY_ON_PASSES:
+        return std::vector<int>();
     case Pid::ANCHOR:
         return int(Anchor::SEGMENT);
     default:

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -178,6 +178,9 @@ public:
     bool playSpanner() const { return m_playSpanner; }
     void setPlaySpanner(bool p) { m_playSpanner = p; }
 
+    const std::vector<int>& playOnPasses() const { return m_playOnPasses; }
+    void setPlayOnPasses(const std::vector<int>& passes) { m_playOnPasses = passes; }
+
     Anchor anchor() const { return m_anchor; }
     void setAnchor(Anchor a) { m_anchor = a; }
 
@@ -282,6 +285,7 @@ private:
     EngravingItem* m_endElement = nullptr;
 
     bool m_playSpanner = true;
+    std::vector<int> m_playOnPasses;
 
     Anchor m_anchor = Anchor::SEGMENT;
     Fraction m_tick = Fraction(-1, 1);

--- a/src/engraving/playback/utils/repeatpassutils.h
+++ b/src/engraving/playback/utils/repeatpassutils.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "../../dom/repeatlist.h"
+#include "../../dom/score.h"
+
+namespace mu::engraving {
+inline int repeatPassForUtick(const Score* score, const int utick)
+{
+    if (!score) {
+        return 1;
+    }
+
+    const RepeatList& repeats = score->repeatList();
+    auto repeatIt = repeats.findRepeatSegmentFromUTick(utick);
+    if (repeatIt == repeats.cend()) {
+        return 1;
+    }
+
+    const int pass = (*repeatIt)->playbackCount;
+    return pass > 0 ? pass : 1;
+}
+
+inline bool shouldApplyOnPass(const std::vector<int>& passes, const int pass)
+{
+    if (passes.empty()) {
+        return true;
+    }
+
+    if (pass <= 0) {
+        return false;
+    }
+
+    return std::find(passes.cbegin(), passes.cend(), pass) != passes.cend();
+}
+}

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2249,6 +2249,8 @@ static void readOttava(XmlReader& e, ReadContext& ctx, Ottava* ottava)
             ottava->setOttavaType(OttavaType(idx));
         } else if (tag == "numbersOnly") {
             ottava->setNumbersOnly(e.readBool());
+        } else if (tag == "playOnPasses") {
+            ottava->setPlayOnPasses(TConv::fromXml(e.readText(), std::vector<int>()));
         } else if (!readTextLineProperties(e, ctx, ottava)) {
             e.unknown();
         }

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3499,6 +3499,8 @@ bool TRead::readProperties(Ottava* o, XmlReader& e, ReadContext& ctx)
         } else {
             o->setOttavaType(OttavaType(idx));
         }
+    } else if (readProperty(o, tag, e, ctx, Pid::PLAY_ON_PASSES)) {
+        return true;
     } else if (readStyledProperty(o, tag, e, ctx)) {
         return true;
     } else if (!readProperties(toTextLineBase(o), e, ctx)) {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2438,6 +2438,7 @@ void TWrite::write(const Ottava* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::OTTAVA_TYPE);
     writeProperty(item, xml, Pid::PLACEMENT);
     writeProperty(item, xml, Pid::NUMBERS_ONLY);
+    writeProperty(item, xml, Pid::PLAY_ON_PASSES);
 //      for (const StyledProperty& spp : *styledProperties())
 //            writeProperty(xml, spp.pid);
     writeProperties(static_cast<const TextLineBase*>(item), xml, ctx);

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/ottava_play_on_pass/ottava_play_on_pass.mscx
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/ottava_play_on_pass/ottava_play_on_pass.mscx
@@ -1,0 +1,114 @@
+<museScore version="4.70">
+  <programVersion>5.0.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>PCzrBB3LRiI_yiPHtx78nGC</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2026-01-31</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Ottava Play on Pass</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="piano">
+        <family id="keyboards">Keyboards</family>
+        </instrument>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>2DZMU/EYjjH_4bQdlpEzjzF</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <eid>+LgfOcJ/0tG_k9O32ys1UfB</eid>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <TimeSig>
+            <eid>uLpVEfTXkJO_TJ4pIXT2FZD</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Spanner type="Ottava">
+            <Ottava>
+              <subtype>8va</subtype>
+              <eid>xiSaE3++lgP_h5WLWVGMbtB</eid>
+              <playOnPasses>2</playOnPasses>
+              </Ottava>
+            <next>
+              <location>
+                <fractions>1/1</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>5+1LmtLqsJO_8yVUchYkXEJ</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>Sf7tzdBco+O_uBlU/l7opSC</eid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>ETnaYBi2ZAE_jejLfhIEQ4B</eid>
+            <durationType>half</durationType>
+            </Rest>
+          <Rest>
+            <eid>c860BTn8afB_4+azj91S3N</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Spanner type="Ottava">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Ottava">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/internal/OttavaStyleSettings.qml
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/internal/OttavaStyleSettings.qml
@@ -65,13 +65,22 @@ FocusableItem {
             navigation.row: typeSection.navigationRowEnd + 1
         }
 
+        TextSection {
+            id: playbackPasses
+            titleText: qsTrc("inspector", "Playback passes")
+            propertyItem: root.model ? root.model.playbackPasses : null
+
+            navigationPanel: root.navigationPanel
+            navigationRowStart: showNumbersOnlyCheckBox.navigation.row + 1
+        }
+
         SeparatorLine { anchors.margins: -12 }
 
         LineWithHooksCommonStyleSettings {
             model: root.model
 
             navigationPanel: root.navigationPanel
-            navigationRowStart: showNumbersOnlyCheckBox.navigation.row + 1
+            navigationRowStart: playbackPasses.navigationRowStart + 2
         }
     }
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.cpp
@@ -50,6 +50,11 @@ PropertyItem* OttavaSettingsModel::showNumbersOnly() const
     return m_showNumbersOnly;
 }
 
+PropertyItem* OttavaSettingsModel::playbackPasses() const
+{
+    return m_playbackPasses;
+}
+
 QVariantList OttavaSettingsModel::possibleOttavaTypes() const
 {
     QMap<mu::engraving::OttavaType, QString> ottavaTypes {
@@ -95,6 +100,7 @@ void OttavaSettingsModel::createProperties()
 
     m_ottavaType = buildPropertyItem(mu::engraving::Pid::OTTAVA_TYPE);
     m_showNumbersOnly = buildPropertyItem(mu::engraving::Pid::NUMBERS_ONLY);
+    m_playbackPasses = buildPropertyItem(mu::engraving::Pid::PLAY_ON_PASSES);
 
     isLineVisible()->setIsVisible(true);
     allowDiagonal()->setIsVisible(true);
@@ -107,6 +113,7 @@ void OttavaSettingsModel::loadProperties()
 
     loadPropertyItem(m_ottavaType);
     loadPropertyItem(m_showNumbersOnly);
+    loadPropertyItem(m_playbackPasses);
     updateStartAndEndHookTypes();
 }
 
@@ -116,4 +123,5 @@ void OttavaSettingsModel::resetProperties()
 
     m_ottavaType->resetToDefault();
     m_showNumbersOnly->resetToDefault();
+    m_playbackPasses->resetToDefault();
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.h
@@ -34,12 +34,14 @@ class OttavaSettingsModel : public TextLineSettingsModel
 
     Q_PROPERTY(mu::inspector::PropertyItem * ottavaType READ ottavaType CONSTANT)
     Q_PROPERTY(mu::inspector::PropertyItem * showNumbersOnly READ showNumbersOnly CONSTANT)
+    Q_PROPERTY(mu::inspector::PropertyItem * playbackPasses READ playbackPasses CONSTANT)
 
 public:
     explicit OttavaSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* ottavaType() const;
     PropertyItem* showNumbersOnly() const;
+    PropertyItem* playbackPasses() const;
 
     Q_INVOKABLE QVariantList possibleOttavaTypes() const;
 
@@ -53,5 +55,6 @@ private:
 
     PropertyItem* m_ottavaType = nullptr;
     PropertyItem* m_showNumbersOnly = nullptr;
+    PropertyItem* m_playbackPasses = nullptr;
 };
 }


### PR DESCRIPTION
This PR tries to implement a "play on pass" system as shown in a screenshot of Sibelius inside of issue #19994. This would allow for playback to only apply certain spanned elements on specific passes through the score. I have added this implementation to an ottava as a demo (since that's what I needed last weekend) and have included a playback test for it. Unlike the Sibelius screenshot, this implementation uses a comma-separated list rather than checkboxes.

I tried to take @jeetee's Feb 5, 2025 comment into account and used `RepeatList::findRepeatSegmentFromUTick` and `RepeatSegment::playbackCount` to determine which "pass" we're currently on. But, the issue doesn't have a lot of other technical information in it. As this is my first time working with the codebase, I am worried that I've done this in a sub-optimal way and am looking for feedback. In particular, I'm evaluating whether the spanned element should apply during playback _per-note_, which...seemed fine? But, this might be a very bad move in terms of performance on other systems, I don't know.

Due to the wording of #19994, I do not believe this PR closes it as-is. If this implementation is acceptable, I'm willing to add other spanned elements as well, which *would* close the issue. But, someone will need to give me a list of what other spanned elements are required. (I understand this is potentially a large undertaking...hopefully the list won't be _too_ long. 😬)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

As an addendum: Trying to use the standard pre-commit hook is very frustrating on macOS. `tidy_file.sh` uses `${extension,,}`, which requires BASH 4.0+, but we only have 3.2.57 by default. The specified version of Uncrustify, 0.74.0, also won't build with a newer CMake out-of-the-box and requires passing `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`. I hope the local changes I made to get everything running didn't mess anything up, but please let me know if anything doesn't pass muster.