### PR TITLE
Remove non-global context accessors from IModuleSetup

### DIFF
--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -57,14 +57,14 @@ std::string AppShellModule::moduleName() const
 
 void AppShellModule::registerExports()
 {
-    m_appShellConfiguration = std::make_shared<AppShellConfiguration>(iocContext());
+    m_appShellConfiguration = std::make_shared<AppShellConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IAppShellConfiguration>(moduleName(), m_appShellConfiguration);
 }
 
 void AppShellModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerPageUri(Uri("musescore://home"));
         ir->registerPageUri(Uri("musescore://notation"));

--- a/src/converter/convertermodule.cpp
+++ b/src/converter/convertermodule.cpp
@@ -37,14 +37,14 @@ std::string ConverterModule::moduleName() const
 
 void ConverterModule::registerExports()
 {
-    globalIoc()->registerExport<IConverterController>(moduleName(), new ConverterController(iocContext()));
+    globalIoc()->registerExport<IConverterController>(moduleName(), new ConverterController(globalCtx()));
 }
 
 void ConverterModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<IApiRegister>(moduleName());
     if (api) {
         api->regApiCreator(moduleName(), "MuseApi.Converter", new ApiCreator<api::ConverterApi>());
     }

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -107,7 +107,7 @@ void EngravingModule::registerExports()
 #ifndef ENGRAVING_NO_INTERNAL
 
     m_configuration = std::make_shared<EngravingConfiguration>();
-    m_engravingfonts = std::make_shared<EngravingFontsProvider>(iocContext());
+    m_engravingfonts = std::make_shared<EngravingFontsProvider>(globalCtx());
 
     globalIoc()->registerExport<IEngravingConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IEngravingFontsProvider>(moduleName(), m_engravingfonts);
@@ -120,14 +120,14 @@ void EngravingModule::registerExports()
 
 #ifdef MUE_BUILD_ENGRAVING_DEVTOOLS
     globalIoc()->registerExport<IEngravingElementsProvider>(moduleName(), new EngravingElementsProvider());
-    globalIoc()->registerExport<IDiagnosticDrawProvider>(moduleName(), new DiagnosticDrawProvider(iocContext()));
+    globalIoc()->registerExport<IDiagnosticDrawProvider>(moduleName(), new DiagnosticDrawProvider(globalCtx()));
 #endif
 }
 
 void EngravingModule::resolveImports()
 {
 #ifdef MUE_BUILD_ENGRAVING_DEVTOOLS
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("musescore://diagnostics/engraving/elements"), "MuseScore.Engraving", "EngravingElementsDialog");
         ir->registerQmlUri(Uri("musescore://diagnostics/engraving/undostack"), "MuseScore.Engraving", "EngravingUndoStackDialog");
@@ -141,7 +141,7 @@ void EngravingModule::registerApi()
 #ifndef ENGRAVING_NO_API
     apiv1::PluginAPI::registerQmlTypes();
 
-    auto api = ioc()->resolve<muse::api::IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<muse::api::IApiRegister>(moduleName());
     if (api) {
         api->regApiCreator(moduleName(), "MuseApi.Engraving", new muse::api::ApiCreator<apiv1::EngravingApiV1>());
 
@@ -271,7 +271,7 @@ void EngravingModule::onInit(const IApplication::RunMode&)
 #ifndef ENGRAVING_NO_ACCESSIBILITY
         AccessibleItem::enabled = false;
 #endif
-        gpaletteScore = compat::ScoreAccess::createMasterScore(iocContext());
+        gpaletteScore = compat::ScoreAccess::createMasterScore(globalCtx());
         gpaletteScore->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(""));
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY

