### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -979,7 +979,7 @@ bool GuitarPro5::read(IODevice* io)
     // NOTE: GP doesn't support multiple tunings on one part
     // We're safe to just take the very first chord rest segment
     // and check if it has any non-standard tuning
-    const Fraction& f{ 0, 1 };
+    const Fraction& frac{ 0, 1 };
 
     for (auto p : score->parts()) {
         for (auto s : p->staves()) {
@@ -987,7 +987,7 @@ bool GuitarPro5::read(IODevice* io)
                 continue;
             }
 
-            Segment* seg = m->findSegment(SegmentType::ChordRest, f);
+            Segment* seg = m->findSegment(SegmentType::ChordRest, frac);
 
             IF_ASSERT_FAILED(seg) {
                 LOGE() << "First measure MUST has a chord rest segment after import";

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2733,7 +2733,7 @@ void GuitarPro::addTunings()
     // NOTE: GP doesn't support multiple tunings on one part
     // We're safe to just take the very first chord rest segment
     // and check if it has any non-standard tuning
-    const Fraction& f{ 0, 1 };
+    const Fraction& frac{ 0, 1 };
 
     for (auto p : score->parts()) {
         for (auto s : p->staves()) {
@@ -2741,7 +2741,7 @@ void GuitarPro::addTunings()
                 continue;
             }
 
-            Segment* seg = m->findSegment(SegmentType::ChordRest, f);
+            Segment* seg = m->findSegment(SegmentType::ChordRest, frac);
 
             IF_ASSERT_FAILED(seg) {
                 LOGE() << "First measure MUST has a chord rest segment after import";


### PR DESCRIPTION
reg.: declaration of 'f' hides class member (C4458)