### PR TITLE
Fixed cross-staff arpeggio duplication on Regroup rhythms tool use.

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -1879,6 +1879,13 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                             delete tieBack2;
                         }
                     }
+                    Arpeggio* arp;
+                    if (nchord->arpeggio()) {                         // save and detach arpeggio from cloned chord
+                        arp = nchord->arpeggio();
+                        arp->detachFromChords(arp->track(), arp->endTrack());
+                        undoRemoveElement(arp);
+                        nchord->setSpanArpeggio(nullptr);
+                    }
                     Chord* startChord = nchord;
                     Measure* measure = nullptr;
                     bool firstpart = true;
@@ -1989,6 +1996,9 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                             undoAddElement(tie);
                         }
                         connectTies();
+                    }
+                    if (arp) { // reattach arp
+                        arp->findAndAttachToChords();
                     }
                 }
             }


### PR DESCRIPTION
Resolves: #32176 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Due to two staves being treated as different tracks, arpeggios would be duplicated as "nchord2->removeMarkings(true);" would never be reached (#32176 contains a good example of this). The provided solution to this pulls the arpeggio from all clones immediately after slurs, and replaces the arpeggio immediately after slurs are replaced.

Also ensured to test with multiple arpeggios in the measure, all seem to be retained now without duplication.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
