### PR TITLE
Highlight / Scroll mixer options

### DIFF
--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -52,6 +52,7 @@ static const Settings::Key MIXER_FADER_SECTION_VISIBLE_KEY(moduleName, "playback
 static const Settings::Key MIXER_MUTE_AND_SOLO_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/muteAndSoloSectionVisible");
 static const Settings::Key MIXER_TITLE_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/titleSectionVisible");
 
+static const Settings::Key MIXER_HIGHLIGHT_SELECTION(moduleName, "playback/mixer/highlightSelection");
 static const Settings::Key MIXER_AUTO_SCROLL_TO_SELECTION(moduleName, "playback/mixer/autoScrollToSelection");
 
 static const Settings::Key MIXER_RESET_SOUND_FLAGS_WHEN_CHANGE_SOUND_WARNING(moduleName,
@@ -293,6 +294,21 @@ gain_t PlaybackConfiguration::defaultAuxSendValue(aux_channel_idx_t index, Audio
     }
 
     return DEFAULT_VALUE;
+}
+
+bool PlaybackConfiguration::highlightSelection() const
+{
+    return settings()->value(MIXER_HIGHLIGHT_SELECTION).toBool();
+}
+
+void PlaybackConfiguration::setHighlightSelection(bool value)
+{
+    settings()->setSharedValue(MIXER_HIGHLIGHT_SELECTION, Val(value));
+}
+
+muse::async::Channel<bool> PlaybackConfiguration::highlightSelectionChanged() const
+{
+    return m_highlightSelectionChanged;
 }
 
 bool PlaybackConfiguration::autoScrollToSelection() const

--- a/src/playback/internal/playbackconfiguration.h
+++ b/src/playback/internal/playbackconfiguration.h
@@ -75,6 +75,10 @@ public:
     muse::audio::gain_t defaultAuxSendValue(muse::audio::aux_channel_idx_t index, muse::audio::AudioSourceType sourceType,
                                             const muse::String& instrumentSoundId) const override;
 
+    bool highlightSelection() const override;
+    void setHighlightSelection(bool value) override;
+    muse::async::Channel<bool> highlightSelectionChanged() const override;
+
     bool autoScrollToSelection() const override;
     void setAutoScrollToSelection(bool value) override;
     muse::async::Channel<bool> autoScrollToSelectionChanged() const override;
@@ -126,6 +130,7 @@ private:
 
     muse::async::Channel<bool> m_muteHiddenInstrumentsChanged;
 
+    muse::async::Channel<bool> m_highlightSelectionChanged;
     muse::async::Channel<bool> m_autoScrollToSelectionChanged;
 };
 }

--- a/src/playback/iplaybackconfiguration.h
+++ b/src/playback/iplaybackconfiguration.h
@@ -68,6 +68,10 @@ public:
     virtual muse::audio::gain_t defaultAuxSendValue(muse::audio::aux_channel_idx_t index, muse::audio::AudioSourceType sourceType,
                                                     const muse::String& instrumentSoundId) const = 0;
 
