### PR TITLE
Fix gcc and MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -815,6 +815,7 @@ static bool breakMultiMeasureRest(const LayoutContext& ctx, Measure* m)
                     return true;
                 }
             }
+            return false;
         };
 
         if (Segment* clefSeg = pm->findSegment(SegmentType::Clef, m->tick())) {


### PR DESCRIPTION
reg. (gcc): control reaches end of non-void function [-Wreturn-type]
and (MSVC): '`breakMultiMeasureRest'::`111'::<lambda_2>::operator()': not all control paths return a value (C4715)

Introduced by #32025, so needs to get ported to 4.7 along with that