### PR TITLE
Qml. Now qml use MuseScore headers in each network requests

### DIFF
--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -68,6 +68,8 @@ target_sources(muse_ui PRIVATE
     internal/dragcontroller.h
     internal/windowscontroller.cpp
     internal/windowscontroller.h
+    internal/qmlnetworkaccessmanagerfactory.cpp
+    internal/qmlnetworkaccessmanagerfactory.h
 
     view/iconcodes.h
     view/mainwindowbridge.cpp

--- a/src/framework/ui/internal/qmlnetworkaccessmanagerfactory.cpp
+++ b/src/framework/ui/internal/qmlnetworkaccessmanagerfactory.cpp
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "qmlnetworkaccessmanagerfactory.h"
+
+using namespace muse::ui;
+
+QNetworkReply* QmlNetworkAccessManager::createRequest(Operation operation, const QNetworkRequest& originalRequest, QIODevice* outgoingData)
+{
+    QNetworkRequest request(originalRequest);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
+
+    muse::network::RequestHeaders _headers = networkConfiguration()->defaultHeaders();
+    for (auto it = _headers.knownHeaders.cbegin(); it != _headers.knownHeaders.cend(); ++it) {
+        request.setHeader(it.key(), it.value());
+    }
+
+    for (auto it = _headers.rawHeaders.cbegin(); it != _headers.rawHeaders.cend(); ++it) {
+        request.setRawHeader(it.key(), it.value());
+    }
+
+    return QNetworkAccessManager::createRequest(operation, request, outgoingData);
+}
+
+QNetworkAccessManager* QmlNetworkAccessManagerFactory::create(QObject* parent)
+{
+    return new QmlNetworkAccessManager(parent);
+}

--- a/src/framework/ui/internal/qmlnetworkaccessmanagerfactory.h
+++ b/src/framework/ui/internal/qmlnetworkaccessmanagerfactory.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QQmlNetworkAccessManagerFactory>
+#include <QNetworkAccessManager>
+
+#include "global/modularity/ioc.h"
+#include "network/inetworkconfiguration.h"
+
+namespace muse::ui {
+class QmlNetworkAccessManager : public QNetworkAccessManager
+{
+    muse::GlobalInject<muse::network::INetworkConfiguration> networkConfiguration;
+
+public:
+    explicit QmlNetworkAccessManager(QObject* parent = nullptr)
+        : QNetworkAccessManager(parent) {}
+
+protected:
+    QNetworkReply* createRequest(Operation operation, const QNetworkRequest& originalRequest, QIODevice* outgoingData) override;
+};
+
+class QmlNetworkAccessManagerFactory : public QQmlNetworkAccessManagerFactory
+{
+public:
+    QNetworkAccessManager* create(QObject* parent) override;
+};
+}

--- a/src/framework/ui/internal/uiengine.cpp
+++ b/src/framework/ui/internal/uiengine.cpp
@@ -69,6 +69,9 @@ void UiEngine::init()
     QJSValue translateFn = translator.property("translate");
     m_engine->globalObject().setProperty("qsTrc", translateFn);
 
+    m_networkManagerFactory = new QmlNetworkAccessManagerFactory();
+    m_engine->setNetworkAccessManagerFactory(m_networkManagerFactory);
+
 #ifdef Q_OS_WIN
     QDir dir(QCoreApplication::applicationDirPath() + QString("/../qml"));
     m_engine->addImportPath(dir.absolutePath());

--- a/src/framework/ui/internal/uiengine.h
+++ b/src/framework/ui/internal/uiengine.h
@@ -25,16 +25,19 @@
 #include <QObject>
 #include <qqmlintegration.h>
 
-#include "../iuiengine.h"
+#include "global/modularity/ioc.h"
+#include "languages/ilanguagesservice.h"
+#include "../iuiconfiguration.h"
+
 #include "../api/themeapi.h"
 #include "../view/qmltooltip.h"
 #include "../view/qmltranslation.h"
 #include "../view/qmlapi.h"
 #include "../view/qmldataformatter.h"
 
-#include "global/modularity/ioc.h"
-#include "languages/ilanguagesservice.h"
-#include "../iuiconfiguration.h"
+#include "qmlnetworkaccessmanagerfactory.h"
+
+#include "../iuiengine.h"
 
 namespace muse::ui {
 class UiEngine : public QObject, public IUiEngine, public Contextable
@@ -113,5 +116,7 @@ private:
     QmlDataFormatter* m_dataFormatter = nullptr;
     QQuickItem* m_rootItem = nullptr;
     mutable int m_isEffectsAllowed = -1;
+
+    QmlNetworkAccessManagerFactory* m_networkManagerFactory = nullptr;
 };
 }


### PR DESCRIPTION
Our c++ network manager uses the MuseScore header in all requests. Now qml too. 