### PR TITLE
Fix ShadowNote x-position in scaled staves

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1236,6 +1236,10 @@ bool Score::getPosition(Position* pos, const PointF& p, voice_idx_t voice) const
     if (segment == 0) {
         return false;
     }
+    const EngravingItem* el = segment->element(track);
+    if (el != nullptr) {
+        x += el->x();
+    }
     //
     // TODO: restrict to reasonable values (pitch 0-127)
     //

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -488,10 +488,12 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
 
     const mu::engraving::Instrument* instr = staff->part()->instrument(tick);
 
-    // in any empty measure, pos will be right next to barline
-    // so pad this by barNoteDistance
-    qreal relX = position.pos.x() - position.segment->measure()->canvasPos().x();
-    position.pos.rx() -= qMin(relX - score()->style().styleMM(mu::engraving::Sid::barNoteDistance) * mag, 0.0);
+    // in any empty measure, pos will be at the rest in the center
+    // so swap this for barNoteDistance
+    if (position.segment->measure()->isEmpty(position.staffIdx)) {
+        position.pos.rx() = position.segment->measure()->canvasPos().x() + score()->style().styleMM(mu::engraving::Sid::barNoteDistance)
+                            * mag;
+    }
 
     mu::engraving::NoteHeadGroup noteheadGroup = mu::engraving::NoteHeadGroup::HEAD_NORMAL;
     mu::engraving::NoteHeadType noteHead = params.duration.headType();


### PR DESCRIPTION
Resolves, in part: #14815  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Towards part 7 of that issue, this modifies `score::getPosition` to return a position with the x-coordinate of an element in the appropriate segment, which accounts for scaling of staves when placing a shadowNote near the co-ordinates of the cursor; `notationInteraction::doShowShadowNote`'s means of handling empty measures was changed to account for this change.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
