### PR TITLE
Fix #32119: Init solo-mute states before exporting audio

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -473,6 +473,8 @@ void MasterNotation::initExcerpts(const ExcerptNotationList& excerpts)
 
         masterScore()->initExcerpt(impl->excerpt());
         impl->init();
+
+        initNotationSoloMuteState(impl->notation());
     }
 }
 


### PR DESCRIPTION
Resolves: #32119

In`ExportProjectScenario::exportScores`, we call `MasterNotation::initExcerpts` on all non-inited excerpts before exporting. This call should also init the solo-mute states for each excerpt.

The following issues should be re-checked in this build before merging: #24985, #27025, #27058, #30383