### PR TITLE
changed use componentComplete to classBegin. 4.7

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.cpp
@@ -80,7 +80,12 @@ NotationStatusBarModel::NotationStatusBarModel(QObject* parent)
 #endif
 }
 
-void NotationStatusBarModel::componentComplete()
+void NotationStatusBarModel::classBegin()
+{
+    init();
+}
+
+void NotationStatusBarModel::init()
 {
     TRACEFUNC;
 

--- a/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.h
+++ b/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.h
@@ -104,8 +104,9 @@ signals:
     void currentZoomPercentageChanged();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     void setNotation(const notation::INotationPtr& notation);
 

--- a/src/framework/extensions/qml/Muse/Extensions/extensionslistmodel.cpp
+++ b/src/framework/extensions/qml/Muse/Extensions/extensionslistmodel.cpp
@@ -48,7 +48,12 @@ ExtensionsListModel::ExtensionsListModel(QObject* parent)
     };
 }
 
-void ExtensionsListModel::componentComplete()
+void ExtensionsListModel::classBegin()
+{
+    init();
+}
+
+void ExtensionsListModel::init()
 {
     provider()->manifestListChanged().onNotify(this, [this]() {
         load();

--- a/src/framework/extensions/qml/Muse/Extensions/extensionslistmodel.h
+++ b/src/framework/extensions/qml/Muse/Extensions/extensionslistmodel.h
@@ -88,9 +88,9 @@ private:
         std::vector<ExecPoint> points;
     };
 
-    void classBegin() override {}
-    void componentComplete() override;
-
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
     void load();
 
     void updatePlugin(const Manifest& plugin);

--- a/src/framework/tours/qml/Muse/Tours/toursprovidermodel.cpp
+++ b/src/framework/tours/qml/Muse/Tours/toursprovidermodel.cpp
@@ -28,7 +28,12 @@ ToursProviderModel::ToursProviderModel(QObject* parent)
 {
 }
 
-void ToursProviderModel::componentComplete()
+void ToursProviderModel::classBegin()
+{
+    init();
+}
+
+void ToursProviderModel::init()
 {
     // TODO: avoid direct usage of ToursProvider, and use IToursProvider only
     ToursProvider* providerPtr = toursProvider();

--- a/src/framework/tours/qml/Muse/Tours/toursprovidermodel.h
+++ b/src/framework/tours/qml/Muse/Tours/toursprovidermodel.h
@@ -56,8 +56,9 @@ signals:
 
 private:
 
-    void classBegin() {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     muse::tours::ToursProvider* toursProvider() const;
 };

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
@@ -45,7 +45,12 @@ InspectorListModel::InspectorListModel(QObject* parent)
 
 InspectorListModel::~InspectorListModel() = default;
 
-void InspectorListModel::componentComplete()
+void InspectorListModel::classBegin()
+{
+    init();
+}
+
+void InspectorListModel::init()
 {
     listenSelectionChanged();
     listenScoreChanges();

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.h
@@ -61,8 +61,9 @@ private:
         InspectorSectionModelRole = Qt::UserRole + 1
     };
 
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     void listenSelectionChanged();
     void listenScoreChanges();

--- a/src/inspector/qml/MuseScore/Inspector/inspectorpopupcontrollermodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorpopupcontrollermodel.cpp
@@ -32,7 +32,12 @@ InspectorPopupControllerModel::InspectorPopupControllerModel(QObject* parent)
 {
 }
 
-void InspectorPopupControllerModel::componentComplete()
+void InspectorPopupControllerModel::classBegin()
+{
+    init();
+}
+
+void InspectorPopupControllerModel::init()
 {
     popupController()->popupChanged().onNotify(this, [this]() {
         emit isAnyPopupOpenChanged();

--- a/src/inspector/qml/MuseScore/Inspector/inspectorpopupcontrollermodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorpopupcontrollermodel.h
@@ -64,7 +64,8 @@ signals:
     void isAnyPopupOpenChanged();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.cpp
@@ -35,7 +35,12 @@ TextStylePopupModel::TextStylePopupModel(QObject* parent)
 
 TextStylePopupModel::~TextStylePopupModel() = default;
 
-void TextStylePopupModel::componentComplete()
+void TextStylePopupModel::classBegin()
+{
+    doInit();
+}
+
+void TextStylePopupModel::doInit()
 {
     AbstractElementPopupModel::init();
 

--- a/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.h
@@ -58,8 +58,9 @@ signals:
     void placeAboveChanged();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void doInit();
 
     void updateItemRect() override;
     bool ignoreTextEditingChanges() const override { return false; }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.cpp
@@ -50,7 +50,12 @@ LayoutPanelTreeModel::LayoutPanelTreeModel(QObject* parent)
 {
 }
 
-void LayoutPanelTreeModel::componentComplete()
+void LayoutPanelTreeModel::classBegin()
+{
+    init();
+}
+
+void LayoutPanelTreeModel::init()
 {
     m_partsNotifyReceiver = std::make_shared<muse::async::Asyncable>();
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.h
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.h
@@ -133,8 +133,9 @@ private slots:
     void updateIsAddingSystemMarkingsAvailable();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     bool removeRows(int row, int count, const QModelIndex& parent) override;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
@@ -48,7 +48,12 @@ StaffVisibilityPopupModel::StaffVisibilityPopupModel(QObject* parent)
 {
 }
 
-void StaffVisibilityPopupModel::componentComplete()
+void StaffVisibilityPopupModel::classBegin()
+{
+    doInit();
+}
+
+void StaffVisibilityPopupModel::doInit()
 {
     AbstractElementPopupModel::init();
 

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.h
@@ -66,8 +66,9 @@ signals:
     void systemIndexChanged();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void doInit();
 
     std::unique_ptr<EmptyStavesVisibilityModel> m_emptyStavesVisibilityModel = nullptr;
     size_t m_systemIndex = 0;

--- a/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.cpp
@@ -30,7 +30,12 @@ UndoHistoryModel::UndoHistoryModel(QObject* parent)
 {
 }
 
-void UndoHistoryModel::componentComplete()
+void UndoHistoryModel::classBegin()
+{
+    init();
+}
+
+void UndoHistoryModel::init()
 {
     onCurrentNotationChanged();
 

--- a/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.h
@@ -55,8 +55,9 @@ signals:
     void currentIndexChanged();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     void onCurrentNotationChanged();
     void onUndoRedo();

--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
@@ -79,7 +79,12 @@ QHash<int, QByteArray> NoteInputBarModel::roleNames() const
     return roles;
 }
 
-void NoteInputBarModel::componentComplete()
+void NoteInputBarModel::classBegin()
+{
+    init();
+}
+
+void NoteInputBarModel::init()
 {
     subscribeOnChanges();
 

--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.h
@@ -62,8 +62,9 @@ private:
         SectionRole
     };
 
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     void setNotation(const INotationPtr& notation);
 

--- a/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
@@ -28,7 +28,12 @@ SearchPopupModel::SearchPopupModel(QObject* parent)
 {
 }
 
-void SearchPopupModel::componentComplete()
+void SearchPopupModel::classBegin()
+{
+    init();
+}
+
+void SearchPopupModel::init()
 {
     dispatcher()->reg(this, "find", [this]() {
         emit showPopupRequested();

--- a/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.h
@@ -50,7 +50,8 @@ signals:
     void showPopupRequested();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 };
 }

--- a/src/palette/qml/MuseScore/Palette/internal/paletterootmodel.cpp
+++ b/src/palette/qml/MuseScore/Palette/internal/paletterootmodel.cpp
@@ -36,7 +36,12 @@ PaletteRootModel::~PaletteRootModel()
     }
 }
 
-void PaletteRootModel::componentComplete()
+void PaletteRootModel::classBegin()
+{
+    init();
+}
+
+void PaletteRootModel::init()
 {
     dispatcher()->reg(this, "palette-search", [this]() {
         emit paletteSearchRequested();

--- a/src/palette/qml/MuseScore/Palette/internal/paletterootmodel.h
+++ b/src/palette/qml/MuseScore/Palette/internal/paletterootmodel.h
@@ -101,7 +101,8 @@ signals:
     void applyCurrentPaletteElementRequested();
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 };
 }

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -46,6 +46,14 @@ MixerPanelModel::MixerPanelModel(QObject* parent)
 
 void MixerPanelModel::componentComplete()
 {
+    init();
+}
+
+void MixerPanelModel::init()
+{
+    //! NOTE Must be set from Qml
+    DO_ASSERT(m_navigationSection);
+
     controller()->currentTrackSequenceIdChanged().onNotify(this, [this]() {
         load();
     });

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.h
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.h
@@ -79,6 +79,7 @@ signals:
 private:
     void classBegin() override {}
     void componentComplete() override;
+    void init();
 
     enum Roles {
         ChannelItemRole = Qt::UserRole + 1

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -121,7 +121,12 @@ ExportDialogModel::~ExportDialogModel()
     m_selectionModel->deleteLater();
 }
 
-void ExportDialogModel::componentComplete()
+void ExportDialogModel::classBegin()
+{
+    init();
+}
+
+void ExportDialogModel::init()
 {
     TRACEFUNC;
 

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
@@ -255,8 +255,9 @@ signals:
     void shouldDestinationFolderBeOpenedOnExportChanged(bool shouldDestinationFolderBeOpenedOnExport);
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     enum Roles {
         RoleTitle = Qt::UserRole + 1,

--- a/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
@@ -34,7 +34,12 @@ ProjectPropertiesModel::ProjectPropertiesModel(QObject* parent)
 {
 }
 
-void ProjectPropertiesModel::componentComplete()
+void ProjectPropertiesModel::classBegin()
+{
+    init();
+}
+
+void ProjectPropertiesModel::init()
 {
     INotationProjectPtr project = context()->currentProject();
     if (project) {

--- a/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.h
@@ -71,8 +71,9 @@ signals:
     void propertyAdded(int index);
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void classBegin() override;
+    void componentComplete() override {}
+    void init();
 
     enum Roles {
         PropertyName = Qt::UserRole + 1,

--- a/src/web/appshell/view/notationstatusbarmodel.cpp
+++ b/src/web/appshell/view/notationstatusbarmodel.cpp
@@ -83,6 +83,11 @@ NotationStatusBarModel::NotationStatusBarModel(QObject* parent)
 
 void NotationStatusBarModel::classBegin()
 {
+    init();
+}
+
+void NotationStatusBarModel::init()
+{
     TRACEFUNC;
 
     m_concertPitchItem = makeMenuItem(TOGGLE_CONCERT_PITCH_CODE);

--- a/src/web/appshell/view/notationstatusbarmodel.h
+++ b/src/web/appshell/view/notationstatusbarmodel.h
@@ -103,6 +103,7 @@ signals:
 private:
     void classBegin() override;
     void componentComplete() override {}
+    void init();
 
     notation::INotationPtr notation() const;
     notation::INotationAccessibilityPtr accessibility() const;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32316 

returned use of `classBegin`

Proposal:

1. To improve semantics and more clearly demonstrate what's happening, I propose adding an "init" method to all models.
2. If "init" requires input arguments (from Qml), then it's ideal to pass them to "init" as arguments. Or, it's acceptable to add a precondition check to ensure the arguments are set.
3. We have three options for calling init:
      * If there are no input arguments or preconditions and the init itself is "lightweight," then it should be called in a `classBegin` method.
      * If there are input arguments or preconditions and the init itself is "lightweight," then it should be called in a `componentComplete` method.
      * In complex cases, for example, if the init is "heavy," or there are some dependencies and call ordering..., then it should be called in Qml, possibly using `Qt.callLater`.
