### PR TITLE
Don't align elements that have user offset

### DIFF
--- a/src/engraving/rendering/score/alignmentlayout.cpp
+++ b/src/engraving/rendering/score/alignmentlayout.cpp
@@ -171,7 +171,7 @@ void AlignmentLayout::alignItemsForSystem(const std::vector<EngravingItem*>& ele
     std::map<staff_idx_t, StaffItemGroups> staffItems;
 
     for (EngravingItem* item : elements) {
-        if (item->addToSkyline() && !item->excludeVerticalAlign()) {
+        if (item->addToSkyline() && !item->excludeVerticalAlign() && item->offset() == item->propertyDefault(Pid::OFFSET).value<PointF>()) {
             item->placeAbove() ? staffItems[item->staffIdx()].itemsAbove.push_back(item)
             : staffItems[item->staffIdx()].itemsBelow.push_back(item);
         }

--- a/src/engraving/rendering/score/alignmentlayout.h
+++ b/src/engraving/rendering/score/alignmentlayout.h
@@ -40,10 +40,12 @@ public:
     static void alignItemsWithTheirSnappingChain(const std::vector<EngravingItem*>& elements, const System* system);
     static void alignStaffCenteredItems(const std::vector<EngravingItem*>& elements, const System* system);
     static void alignItemsForSystem(const std::vector<EngravingItem*>& elements, const System* system);
-    static void alignItemsGroup(const std::vector<EngravingItem*>& elements, const System* system);
+
     static void alignHopoLetters(const HammerOnPullOff* hopo, const System* system);
 
 private:
+    static void alignItemsGroup(const std::vector<EngravingItem*>& elements, const System* system);
+
     static void moveItemToY(EngravingItem* item, double y, const System* system);
     static double yOpticalCenter(const EngravingItem* item);
     static void scanConnectedItems(EngravingItem* item, const System* system, std::function<void(EngravingItem*)> func);

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -930,14 +930,15 @@ void SystemLayout::layoutVoltas(const ElementsToLayout& elementsToLayout, Layout
 
         for (size_t j = i + 1; j < elementsToLayout.voltas.size(); ++j) {
             Volta* volta2 = toVolta(elementsToLayout.voltas[j]);
-            if (volta2->staffIdx() == volta1->staffIdx() && volta2->tick() == volta1->tick2()) {
+            if (volta2->staffIdx() == volta1->staffIdx() && volta2->tick() == volta1->tick2()
+                && volta1->placeAbove() == volta2->placeAbove()) {
                 voltasToAlign.push_back(volta2->frontSegment());
                 volta1 = volta2;
             }
         }
 
         if (voltasToAlign.size() > 1) {
-            AlignmentLayout::alignItemsGroup(voltasToAlign, system);
+            AlignmentLayout::alignItemsForSystem(voltasToAlign, system);
             for (EngravingItem* vs : voltasToAlign) {
                 alignedVoltas.insert(toVoltaSegment(vs)->volta());
             }


### PR DESCRIPTION
Resolves: #31518 
Resolves: #31445 

This is another instance of #22622. We won't be able to fix this properly until we remove offsets from default positions.

For now, the only thing we can do about this is exclude from the alignment chain elements that have been offset by the user. Not a perfect solution, but the only possible one.