--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -40,8 +40,8 @@ std::string AccessibilityModule::moduleName() const
 
 void AccessibilityModule::registerExports()
 {
-    m_configuration = std::make_shared<AccessibilityConfiguration>(iocContext());
-    m_controller = std::make_shared<AccessibilityController>(iocContext());
+    m_configuration = std::make_shared<AccessibilityConfiguration>(globalCtx());
+    m_controller = std::make_shared<AccessibilityController>(globalCtx());
 
     globalIoc()->registerExport<IAccessibilityConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IAccessibilityController>(moduleName(), m_controller);
@@ -50,7 +50,7 @@ void AccessibilityModule::registerExports()
 
 void AccessibilityModule::resolveImports()
 {
-    auto accr = ioc()->resolve<IQAccessibleInterfaceRegister>(moduleName());
+    auto accr = globalIoc()->resolve<IQAccessibleInterfaceRegister>(moduleName());
     if (accr) {
 #ifdef Q_OS_MAC
         accr->registerInterfaceGetter("QQuickWindow", AccessibilityController::accessibleInterface);
@@ -63,7 +63,7 @@ void AccessibilityModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<IApiRegister>(moduleName());
     if (api) {
         api->regApiCreator(moduleName(), "MuseInternal.Accessibility", new ApiCreator<api::AccessibilityApi>());
     }

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -85,7 +85,7 @@ void AccessibilityController::setAccessibilityEnabled(bool enabled)
 static QAccessibleInterface* muAccessibleFactory(const QString& classname, QObject* object)
 {
     if (!accessibleInterfaceRegister) {
-        accessibleInterfaceRegister = ioc()->resolve<IQAccessibleInterfaceRegister>("accessibility");
+        accessibleInterfaceRegister = globalIoc()->resolve<IQAccessibleInterfaceRegister>("accessibility");
     }
 
     auto interfaceGetter = accessibleInterfaceRegister->interfaceGetter(classname);

--- a/src/framework/actions/actionsmodule.cpp
+++ b/src/framework/actions/actionsmodule.cpp
@@ -42,7 +42,7 @@ void ActionsModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(mname);
+    auto api = globalIoc()->resolve<IApiRegister>(mname);
     if (api) {
         api->regApiCreator(mname, "MuseInternal.Dispatcher", new ApiCreator<DispatcherApi>());
     }

--- a/src/framework/audio/main/audiomodule.cpp
+++ b/src/framework/audio/main/audiomodule.cpp
@@ -63,7 +63,7 @@ std::string AudioModule::moduleName() const
 
 void AudioModule::registerExports()
 {
-    m_configuration = std::make_shared<AudioConfiguration>(iocContext());
+    m_configuration = std::make_shared<AudioConfiguration>(globalCtx());
 
 #ifdef Q_OS_WASM
     m_rpcChannel = std::make_shared<rpc::WebRpcChannel>();
@@ -71,15 +71,15 @@ void AudioModule::registerExports()
     m_rpcChannel = std::make_shared<rpc::GeneralRpcChannel>();
 #endif
 
-    m_audioDriverController = std::make_shared<AudioDriverController>(iocContext());
+    m_audioDriverController = std::make_shared<AudioDriverController>(globalCtx());
 
 #ifdef Q_OS_WASM
     m_soundFontController = std::make_shared<WebSoundFontController>();
 #else
-    m_soundFontController = std::make_shared<GeneralSoundFontController>(iocContext());
+    m_soundFontController = std::make_shared<GeneralSoundFontController>(globalCtx());
 #endif
 
-    m_startAudioController = std::make_shared<StartAudioController>(m_rpcChannel, iocContext());
+    m_startAudioController = std::make_shared<StartAudioController>(m_rpcChannel, globalCtx());
 
     globalIoc()->registerExport<IAudioConfiguration>(mname, m_configuration);
     globalIoc()->registerExport<IAudioThreadSecurer>(mname, std::make_shared<AudioThreadSecurer>());

--- a/src/framework/audioplugins/audiopluginsmodule.cpp
+++ b/src/framework/audioplugins/audiopluginsmodule.cpp
@@ -46,11 +46,11 @@ std::string AudioPluginsModule::moduleName() const
 
 void AudioPluginsModule::registerExports()
 {
-    m_configuration = std::make_shared<AudioPluginsConfiguration>(iocContext());
-    m_registerAudioPluginsScenario = std::make_shared<RegisterAudioPluginsScenario>(iocContext());
+    m_configuration = std::make_shared<AudioPluginsConfiguration>(globalCtx());
+    m_registerAudioPluginsScenario = std::make_shared<RegisterAudioPluginsScenario>(globalCtx());
 
     globalIoc()->registerExport<IAudioPluginsConfiguration>(moduleName(), m_configuration);
-    globalIoc()->registerExport<IKnownAudioPluginsRegister>(moduleName(), std::make_shared<KnownAudioPluginsRegister>(iocContext()));
+    globalIoc()->registerExport<IKnownAudioPluginsRegister>(moduleName(), std::make_shared<KnownAudioPluginsRegister>(globalCtx()));
     globalIoc()->registerExport<IAudioPluginsScannerRegister>(moduleName(), std::make_shared<AudioPluginsScannerRegister>());
     globalIoc()->registerExport<IAudioPluginMetaReaderRegister>(moduleName(), std::make_shared<AudioPluginMetaReaderRegister>());
     globalIoc()->registerExport<IRegisterAudioPluginsScenario>(moduleName(), m_registerAudioPluginsScenario);
@@ -65,7 +65,7 @@ void AudioPluginsModule::onInit(const IApplication::RunMode&)
     m_registerAudioPluginsScenario->init();
 
     //! --- Diagnostics ---
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
         pr->reg("known_audio_plugins", m_configuration->knownAudioPluginsFilePath());
     }

--- a/src/framework/autobot/autobotmodule.cpp
+++ b/src/framework/autobot/autobotmodule.cpp
@@ -50,14 +50,14 @@ std::string AutobotModule::moduleName() const
 
 void AutobotModule::registerExports()
 {
-    m_configuration = std::make_shared<AutobotConfiguration>(iocContext());
+    m_configuration = std::make_shared<AutobotConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IAutobotConfiguration>(mname, m_configuration);
 }
 
 void AutobotModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("muse://diagnostics/autobot/scripts"), "Muse.Autobot", "ScriptsDialog");
         ir->registerQmlUri(Uri("muse://autobot/selectfile"), "Muse.Autobot", "AutobotSelectFileDialog");

--- a/src/framework/cloud/cloudmodule.cpp
+++ b/src/framework/cloud/cloudmodule.cpp
@@ -42,19 +42,19 @@ std::string CloudModule::moduleName() const
 
 void CloudModule::registerExports()
 {
-    m_cloudConfiguration = std::make_shared<CloudConfiguration>(iocContext());
+    m_cloudConfiguration = std::make_shared<CloudConfiguration>(globalCtx());
     globalIoc()->registerExport<ICloudConfiguration>(moduleName(), m_cloudConfiguration);
 #ifdef MUSE_MODULE_CLOUD_MUSESCORECOM
-    m_museScoreComService = std::make_shared<MuseScoreComService>(iocContext());
+    m_museScoreComService = std::make_shared<MuseScoreComService>(globalCtx());
     globalIoc()->registerExport<IMuseScoreComService>(moduleName(), m_museScoreComService);
 #endif
-    m_audioComService = std::make_shared<AudioComService>(iocContext());
+    m_audioComService = std::make_shared<AudioComService>(globalCtx());
     globalIoc()->registerExport<IAudioComService>(moduleName(), m_audioComService);
 }
 
 void CloudModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("muse://cloud/requireauthorization"), "Muse.Cloud", "RequireAuthorizationDialog");
     }

--- a/src/framework/diagnostics/diagnosticsmodule.cpp
+++ b/src/framework/diagnostics/diagnosticsmodule.cpp
@@ -53,13 +53,13 @@ std::string DiagnosticsModule::moduleName() const
 
 void DiagnosticsModule::registerExports()
 {
-    m_configuration = std::make_shared<DiagnosticsConfiguration>(iocContext());
+    m_configuration = std::make_shared<DiagnosticsConfiguration>(globalCtx());
     globalIoc()->registerExport<IDiagnosticsConfiguration>(mname, m_configuration);
 }
 
 void DiagnosticsModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("muse://diagnostics/system/paths"), "Muse.Diagnostics", "DiagnosticPathsDialog");
         ir->registerQmlUri(Uri("muse://diagnostics/system/graphicsinfo"), "Muse.Diagnostics", "DiagnosticGraphicsInfoDialog");

--- a/src/framework/dockwindow/dockmodule.cpp
+++ b/src/framework/dockwindow/dockmodule.cpp
@@ -116,9 +116,9 @@ void DockModule::onInit(const IApplication::RunMode&)
     // Setup KDDockWidgets
     // ===================================
 
-    QQmlEngine* engine = ioc()->resolve<ui::IUiEngine>(moduleName())->qmlEngine();
+    QQmlEngine* engine = globalIoc()->resolve<ui::IUiEngine>(moduleName())->qmlEngine();
 
-    KDDockWidgets::Config::self().setFrameworkWidgetFactory(new DockWidgetFactory(iocContext()));
+    KDDockWidgets::Config::self().setFrameworkWidgetFactory(new DockWidgetFactory(globalCtx()));
     KDDockWidgets::Config::self().setQmlEngine(engine);
 
     auto flags = KDDockWidgets::Config::self().flags()

--- a/src/framework/draw/drawmodule.cpp
+++ b/src/framework/draw/drawmodule.cpp
@@ -51,7 +51,7 @@ void DrawModule::registerExports()
 
     auto qtFProvider = std::make_shared<QFontProvider>();
 
-    m_fontsEngine = std::make_shared<FontsEngine>(iocContext());
+    m_fontsEngine = std::make_shared<FontsEngine>(globalCtx());
     globalIoc()->registerExport<draw::IFontProvider>(moduleName(), qtFProvider);
     globalIoc()->registerExport<draw::IFontsEngine>(moduleName(), m_fontsEngine);
     globalIoc()->registerExport<draw::IFontsDatabase>(moduleName(), new FontsDatabase());

--- a/src/framework/extensions/extensionsmodule.cpp
+++ b/src/framework/extensions/extensionsmodule.cpp
@@ -49,20 +49,20 @@ std::string ExtensionsModule::moduleName() const
 
 void ExtensionsModule::registerExports()
 {
-    m_configuration = std::make_shared<ExtensionsConfiguration>(iocContext());
-    m_provider = std::make_shared<ExtensionsProvider>(iocContext());
+    m_configuration = std::make_shared<ExtensionsConfiguration>(globalCtx());
+    m_provider = std::make_shared<ExtensionsProvider>(globalCtx());
     m_execPointsRegister = std::make_shared<ExtensionsExecPointsRegister>();
 
     globalIoc()->registerExport<IExtensionsProvider>(moduleName(), m_provider);
     globalIoc()->registerExport<IExtensionsConfiguration>(moduleName(), m_configuration);
-    globalIoc()->registerExport<IExtensionsUiEngine>(moduleName(), new ExtensionsUiEngine(iocContext()));
-    globalIoc()->registerExport<IExtensionInstaller>(moduleName(), new ExtensionInstaller(iocContext()));
+    globalIoc()->registerExport<IExtensionsUiEngine>(moduleName(), new ExtensionsUiEngine(globalCtx()));
+    globalIoc()->registerExport<IExtensionInstaller>(moduleName(), new ExtensionInstaller(globalCtx()));
     globalIoc()->registerExport<IExtensionsExecPointsRegister>(moduleName(), m_execPointsRegister);
 }
 
 void ExtensionsModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("muse://extensions/viewer"), "Muse.Extensions", "ExtensionViewerDialog");
         ir->registerQmlUri(Uri("muse://extensions/apidump"), "Muse.Extensions", "ExtensionsApiDumpDialog");
@@ -83,7 +83,7 @@ void ExtensionsModule::onInit(const IApplication::RunMode&)
     m_provider->reloadExtensions();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
         pr->reg("extensions: defaultPath", m_configuration->defaultPath());
         pr->reg("extensions: userPath", m_configuration->userPath());

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -123,7 +123,7 @@ void GlobalModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<IApiRegister>(moduleName());
     if (api) {
         api->regApiCreator(moduleName(), "MuseApi.Log", new ApiCreator<LogApi>());
         api->regApiCreator(moduleName(), "api.process", new ApiCreator<ProcessApi>());
@@ -229,7 +229,7 @@ void GlobalModule::onPreInit(const IApplication::RunMode& mode)
 
     //! --- Diagnostics ---
 #ifdef MUSE_MODULE_DIAGNOSTICS
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
         pr->reg("appBinPath", m_configuration->appBinPath());
         pr->reg("appBinDirPath", m_configuration->appBinDirPath());

--- a/src/framework/global/modularity/imodulesetup.h
+++ b/src/framework/global/modularity/imodulesetup.h
@@ -89,9 +89,6 @@ public:
 
     std::shared_ptr<IApplication> application() const { return m_application; }
 
-    const modularity::ContextPtr iocContext() const { return m_application ? m_application->iocContext() : muse::modularity::globalCtx(); }
-    ModulesIoC* ioc() const { return m_application ? m_application->ioc() : muse::modularity::globalIoc(); }
-
 protected:
     std::shared_ptr<IApplication> m_application;
 };

--- a/src/framework/global/modularity/ioc.h
+++ b/src/framework/global/modularity/ioc.h
@@ -37,7 +37,7 @@ using kors::modularity::ContextPtr;
 
 using kors::modularity::Creator;
 
-inline ModulesIoC* ioc(const ContextPtr& ctx = nullptr)
+inline ModulesIoC* ioc(const ContextPtr& ctx)
 {
     return kors::modularity::ioc(ctx);
 }

