### PR TITLE
Fix error reporting when exporting score as PDF

### DIFF
--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -21,7 +21,7 @@
  */
 #include "exportprojectscenario.h"
 
-#include "global/io/file.h"
+#include "global/io/buffer.h"
 #include "global/io/fileinfo.h"
 
 #include "translation.h"
@@ -407,9 +407,19 @@ Ret ExportProjectScenario::doExportLoop(const muse::io::path_t& scorePath, std::
     }
 
     while (true) {
-        io::File outputFile(scorePath);
-        outputFile.setMeta("file_path", scorePath.toStdString());
-        if (!outputFile.open(File::WriteOnly)) {
+        Buffer outputBuf;
+        outputBuf.setMeta("file_path", scorePath.toStdString());
+        IF_ASSERT_FAILED(outputBuf.open(IODevice::WriteOnly)) {
+            return make_ret(Ret::Code::InternalError);
+        }
+
+        Ret ret = exportFunction(outputBuf);
+        outputBuf.close();
+        if (!ret) {
+            if (ret.code() == static_cast<int>(Ret::Code::Cancel)) {
+                return ret;
+            }
+
             if (askForRetry(filename)) {
                 continue;
             } else {
@@ -417,15 +427,8 @@ Ret ExportProjectScenario::doExportLoop(const muse::io::path_t& scorePath, std::
             }
         }
 
-        Ret ret = exportFunction(outputFile);
-        outputFile.close();
-
+        ret = fileSystem()->writeFile(scorePath, outputBuf.data());
         if (!ret) {
-            if (ret.code() == static_cast<int>(Ret::Code::Cancel)) {
-                fileSystem()->remove(scorePath);
-                return ret;
-            }
-
             if (askForRetry(filename)) {
                 continue;
             } else {


### PR DESCRIPTION
Resolves: #28061

This is resolved by replacing `File` with `Buffer` like in #31984

`File::open` succeeds even though another app holds onto the file. My guess is that the semantics of `QFileInfo::isWriteable` changed at some point so that it only checks for permissions and not whether or not a file can actually be opened.

*Small comment on file ops in the code base*: Doing these checks before the actual operation is flawed anyway, because the filesystem is a shared resource. Any info from these checks is immediately out-of-date and the supposedly guarded operation might fail anyway. So might as well just try the file operation and return appropriate errors from them.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
