### PR TITLE
Allow plugins to get whitelisted write paths, and to write to the project folder when it's stored as mscx

### DIFF
--- a/src/engraving/api/v1/util.h
+++ b/src/engraving/api/v1/util.h
@@ -109,10 +109,14 @@ public:
     Q_INVOKABLE QStringList userSoundFontDirectories();
     // Returns the plugin's folder's path
     Q_INVOKABLE QString pluginDirectoryPath();
+    // Returns the project's path (ex: .../Desktop/project.mscz)
+    Q_INVOKABLE QString projectPath();
     // Returns whether or not the project is stored as a folder (with a .mscx file)
-    Q_INVOKABLE bool isProjectStoredAsDirectory();
+    Q_INVOKABLE bool isProjectDirectory();
     // Returns the project's folder's path
     Q_INVOKABLE QString projectDirectoryPath();
+    /// Returns true if the plugin is allowed to write to the path
+    Q_INVOKABLE bool isPathWriteable(const QString& path);
 
     /// muse::Returns the file's last modification time
     Q_INVOKABLE int modifiedTime();


### PR DESCRIPTION
Resolves: #32091 and #32092 

As part of adding binary writing support to FileIO plugin API ([https://github.com/musescore/MuseScore/pull/31066](url)), the paths for where a plugin can write files is now controlled by a whitelist. With the existing whitelist, plugins cannot easily store a per-project config nor write files in a way that is contained within an individual project.

**This request adds the project directory to the whitelist when the project's `MscIoMode` is `Dir`, which means it is stored uncompressed: as a folder containing a `.mscx` file.**

For example, if the project is stored at `.../Desktop/testing/testing.mscx`, the `.../Desktop/testing` folder becomes a whitelisted write location. However, if the project is stored as a `.mscz` file, like `.../Desktop/testing.mscz`, nothing new is added to the whitelist.

Additionally, whitelisted write locations are not currently accessible through the FileIO API. **This pull request makes those paths accessible via the following functions so plugins can ensure they're attempting to write to valid locations.**

```
// Returns the user's MuseScore documents directory 
// (default location for Scores, Plugins, SoundFonts, Styles, Templates)
Q_INVOKABLE QString userDataPath();

// Returns the user-configured Plugins directory (Preferences → Folders → Plugins)
Q_INVOKABLE QString pluginsUserPath(); 

// Returns the user-configured Scores directory (Preferences → Folders → Scores)
Q_INVOKABLE QString userProjectsPath();

// Returns the user-configured Templates directory (Preferences → Folders → Templates)
Q_INVOKABLE QString userTemplatesPath();

// Returns the user-configured Styles directory (Preferences → Folders → Styles)
Q_INVOKABLE QString userStylesPath();

// Returns the user-configured SoundFonts directories (Preferences → Folders → SoundFonts)
Q_INVOKABLE QStringList userSoundFontDirectories();

// Returns the plugin's folder's path
Q_INVOKABLE QString pluginDirectoryPath();

// Returns whether or not the project is stored as a folder (with a .mscx file)
Q_INVOKABLE bool isProjectStoredAsDirectory();

// Returns the project's folder's path
// (which is only able to be written to if isProjectStoredAsDirectory() is true)
Q_INVOKABLE QString projectDirectoryPath();
```

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)