### PR TITLE
CI. Backend. Build only linux/amd64

### DIFF
--- a/buildscripts/ci/backend/build_docker.sh
+++ b/buildscripts/ci/backend/build_docker.sh
@@ -48,10 +48,17 @@ cp $HERE/docker/install_mu_template.sh $DOCKER_WORK_DIR/install_mu.sh
 
 sed -i 's|x.x.x.xxxxxx|'${MU_VERSION}'|' $DOCKER_WORK_DIR/install_mu.sh
 
-
 cd $DOCKER_WORK_DIR
 echo "Build Docker"
-docker build -t ghcr.io/musescore/converter_4:${MU_VERSION} .
+
+# Enable buildx
+docker buildx create --use >/dev/null 2>&1 || true
+
+docker buildx build \
+    --platform linux/amd64\
+    -t ghcr.io/musescore/converter_4:${MU_VERSION} \
+    --load .
+
 cd $ORIGIN_DIR
 
 echo "Done!!"


### PR DESCRIPTION
There have been some changes in the build system, and we have started registering arm64 and unknown architectures. For example [here](https://github.com/orgs/musescore/packages/container/converter_4/692703440?tag=5.0.0.260218105). And when attempting to download Docker along the path, for example, `ghcr.io/musescore/converter_4:5.0.0.260218105`, we are getting the error `no matching manifest for linux/arm64/v8 in the manifest list entries`.

The current pr clearly indicates the architecture of the created docker. 