### PR TITLE
fixed #32019: Occasional crash opening Style dialog

### DIFF
--- a/src/framework/interactive/internal/interactive.h
+++ b/src/framework/interactive/internal/interactive.h
@@ -176,6 +176,8 @@ private:
     Ret toRet(const QVariant& jsr) const;
     RetVal<Val> toRetVal(const QVariant& jsrv) const;
 
+    RetVal<bool> isOpened(const QString& objectId) const;
+
     RetVal<OpenData> openExtensionDialog(const UriQuery& q, const QVariantMap& params);
     RetVal<OpenData> openWidgetDialog(const Uri& uri, const QVariantMap& params);
     RetVal<OpenData> openQml(const Uri& uri, const QVariantMap& params);

--- a/src/framework/interactive/internal/widgetdialogadapter.cpp
+++ b/src/framework/interactive/internal/widgetdialogadapter.cpp
@@ -36,6 +36,18 @@ WidgetDialogAdapter::WidgetDialogAdapter(QDialog* parent)
     }
 
     m_dialog->installEventFilter(this);
+
+    connect(m_dialog, &QDialog::accepted, this, [this](){
+        if (m_onHideCallBack) {
+            m_onHideCallBack();
+        }
+    });
+
+    connect(m_dialog, &QDialog::rejected, this, [this](){
+        if (m_onHideCallBack) {
+            m_onHideCallBack();
+        }
+    });
 }
 
 bool WidgetDialogAdapter::eventFilter(QObject* watched, QEvent* event)
@@ -44,7 +56,7 @@ bool WidgetDialogAdapter::eventFilter(QObject* watched, QEvent* event)
         m_onShownCallBack();
     }
 
-    if (event->type() == QEvent::Hide && m_onHideCallBack) {
+    if (event->type() == QEvent::Close && m_onHideCallBack) {
         m_onHideCallBack();
     }
 


### PR DESCRIPTION
Resolve: #32019

It's very easy to reproduce on Linux when you open a dialog box and quickly click on the main window before it opens. 
Then the main window becomes the focus -> the dialog changes its state to Window<something there> -> hide is called for the dialog -> interactive calls for the dialog to be deleted -> hide is called again -> interactive tries to delete it again -> crash

The same thing happens with the show signal. For some reason, the Exposed signal comes to qt, and qt sends a Show event to redraw the widget. 

The solution is to filter subsequent processing of such signals. 