### PR TITLE
Fire TextEditingChanged when cutting and pasting text

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5470,6 +5470,7 @@ void NotationInteraction::pasteIntoTextEdit()
     if (mimeData->hasFormat(TextEditData::mimeRichTextFormat)) {
         const QString txt = QString::fromUtf8(mimeData->data(TextEditData::mimeRichTextFormat));
         toTextBase(m_editData.element)->paste(m_editData, txt);
+        notifyAboutTextEditingChanged();
         return;
     }
 
@@ -5480,6 +5481,7 @@ void NotationInteraction::pasteIntoTextEdit()
     }
 
     toTextBase(m_editData.element)->paste(m_editData, textForPaste);
+    notifyAboutTextEditingChanged();
 
     if (textForPaste.isEmpty() || !m_editData.element->isLyrics()) {
         return;
@@ -5529,7 +5531,11 @@ void NotationInteraction::deleteSelection()
         if (!textBase->deleteSelectedText(m_editData)) {
             m_editData.key = Qt::Key_Backspace;
             m_editData.modifiers = {};
-            textBase->edit(m_editData);
+            if (textBase->edit(m_editData)) {
+                notifyAboutTextEditingChanged();
+            }
+        } else {
+            notifyAboutTextEditingChanged();
         }
     } else {
         doEndEditElement();


### PR DESCRIPTION
Resolves: #32284 

`TextCursorChanged`, `TextInserted` and `TextRemoved` should be fired when cutting and pasting text but this is more complicated to implement and outside of the scope of this PR. So for this PR the change is to simply fire `TextEditingChanged` on cut/paste. In the `NotationInteraction` constructor we start listening for `TextEditingChanged` (around line 273) and when we receive it, we call `onTextEditingChanged` which now updates the cursor's visibility.

- [X ] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
