### PR TITLE
Fix API Dump dialog failing to open

### DIFF
--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsApiDump.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsApiDump.qml
@@ -85,7 +85,7 @@ Rectangle {
         clip: true
         model: apiModel
 
-        section.property: "groupRole"
+        section.property: "group"
         section.delegate: Rectangle {
             id: sectionDelegate
             required property string section
@@ -105,7 +105,7 @@ Rectangle {
         delegate: ListItemBlank {
             id: itemDelegate
 
-            required property string data
+            required property string itemData
 
             anchors.left: parent ? parent.left : undefined
             anchors.right: parent ? parent.right : undefined
@@ -117,7 +117,7 @@ Rectangle {
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignLeft
                 font.family: "Consolas"
-                text: itemDelegate.data
+                text: itemDelegate.itemData
             }
         }
     }

--- a/src/framework/extensions/qml/Muse/Extensions/devtools/apidumpmodel.cpp
+++ b/src/framework/extensions/qml/Muse/Extensions/devtools/apidumpmodel.cpp
@@ -75,7 +75,7 @@ int ApiDumpModel::rowCount(const QModelIndex& parent) const
 QHash<int, QByteArray> ApiDumpModel::roleNames() const
 {
     static const QHash<int, QByteArray> roles = {
-        { rData, "data" },
+        { rData, "itemData" },
         { rGroup, "group" },
     };
     return roles;


### PR DESCRIPTION
Resolves: #32254

The API Dump developer dialog (Help > Diagnostics > Extensions > API Dump) fails
to open since commit 97a38f583d ("Migrate extensions module to proper QML module").

Two issues in `ExtensionsApiDump.qml`:

1. The delegate declared `required property string data`, but `data` is the
   built-in default property of `QQuickItem` (`QQmlListProperty<QObject>`).
   Redeclaring it as `string` causes a type conflict:
   `Cannot assign to property of unknown type "QString"`.
   Renamed the model role from `"data"` to `"itemData"`.

2. `section.property` referenced `"groupRole"`, but the actual role name in
   `ApiDumpModel::roleNames()` is `"group"`. Fixed to match.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)