### PR TITLE
Fixed #32190: "full" label was "1" when bend style set to Level.

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1484,7 +1484,7 @@ String bendAmountToString(int fulls, int quarts, bool useFractions)
             break;
         }
     } else {
-        if (!string.empty()) {
+        if (!string.empty() && quarts != 0) {
             string += u" ";
         }
         switch (std::abs(quarts)) {


### PR DESCRIPTION
Resolves: #32190 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Previously, an extra space would be appended in level mode to _any_ non-empty string even without any fraction present. As a result:

In bendAmountToString, "1" would be changed to "1 ".

In computeBendText, the following condition would always result to false and the text would never be replaced with "full".
```if (string == u"1" && style().styleB(Sid::guitarBendUseFull)) ```

Added an additional check for zero quarts before adding the space (```if (!string.empty() && quarts != 0)```), resolving this case and allowing the condition to properly be met.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
