### PR TITLE
Make line distance available in staff

### DIFF
--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1626,6 +1626,8 @@ PropertyValue Staff::getProperty(Pid id) const
         return staffType(Fraction(0, 1))->isSmall();
     case Pid::MAG:
         return staffType(Fraction(0, 1))->userMag();
+    case Pid::LINE_DISTANCE:
+        return staffType(Fraction(0, 1))->lineDistance();
     case Pid::STAFF_INVISIBLE:
         return staffType(Fraction(0, 1))->invisible();
     case Pid::HIDE_WHEN_EMPTY:
@@ -1677,8 +1679,12 @@ bool Staff::setProperty(Pid id, const PropertyValue& v)
         double _spatium = spatium(Fraction(0, 1));
         staffType(Fraction(0, 1))->setUserMag(v.toReal());
         setLocalSpatium(_spatium, spatium(Fraction(0, 1)), Fraction(0, 1));
+        break;
     }
-    break;
+    case Pid::LINE_DISTANCE: {
+        staffType(Fraction(0, 1))->setLineDistance(v.value<Spatium>());
+        break;
+    }
     case Pid::HIDE_WHEN_EMPTY:
         setHideWhenEmpty(v.value<AutoOnOff>());
         break;


### PR DESCRIPTION
In addition to #32402 this makes the line distance property accesible from staff objects, in parallel to `Pid:SMALL` and `Pid::MAG`.
