### PR TITLE
added subscribe on change to IoC

### DIFF
--- a/src/app/internal/consoleapp.h
+++ b/src/app/internal/consoleapp.h
@@ -94,7 +94,7 @@ private:
     CmdOptions m_options;
 
     //! NOTE Separately to initialize logger and profiler as early as possible
-    muse::GlobalModule m_globalModule;
+    muse::GlobalModule* m_globalModule = nullptr;
 
     std::vector<muse::modularity::IModuleSetup*> m_modules;
     muse::modularity::ContextPtr m_context;

--- a/src/app/internal/guiapp.h
+++ b/src/app/internal/guiapp.h
@@ -50,7 +50,7 @@ private:
     appshell::SplashScreen* m_splashScreen = nullptr;
 
     //! NOTE Separately to initialize logger and profiler as early as possible
-    muse::GlobalModule m_globalModule;
+    muse::GlobalModule* m_globalModule = nullptr;
     std::vector<muse::modularity::IModuleSetup*> m_modules;
 
     struct Context {

--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -82,6 +82,8 @@ IContextSetup* AccessibilityModule::newContext(const muse::modularity::ContextPt
 // Context
 void AccessibilityContext::registerExports()
 {
+    //! FIXME AccessibilityController has a global component and a contextual component.
+    // It probably needs to be split into two separate classes.
     m_controller = std::make_shared<AccessibilityController>(iocContext());
     ioc()->registerExport<IAccessibilityController>(mname, m_controller);
 }
@@ -89,4 +91,9 @@ void AccessibilityContext::registerExports()
 void AccessibilityContext::onPreInit(const IApplication::RunMode&)
 {
     m_controller->setAccessibilityEnabled(true);
+}
+
+void AccessibilityContext::onDeinit()
+{
+    m_controller->deinit();
 }

--- a/src/framework/accessibility/accessibilitymodule.h
+++ b/src/framework/accessibility/accessibilitymodule.h
@@ -55,6 +55,7 @@ public:
 
     void registerExports() override;
     void onPreInit(const IApplication::RunMode& mode) override;
+    void onDeinit() override;
 
 private:
     std::shared_ptr<AccessibilityController> m_controller;

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -68,13 +68,17 @@ AccessibilityController::AccessibilityController(const muse::modularity::Context
 
 AccessibilityController::~AccessibilityController()
 {
-    m_pretendFocusTimer.stop();
-    unreg(this);
 }
 
 QAccessibleInterface* AccessibilityController::accessibleInterface(QObject*)
 {
     return static_cast<QAccessibleInterface*>(new AccessibleItemInterface(s_rootObject));
+}
+
+void AccessibilityController::deinit()
+{
+    m_pretendFocusTimer.stop();
+    unreg(this);
 }
 
 void AccessibilityController::setAccessibilityEnabled(bool enabled)

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -67,6 +67,7 @@ public:
     static QAccessibleInterface* accessibleInterface(QObject* object);
 
     void setAccessibilityEnabled(bool enabled);
+    void deinit();
 
     // IAccessibilityController
     void reg(IAccessible* item) override;

--- a/src/framework/global/modularity/ioc.h
+++ b/src/framework/global/modularity/ioc.h
@@ -65,6 +65,11 @@ inline void removeIoC(const ContextPtr& ctx = nullptr)
 {
     kors::modularity::removeIoC(ctx);
 }
+
+inline void resetAll()
+{
+    kors::modularity::resetAll();
+}
 }
 
 namespace muse {

--- a/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
@@ -94,3 +94,11 @@ void kors::modularity::removeIoC(const ContextPtr& ctx)
         s_contexts.erase(it);
     }
 }
+
+void kors::modularity::resetAll()
+{
+    for (auto& c : s_contexts) {
+        c.second->reset();
+    }
+    globalIoc()->reset();
+}

--- a/src/framework/testing/environment.h
+++ b/src/framework/testing/environment.h
@@ -27,6 +27,10 @@
 
 #include "modularity/imodulesetup.h"
 
+namespace muse {
+class GlobalModule;
+}
+
 namespace muse::testing {
 class Environment
 {
@@ -52,6 +56,7 @@ private:
     static PreInit m_preInit;
     static PostInit m_postInit;
     static DeInit m_deInit;
+    static muse::GlobalModule* m_globalModule;
 };
 
 class SuiteEnvironment


### PR DESCRIPTION
Problem: There are circular dependencies, which prevents objects from being deleted when the context (window) or application terminates.

Solution: Injects subscribe to changes, the container notifies them when the implementation changes or is removed from the container, injects can nullify their class member, thereby breaking the link.

As a bonus, we've added the ability to change the implementation in container on the fly. This wasn't possible before, and it's not really needed, but I've always wanted to add it