### PR TITLE
Allow to use spacers instead of separators in the toolbar

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarView.qml
@@ -42,6 +42,9 @@ Item {
     property int rowHeight: 32
     property int separatorHeight: rowHeight
 
+    property bool useSpacersAsSeparators: false
+    property int spacerWidth: 12
+
     property int maximumWidth: -1
     property bool isMultiline: height > rowHeight
 
@@ -125,7 +128,7 @@ Item {
 
                         switch(type) {
                         case ToolBarItemType.ACTION: return actionComp
-                        case ToolBarItemType.SEPARATOR: return separatorComp
+                        case ToolBarItemType.SEPARATOR: return root.useSpacersAsSeparators ? spacerComp : separatorComp
                         }
 
                         return null
@@ -151,6 +154,17 @@ Item {
                             height: root.separatorHeight
 
                             orientation: Qt.Vertical
+                        }
+                    }
+
+                    Component {
+                        id: spacerComp
+
+                        Item {
+                            property var itemData: delegateItem.item
+
+                            width: root.spacerWidth
+                            height: root.separatorHeight
                         }
                     }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6787

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

QA:
- [ ] there should be no visible change on the playback toolbar