### PR TITLE
#32337 Tie duration fix

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2119,7 +2119,6 @@ void Score::cmdAddTie(bool addToChord)
         // if no note to re-use, create one
         NoteVal nval(note->noteVal());
         if (!n) {
-            m_is.setDuration(note->chord()->durationType());
             n = addPitch(nval, addFlag);
             if (staffMove != 0) {
                 undo(new ChangeChordStaffMove(n->chord(), staffMove));


### PR DESCRIPTION
Resolves: #32337 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Ties weren't following the currently selected note duration in note input mode.

Reverted line from 67926453384810005c94ee9912bfbaf87e300902 which caused this. Tests still pass.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