--- a/src/framework/interactive/interactivemodule.cpp
+++ b/src/framework/interactive/interactivemodule.cpp
@@ -50,7 +50,7 @@ std::string InteractiveModule::moduleName() const
 
 void InteractiveModule::registerExports()
 {
-    auto interactive = std::make_shared<Interactive>(iocContext());
+    auto interactive = std::make_shared<Interactive>(globalCtx());
 #ifdef Q_OS_WASM
     globalIoc()->registerExport<IInteractive>(mname, new WebInteractive(interactive));
 #else
@@ -65,7 +65,7 @@ void InteractiveModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(mname);
+    auto api = globalIoc()->resolve<IApiRegister>(mname);
     if (api) {
         api->regApiCreator(mname, "MuseApi.Interactive", new ApiCreator<InteractiveApi>());
 
@@ -75,7 +75,7 @@ void InteractiveModule::registerApi()
 
 void InteractiveModule::resolveImports()
 {
-    auto ir = ioc()->resolve<IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("muse://interactive/standard"), "Muse.Interactive", "StandardDialog");
         ir->registerQmlUri(Uri("muse://interactive/error"), "Muse.Interactive", "ErrorDetailsView");

--- a/src/framework/languages/languagesmodule.cpp
+++ b/src/framework/languages/languagesmodule.cpp
@@ -42,8 +42,8 @@ std::string LanguagesModule::moduleName() const
 
 void LanguagesModule::registerExports()
 {
-    m_languagesConfiguration = std::make_shared<LanguagesConfiguration>(iocContext());
-    m_languagesService = std::make_shared<LanguagesService>(iocContext());
+    m_languagesConfiguration = std::make_shared<LanguagesConfiguration>(globalCtx());
+    m_languagesService = std::make_shared<LanguagesService>(globalCtx());
 
     globalIoc()->registerExport<ILanguagesConfiguration>(moduleName(), m_languagesConfiguration);
     globalIoc()->registerExport<ILanguagesService>(moduleName(), m_languagesService);
@@ -56,7 +56,7 @@ void LanguagesModule::onPreInit(const IApplication::RunMode&)
     m_languagesService->init();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
         pr->reg("languagesAppDataPath", m_languagesConfiguration->languagesAppDataPath());
         pr->reg("languagesUserAppDataPath", m_languagesConfiguration->languagesUserAppDataPath());

--- a/src/framework/learn/learnmodule.cpp
+++ b/src/framework/learn/learnmodule.cpp
@@ -36,8 +36,8 @@ std::string LearnModule::moduleName() const
 
 void LearnModule::registerExports()
 {
-    m_learnConfiguration = std::make_shared<LearnConfiguration>(iocContext());
-    m_learnService = std::make_shared<LearnService>(iocContext());
+    m_learnConfiguration = std::make_shared<LearnConfiguration>(globalCtx());
+    m_learnService = std::make_shared<LearnService>(globalCtx());
 
     globalIoc()->registerExport<ILearnConfiguration>(moduleName(), m_learnConfiguration);
     globalIoc()->registerExport<ILearnService>(moduleName(), m_learnService);

--- a/src/framework/mpe/mpemodule.cpp
+++ b/src/framework/mpe/mpemodule.cpp
@@ -37,7 +37,7 @@ std::string MpeModule::moduleName() const
 
 void MpeModule::registerExports()
 {
-    m_profilesRepository = std::make_shared<ArticulationProfilesRepository>(iocContext());
+    m_profilesRepository = std::make_shared<ArticulationProfilesRepository>(globalCtx());
 
     globalIoc()->registerExport<IArticulationProfilesRepository>(moduleName(), m_profilesRepository);
 }

--- a/src/framework/multiwindows/multiwindowsmodule.cpp
+++ b/src/framework/multiwindows/multiwindowsmodule.cpp
@@ -49,7 +49,7 @@ void MultiInstancesModule::registerExports()
 #ifdef MUSE_MULTICONTEXT_WIP
     m_windowsProvider = std::make_shared<SingleProcessProvider>();
 #else
-    m_windowsProvider = std::make_shared<MultiProcessProvider>(iocContext());
+    m_windowsProvider = std::make_shared<MultiProcessProvider>(globalCtx());
     globalIoc()->registerExport<IMultiProcessProvider>(moduleName(), m_windowsProvider);
 #endif
 
@@ -58,12 +58,12 @@ void MultiInstancesModule::registerExports()
 
 void MultiInstancesModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("muse://devtools/multiwindows/info"), "Muse.MultiWindows", "MultiInstancesDevDialog");
     }
 
-    auto ar = ioc()->resolve<muse::ui::IUiActionsRegister>(moduleName());
+    auto ar = globalIoc()->resolve<muse::ui::IUiActionsRegister>(moduleName());
     if (ar) {
         ar->reg(std::make_shared<MultiInstancesUiActions>());
     }

--- a/src/framework/musesampler/musesamplermodule.cpp
+++ b/src/framework/musesampler/musesamplermodule.cpp
@@ -47,9 +47,9 @@ std::string MuseSamplerModule::moduleName() const
 
 void MuseSamplerModule::registerExports()
 {
-    m_configuration = std::make_shared<MuseSamplerConfiguration>(iocContext());
-    m_actionController = std::make_shared<MuseSamplerActionController>(iocContext());
-    m_resolver = std::make_shared<MuseSamplerResolver>(iocContext());
+    m_configuration = std::make_shared<MuseSamplerConfiguration>(globalCtx());
+    m_actionController = std::make_shared<MuseSamplerActionController>(globalCtx());
+    m_resolver = std::make_shared<MuseSamplerResolver>(globalCtx());
 
     globalIoc()->registerExport<IMuseSamplerConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IMuseSamplerInfo>(moduleName(), m_resolver);
@@ -57,13 +57,13 @@ void MuseSamplerModule::registerExports()
 
 void MuseSamplerModule::resolveImports()
 {
-    auto synthResolver = ioc()->resolve<synth::ISynthResolver>(moduleName());
+    auto synthResolver = globalIoc()->resolve<synth::ISynthResolver>(moduleName());
 
     if (synthResolver) {
         synthResolver->registerResolver(AudioSourceType::MuseSampler, m_resolver);
     }
 
-    auto ar = ioc()->resolve<muse::ui::IUiActionsRegister>(moduleName());
+    auto ar = globalIoc()->resolve<muse::ui::IUiActionsRegister>(moduleName());
     if (ar) {
         ar->reg(std::make_shared<MuseSamplerUiActions>());
     }
@@ -75,7 +75,7 @@ void MuseSamplerModule::onInit(const IApplication::RunMode&)
     m_resolver->init();
     m_actionController->init(m_resolver);
 
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
         pr->reg("musesampler", m_configuration->libraryPath());
     }

--- a/src/framework/network/networkmodule.cpp
+++ b/src/framework/network/networkmodule.cpp
@@ -41,7 +41,7 @@ std::string NetworkModule::moduleName() const
 
 void NetworkModule::registerExports()
 {
-    m_configuration = std::make_shared<NetworkConfiguration>(iocContext());
+    m_configuration = std::make_shared<NetworkConfiguration>(muse::modularity::globalCtx());
 
     globalIoc()->registerExport<INetworkManagerCreator>(moduleName(), new NetworkManagerCreator());
     globalIoc()->registerExport<INetworkConfiguration>(moduleName(), m_configuration);
@@ -51,7 +51,7 @@ void NetworkModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<IApiRegister>(moduleName());
     if (api) {
 #ifdef MUSE_MODULE_NETWORK_WEBSOCKET
         api->regApiCreator(moduleName(), "MuseApi.Websocket", new ApiCreator<api::WebSocketApi>());

--- a/src/framework/shortcuts/shortcutsmodule.cpp
+++ b/src/framework/shortcuts/shortcutsmodule.cpp
@@ -50,7 +50,7 @@ std::string ShortcutsModule::moduleName() const
 
 void ShortcutsModule::registerExports()
 {
-    m_configuration = std::make_shared<ShortcutsConfiguration>(iocContext());
+    m_configuration = std::make_shared<ShortcutsConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IShortcutsConfiguration>(mname, m_configuration);
 }
@@ -59,7 +59,7 @@ void ShortcutsModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(mname);
+    auto api = globalIoc()->resolve<IApiRegister>(mname);
     if (api) {
         api->regApiCreator(mname, "MuseInternal.Shortcuts", new ApiCreator<api::ShortcutsApi>());
     }
@@ -92,7 +92,7 @@ void ShortcutsContext::onInit(const IApplication::RunMode&)
     m_midiRemote->init();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
-    auto configuration = globalIoc()->resolve<IShortcutsConfiguration>(mname);
+    auto configuration = ioc()->resolve<IShortcutsConfiguration>(mname);
     auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(mname);
     if (pr && configuration) {
         pr->reg("shortcutsUserAppDataPath", configuration->shortcutsUserAppDataPath());

--- a/src/framework/stubs/accessibility/accessibilitystubmodule.cpp
+++ b/src/framework/stubs/accessibility/accessibilitystubmodule.cpp
@@ -36,6 +36,6 @@ std::string AccessibilityModule::moduleName() const
 
 void AccessibilityModule::registerExports()
 {
-    ioc()->registerExport<IAccessibilityConfiguration>(moduleName(), new AccessibilityConfigurationStub());
-    ioc()->registerExport<IAccessibilityController>(moduleName(), new AccessibilityControllerStub());
+    globalIoc()->registerExport<IAccessibilityConfiguration>(moduleName(), new AccessibilityConfigurationStub());
+    globalIoc()->registerExport<IAccessibilityController>(moduleName(), new AccessibilityControllerStub());
 }

--- a/src/framework/stubs/audio/audiostubmodule.cpp
+++ b/src/framework/stubs/audio/audiostubmodule.cpp
@@ -39,11 +39,11 @@ std::string AudioModule::moduleName() const
 
 void AudioModule::registerExports()
 {
-    ioc()->registerExport<IAudioConfiguration>(moduleName(), new AudioConfigurationStub());
-    ioc()->registerExport<IAudioDriverController>(moduleName(), new AudioDriverControllerStub());
+    globalIoc()->registerExport<IAudioConfiguration>(moduleName(), new AudioConfigurationStub());
+    globalIoc()->registerExport<IAudioDriverController>(moduleName(), new AudioDriverControllerStub());
 
-    ioc()->registerExport<synth::ISynthResolver>(moduleName(), new synth::SynthResolverStub());
-    ioc()->registerExport<fx::IFxResolver>(moduleName(), new fx::FxResolverStub());
+    globalIoc()->registerExport<synth::ISynthResolver>(moduleName(), new synth::SynthResolverStub());
+    globalIoc()->registerExport<fx::IFxResolver>(moduleName(), new fx::FxResolverStub());
 
-    ioc()->registerExport<ISoundFontController>(moduleName(), new SoundFontControllerStub());
+    globalIoc()->registerExport<ISoundFontController>(moduleName(), new SoundFontControllerStub());
 }

--- a/src/framework/stubs/cloud/cloudstubmodule.cpp
+++ b/src/framework/stubs/cloud/cloudstubmodule.cpp
@@ -36,5 +36,5 @@ std::string CloudModule::moduleName() const
 
 void CloudModule::registerExports()
 {
-    ioc()->registerExport<IAuthorizationService>(moduleName(), new AuthorizationServiceStub());
+    globalIoc()->registerExport<IAuthorizationService>(moduleName(), new AuthorizationServiceStub());
 }

--- a/src/framework/stubs/extensions/extensionsstubmodule.cpp
+++ b/src/framework/stubs/extensions/extensionsstubmodule.cpp
@@ -35,5 +35,5 @@ std::string ExtensionsModule::moduleName() const
 
 void ExtensionsModule::registerExports()
 {
-    ioc()->registerExport<IExtensionsProvider>(moduleName(), new ExtensionsProviderStub());
+    globalIoc()->registerExport<IExtensionsProvider>(moduleName(), new ExtensionsProviderStub());
 }

--- a/src/framework/stubs/languages/languagesstubmodule.cpp
+++ b/src/framework/stubs/languages/languagesstubmodule.cpp
@@ -37,6 +37,6 @@ std::string LanguagesModule::moduleName() const
 
 void LanguagesModule::registerExports()
 {
-    ioc()->registerExport<ILanguagesConfiguration>(moduleName(), new LanguagesConfigurationStub());
-    ioc()->registerExport<ILanguagesService>(moduleName(), new LanguagesServiceStub());
+    globalIoc()->registerExport<ILanguagesConfiguration>(moduleName(), new LanguagesConfigurationStub());
+    globalIoc()->registerExport<ILanguagesService>(moduleName(), new LanguagesServiceStub());
 }

--- a/src/framework/stubs/midi/midistubmodule.cpp
+++ b/src/framework/stubs/midi/midistubmodule.cpp
@@ -38,7 +38,7 @@ std::string MidiModule::moduleName() const
 
 void MidiModule::registerExports()
 {
-    ioc()->registerExport<IMidiConfiguration>(moduleName(), new MidiConfigurationStub());
-    ioc()->registerExport<IMidiOutPort>(moduleName(), new MidiOutPortStub());
-    ioc()->registerExport<IMidiInPort>(moduleName(), new MidiInPortStub());
+    globalIoc()->registerExport<IMidiConfiguration>(moduleName(), new MidiConfigurationStub());
+    globalIoc()->registerExport<IMidiOutPort>(moduleName(), new MidiOutPortStub());
+    globalIoc()->registerExport<IMidiInPort>(moduleName(), new MidiInPortStub());
 }

--- a/src/framework/stubs/mpe/mpestubmodule.cpp
+++ b/src/framework/stubs/mpe/mpestubmodule.cpp
@@ -35,5 +35,5 @@ std::string MpeModule::moduleName() const
 
 void MpeModule::registerExports()
 {
-    ioc()->registerExport<IArticulationProfilesRepository>(moduleName(), new ArticulationProfilesRepositoryStub());
+    globalIoc()->registerExport<IArticulationProfilesRepository>(moduleName(), new ArticulationProfilesRepositoryStub());
 }

--- a/src/framework/stubs/multiwindows/multiwindowsstubmodule.cpp
+++ b/src/framework/stubs/multiwindows/multiwindowsstubmodule.cpp
@@ -34,5 +34,5 @@ std::string MultiInstancesModule::moduleName() const
 
 void MultiInstancesModule::registerExports()
 {
-    ioc()->registerExport<IMultiWindowsProvider>(moduleName(), new MultiWindowsStubProvider());
+    globalIoc()->registerExport<IMultiWindowsProvider>(moduleName(), new MultiWindowsStubProvider());
 }

--- a/src/framework/stubs/network/networkstubmodule.cpp
+++ b/src/framework/stubs/network/networkstubmodule.cpp
@@ -36,6 +36,6 @@ std::string NetworkModule::moduleName() const
 
 void NetworkModule::registerExports()
 {
-    ioc()->registerExport<INetworkManagerCreator>(moduleName(), new NetworkManagerCreatorStub());
-    ioc()->registerExport<INetworkConfiguration>(moduleName(), new NetworkConfigurationStub());
+    globalIoc()->registerExport<INetworkManagerCreator>(moduleName(), new NetworkManagerCreatorStub());
+    globalIoc()->registerExport<INetworkConfiguration>(moduleName(), new NetworkConfigurationStub());
 }

--- a/src/framework/stubs/shortcuts/shortcutsstubmodule.cpp
+++ b/src/framework/stubs/shortcuts/shortcutsstubmodule.cpp
@@ -38,8 +38,8 @@ std::string ShortcutsModule::moduleName() const
 
 void ShortcutsModule::registerExports()
 {
-    ioc()->registerExport<IShortcutsRegister>(moduleName(), new ShortcutsRegisterStub());
-    ioc()->registerExport<IShortcutsController>(moduleName(), new ShortcutsControllerStub());
-    ioc()->registerExport<IMidiRemote>(moduleName(), new MidiRemoteStub());
-    ioc()->registerExport<IShortcutsConfiguration>(moduleName(), new ShortcutsConfigurationStub());
+    globalIoc()->registerExport<IShortcutsRegister>(moduleName(), new ShortcutsRegisterStub());
+    globalIoc()->registerExport<IShortcutsController>(moduleName(), new ShortcutsControllerStub());
+    globalIoc()->registerExport<IMidiRemote>(moduleName(), new MidiRemoteStub());
+    globalIoc()->registerExport<IShortcutsConfiguration>(moduleName(), new ShortcutsConfigurationStub());
 }

--- a/src/framework/stubs/tours/toursstubmodule.cpp
+++ b/src/framework/stubs/tours/toursstubmodule.cpp
@@ -37,7 +37,7 @@ std::string ToursModule::moduleName() const
 
 void ToursModule::registerExports()
 {
-    ioc()->registerExport<IToursConfiguration>(moduleName(), new ToursConfigurationStub());
-    ioc()->registerExport<IToursService>(moduleName(), new ToursServiceStub());
-    ioc()->registerExport<IToursProvider>(moduleName(), new ToursProviderStub());
+    globalIoc()->registerExport<IToursConfiguration>(moduleName(), new ToursConfigurationStub());
+    globalIoc()->registerExport<IToursService>(moduleName(), new ToursServiceStub());
+    globalIoc()->registerExport<IToursProvider>(moduleName(), new ToursProviderStub());
 }

--- a/src/framework/stubs/update/updatestubmodule.cpp
+++ b/src/framework/stubs/update/updatestubmodule.cpp
@@ -38,7 +38,7 @@ std::string UpdateModule::moduleName() const
 
 void UpdateModule::registerExports()
 {
-    ioc()->registerExport<IAppUpdateService>(moduleName(), std::make_shared<AppUpdateServiceStub>());
-    ioc()->registerExport<IAppUpdateScenario>(moduleName(), std::make_shared<AppUpdateScenarioStub>());
-    ioc()->registerExport<IUpdateConfiguration>(moduleName(), std::make_shared<UpdateConfigurationStub>());
+    globalIoc()->registerExport<IAppUpdateService>(moduleName(), std::make_shared<AppUpdateServiceStub>());
+    globalIoc()->registerExport<IAppUpdateScenario>(moduleName(), std::make_shared<AppUpdateScenarioStub>());
+    globalIoc()->registerExport<IUpdateConfiguration>(moduleName(), std::make_shared<UpdateConfigurationStub>());
 }

--- a/src/framework/stubs/workspace/workspacestubmodule.cpp
+++ b/src/framework/stubs/workspace/workspacestubmodule.cpp
@@ -37,7 +37,7 @@ std::string WorkspaceModule::moduleName() const
 
 void WorkspaceModule::registerExports()
 {
-    ioc()->registerExport<IWorkspaceConfiguration>(moduleName(), new WorkspaceConfigurationStub());
-    ioc()->registerExport<IWorkspaceManager>(moduleName(), new WorkspaceManagerStub());
-    ioc()->registerExport<IWorkspacesDataProvider>(moduleName(), new WorkspacesDataProviderStub());
+    globalIoc()->registerExport<IWorkspaceConfiguration>(moduleName(), new WorkspaceConfigurationStub());
+    globalIoc()->registerExport<IWorkspaceManager>(moduleName(), new WorkspaceManagerStub());
+    globalIoc()->registerExport<IWorkspacesDataProvider>(moduleName(), new WorkspacesDataProviderStub());
 }

--- a/src/framework/tours/toursmodule.cpp
+++ b/src/framework/tours/toursmodule.cpp
@@ -38,9 +38,9 @@ std::string ToursModule::moduleName() const
 
 void ToursModule::registerExports()
 {
-    m_service = std::make_shared<ToursService>(iocContext());
-    m_configuration = std::make_shared<ToursConfiguration>(iocContext());
-    m_provider = std::make_shared<ToursProvider>(iocContext());
+    m_service = std::make_shared<ToursService>(globalCtx());
+    m_configuration = std::make_shared<ToursConfiguration>(globalCtx());
+    m_provider = std::make_shared<ToursProvider>(globalCtx());
 
     globalIoc()->registerExport<IToursService>(moduleName(), m_service);
     globalIoc()->registerExport<IToursConfiguration>(moduleName(), m_configuration);

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -69,8 +69,8 @@ std::string UiModule::moduleName() const
 
 void UiModule::registerExports()
 {
-    m_uiengine = std::make_shared<UiEngine>(iocContext());
-    m_configuration = std::make_shared<UiConfiguration>(iocContext());
+    m_uiengine = std::make_shared<UiEngine>(globalCtx());
+    m_configuration = std::make_shared<UiConfiguration>(globalCtx());
 
     #ifdef Q_OS_MAC
     m_platformTheme = std::make_shared<MacOSPlatformTheme>();
@@ -98,7 +98,7 @@ void UiModule::registerExports()
 void UiModule::resolveImports()
 {
 #ifdef MUSE_MULTICONTEXT_WIP
-    auto ar = ioc()->resolve<IUiActionsRegister>(moduleName());
+    auto ar = globalIoc()->resolve<IUiActionsRegister>(moduleName());
     if (ar) {
         ar->reg(std::make_shared<NavigationUiActions>());
     }
@@ -109,7 +109,7 @@ void UiModule::registerApi()
 {
     using namespace muse::api;
 
-    auto api = ioc()->resolve<IApiRegister>(moduleName());
+    auto api = globalIoc()->resolve<IApiRegister>(moduleName());
     if (api) {
         api->regApiCreator(moduleName(), "MuseInternal.Navigation", new ApiCreator<muse::api::NavigationApi>());
         api->regApiCreator(moduleName(), "MuseInternal.Keyboard", new ApiCreator<muse::api::KeyboardApi>());

--- a/src/framework/uicomponents/uicomponentsmodule.cpp
+++ b/src/framework/uicomponents/uicomponentsmodule.cpp
@@ -36,7 +36,7 @@ std::string UiComponentsModule::moduleName() const
 
 void UiComponentsModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("muse://interactive/selectmultipledirectories"), "Muse.UiComponents", "SelectMultipleDirectoriesDialog");
     }

--- a/src/framework/update/updatemodule.cpp
+++ b/src/framework/update/updatemodule.cpp
@@ -45,14 +45,14 @@ std::string UpdateModule::moduleName() const
 
 void UpdateModule::registerExports()
 {
-    m_configuration = std::make_shared<UpdateConfiguration>(iocContext());
+    m_configuration = std::make_shared<UpdateConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IUpdateConfiguration>(mname, m_configuration);
 }
 
 void UpdateModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("muse://update/appreleaseinfo"), "Muse.Update", "AppReleaseInfoDialog");
         ir->registerQmlUri(Uri("muse://update/app"), "Muse.Update", "AppUpdateProgressDialog");

--- a/src/framework/vst/vstmodule.cpp
+++ b/src/framework/vst/vstmodule.cpp
@@ -55,13 +55,13 @@ std::string VSTModule::moduleName() const
 void VSTModule::registerExports()
 {
     m_configuration = std::make_shared<VstConfiguration>();
-    m_pluginModulesRepo = std::make_shared<VstModulesRepository>(iocContext());
-    m_pluginInstancesRegister = std::make_shared<VstInstancesRegister>(iocContext());
-    m_actionsController = std::make_shared<VstActionsController>(iocContext());
+    m_pluginModulesRepo = std::make_shared<VstModulesRepository>(globalCtx());
+    m_pluginInstancesRegister = std::make_shared<VstInstancesRegister>(globalCtx());
+    m_actionsController = std::make_shared<VstActionsController>(globalCtx());
 
-    ioc()->registerExport<IVstConfiguration>(moduleName(), m_configuration);
-    ioc()->registerExport<IVstModulesRepository>(moduleName(), m_pluginModulesRepo);
-    ioc()->registerExport<IVstInstancesRegister>(moduleName(), m_pluginInstancesRegister);
+    globalIoc()->registerExport<IVstConfiguration>(moduleName(), m_configuration);
+    globalIoc()->registerExport<IVstModulesRepository>(moduleName(), m_pluginModulesRepo);
+    globalIoc()->registerExport<IVstInstancesRegister>(moduleName(), m_pluginInstancesRegister);
 }
 
 void VSTModule::resolveImports()
@@ -70,33 +70,33 @@ void VSTModule::resolveImports()
     //! switches the action controller, so registration is there now.
     //! as soon as the new view is stabilized, we need to remove the old one and do as usual
 
-    // auto ir = ioc()->resolve<IInteractiveUriRegister>(moduleName());
+    // auto ir = globalIoc()->resolve<IInteractiveUriRegister>(moduleName());
     // if (ir) {
     //     ir->registerWidgetUri<VstViewDialog>(Uri("muse://vst/editor"));
     //     ir->registerQmlUri(Uri("muse://vst/editor"), "Muse.Vst", "VstEditorDialog");
     // }
 
-    auto ar = ioc()->resolve<ui::IUiActionsRegister>(moduleName());
+    auto ar = globalIoc()->resolve<ui::IUiActionsRegister>(moduleName());
     if (ar) {
         ar->reg(std::make_shared<VstUiActions>(m_actionsController));
     }
 
-    auto synthResolver = ioc()->resolve<ISynthResolver>(moduleName());
+    auto synthResolver = globalIoc()->resolve<ISynthResolver>(moduleName());
     if (synthResolver) {
-        synthResolver->registerResolver(AudioSourceType::Vsti, std::make_shared<VstiResolver>(iocContext()));
+        synthResolver->registerResolver(AudioSourceType::Vsti, std::make_shared<VstiResolver>(globalCtx()));
     }
 
-    auto fxResolver = ioc()->resolve<IFxResolver>(moduleName());
+    auto fxResolver = globalIoc()->resolve<IFxResolver>(moduleName());
     if (fxResolver) {
-        fxResolver->registerResolver(AudioFxType::VstFx, std::make_shared<VstFxResolver>(iocContext()));
+        fxResolver->registerResolver(AudioFxType::VstFx, std::make_shared<VstFxResolver>(globalCtx()));
     }
 
-    auto scannerRegister = ioc()->resolve<IAudioPluginsScannerRegister>(moduleName());
+    auto scannerRegister = globalIoc()->resolve<IAudioPluginsScannerRegister>(moduleName());
     if (scannerRegister) {
         scannerRegister->registerScanner(std::make_shared<VstPluginsScanner>());
     }
 
-    auto metaReaderRegister = ioc()->resolve<IAudioPluginMetaReaderRegister>(moduleName());
+    auto metaReaderRegister = globalIoc()->resolve<IAudioPluginMetaReaderRegister>(moduleName());
     if (metaReaderRegister) {
         metaReaderRegister->registerReader(std::make_shared<VstPluginMetaReader>());
     }

--- a/src/framework/workspace/workspacemodule.cpp
+++ b/src/framework/workspace/workspacemodule.cpp
@@ -50,13 +50,13 @@ std::string WorkspaceModule::moduleName() const
 
 void WorkspaceModule::registerExports()
 {
-    m_configuration = std::make_shared<WorkspaceConfiguration>(iocContext());
+    m_configuration = std::make_shared<WorkspaceConfiguration>(globalCtx());
     globalIoc()->registerExport<IWorkspaceConfiguration>(mname, m_configuration);
 }
 
 void WorkspaceModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("muse://workspace/select"), "Muse.Workspace", "WorkspacesDialog");
         ir->registerQmlUri(Uri("muse://workspace/create"), "Muse.Workspace", "NewWorkspaceDialog");
@@ -68,7 +68,7 @@ void WorkspaceModule::onInit(const IApplication::RunMode&)
     m_configuration->init();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
-    auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(mname);
+    auto pr = globalIoc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(mname);
     if (pr) {
         io::paths_t paths = m_configuration->workspacePaths();
         for (const io::path_t& p : paths) {

--- a/src/importexport/audioexport/audioexportmodule.cpp
+++ b/src/importexport/audioexport/audioexportmodule.cpp
@@ -52,12 +52,12 @@ void AudioExportModule::registerExports()
 
 void AudioExportModule::resolveImports()
 {
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "wav" }, std::make_shared<WaveWriter>(iocContext()));
-        writers->reg({ "mp3" }, std::make_shared<Mp3Writer>(iocContext()));
-        writers->reg({ "ogg" }, std::make_shared<OggWriter>(iocContext()));
-        writers->reg({ "flac" }, std::make_shared<FlacWriter>(iocContext()));
+        writers->reg({ "wav" }, std::make_shared<WaveWriter>(globalCtx()));
+        writers->reg({ "mp3" }, std::make_shared<Mp3Writer>(globalCtx()));
+        writers->reg({ "ogg" }, std::make_shared<OggWriter>(globalCtx()));
+        writers->reg({ "flac" }, std::make_shared<FlacWriter>(globalCtx()));
     }
 }
 

--- a/src/importexport/bb/bbmodule.cpp
+++ b/src/importexport/bb/bbmodule.cpp
@@ -39,7 +39,7 @@ std::string BBModule::moduleName() const
 
 void BBModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "mgu", "sgu" }, std::make_shared<NotationBBReader>());
     }

--- a/src/importexport/bww/bwwmodule.cpp
+++ b/src/importexport/bww/bwwmodule.cpp
@@ -39,7 +39,7 @@ std::string BwwModule::moduleName() const
 
 void BwwModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "bmw", "bww" }, std::make_shared<NotationBwwReader>());
     }

