### PR TITLE
Tweaks to scrolling behaviour (#11363 & #11325)

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -36,7 +36,7 @@ using namespace muse::ui;
 using namespace muse::draw;
 using namespace muse::actions;
 
-static constexpr qreal SCROLL_LIMIT_OFF_OVERSCROLL_FACTOR = 0.75;
+static constexpr qreal SCROLL_LIMIT_OFF_OVERSCROLL_FACTOR = 0.5;
 
 static void compensateFloatPart(RectF& rect)
 {
@@ -871,11 +871,12 @@ RectF AbstractNotationPaintView::notationContentRect() const
 RectF AbstractNotationPaintView::scrollableAreaRect() const
 {
     TRACEFUNC;
-    RectF viewport = this->viewport();
-    qreal overscrollFactor = configuration()->isLimitCanvasScrollArea() ? 0.0 : SCROLL_LIMIT_OFF_OVERSCROLL_FACTOR;
+    const RectF viewport = this->viewport();
+    const qreal overscrollFactor = configuration()->isLimitCanvasScrollArea() ? 0.0 : SCROLL_LIMIT_OFF_OVERSCROLL_FACTOR;
 
-    qreal overscrollX = viewport.width() * overscrollFactor;
-    qreal overscrollY = viewport.height() * overscrollFactor;
+    const ViewMode& viewMode = notation()->viewMode();
+    const qreal overscrollX = viewMode == engraving::LayoutMode::LINE ? 0 : viewport.width() * overscrollFactor;
+    const qreal overscrollY = viewMode == engraving::LayoutMode::SYSTEM ? 0 : viewport.height() * overscrollFactor;
 
     return notationContentRect().adjusted(-overscrollX, -overscrollY, overscrollX, overscrollY);
 }


### PR DESCRIPTION
Resolves: #11363
Resolves: #11325

Closes: #21241
Closes: #28138

1. Tighten overscroll area (before the overscroll could span 75% of width/height, just 50% in this PR)
2. Prevent left/right overscrolling in horizontal continuous view
3. Prevent top/bottom overscrolling in vertical continuous view

Maximum overscroll in page view before:
<img width="1512" height="982" alt="before" src="https://github.com/user-attachments/assets/a9e208f5-495a-4f7d-9ca6-c86e650d10fb" />

After:
<img width="1512" height="982" alt="after" src="https://github.com/user-attachments/assets/aa7a32a8-0b4a-43d3-9326-b765bec84ef9" />