### PR TITLE
Add flag to ShortcutOverrideModel to specify direction keys

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
@@ -177,6 +177,8 @@ FocusScope {
 
                 ShortcutOverrideModel {
                     id: shortcutOverrideModel
+                    // Direction keys should not trigger navigation, override them...
+                    directionKeysForOverride: ShortcutOverrideModel.All
                 }
 
                 Component.onCompleted: {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
@@ -184,6 +184,8 @@ FocusScope {
 
             ShortcutOverrideModel {
                 id: shortcutOverrideModel
+                // Left/right should not trigger navigation - override them...
+                directionKeysForOverride: ShortcutOverrideModel.LeftRight
             }
 
             Component.onCompleted: {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/shortcutoverridemodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/shortcutoverridemodel.cpp
@@ -72,6 +72,22 @@ bool ShortcutOverrideModel::handleShortcut(Qt::Key key, Qt::KeyboardModifiers mo
     return found;
 }
 
+ShortcutOverrideModel::DirectionKeys ShortcutOverrideModel::directionKeysForOverride() const
+{
+    return m_directionKeysForOverride;
+}
+
+void ShortcutOverrideModel::setDirectionKeysForOverride(const ShortcutOverrideModel::DirectionKeys& keys)
+{
+    if (m_directionKeysForOverride == keys) {
+        return;
+    }
+    m_directionKeysForOverride = keys;
+    emit directionKeysForOverrideChanged();
+
+    loadDisallowedOverrides();
+}
+
 void ShortcutOverrideModel::loadDisallowedOverrides()
 {
     //! NOTE: navigation shortcuts cannot be overridden...
@@ -83,10 +99,6 @@ void ShortcutOverrideModel::loadDisallowedOverrides()
         "nav-next-tab",
         "nav-prev-tab",
         "nav-trigger-control",
-        "nav-up",
-        "nav-down",
-        "nav-right",
-        "nav-left",
         "nav-first-control",
         "nav-last-control",
         "nav-nextrow-control",
@@ -95,6 +107,18 @@ void ShortcutOverrideModel::loadDisallowedOverrides()
 
     for (const std::string& actionCode : actionCodes) {
         m_notAllowedForOverrideShortcuts.push_back(shortcutsRegister()->shortcut(actionCode));
+    }
+
+    if (!m_directionKeysForOverride.testFlag(DirectionKey::LeftRight)) {
+        // We don't want to override left/right - dispatch navigation instead...
+        m_notAllowedForOverrideShortcuts.push_back(shortcutsRegister()->shortcut("nav-left"));
+        m_notAllowedForOverrideShortcuts.push_back(shortcutsRegister()->shortcut("nav-right"));
+    }
+
+    if (!m_directionKeysForOverride.testFlag(DirectionKey::UpDown)) {
+        // We don't want to override up/down - dispatch navigation instead...
+        m_notAllowedForOverrideShortcuts.push_back(shortcutsRegister()->shortcut("nav-up"));
+        m_notAllowedForOverrideShortcuts.push_back(shortcutsRegister()->shortcut("nav-down"));
     }
 }
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/shortcutoverridemodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/shortcutoverridemodel.h
@@ -35,6 +35,10 @@ namespace muse::uicomponents {
 class ShortcutOverrideModel : public QObject, public muse::Contextable, public async::Asyncable
 {
     Q_OBJECT
+
+    Q_PROPERTY(DirectionKeys directionKeysForOverride READ directionKeysForOverride
+               WRITE setDirectionKeysForOverride NOTIFY directionKeysForOverrideChanged)
+
     QML_ELEMENT;
 
     muse::ContextInject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
@@ -43,14 +47,30 @@ class ShortcutOverrideModel : public QObject, public muse::Contextable, public a
 public:
     explicit ShortcutOverrideModel(QObject* parent = nullptr);
 
+    enum class DirectionKey {
+        None      = 0x0,
+        LeftRight = 0x1,
+        UpDown    = 0x2,
+        All       = LeftRight | UpDown,
+    };
+    Q_DECLARE_FLAGS(DirectionKeys, DirectionKey)
+    Q_FLAG(DirectionKeys)
+
     Q_INVOKABLE void init();
     Q_INVOKABLE bool isShortcutOverrideAllowed(Qt::Key key, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE bool handleShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
+
+    DirectionKeys directionKeysForOverride() const;
+    void setDirectionKeysForOverride(const DirectionKeys& keys);
+
+signals:
+    void directionKeysForOverrideChanged();
 
 private:
     void loadDisallowedOverrides();
     shortcuts::Shortcut disallowedOverride(Qt::Key key, Qt::KeyboardModifiers modifiers) const;
 
     shortcuts::ShortcutList m_notAllowedForOverrideShortcuts;
+    DirectionKeys m_directionKeysForOverride = DirectionKey::None;
 };
 }


### PR DESCRIPTION
Fixes a bug for `TextInputAreas` where directional keys were triggering navigation:

- `TextInputAreas` overrides _all_ directional keys
- `TextInputFields` overrides only the left/right keys
- `StyledMenus` don't override any directional keys (navigation is always triggered)