--- a/src/importexport/capella/capellamodule.cpp
+++ b/src/importexport/capella/capellamodule.cpp
@@ -38,7 +38,7 @@ std::string CapellaModule::moduleName() const
 
 void CapellaModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "cap", "capx" }, std::make_shared<CapellaReader>());
     }

--- a/src/importexport/guitarpro/guitarpromodule.cpp
+++ b/src/importexport/guitarpro/guitarpromodule.cpp
@@ -47,8 +47,8 @@ void GuitarProModule::registerExports()
 
 void GuitarProModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
-        readers->reg({ "gtp", "gp3", "gp4", "gp5", "gpx", "gp", "ptb" }, std::make_shared<GuitarProReader>(iocContext()));
+        readers->reg({ "gtp", "gp3", "gp4", "gp5", "gpx", "gp", "ptb" }, std::make_shared<GuitarProReader>(muse::modularity::globalCtx()));
     }
 }

--- a/src/importexport/imagesexport/imagesexportmodule.cpp
+++ b/src/importexport/imagesexport/imagesexportmodule.cpp
@@ -50,11 +50,11 @@ void ImagesExportModule::registerExports()
 
 void ImagesExportModule::resolveImports()
 {
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "pdf" }, std::make_shared<PdfWriter>(iocContext()));
-        writers->reg({ "svg" }, std::make_shared<SvgWriter>(iocContext()));
-        writers->reg({ "png" }, std::make_shared<PngWriter>(iocContext()));
+        writers->reg({ "pdf" }, std::make_shared<PdfWriter>(muse::modularity::globalCtx()));
+        writers->reg({ "svg" }, std::make_shared<SvgWriter>(muse::modularity::globalCtx()));
+        writers->reg({ "png" }, std::make_shared<PngWriter>(muse::modularity::globalCtx()));
     }
 }
 