+    virtual bool highlightSelection() const = 0;
+    virtual void setHighlightSelection(bool value) = 0;
+    virtual muse::async::Channel<bool> highlightSelectionChanged() const = 0;
+
     virtual bool autoScrollToSelection() const = 0;
     virtual void setAutoScrollToSelection(bool value) = 0;
     virtual muse::async::Channel<bool> autoScrollToSelectionChanged() const = 0;

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -33,6 +33,11 @@ MixerPanelSection {
 
     headerTitle: qsTrc("playback", "Name")
 
+    // provided by MixerPanel.qml
+    property int activeChannelIndex: -1
+    property var activeChannelItem: null
+    property bool highlightSelection: true
+
     Rectangle {
         id: content
 
@@ -40,6 +45,9 @@ MixerPanelSection {
 
         width: root.channelItemWidth
         height: 22
+
+        // is title cell the active channel?
+        readonly property bool isActive: content.channelItem === root.activeChannelItem
 
         function resolveLabelColor() {
             switch(channelItem.type) {
@@ -59,8 +67,9 @@ MixerPanelSection {
             if (channelItem.type === MixerChannelItem.SecondaryInstrument) {
                 return 0.25
             }
-
-            return 0.5
+            if (!root.highlightSelection)
+                return 0.5
+            return content.isActive ? 0.8 : 0.5
         }
 
         readonly property color labelColor: resolveLabelColor()

--- a/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.h
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.h
@@ -44,6 +44,7 @@ class MixerPanelContextMenuModel : public muse::uicomponents::AbstractMenuModel,
     Q_PROPERTY(bool faderSectionVisible READ faderSectionVisible NOTIFY faderSectionVisibleChanged)
     Q_PROPERTY(bool muteAndSoloSectionVisible READ muteAndSoloSectionVisible NOTIFY muteAndSoloSectionVisibleChanged)
     Q_PROPERTY(bool titleSectionVisible READ titleSectionVisible NOTIFY titleSectionVisibleChanged)
+    Q_PROPERTY(bool highlightSelection READ highlightSelection WRITE setHighlightSelection NOTIFY highlightSelectionChanged)
     Q_PROPERTY(bool autoScrollToSelection READ autoScrollToSelection WRITE setAutoScrollToSelection NOTIFY autoScrollToSelectionChanged)
 
     QML_ELEMENT
@@ -63,6 +64,9 @@ public:
     bool faderSectionVisible() const;
     bool muteAndSoloSectionVisible() const;
     bool titleSectionVisible() const;
+
+    bool highlightSelection() const { return m_highlightSelection; }
+    void setHighlightSelection(bool v);
     bool autoScrollToSelection() const { return m_autoScrollToSelection; }
     void setAutoScrollToSelection(bool v);
 
@@ -78,20 +82,24 @@ signals:
     void faderSectionVisibleChanged();
     void muteAndSoloSectionVisibleChanged();
     void titleSectionVisibleChanged();
+    void highlightSelectionChanged();
     void autoScrollToSelectionChanged();
 
 private:
     bool isSectionVisible(MixerSectionType sectionType) const;
+    bool m_highlightSelection = false;
     bool m_autoScrollToSelection = false;
 
     muse::uicomponents::MenuItem* buildSectionVisibleItem(MixerSectionType sectionType);
     muse::uicomponents::MenuItem* buildAuxSendVisibleItem(muse::audio::aux_channel_idx_t index);
     muse::uicomponents::MenuItem* buildAuxChannelVisibleItem(muse::audio::aux_channel_idx_t index);
+    muse::uicomponents::MenuItem* m_highlightMenuItem = nullptr;
     muse::uicomponents::MenuItem* m_autoScrollMenuItem = nullptr;
 
     void toggleMixerSection(const muse::actions::ActionData& args);
     void toggleAuxSend(const muse::actions::ActionData& args);
     void toggleAuxChannel(const muse::actions::ActionData& args);
+    void toggleHighlight(const muse::actions::ActionData& args);
     void toggleAutoScroll(const muse::actions::ActionData& args);
 
     void emitMixerSectionVisibilityChanged(MixerSectionType sectionType);

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -575,12 +575,20 @@ int MixerPanelModel::computeIndexForCurrentSelection() const
 
 void MixerPanelModel::resyncToCurrentSelection()
 {
-    if (!m_autoScrollEnabled) {
+    if (!m_autoScrollEnabled && !m_highlightEnabled) {
         return;
     }
 
     const int idx = computeIndexForCurrentSelection();
-    if (idx != INVALID_INDEX) {
+    if (idx == INVALID_INDEX) {
+        return;
+    }
+
+    if (m_highlightEnabled) {
+        emit highlightIndexRequested(idx);
+    }
+
+    if (m_autoScrollEnabled) {
         emit scrollToIndexRequested(idx);
     }
 }

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.h
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.h
@@ -55,6 +55,7 @@ class MixerPanelModel : public QAbstractListModel, public QQmlParserStatus, publ
 
     Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
 
+    Q_PROPERTY(bool highlightEnabled READ highlightEnabled WRITE setHighlightEnabled NOTIFY highlightEnabledChanged)
     Q_PROPERTY(bool autoScrollEnabled READ autoScrollEnabled WRITE setAutoScrollEnabled NOTIFY autoScrollEnabledChanged)
 
     QML_ELEMENT
@@ -80,6 +81,16 @@ public:
     int navigationOrderStart() const;
     void setNavigationOrderStart(int navigationOrderStart);
 
+    bool highlightEnabled() const { return m_highlightEnabled; }
+    void setHighlightEnabled(bool b)
+    {
+        if (m_highlightEnabled == b) {
+            return;
+        }
+        m_highlightEnabled = b;
+        emit highlightEnabledChanged();
+    }
+
     bool autoScrollEnabled() const { return m_autoScrollEnabled; }
     void setAutoScrollEnabled(bool b)
     {
@@ -94,6 +105,8 @@ signals:
     void navigationSectionChanged();
     void navigationOrderStartChanged();
     void rowCountChanged();
+    void highlightIndexRequested(int index);
+    void highlightEnabledChanged();
     void scrollToIndexRequested(int index);
     void autoScrollEnabledChanged();
 
@@ -143,6 +156,7 @@ private:
     muse::ui::NavigationSection* m_navigationSection = nullptr;
     int m_navigationOrderStart = 1;
 
+    bool m_highlightEnabled = true;
     bool m_autoScrollEnabled = true;
 };
 }


### PR DESCRIPTION
Resolves: #23662

This PR adds two options to the mixer menu: Highlight selection and Scroll to selection.
<img width="1308" height="939" alt="mixer" src="https://github.com/user-attachments/assets/49026850-42f1-4842-ba67-68783b7742cf" />

https://github.com/user-attachments/assets/f4d23e1c-a666-4e9d-a1f8-a8b326d631e2



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
