### PR TITLE
Improve height of bounding rectangle of empty texts

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -26,6 +26,7 @@
 #include "dom/harppedaldiagram.h"
 #include "draw/fontmetrics.h"
 
+#include "engraving/rendering/score/textlayout.h"
 #include "iengravingfont.h"
 
 #include "style/textstyle.h"
@@ -58,6 +59,7 @@
 using namespace mu;
 using namespace muse::draw;
 using namespace mu::engraving;
+using namespace mu::engraving::rendering::score;
 
 namespace mu::engraving {
 static const char* FALLBACK_SYMBOL_FONT = "Bravura";
@@ -280,11 +282,9 @@ RectF TextCursor::cursorRect() const
     const TextFragment* fragment = tline.fragment(static_cast<int>(column()));
 
     Font _font  = fragment ? fragment->font(m_text) : m_text->font();
-    if (fragment && _font.type() == Font::Type::MusicSymbol) {
+    if (fragment) {
         // Ensure the cursor height matches that of the associated text font
-        String textFontId(_font.family().id() + String(u" Text"));
-        _font.setFamily(textFontId, Font::Type::MusicSymbolText);
-        _font.setPointSizeF(fragment->format.fontSize());
+        TextLayout::substituteMusicSymbolFontWithMusicSymbolText(_font, fragment->format.fontSize());
     }
 
     double ascent = FontMetrics::ascent(_font);

--- a/src/engraving/rendering/score/textlayout.cpp
+++ b/src/engraving/rendering/score/textlayout.cpp
@@ -307,13 +307,15 @@ void TextLayout::layoutTextBlock(TextBlock* item, const TextBase* t)
 
     if (fragments.empty()) {
         FontMetrics fm = t->fontMetrics();
-        shape.add(RectF(0.0, -fm.ascent(), 1.0, fm.descent()), t);
+        shape.add(RectF(0.0, -fm.ascent(), 1.0, fm.ascent()), t);
         lineSpacing = fm.lineSpacing();
     } else if (fragments.size() == 1 && fragments.front().text.isEmpty()) {
         auto fi = fragments.begin();
         TextFragment& f = *fi;
         f.pos.setX(x);
-        FontMetrics fm(f.font(t));
+        Font font = f.font(t);
+        substituteMusicSymbolFontWithMusicSymbolText(font, f.format.fontSize());
+        FontMetrics fm(font);
         if (f.format.valign() != VerticalAlignment::AlignNormal) {
             double voffset = fm.xHeight() / SUBSCRIPT_SIZE;   // use original height
             if (f.format.valign() == VerticalAlignment::AlignSubScript) {
@@ -327,7 +329,7 @@ void TextLayout::layoutTextBlock(TextBlock* item, const TextBase* t)
             f.pos.setY(0.0);
         }
 
-        RectF temp(0.0, -fm.ascent(), 1.0, fm.descent());
+        RectF temp(0.0, -fm.ascent(), 1.0, fm.ascent());
         shape.add(temp, t);
         lineSpacing = std::max(lineSpacing, fm.lineSpacing());
     } else {
@@ -386,6 +388,16 @@ void TextLayout::layoutTextBlock(TextBlock* item, const TextBase* t)
     // Apply style/custom line spacing
     lineSpacing *= t->textLineSpacing();
     item->setLineSpacing(lineSpacing);
+}
+
+void TextLayout::substituteMusicSymbolFontWithMusicSymbolText(Font& font, double size)
+{
+    if (font.type() != Font::Type::MusicSymbol) {
+        return;
+    }
+    String textFontId(font.family().id() + String(u" Text"));
+    font.setFamily(textFontId, Font::Type::MusicSymbolText);
+    font.setPointSizeF(size);
 }
 
 double TextLayout::musicSymbolBaseLineAdjust(const TextBlock* block, const TextBase* t, const TextFragment& f,

--- a/src/engraving/rendering/score/textlayout.h
+++ b/src/engraving/rendering/score/textlayout.h
@@ -24,6 +24,7 @@
 
 #include "layoutcontext.h"
 #include "dom/textbase.h"
+#include "draw/types/font.h"
 
 namespace mu::engraving::rendering::score {
 class TextLayout
@@ -36,6 +37,9 @@ public:
 
     static void computeTextHighResShape(const TextBase* item, TextBase::LayoutData* ldata);
     static void layoutTextBlock(TextBlock* item, const TextBase* t);
+
+    static void substituteMusicSymbolFontWithMusicSymbolText(muse::draw::Font& font, double size);
+
 private:
     static void textHorizontalLayout(const TextBase* item, Shape& shape, double maxBlockWidth, TextBase::LayoutData* ldata);
     static void justifyLine(const TextBase* item, TextBlock* textBlock, double maxBlockWidth);

--- a/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
@@ -118,7 +118,7 @@ the video game: a tone poem</metaTag>
       </Part>
     <Staff id="1">
       <VBox>
-        <height>10.636</height>
+        <height>11.7828</height>
         <eid>D_D</eid>
         <Text>
           <eid>E_E</eid>

--- a/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
@@ -120,7 +120,7 @@ Words &amp; Music by also Henry Ives (and ampersands)
       </Part>
     <Staff id="1">
       <VBox>
-        <height>10.3705</height>
+        <height>11.0385</height>
         <eid>D_D</eid>
         <Text>
           <eid>E_E</eid>


### PR DESCRIPTION
Resolves: #32314 

1. Changes the height of the bounding rectangle of empty texts from `fm.descent()` to `fm.ascent()`.

2. When calculating the bounding rectangle of empty texts, a music symbol font (e.g. 'Leland') will now be substituted with its music symbol font ('Leland Text') like it is done for the cursor's rectangle. This fixes the issue with the very tall frame around empty dynamics (I explain it in the associated issue #32314 and demonstrate it in a video there).

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