--- a/src/importexport/lyricsexport/lyricsexportmodule.cpp
+++ b/src/importexport/lyricsexport/lyricsexportmodule.cpp
@@ -46,9 +46,9 @@ void LyricsExportModule::registerExports()
 
 void LyricsExportModule::resolveImports()
 {
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "lrc" }, std::make_shared<LRCWriter>(iocContext()));
+        writers->reg({ "lrc" }, std::make_shared<LRCWriter>(muse::modularity::globalCtx()));
     }
 }
 

--- a/src/importexport/mei/meimodule.cpp
+++ b/src/importexport/mei/meimodule.cpp
@@ -49,12 +49,12 @@ void MeiModule::registerExports()
 
 void MeiModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
-        readers->reg({ "mei" }, std::make_shared<MeiReader>(iocContext()));
+        readers->reg({ "mei" }, std::make_shared<MeiReader>(muse::modularity::globalCtx()));
     }
 
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
         writers->reg({ "mei" }, std::make_shared<MeiWriter>());
     }

--- a/src/importexport/midi/midimodule.cpp
+++ b/src/importexport/midi/midimodule.cpp
@@ -50,14 +50,14 @@ void MidiModule::registerExports()
 
 void MidiModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "mid", "midi", "kar" }, std::make_shared<NotationMidiReader>());
     }
 
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "mid", "midi", "kar" }, std::make_shared<NotationMidiWriter>(iocContext()));
+        writers->reg({ "mid", "midi", "kar" }, std::make_shared<NotationMidiWriter>(globalCtx()));
     }
 }
 

