### PR TITLE
Fix #32117: Crash involving chord symbols and history panel

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4631,6 +4631,7 @@ void NotationInteraction::redo()
 
 void NotationInteraction::undoRedoToIndex(size_t idx)
 {
+    endEditElement();
     m_undoStack->undoRedoToIndex(idx, &m_editData);
 }
 


### PR DESCRIPTION
Resolves: #32117

`UndoStack::undo` has some logic where we return early if there are no text edits to undo. This means the undo stack's index never changes in `NotationUndoStack::undoRedoToIndex` and we get caught in an infinite loop.

There are a few ways we could approach this, but the easiest option is simply to end the text editing whenever we use `NotationInteraction::undoRedoToIndex`.