### PR TITLE
Update QCoreApplication application name

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -112,12 +112,10 @@ int main(int argc, char** argv)
 
     QGuiApplication::styleHints()->setMousePressAndHoldInterval(250);
 
-// Can't use MUSE_APP_TITLE until next major release, because this "application name" is used to determine
-// where user settings are stored. Changing it would result in all user settings being lost.
 #ifdef MUSE_APP_UNSTABLE
-    QCoreApplication::setApplicationName("MuseScore5Development");
+    QCoreApplication::setApplicationName(MUSE_APP_NAME_MACHINE_READABLE MUSE_APP_VERSION_MAJOR "Development");
 #else
-    QCoreApplication::setApplicationName("MuseScore5");
+    QCoreApplication::setApplicationName(MUSE_APP_NAME_MACHINE_READABLE MUSE_APP_VERSION_MAJOR);
 #endif
     QCoreApplication::setOrganizationName("MuseScore");
     QCoreApplication::setOrganizationDomain("musescore.org");

--- a/src/framework/testing/gmain.cpp
+++ b/src/framework/testing/gmain.cpp
@@ -37,6 +37,9 @@
 
 GTEST_API_ int main(int argc, char** argv)
 {
+    QCoreApplication::setOrganizationName("MuseScore");
+    QCoreApplication::setOrganizationDomain("musescore.org");
+
     QGuiApplication app(argc, argv);
 
     qputenv("QML_DISABLE_DISK_CACHE", "true");

--- a/src/framework/testing/qmain.cpp
+++ b/src/framework/testing/qmain.cpp
@@ -28,6 +28,9 @@
 
 int main(int argc, char** argv)
 {
+    QCoreApplication::setOrganizationName("MuseScore");
+    QCoreApplication::setOrganizationDomain("musescore.org");
+
     QGuiApplication app(argc, argv);
 
     qputenv("QML_DISABLE_DISK_CACHE", "true");


### PR DESCRIPTION
The user settings folder will now be called `MuseScore/MuseScoreStudio5Development`.

The additions in `qmain.cpp` and `gmain.cpp` ensure that tests settings folders are placed inside a `MuseScore` folder, instead of polluting my `~/Library/Application Support`.

(Ideally, tests should probably not write anything to disk at all unless they are explicitly asked to, but that's for another day.)

(Edit: apparently it's not so much settings that are being written to those folders, but rather logs.)