--- a/src/importexport/mnx/mnxmodule.cpp
+++ b/src/importexport/mnx/mnxmodule.cpp
@@ -46,13 +46,13 @@ void MnxModule::registerExports()
 
 void MnxModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
-        readers->reg({ "mnx", "json" }, std::make_shared<NotationMnxReader>(iocContext()));
+        readers->reg({ "mnx", "json" }, std::make_shared<NotationMnxReader>(globalCtx()));
     }
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "mnx" }, std::make_shared<NotationMnxWriter>(iocContext()));
+        writers->reg({ "mnx" }, std::make_shared<NotationMnxWriter>(globalCtx()));
     }
 }
 

--- a/src/importexport/musedata/musedatamodule.cpp
+++ b/src/importexport/musedata/musedatamodule.cpp
@@ -38,7 +38,7 @@ std::string MuseDataModule::moduleName() const
 
 void MuseDataModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "md" }, std::make_shared<MuseDataReader>());
     }

--- a/src/importexport/musicxml/musicxmlmodule.cpp
+++ b/src/importexport/musicxml/musicxmlmodule.cpp
@@ -54,12 +54,12 @@ void MusicXmlModule::resolveImports()
 #ifndef MUSICXML_NO_INTERNAL
     using namespace mu::project;
 
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "xml", "musicxml", "mxl" }, std::make_shared<MusicXmlReader>());
     }
 
-    auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
+    auto writers = globalIoc()->resolve<INotationWritersRegister>(moduleName());
     if (writers) {
         writers->reg({ "musicxml", "xml" }, std::make_shared<MusicXmlWriter>());
         writers->reg({ "mxl" }, std::make_shared<MxlWriter>());

--- a/src/importexport/ove/ovemodule.cpp
+++ b/src/importexport/ove/ovemodule.cpp
@@ -47,7 +47,7 @@ void OveModule::registerExports()
 
 void OveModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "ove", "scw" }, std::make_shared<OveReader>());
     }

--- a/src/importexport/tabledit/tableditmodule.cpp
+++ b/src/importexport/tabledit/tableditmodule.cpp
@@ -38,7 +38,7 @@ std::string TablEditModule::moduleName() const
 
 void TablEditModule::resolveImports()
 {
-    auto readers = ioc()->resolve<INotationReadersRegister>(moduleName());
+    auto readers = globalIoc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "tef" }, std::make_shared<TablEditReader>());
     }

