### PR TITLE
Fix positioning/screen of popups (#32149, #32249) [4.7.0]

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
@@ -59,6 +59,15 @@ PopupView {
         if (!(openPolicies & PopupView.NoActivateFocus) && content.navigationSection) {
             content.navigationSection.requestActive()
         }
+        Qt.callLater(root.repositionWindowIfNeed)
+    }
+
+    onWidthChanged: {
+        Qt.callLater(root.repositionWindowIfNeed)
+    }
+
+    onHeightChanged: {
+        Qt.callLater(root.repositionWindowIfNeed)
     }
 
     onClosed: {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolTip.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolTip.qml
@@ -46,14 +46,6 @@ StyledPopupView {
     //! NOTE: No navigation needed for tooltip
     navigationSection: null
 
-    onWidthChanged: {
-        Qt.callLater(root.repositionWindowIfNeed)
-    }
-
-    onHeightChanged: {
-        Qt.callLater(root.repositionWindowIfNeed)
-    }
-
     ColumnLayout {
         id: content
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
@@ -426,18 +426,10 @@ void WindowView::resolveParentWindow()
 
 QScreen* WindowView::resolveScreen() const
 {
-    QScreen* screen = nullptr;
-
-    if (!m_globalPos.isNull()) {
-        screen = QGuiApplication::screenAt(m_globalPos.toPoint());
-    } else {
-        screen = m_parentWindow ? m_parentWindow->screen() : nullptr;
-    }
-
+    QScreen* screen = m_parentWindow ? m_parentWindow->screen() : nullptr;
     if (!screen) {
         screen = QGuiApplication::primaryScreen();
     }
-
     return screen;
 }
 


### PR DESCRIPTION
Resolves: #32149
Resolves: #32249

Reverts: #31244
Reopens: #28489

Looks like there are two issues at play here - one of them is the positioning of the popups. To fix this we need to call `repositionWindowIfNeed` on open/resize.

The other issue issue is the screen of the popups (introduced with #31244). The problem here seems to be that the screen we're resolving in `WindowView::resolveScreen` ends up being different to that of the parent item (the palettes button in this case). Since the linked issue to this PR is less severe than the regression it caused, for now we'll simply revert.

Issues #29556 and #31821 should be re-checked before merging.