### PR TITLE
Fix initial selection at EditStyle > ClefKeyTimeSigPage > When changing…

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
@@ -512,7 +512,7 @@ StyledFlickable {
 
                             delegate: RoundedRadioButton {
                                 required text
-                                required property bool value
+                                required property int value
 
                                 width: ListView.view.width
 


### PR DESCRIPTION
In https://github.com/musescore/MuseScore/issues/32136#issuecomment-3897733535, I spotted that no option is selected initially when opening the dialog:

<img width="683" height="461" alt="Scherm­afbeelding 2026-02-13 om 16 28 38" src="https://github.com/user-attachments/assets/866182ad-df1d-4825-aee7-141af84b2d5d" />

Fixed by using the correct type so that operator `===` works correctly