### PR TITLE
[4.7] fixed #32343: Esc doesn't work when navigating Mixer submenus

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -260,6 +260,11 @@ MenuView {
         }
 
         Keys.onShortcutOverride: function(event) {
+            if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return || event.key === Qt.Key_Escape) {
+                event.accepted = false
+                return
+            }
+
             if (root.isSubMenuOpen && shortcutOverrideModel.isShortcutOverrideAllowed(event.key, event.modifiers)) {
                 event.accepted = true
             } else {


### PR DESCRIPTION
Resolves: #32343