### PR TITLE
Fix loosing spaces between differently formatted text

### DIFF
--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -85,7 +85,7 @@ void TextBase::editInsertText(TextCursor* cursor, const String& s)
 
     const TextBlock& block = ldata->blocks.at(cursor->row());
     const CharFormat* previousFormat = block.formatAt(std::max(int(cursor->column()) - 1, 0));
-    if (previousFormat && previousFormat->fontFamily() == "ScoreText" && s == " ") {
+    if (previousFormat && s == " ") {
         // This space would be ignored by the xml parser (see #15629)
         // We must use the nonBreaking space character instead
         String nonBreakingSpace = String(Char(0xa0));


### PR DESCRIPTION
Resolves: #16824
Resolves: #18553

Had been fixed in #17739, but only for "ScoreText", i.e. when a Musical Text Font is involved, for #15629. This change here fixes it for 'normal'  text fonts too.