### PR TITLE
CI. Deploy. Install cmake before running a script that uses cmake

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,10 @@ jobs:
       run: |
         git tag --list | tail -n 20
         echo ==========
+
+        sudo apt-get update
+        sudo apt-get install cmake
+
         buildscripts/ci/release/make_tag_name.sh | tee -a "${GITHUB_OUTPUT}"
         echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
         echo ==========


### PR DESCRIPTION
there was [a problem](https://github.com/musescore/MuseScore/actions/runs/21718818905/job/62642366641) with using make_tag_name.sh script after moving to ubuntu-slim runner

You can see that the step was successful [here](https://github.com/Eism/MuseScore/actions/runs/21823757434)