### PR TITLE
Fix breath position

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1491,6 +1491,8 @@ void TLayout::layoutBreath(const Breath* item, Breath::LayoutData* ldata, const 
     }
 
     ldata->setBbox(item->symBbox(item->symId()));
+
+    ldata->setPosX(-ldata->bbox().right());
 }
 
 void TLayout::layoutChord(Chord* item, LayoutContext& ctx)


### PR DESCRIPTION
Resolves: #31939 

The breath symbol should be right-aligned to its segment, like clefs.
