### PR TITLE
Fix fretting logic [4.7]

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -2094,9 +2094,11 @@ void Score::upDown(bool up, UpDownMode mode)
                     }
                 }
             }
-            part->stringData(tick, staff->idx())->convertPitch(newPitch, staff, tick, &string, &fret);
             undoChangePitch(oNote, newPitch, newTpc1, newTpc2);
-            undoChangeFretting(oNote, newPitch, string, fret, newTpc1, newTpc2);
+            if (mode == UpDownMode::DIATONIC) {
+                part->stringData(tick, staff->idx())->convertPitch(newPitch, staff, tick, &string, &fret);
+                undoChangeFretting(oNote, newPitch, string, fret, newTpc1, newTpc2);
+            }
         }
         // store fret change only if undoChangePitch has not been called,
         // as undoChangePitch() already manages fret changes, if necessary


### PR DESCRIPTION
Resolves: #32140

This restores the behaviour from 4.6.5 - when moving a TAB fret mark up or down with just up/down the same string is kept. When using Alt+Shift+up/down, the highest string is found.

When moving standard notes with a linked tablature stave, the highest string is always used.