### PR TITLE
[4.7] Fix Style dialog dropdown items too dark on Windows (light mode) #32000

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ComboBoxDropdown.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ComboBoxDropdown.qml
@@ -120,8 +120,6 @@ ComboBox {
             height: comboDropdown.itemHeight
             width: comboDropdown.contentWidth
 
-            normalColor: ui.theme.buttonColor
-
             isSelected: index === comboDropdown.currentIndex
 
             StyledTextLabel {


### PR DESCRIPTION
Resolves: #32000 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
`ComboBoxDropdown.qml` explicitly sets the `ListItemBlank` delegate’s normal background (`normalColor: ui.theme.buttonColor`), forcing items to be filled at all times.

This change removes that override so dropdown items use the default `ListItemBlank` styling (transparent idle background + theme-driven hover/pressed/selected states).

This keeps the change minimal and avoids broader dropdown/popup styling changes.
Tested on Windows 11 light mode (Chord Symbols / Measure Numbers / Repeats). Before/after screenshots attached.

<img width="598" height="288" alt="スクリーンショット 2026-02-27 232709" src="https://github.com/user-attachments/assets/56d6df52-5a41-40fa-b175-cc17ac27f000" />
<img width="584" height="765" alt="スクリーンショット 2026-02-27 232721" src="https://github.com/user-attachments/assets/3ac587dd-f0e1-49b1-a335-144cd37b2fb8" />
<img width="609" height="848" alt="スクリーンショット 2026-02-27 232732" src="https://github.com/user-attachments/assets/8ceb9db1-27ef-49fa-81b5-8c5f8b91bfa5" />
<img width="412" height="306" alt="スクリーンショット 2026-02-27 232826" src="https://github.com/user-attachments/assets/2c1cc788-cc53-427a-8bfd-ca7a9675d278" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
