### PR TITLE
[4.7] Fix audio export writing empty files

### DIFF
--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -420,7 +420,7 @@ Ret ExportProjectScenario::doExportLoop(const muse::io::path_t& scorePath, std::
         Ret ret = exportFunction(outputFile);
         outputFile.close();
 
-        if (!ret) {
+        if (!ret || outputFile.hasError()) {
             if (ret.code() == static_cast<int>(Ret::Code::Cancel)) {
                 fileSystem()->remove(scorePath);
                 return ret;


### PR DESCRIPTION
Resolves: #32311
Retest #28061 please

The audio writers ignore the `IODevice` and do their own file writing. This worked before, because `File::open` doesn't open anything and a file is only created when `IODevice::write` is called, which never happened when writing audio. See:
https://github.com/musescore/MuseScore/blob/11f6dc89215b8e37f7a95bb6ff528604644d04b5/src/importexport/audioexport/internal/abstractaudiowriter.cpp#L91-L97
The file that was written this way was then overwritten by an empty file here:
https://github.com/musescore/MuseScore/blob/11f6dc89215b8e37f7a95bb6ff528604644d04b5/src/project/internal/exportprojectscenario.cpp#L430

This PR reverts my previous solution for #28061 and applies a simpler alternative fix for 4.7.
Proper fix: #32329 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
