### PR TITLE
Include parentheses in range selection

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1417,6 +1417,11 @@ std::unordered_set<EngravingItem*> collectElementsAnchoredToNote(const Note* not
             elems.emplace(sp);
         }
     }
+    const NoteParenthesisInfo* noteParenInfo = note->parenInfo();
+    if (noteParenInfo && noteParenInfo->notes.size()) {
+        elems.emplace(noteParenInfo->leftParen);
+        elems.emplace(noteParenInfo->rightParen);
+    }
     return elems;
 }
 


### PR DESCRIPTION
Resolves:
<img width="899" height="424" alt="Screenshot 2026-02-26 at 11 50 04" src="https://github.com/user-attachments/assets/93e1e190-b291-420f-9d07-5c49a79def3e" />