--- a/src/importexport/videoexport/videoexportmodule.cpp
+++ b/src/importexport/videoexport/videoexportmodule.cpp
@@ -43,13 +43,13 @@ std::string VideoExportModule::moduleName() const
 
 void VideoExportModule::registerExports()
 {
-    ioc()->registerExport<VideoExportConfiguration>(moduleName(), s_configuration);
+    globalIoc()->registerExport<VideoExportConfiguration>(moduleName(), s_configuration);
 }
 
 void VideoExportModule::resolveImports()
 {
-    auto projectRWreg = ioc()->resolve<IProjectRWRegister>(moduleName());
+    auto projectRWreg = globalIoc()->resolve<IProjectRWRegister>(moduleName());
     if (projectRWreg) {
-        projectRWreg->regWriter({ "mp4" }, std::make_shared<VideoWriter>(iocContext()));
+        projectRWreg->regWriter({ "mp4" }, std::make_shared<VideoWriter>(globalCtx()));
     }
 }

--- a/src/inspector/inspectormodule.cpp
+++ b/src/inspector/inspectormodule.cpp
@@ -33,7 +33,7 @@ std::string InspectorModule::moduleName() const
 
 void InspectorModule::registerExports()
 {
-    m_popupController = std::make_shared<InspectorPopupController>(iocContext());
+    m_popupController = std::make_shared<InspectorPopupController>(muse::modularity::globalCtx());
 
     globalIoc()->registerExport<IInspectorPopupController>(moduleName(), m_popupController);
 }

--- a/src/instrumentsscene/instrumentsscenemodule.cpp
+++ b/src/instrumentsscene/instrumentsscenemodule.cpp
@@ -44,7 +44,7 @@ std::string InstrumentsSceneModule::moduleName() const
 
 void InstrumentsSceneModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("musescore://instruments/select"), "MuseScore.InstrumentsScene", "InstrumentsDialog");
     }

--- a/src/musesounds/musesoundsmodule.cpp
+++ b/src/musesounds/musesoundsmodule.cpp
@@ -34,6 +34,7 @@
 
 using namespace mu::musesounds;
 using namespace muse;
+using namespace muse::modularity;
 
 std::string MuseSoundsModule::moduleName() const
 {
@@ -42,13 +43,13 @@ std::string MuseSoundsModule::moduleName() const
 
 void MuseSoundsModule::registerExports()
 {
-    m_configuration = std::make_shared<MuseSoundsConfiguration>(iocContext());
-    m_repository = std::make_shared<MuseSoundsRepository>(iocContext());
+    m_configuration = std::make_shared<MuseSoundsConfiguration>(globalCtx());
+    m_repository = std::make_shared<MuseSoundsRepository>(globalCtx());
 
-    m_museSoundsCheckUpdateScenario = std::make_shared<MuseSoundsCheckUpdateScenario>(iocContext());
-    m_museSoundsCheckUpdateService = std::make_shared<MuseSoundsCheckUpdateService>(iocContext());
-    m_museSamplerCheckUpdateService = std::make_shared<MuseSamplerCheckUpdateService>(iocContext());
-    m_museSamplerCheckUpdateScenario = std::make_shared<MuseSamplerCheckUpdateScenario>(iocContext());
+    m_museSoundsCheckUpdateScenario = std::make_shared<MuseSoundsCheckUpdateScenario>(globalCtx());
+    m_museSoundsCheckUpdateService = std::make_shared<MuseSoundsCheckUpdateService>(globalCtx());
+    m_museSamplerCheckUpdateService = std::make_shared<MuseSamplerCheckUpdateService>(globalCtx());
+    m_museSamplerCheckUpdateScenario = std::make_shared<MuseSamplerCheckUpdateScenario>(globalCtx());
 
     globalIoc()->registerExport<IMuseSoundsConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IMuseSoundsRepository>(moduleName(), m_repository);
@@ -62,7 +63,7 @@ void MuseSoundsModule::registerExports()
 
 void MuseSoundsModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("musescore://musesounds/musesoundsreleaseinfo"), "MuseScore.MuseSounds", "MuseSoundsReleaseInfoDialog");
     }

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -57,7 +57,7 @@ void NotationModule::onInit(const IApplication::RunMode&)
     bool isVertical = m_configuration->canvasOrientation().val == muse::Orientation::Vertical;
     mu::engraving::MScore::setVerticalOrientation(isVertical);
 
-    auto pr = ioc()->resolve<diagnostics::IDiagnosticsPathsRegister>(mname);
+    auto pr = globalIoc()->resolve<diagnostics::IDiagnosticsPathsRegister>(mname);
     if (pr) {
         pr->reg("instruments", m_configuration->instrumentsXmlPath());
         pr->reg("score orders", m_configuration->scoreOrdersXmlPath());

--- a/src/notationscene/notationscenemodule.cpp
+++ b/src/notationscene/notationscenemodule.cpp
@@ -57,14 +57,14 @@ std::string NotationSceneModule::moduleName() const
 
 void NotationSceneModule::registerExports()
 {
-    m_configuration = std::make_shared<NotationSceneConfiguration>(iocContext());
+    m_configuration = std::make_shared<NotationSceneConfiguration>(globalCtx());
 
     globalIoc()->registerExport<INotationSceneConfiguration>(mname, m_configuration);
 }
 
 void NotationSceneModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>("notationscene");
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>("notationscene");
     if (ir) {
         ir->registerWidgetUri<EditStyle>(Uri("musescore://notation/style"));
         ir->registerWidgetUri<PageSettings>(Uri("musescore://notation/pagesettings"));

--- a/src/palette/palettemodule.cpp
+++ b/src/palette/palettemodule.cpp
@@ -55,14 +55,14 @@ std::string PaletteModule::moduleName() const
 
 void PaletteModule::registerExports()
 {
-    m_configuration = std::make_shared<PaletteConfiguration>(iocContext());
+    m_configuration = std::make_shared<PaletteConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IPaletteConfiguration>(mname, m_configuration);
 }
 
 void PaletteModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerWidgetUri<MasterPalette>(Uri("musescore://palette/masterpalette"));
         ir->registerWidgetUri<SpecialCharactersDialog>(Uri("musescore://palette/specialcharacters"));

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -46,14 +46,14 @@ std::string PlaybackModule::moduleName() const
 
 void PlaybackModule::registerExports()
 {
-    m_configuration = std::make_shared<PlaybackConfiguration>(iocContext());
+    m_configuration = std::make_shared<PlaybackConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IPlaybackConfiguration>(mname, m_configuration);
 }
 
 void PlaybackModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("musescore://playback/soundprofilesdialog"), "MuseScore.Playback", "SoundProfilesDialog");
     }

--- a/src/preferences/preferencesmodule.cpp
+++ b/src/preferences/preferencesmodule.cpp
@@ -37,7 +37,7 @@ std::string PreferencesModule::moduleName() const
 
 void PreferencesModule::resolveImports()
 {
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("muse://preferences"), "MuseScore.Preferences", "PreferencesDialog");
     }

