### PR TITLE
Don't use fallback font if the symbol doesn't exist in that font either

### DIFF
--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -238,6 +238,9 @@ public:
     muse::draw::Font font(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, const FormatValue& data);
+
+private:
+    void resolveFallback(muse::draw::Font::Type fontType, const String& text, const muse::draw::FontMetrics& fm, String& family) const;
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #31478 

There's a chain of effects going on.

- For all music-text fonts except Leland Text, where Simon made sure that the quarter note and the augmentation dot have the correct distance encoded in the font, we need to add a space between the two symbols, otherwise the dot is too close to the note.
- We can't just add a space in our files, because it would be ignored by the XML reader, so we add a fake space symbol like `<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym>`.
- When laying out text, we replace `<sym>space</sym>` with a normal space character, however
- The space character isn't part of Leland, which means when setting the font of the TextFragment we end up falling back to Bravura. That's what causes the note to be vertically off (the difference in the note baseline between Leland Text and Bravura Text is intentional). 
- Plot twist: the fallback to Bravura is pointless because Bravura _also_ doesn't have a space character, because it isn't part of Smufl afaict. 

So the temporary solution here is to avoid falling back to a font if that font doesn't contain the character either. 

The proper solution would be getting rid of the fake space symbol and just save to our files an explicitely text-font space, which is what already happens if you manually type a space between the two symbols in the score and save it.