### PR TITLE
Speed up loading of recent files thumbnails

### DIFF
--- a/src/notation/tests/CMakeLists.txt
+++ b/src/notation/tests/CMakeLists.txt
@@ -21,7 +21,6 @@
 set(MODULE_TEST notation_tests)
 
 set(MODULE_TEST_SRC
-    ${CMAKE_CURRENT_LIST_DIR}/mocks/msczreadermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/notationconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/notationinteractionmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/notationselectionmock.h

--- a/src/project/imscmetareader.h
+++ b/src/project/imscmetareader.h
@@ -19,14 +19,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PROJECT_IMSCMETAREADER_H
-#define MU_PROJECT_IMSCMETAREADER_H
 
-#include <QString>
+#pragma once
 
-#include "modularity/imoduleinterface.h"
-#include "io/path.h"
-#include "types/retval.h"
+#include "global/modularity/imoduleinterface.h"
+
+#include <QPixmap>
+
+#include "global/io/path.h"
+#include "global/types/retval.h"
 
 #include "types/projectmeta.h"
 #include "types/projecttypes.h"
@@ -39,9 +40,8 @@ class IMscMetaReader : MODULE_GLOBAL_INTERFACE
 public:
     virtual ~IMscMetaReader() = default;
 
+    virtual muse::RetVal<QPixmap> readThumbnail(const muse::io::path_t& filePath) const = 0;
     virtual muse::RetVal<ProjectMeta> readMeta(const muse::io::path_t& filePath) const = 0;
     virtual muse::RetVal<CloudProjectInfo> readCloudProjectInfo(const muse::io::path_t& filePath) const = 0;
 };
 }
-
-#endif // MU_PROJECT_IMSCMETAREADER_H

--- a/src/project/internal/mscmetareader.h
+++ b/src/project/internal/mscmetareader.h
@@ -37,6 +37,7 @@ class MscMetaReader : public IMscMetaReader
     muse::GlobalInject<muse::io::IFileSystem> fileSystem;
 
 public:
+    muse::RetVal<QPixmap> readThumbnail(const muse::io::path_t& filePath) const override;
     muse::RetVal<ProjectMeta> readMeta(const muse::io::path_t& filePath) const override;
     muse::RetVal<CloudProjectInfo> readCloudProjectInfo(const muse::io::path_t& filePath) const override;
 

--- a/src/project/internal/recentfilescontroller.cpp
+++ b/src/project/internal/recentfilescontroller.cpp
@@ -273,13 +273,13 @@ Promise<QPixmap> RecentFilesController::thumbnail(const muse::io::path_t& filePa
                 }
             }
 
-            RetVal<ProjectMeta> rv = mscMetaReader()->readMeta(filePath);
-            if (!rv.ret) {
+            RetVal<QPixmap> thumbnail = mscMetaReader()->readThumbnail(filePath);
+            if (!thumbnail.ret) {
                 m_thumbnailCache[filePath] = CachedThumbnail();
-                (void)reject(rv.ret.code(), rv.ret.toString());
+                (void)reject(thumbnail.ret.code(), thumbnail.ret.toString());
             } else {
-                m_thumbnailCache[filePath] = CachedThumbnail { rv.val.thumbnail, lastModified };
-                (void)resolve(rv.val.thumbnail);
+                m_thumbnailCache[filePath] = CachedThumbnail { thumbnail.val, lastModified };
+                (void)resolve(thumbnail.val);
             }
         });
 #else

--- a/src/project/tests/CMakeLists.txt
+++ b/src/project/tests/CMakeLists.txt
@@ -21,6 +21,7 @@
 set(MODULE_TEST project_test)
 
 set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/mscmetareadermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projectconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mscmetareadertests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/templatesrepositorytest.cpp

--- a/src/project/tests/mocks/mscmetareadermock.h
+++ b/src/project/tests/mocks/mscmetareadermock.h
@@ -19,20 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_NOTATIONMSCZREADERMOCK_H
-#define MU_NOTATION_NOTATIONMSCZREADERMOCK_H
+
+#pragma once
 
 #include <gmock/gmock.h>
 
 #include "project/imscmetareader.h"
 
 namespace mu::notation {
-class MsczReaderMock : public project::IMscMetaReader
+class MscMetaReaderMock : public project::IMscMetaReader
 {
 public:
+    MOCK_METHOD(muse::RetVal<QPixmap>, readThumbnail, (const muse::io::path_t& filePath), (const, override));
     MOCK_METHOD(muse::RetVal<project::ProjectMeta>, readMeta, (const muse::io::path_t& filePath), (const, override));
     MOCK_METHOD(muse::RetVal<project::CloudProjectInfo>, readCloudProjectInfo, (const muse::io::path_t& filePath), (const, override));
 };
 }
-
-#endif // MU_NOTATION_NOTATIONMSCZREADERMOCK_H

--- a/src/project/tests/templatesrepositorytest.cpp
+++ b/src/project/tests/templatesrepositorytest.cpp
@@ -23,7 +23,7 @@
 
 #include "project/internal/templatesrepository.h"
 
-#include "notation/tests/mocks/msczreadermock.h"
+#include "mocks/mscmetareadermock.h"
 #include "mocks/projectconfigurationmock.h"
 #include "global/tests/mocks/filesystemmock.h"
 
@@ -44,12 +44,12 @@ protected:
     void SetUp() override
     {
         m_repository = std::make_shared<TemplatesRepository>();
-        m_msczReader = std::make_shared<NiceMock<MsczReaderMock> >();
+        m_mscMetaReader = std::make_shared<NiceMock<MscMetaReaderMock> >();
         m_fileSystem = std::make_shared<NiceMock<FileSystemMock> >();
         m_configuration = std::make_shared<NiceMock<ProjectConfigurationMock> >();
 
         m_repository->configuration.set(m_configuration);
-        m_repository->mscReader.set(m_msczReader);
+        m_repository->mscReader.set(m_mscMetaReader);
         m_repository->fileSystem.set(m_fileSystem);
     }
 
@@ -84,7 +84,7 @@ protected:
 
     std::shared_ptr<TemplatesRepository> m_repository;
     std::shared_ptr<ProjectConfigurationMock> m_configuration;
-    std::shared_ptr<MsczReaderMock> m_msczReader;
+    std::shared_ptr<MscMetaReaderMock> m_mscMetaReader;
     std::shared_ptr<FileSystemMock> m_fileSystem;
 };
 
@@ -176,7 +176,7 @@ TEST_F(Project_TemplatesRepositoryTest, Templates)
     }
 
     for (const Template& templ : std::as_const(expectedTemplates)) {
-        ON_CALL(*m_msczReader, readMeta(templ.meta.filePath))
+        ON_CALL(*m_mscMetaReader, readMeta(templ.meta.filePath))
         .WillByDefault(Return(RetVal<ProjectMeta>::make_ok(templ.meta)));
     }
 


### PR DESCRIPTION
The `RecentFilesController` got the thumbnail by calling `IMscMetaReader::readMeta`. This method, in addition to loading the thumbnail, also parses the main score XML file.
A noticeable speedup can be achieved by providing a separate method to read a thumbnail for a score.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
