### PR TITLE
Fix initial clef changing when replacing instrument after an instrument change (#32340)

### DIFF
--- a/src/notationscene/widgets/editstaff.cpp
+++ b/src/notationscene/widgets/editstaff.cpp
@@ -499,7 +499,7 @@ void EditStaff::applyStaffProperties()
     config.userDistance = Spatium(spinExtraDistance->value());
     config.hideSystemBarline = hideSystemBarLine->isChecked();
     config.mergeMatchingRests = static_cast<AutoOnOff>(mergeMatchingRests->currentIndex());
-    config.clefTypeList = m_instrument.clefType(m_orgStaff->rstaff());
+    config.clefTypeList = m_orgStaff->defaultClefType();
     config.staffType = *m_staff->staffType(mu::engraving::Fraction(0, 1));
     config.reflectTranspositionInLinkedTab = !noReflectTranspositionInLinkedTab->isChecked();
 


### PR DESCRIPTION

Resolves: #32340 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR fixes #32340 where replacing an instrument via Staff/Part Properties after an instrument change unexpectedly changes the initial clef (staff `<defaultClef>`).

Use the staff’s current default clef instead, so the dialog does not update the staff `<defaultClef>` in the instrument-change scenario.

## Testing
1. after instrument change: replace instrument → initial clef unchanged (fixed)
2. before instrument change: replace instrument → initial clef changes (expected)
3. another staff without instrument change: replace instrument → initial clef changes (expected)

https://github.com/user-attachments/assets/f97af736-98e6-4ff5-b806-b9663437d162

If you already have a fix in progress, feel free to close this PR.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
