### PR TITLE
fix #16842: alignment of winged repeat barline

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1082,11 +1082,11 @@ void TLayout::layoutBarLine(const BarLine* item, BarLine::LayoutData* ldata, con
             r.unite(font->bbox(SymId::bracketTop, magS).translated(0, ldata->y1));
         } break;
         case BarLineType::END_REPEAT: {
-            double w1 = 0.0;
+            double w1 = font->width(SymId::reversedBracketTop, magS) - w;
             r.unite(font->bbox(SymId::reversedBracketTop, magS).translated(-w1, ldata->y1));
         } break;
         case BarLineType::END_START_REPEAT: {
-            double w1 = 0.0;
+            double w1 = font->width(SymId::reversedBracketTop, magS) - w;
             r.unite(font->bbox(SymId::reversedBracketTop, magS).translated(-w1, ldata->y1));
             r.unite(font->bbox(SymId::bracketTop, magS).translated(0, ldata->y1));
         } break;
@@ -1213,14 +1213,14 @@ void TLayout::layoutBarLine2(BarLine* item, LayoutContext& ctx)
             break;
         case BarLineType::END_REPEAT:
         {
-            double w1 = 0.0;               //symBbox(SymId::reversedBracketTop).width();
+            double w1 = item->symBbox(SymId::reversedBracketTop).x() - bbox.x();
             bbox.unite(item->symBbox(SymId::reversedBracketTop).translated(-w1, ldata->y1));
             bbox.unite(item->symBbox(SymId::reversedBracketBottom).translated(-w1, ldata->y2));
             break;
         }
         case BarLineType::END_START_REPEAT:
         {
-            double w1 = 0.0;               //symBbox(SymId::reversedBracketTop).width();
+            double w1 = item->symBbox(SymId::reversedBracketTop).x() - bbox.x();
             bbox.unite(item->symBbox(SymId::reversedBracketTop).translated(-w1, ldata->y1));
             bbox.unite(item->symBbox(SymId::reversedBracketBottom).translated(-w1, ldata->y2));
             bbox.unite(item->symBbox(SymId::bracketTop).translated(0, ldata->y1));


### PR DESCRIPTION
Resolves: #16842

The root cause of the issue is that, for end repeat barlines, the repeat dot is used as the origin of the X coordinate, causing the bounding box to extend beyond the right edge of the barline.

I updated the calculation of the horizontal offset `w1` for `reversedBracket`, which was previously fixed to 0, so that it is computed correctly when a wing is present.

In TLayout::layoutBarLine:
w1 is calculated as the difference between the width of a repeat barline without wings (w) and the width of the wing (font->width(SymId::reversedBracketTop, magS)).

In TLayout::layoutBarLine2:
Since bbox.x() already accounts for this offset, w1 is obtained as the difference from item->symBbox(SymId::reversedBracketTop).x(), which does not account for the offset.


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<img width="601" height="292" alt="20260301_MuseScore_WingedRepeatBarline" src="https://github.com/user-attachments/assets/9c69e567-e4ad-4241-a971-7bbb36c235b0" />

<img width="1287" height="877" alt="20260301_MuseScore_WingedRepeatBarline_CheckResult" src="https://github.com/user-attachments/assets/6315a555-ce5b-42bf-a805-748fcd41ebb2" />