### PR TITLE
[4.7.0] Fix #32429: restore missing null checks

### DIFF
--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3598,7 +3598,8 @@ Ret Read206::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
         for (staff_idx_t staffIdx = 0; staffIdx < numStaves; ++staffIdx) {
             const size_t maxSpan = numStaves - staffIdx - 1;
             const track_idx_t trackIdx = staff2track(staffIdx);
-            BarLine* barLine = toBarLine(s->element(trackIdx));
+            EngravingItem* el = s->element(trackIdx);
+            BarLine* barLine = el && el->isBarLine() ? toBarLine(el) : nullptr;
             if (barLine) {
                 if (const std::optional<size_t> span = ctx.getBarLineSpan(barLine)) {
                     if (*span > maxSpan) {
@@ -3623,13 +3624,17 @@ Ret Read206::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
                     // clone previous bar line. This is safe because we always have a previous barline when
                     // barLineSpan != std::nullopt because it's either the one that was read or the one cloned
                     // in the previous iteration
-                    barLine = toBarLine(s->element(staff2track(staffIdx - 1)))
-                              ->clone();
-                    barLine->setTrack(trackIdx);
-                    s->add(barLine);
+                    el = s->element(staff2track(staffIdx - 1));
+                    if (el && el->isBarLine()) {
+                        barLine = toBarLine(el)->clone();
+                        barLine->setTrack(trackIdx);
+                        s->add(barLine);
+                    }
                 }
 
-                barLine->setSpanStaff(shouldBarLineSpan);
+                if (barLine) {
+                    barLine->setSpanStaff(shouldBarLineSpan);
+                }
             }
             if (*barLineSpan == 0) {
                 // we're done applying the local override


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32429
Caused by: https://github.com/musescore/MuseScore/pull/29603