### PR TITLE
vertically center dialogs

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.cpp
@@ -325,3 +325,15 @@ void DialogView::reject(int code)
 
     close();
 }
+
+void DialogView::repositionWindowIfNeed()
+{
+    if (!isOpened() || !m_view) {
+        return;
+    }
+
+    updateGeometry();
+
+    const QRect geometry = viewGeometry();
+    m_view->setGeometry(geometry);
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.h
@@ -80,6 +80,7 @@ public:
     Q_INVOKABLE void raise();
     Q_INVOKABLE void accept();
     Q_INVOKABLE void reject(int code = -1);
+    Q_INVOKABLE void repositionWindowIfNeed() override;
 
 signals:
     void titleChanged(QString title);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
@@ -131,6 +131,7 @@ void WindowView::setViewContent(QQuickItem* item)
         }
         if (item->implicitHeight() != m_view->height()) {
             updateSize(QSize(item->implicitWidth(), item->implicitHeight()));
+            repositionWindowIfNeed();
         }
     });
 }


### PR DESCRIPTION
Resolves: vertically center dialogs by adding repositionWindowIfNeed method to DialogView and trigger during size update

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