--- a/src/print/printmodule.cpp
+++ b/src/print/printmodule.cpp
@@ -37,5 +37,5 @@ std::string PrintModule::moduleName() const
 
 void PrintModule::registerExports()
 {
-    globalIoc()->registerExport<IPrintProvider>(moduleName(), std::make_shared<PrintProvider>(iocContext()));
+    globalIoc()->registerExport<IPrintProvider>(moduleName(), std::make_shared<PrintProvider>(globalCtx()));
 }

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -65,7 +65,7 @@ std::string ProjectModule::moduleName() const
 
 void ProjectModule::registerExports()
 {
-    m_configuration = std::make_shared<ProjectConfiguration>(iocContext());
+    m_configuration = std::make_shared<ProjectConfiguration>(globalCtx());
 
     globalIoc()->registerExport<IProjectConfiguration>(mname, m_configuration);
     globalIoc()->registerExport<IProjectCreator>(mname, new ProjectCreator());
@@ -74,7 +74,7 @@ void ProjectModule::registerExports()
 
 void ProjectModule::resolveImports()
 {
-    auto ir = ioc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
+    auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
         ir->registerQmlUri(Uri("musescore://project/newscore"), "MuseScore.Project", "NewScoreDialog");
         ir->registerQmlUri(Uri("musescore://project/asksavelocationtype"), "MuseScore.Project", "AskSaveLocationTypeDialog");

--- a/src/stubs/braille/braillestubmodule.cpp
+++ b/src/stubs/braille/braillestubmodule.cpp
@@ -35,5 +35,5 @@ std::string BrailleModule::moduleName() const
 
 void BrailleModule::registerExports()
 {
-    ioc()->registerExport<IBrailleConfiguration>(moduleName(), new BrailleConfigurationStub());
+    globalIoc()->registerExport<IBrailleConfiguration>(moduleName(), new BrailleConfigurationStub());
 }

--- a/src/stubs/importexport/mei/meimodule.cpp
+++ b/src/stubs/importexport/mei/meimodule.cpp
@@ -33,5 +33,5 @@ std::string MeiModule::moduleName() const
 
 void MeiModule::registerExports()
 {
-    ioc()->registerExport<IMeiConfiguration>(moduleName(), new MeiConfigurationStub());
+    globalIoc()->registerExport<IMeiConfiguration>(moduleName(), new MeiConfigurationStub());
 }

--- a/src/stubs/importexport/midi/midimodule.cpp
+++ b/src/stubs/importexport/midi/midimodule.cpp
@@ -33,5 +33,5 @@ std::string MidiModule::moduleName() const
 
 void MidiModule::registerExports()
 {
-    ioc()->registerExport<IMidiImportExportConfiguration>(moduleName(), new MidiConfigurationStub());
+    globalIoc()->registerExport<IMidiImportExportConfiguration>(moduleName(), new MidiConfigurationStub());
 }

--- a/src/stubs/importexport/mnx/mnxmodule.cpp
+++ b/src/stubs/importexport/mnx/mnxmodule.cpp
@@ -35,5 +35,5 @@ std::string MnxModule::moduleName() const
 
 void MnxModule::registerExports()
 {
-    ioc()->registerExport<IMnxConfiguration>(moduleName(), new MnxConfigurationStub());
+    globalIoc()->registerExport<IMnxConfiguration>(moduleName(), new MnxConfigurationStub());
 }

--- a/src/stubs/importexport/musicxml/musicxmlmodule.cpp
+++ b/src/stubs/importexport/musicxml/musicxmlmodule.cpp
@@ -33,5 +33,5 @@ std::string MusicXmlModule::moduleName() const
 
 void MusicXmlModule::registerExports()
 {
-    ioc()->registerExport<IMusicXmlConfiguration>(moduleName(), new MusicXmlConfiguration());
+    globalIoc()->registerExport<IMusicXmlConfiguration>(moduleName(), new MusicXmlConfiguration());
 }

--- a/src/stubs/importexport/ove/ovemodule.cpp
+++ b/src/stubs/importexport/ove/ovemodule.cpp
@@ -33,5 +33,5 @@ std::string OveModule::moduleName() const
 
 void OveModule::registerExports()
 {
-    ioc()->registerExport<IOveConfiguration>(moduleName(), new OveConfiguration());
+    globalIoc()->registerExport<IOveConfiguration>(moduleName(), new OveConfiguration());
 }

--- a/src/stubs/instrumentsscene/instrumentsscenestubmodule.cpp
+++ b/src/stubs/instrumentsscene/instrumentsscenestubmodule.cpp
@@ -35,5 +35,5 @@ std::string InstrumentsSceneModule::moduleName() const
 
 void InstrumentsSceneModule::registerExports()
 {
-    ioc()->registerExport<notation::ISelectInstrumentsScenario>(moduleName(), new SelectInstrumentsScenarioStub());
+    globalIoc()->registerExport<notation::ISelectInstrumentsScenario>(moduleName(), new SelectInstrumentsScenarioStub());
 }

--- a/src/stubs/musesounds/musesoundsstubmodule.cpp
+++ b/src/stubs/musesounds/musesoundsstubmodule.cpp
@@ -39,8 +39,8 @@ std::string MuseSoundsModule::moduleName() const
 
 void MuseSoundsModule::registerExports()
 {
-    ioc()->registerExport<IMuseSoundsCheckUpdateScenario>(moduleName(), new MuseSoundsCheckUpdateScenarioStub());
-    ioc()->registerExport<IMuseSoundsCheckUpdateService>(moduleName(), new MuseSoundsCheckUpdateServiceStub());
-    ioc()->registerExport<IMuseSamplerCheckUpdateScenario>(moduleName(), new MuseSamplerCheckUpdateScenarioStub());
-    ioc()->registerExport<IMuseSamplerCheckUpdateService>(moduleName(), new MuseSamplerCheckUpdateServiceStub());
+    globalIoc()->registerExport<IMuseSoundsCheckUpdateScenario>(moduleName(), new MuseSoundsCheckUpdateScenarioStub());
+    globalIoc()->registerExport<IMuseSoundsCheckUpdateService>(moduleName(), new MuseSoundsCheckUpdateServiceStub());
+    globalIoc()->registerExport<IMuseSamplerCheckUpdateScenario>(moduleName(), new MuseSamplerCheckUpdateScenarioStub());
+    globalIoc()->registerExport<IMuseSamplerCheckUpdateService>(moduleName(), new MuseSamplerCheckUpdateServiceStub());
 }

--- a/src/stubs/notation/notationstubmodule.cpp
+++ b/src/stubs/notation/notationstubmodule.cpp
@@ -36,6 +36,6 @@ std::string NotationModule::moduleName() const
 
 void NotationModule::registerExports()
 {
-    ioc()->registerExport<INotationConfiguration>(moduleName(), new NotationConfigurationStub());
-    ioc()->registerExport<IInstrumentsRepository>(moduleName(), new InstrumentsRepositoryStub());
+    globalIoc()->registerExport<INotationConfiguration>(moduleName(), new NotationConfigurationStub());
+    globalIoc()->registerExport<IInstrumentsRepository>(moduleName(), new InstrumentsRepositoryStub());
 }

--- a/src/stubs/palette/palettestubmodule.cpp
+++ b/src/stubs/palette/palettestubmodule.cpp
@@ -36,5 +36,5 @@ std::string PaletteModule::moduleName() const
 
 void PaletteModule::registerExports()
 {
-    ioc()->registerExport<IPaletteConfiguration>(moduleName(), new PaletteConfigurationStub());
+    globalIoc()->registerExport<IPaletteConfiguration>(moduleName(), new PaletteConfigurationStub());
 }

--- a/src/stubs/playback/playbackstubmodule.cpp
+++ b/src/stubs/playback/playbackstubmodule.cpp
@@ -37,6 +37,6 @@ std::string PlaybackModule::moduleName() const
 
 void PlaybackModule::registerExports()
 {
-    ioc()->registerExport<IPlaybackController>(moduleName(), new PlaybackControllerStub());
-    ioc()->registerExport<IPlaybackConfiguration>(moduleName(), new PlaybackConfigurationStub());
+    globalIoc()->registerExport<IPlaybackController>(moduleName(), new PlaybackControllerStub());
+    globalIoc()->registerExport<IPlaybackConfiguration>(moduleName(), new PlaybackConfigurationStub());
 }

--- a/src/stubs/project/projectstubmodule.cpp
+++ b/src/stubs/project/projectstubmodule.cpp
@@ -36,6 +36,6 @@ std::string ProjectModule::moduleName() const
 
 void ProjectModule::registerExports()
 {
-    ioc()->registerExport<IProjectConfiguration>(moduleName(), new ProjectConfigurationStub());
-    ioc()->registerExport<IRecentFilesController>(moduleName(), new RecentFilesControllerStub());
+    globalIoc()->registerExport<IProjectConfiguration>(moduleName(), new ProjectConfigurationStub());
+    globalIoc()->registerExport<IRecentFilesController>(moduleName(), new RecentFilesControllerStub());
 }

--- a/src/web/appshell/appshellmodule.cpp
+++ b/src/web/appshell/appshellmodule.cpp
@@ -56,22 +56,22 @@ std::string AppShellModule::moduleName() const
 
 void AppShellModule::registerExports()
 {
-    m_applicationActionController = std::make_shared<ApplicationActionController>(iocContext());
-    m_applicationUiActions = std::make_shared<ApplicationUiActions>(m_applicationActionController, iocContext());
-    m_appShellConfiguration = std::make_shared<AppShellConfiguration>(iocContext());
+    m_applicationActionController = std::make_shared<ApplicationActionController>(globalCtx());
+    m_applicationUiActions = std::make_shared<ApplicationUiActions>(m_applicationActionController, globalCtx());
+    m_appShellConfiguration = std::make_shared<AppShellConfiguration>(globalCtx());
 
-    ioc()->registerExport<IAppShellConfiguration>(moduleName(), m_appShellConfiguration);
-    ioc()->registerExport<IStartupScenario>(moduleName(), new StartupScenario(iocContext()));
+    globalIoc()->registerExport<IAppShellConfiguration>(moduleName(), m_appShellConfiguration);
+    globalIoc()->registerExport<IStartupScenario>(moduleName(), new StartupScenario(globalCtx()));
 }
 
 void AppShellModule::resolveImports()
 {
-    auto ar = ioc()->resolve<ui::IUiActionsRegister>(moduleName());
+    auto ar = globalIoc()->resolve<ui::IUiActionsRegister>(moduleName());
     if (ar) {
         ar->reg(m_applicationUiActions);
     }
 
-    auto ir = ioc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
+    auto ir = globalIoc()->resolve<interactive::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerPageUri(Uri("musescore://notation"));
         ir->registerPageUri(Uri("musescore://devtools"));


### PR DESCRIPTION

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
