### PR TITLE
added palette score provider

### DIFF
--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -340,6 +340,8 @@ else()
         internal/engravingfontsprovider.h
         internal/engravingfont.cpp
         internal/engravingfont.h
+        internal/palettescoreprovider.cpp
+        internal/palettescoreprovider.h
         ${API_V1_SRC}
     )
 endif()

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -250,8 +250,6 @@ private:
 
     bool m_saved = false;
 };
-
-extern MasterScore* gpaletteScore;
 }
 
 #endif // MU_ENGRAVING_MASTERSCORE_H

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -119,7 +119,6 @@ using namespace muse;
 using namespace mu::engraving;
 
 namespace mu::engraving {
-MasterScore* gpaletteScore;                 ///< system score, used for palettes etc.
 std::set<Score*> Score::validScores;
 
 bool noSeq           = false;
@@ -338,14 +337,14 @@ Score* Score::clone()
     return excerpt->excerptScore();
 }
 
-Score* Score::paletteScore()
+Score* Score::paletteScore() const
 {
-    return gpaletteScore;
+    return paletteScoreProvider() ? paletteScoreProvider()->paletteScore() : nullptr;
 }
 
 bool Score::isPaletteScore() const
 {
-    return this == gpaletteScore;
+    return this == paletteScore();
 }
 
 static void onBracketItemDestruction(const Score* score, const BracketItem* item)

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -39,6 +39,7 @@
 #include "draw/iimageprovider.h"
 #include "global/iapplication.h"
 #include "../iengravingfontsprovider.h"
+#include "../ipalettescoreprovider.h"
 
 #include "../types/constants.h"
 
@@ -333,7 +334,7 @@ class Score : public EngravingObject, public muse::Contextable
     muse::GlobalInject<IEngravingFontsProvider> engravingFonts;
     muse::GlobalInject<muse::IApplication> application;
     muse::ContextInject<IEngravingElementsProvider> elementsProvider = { this };
-
+    muse::ContextInject<IPaletteScoreProvider> paletteScoreProvider = { this };
     // internal
     muse::GlobalInject<rendering::IScoreRenderer> renderer;
 
@@ -343,7 +344,7 @@ public:
     virtual ~Score();
     Score* clone();
 
-    static Score* paletteScore();
+    Score* paletteScore() const;
     bool isPaletteScore() const;
 
     virtual bool isMaster() const { return false; }

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -28,15 +28,11 @@
 #include "draw/internal/ifontsdatabase.h"
 
 #include "infrastructure/smufl.h"
-#include "infrastructure/localfileinfoprovider.h"
 
 #ifndef ENGRAVING_NO_INTERNAL
 #include "internal/engravingconfiguration.h"
 #include "internal/engravingfontsprovider.h"
-#endif
-
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-#include "engraving/accessibility/accessibleitem.h"
+#include "internal/palettescoreprovider.h"
 #endif
 
 #include "engraving/style/defaultstyle.h"
@@ -46,13 +42,10 @@
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/drumset.h"
 #include "engraving/dom/figuredbass.h"
-#include "engraving/dom/fret.h"
 
 #include "rendering/score/scorerenderer.h"
 #include "rendering/single/singlerenderer.h"
 #include "rendering/editmode/editmoderenderer.h"
-
-#include "compat/scoreaccess.h"
 
 #ifndef ENGRAVING_NO_API
 #include "global/api/iapiregister.h"
@@ -267,32 +260,6 @@ void EngravingModule::onInit(const IApplication::RunMode&)
     MScore::setNudgeStep10(1.0);     // Ctrl + cursor key (default 1.0)
     MScore::setNudgeStep50(0.01);     // Alt  + cursor key (default 0.01)
 
-    // Palette
-    {
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-        AccessibleItem::enabled = false;
-#endif
-        gpaletteScore = compat::ScoreAccess::createMasterScore(globalCtx());
-        gpaletteScore->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(""));
-
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-        AccessibleItem::enabled = true;
-#endif
-
-        if (gpaletteScore->elementsProvider()) {
-            gpaletteScore->elementsProvider()->unreg(gpaletteScore);
-        }
-
-#ifndef ENGRAVING_NO_INTERNAL
-        gpaletteScore->setStyle(DefaultStyle::baseStyle());
-        gpaletteScore->style().set(Sid::musicalTextFont, String(u"Leland Text"));
-        IEngravingFontPtr scoreFont = m_engravingfonts->fontByName("Leland");
-        gpaletteScore->setEngravingFont(scoreFont);
-        gpaletteScore->setNoteHeadWidth(scoreFont->width(SymId::noteheadBlack,
-                                                         gpaletteScore->style().spatium()) / gpaletteScore->style().defaultSpatium());
-#endif
-    }
-
     //! NOTE And some initialization in the `Notation::init()`
 }
 
@@ -303,12 +270,6 @@ void EngravingModule::onDeinit()
 #endif
 }
 
-void EngravingModule::onDestroy()
-{
-    delete gpaletteScore;
-    gpaletteScore = nullptr;
-}
-
 IContextSetup* EngravingModule::newContext(const muse::modularity::ContextPtr& ctx) const
 {
     return new EngravingContext(ctx);
@@ -316,7 +277,23 @@ IContextSetup* EngravingModule::newContext(const muse::modularity::ContextPtr& c
 
 void EngravingContext::registerExports()
 {
-#ifdef MUE_BUILD_ENGRAVING_DEVTOOLS
+#ifndef ENGRAVING_NO_INTERNAL
+    m_paletteScoreProvider = std::make_shared<PaletteScoreProvider>(iocContext());
+    ioc()->registerExport<IPaletteScoreProvider>(mname, m_paletteScoreProvider);
     ioc()->registerExport<IEngravingElementsProvider>(mname, new EngravingElementsProvider());
+#endif
+}
+
+void EngravingContext::onInit(const muse::IApplication::RunMode&)
+{
+#ifndef ENGRAVING_NO_INTERNAL
+    m_paletteScoreProvider->init();
+#endif
+}
+
+void EngravingContext::onDeinit()
+{
+#ifndef ENGRAVING_NO_INTERNAL
+    m_paletteScoreProvider->deinit();
 #endif
 }

--- a/src/engraving/engravingmodule.h
+++ b/src/engraving/engravingmodule.h
@@ -29,6 +29,7 @@
 namespace mu::engraving {
 class EngravingConfiguration;
 class EngravingFontsProvider;
+class PaletteScoreProvider;
 class EngravingModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -41,7 +42,6 @@ public:
     void registerUiTypes() override;
     void onInit(const muse::IApplication::RunMode& mode) override;
     void onDeinit() override;
-    void onDestroy() override;
 
     muse::modularity::IContextSetup* newContext(const muse::modularity::ContextPtr& ctx) const override;
 
@@ -59,6 +59,12 @@ public:
         : muse::modularity::IContextSetup(ctx) {}
 
     void registerExports() override;
+    void onInit(const muse::IApplication::RunMode& mode) override;
+    void onDeinit() override;
+
+private:
+
+    std::shared_ptr<PaletteScoreProvider> m_paletteScoreProvider;
 };
 }
 

--- a/src/engraving/internal/palettescoreprovider.cpp
+++ b/src/engraving/internal/palettescoreprovider.cpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ #include "palettescoreprovider.h"
+
+#ifndef ENGRAVING_NO_ACCESSIBILITY
+#include "../accessibility/accessibleitem.h"
+#endif
+
+ #include "../compat/scoreaccess.h"
+ #include "../infrastructure/localfileinfoprovider.h"
+ #include "../style/defaultstyle.h"
+
+using namespace muse;
+using namespace mu::engraving;
+
+PaletteScoreProvider::PaletteScoreProvider(const modularity::ContextPtr& iocCtx)
+    : muse::Contextable(iocCtx)
+{
+}
+
+PaletteScoreProvider::~PaletteScoreProvider()
+{
+}
+
+void PaletteScoreProvider::init()
+{
+#ifndef ENGRAVING_NO_ACCESSIBILITY
+    AccessibleItem::enabled = false;
+#endif
+    m_paletteScore = compat::ScoreAccess::createMasterScore(iocContext());
+    m_paletteScore->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(""));
+
+#ifndef ENGRAVING_NO_ACCESSIBILITY
+    AccessibleItem::enabled = true;
+#endif
+
+    if (m_paletteScore->elementsProvider()) {
+        m_paletteScore->elementsProvider()->unreg(m_paletteScore);
+    }
+
+    m_paletteScore->setStyle(DefaultStyle::baseStyle());
+    m_paletteScore->style().set(Sid::musicalTextFont, String(u"Leland Text"));
+    IEngravingFontPtr scoreFont = engravingfonts()->fontByName("Leland");
+    m_paletteScore->setEngravingFont(scoreFont);
+    m_paletteScore->setNoteHeadWidth(scoreFont->width(SymId::noteheadBlack,
+                                                      m_paletteScore->style().spatium()) / m_paletteScore->style().defaultSpatium());
+}
+
+void PaletteScoreProvider::deinit()
+{
+    delete m_paletteScore;
+    m_paletteScore = nullptr;
+}
+
+MasterScore* PaletteScoreProvider::paletteScore() const
+{
+    return m_paletteScore;
+}

--- a/src/engraving/internal/palettescoreprovider.h
+++ b/src/engraving/internal/palettescoreprovider.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ #pragma once
+
+ #include "modularity/ioc.h"
+ #include "../ipalettescoreprovider.h"
+ #include "../iengravingfontsprovider.h"
+
+namespace mu::engraving {
+class PaletteScoreProvider : public IPaletteScoreProvider, public muse::Contextable
+{
+    muse::GlobalInject<IEngravingFontsProvider> engravingfonts;
+public:
+    PaletteScoreProvider(const muse::modularity::ContextPtr& iocCtx);
+    ~PaletteScoreProvider() override;
+
+    void init();
+    void deinit();
+
+    MasterScore* paletteScore() const override;
+
+private:
+    MasterScore* m_paletteScore = nullptr;
+};
+}

--- a/src/engraving/ipalettescoreprovider.h
+++ b/src/engraving/ipalettescoreprovider.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ #pragma once
+
+ #include "modularity/imoduleinterface.h"
+
+namespace mu::engraving {
+class MasterScore;
+class IPaletteScoreProvider : MODULE_CONTEXT_INTERFACE
+{
+    INTERFACE_ID(IPaletteScoreProvider)
+
+public:
+    virtual ~IPaletteScoreProvider() = default;
+
+    virtual MasterScore* paletteScore() const = 0;
+};
+}

--- a/src/engraving/qml/MuseScore/Engraving/devtools/engravingelementsmodel.cpp
+++ b/src/engraving/qml/MuseScore/Engraving/devtools/engravingelementsmodel.cpp
@@ -224,7 +224,7 @@ void EngravingElementsModel::reload()
     EngravingObjectSet notpalettes;
 
     for (const mu::engraving::EngravingObject* el : elements) {
-        if (el == mu::engraving::gpaletteScore || el->score() == mu::engraving::gpaletteScore) {
+        if (el->score()->isPaletteScore()) {
             continue;
         }
 
@@ -252,7 +252,7 @@ void EngravingElementsModel::load(const EngravingObjectSet& elements, Item* root
 {
     TRACEFUNC;
     for (const mu::engraving::EngravingObject* el : elements) {
-        if (el == mu::engraving::gpaletteScore) {
+        if (el->score()->isPaletteScore()) {
             continue;
         }
 

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -89,24 +89,10 @@ void UiModule::registerExports()
 
     globalIoc()->registerExport<IUiConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IPlatformTheme>(moduleName(), m_platformTheme);
-
-#ifdef MUSE_MULTICONTEXT_WIP
-    globalIoc()->registerExport<INavigationController>(moduleName(), new NavigationController(globalCtx()));
-    globalIoc()->registerExport<IDragController>(moduleName(), new DragController());
-    globalIoc()->registerExport<IWindowsController>(moduleName(), new WindowsController());
-    globalIoc()->registerExport<IUiActionsRegister>(module_name, new UiActionsRegister(nullptr));
-    globalIoc()->registerExport<IMainWindow>(module_name, new MainWindow());
-#endif
 }
 
 void UiModule::resolveImports()
 {
-#ifdef MUSE_MULTICONTEXT_WIP
-    auto ar = globalIoc()->resolve<IUiActionsRegister>(moduleName());
-    if (ar) {
-        ar->reg(std::make_shared<NavigationUiActions>());
-    }
-#endif
 }
 
 void UiModule::registerApi()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -550,8 +550,8 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
     mu::engraving::SymId symNotehead;
 
     if (inputState.rest()) {
-        mu::engraving::Rest* rest = mu::engraving::Factory::createRest(
-            mu::engraving::gpaletteScore->dummy()->segment(), params.duration.type());
+        Score* s = score()->paletteScore() ? score()->paletteScore() : score();
+        mu::engraving::Rest* rest = mu::engraving::Factory::createRest(s->dummy()->segment(), params.duration.type());
         rest->setTicks(params.duration.fraction());
         symNotehead = rest->getSymbol(params.duration.type(), 0, staff->lines(position.segment->tick()));
         shadowNote.setState(symNotehead, params.duration, true, segmentSkylineTopY, segmentSkylineBottomY, params.position.beyondScore);

--- a/src/notationscene/utilities/engravingitempreviewpainter.cpp
+++ b/src/notationscene/utilities/engravingitempreviewpainter.cpp
@@ -55,7 +55,8 @@ void EngravingItemPreviewPainter::paintPreview(std::shared_ptr<engraving::render
 
     painter->translate(params.xoffset * params.spatium, params.yoffset * params.spatium); // additional offset for element only
 
-    const double sizeRatio = params.spatium / gpaletteScore->style().spatium();
+    const Score* score = element->score()->paletteScore() ? element->score()->paletteScore() : element->score();
+    const double sizeRatio = params.spatium / score->style().spatium();
     painter->scale(sizeRatio, sizeRatio); // scale coordinates so element is drawn at correct size
 
     // calculate bbox

--- a/src/notationscene/utilities/percussionutilities.cpp
+++ b/src/notationscene/utilities/percussionutilities.cpp
@@ -54,7 +54,7 @@ void PercussionUtilities::readDrumset(const muse::ByteArray& drumMapping, Drumse
 /// Returns a drum note prepared for preview.
 std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset* drumset, int pitch)
 {
-    double _spatium = gpaletteScore->style().spatium(); // TODO: Don't use palette here?
+    double _spatium = paletteScoreProvider()->paletteScore()->style().spatium(); // TODO: Don't use palette here?
 
     bool up = false;
     int line = drumset->line(pitch);
@@ -70,7 +70,7 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
         up = line > 4;
     }
 
-    auto chord = Factory::makeChord(gpaletteScore->dummy()->segment());
+    auto chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy()->segment());
     chord->setDurationType(DurationType::V_QUARTER);
     chord->setStemDirection(dir);
     chord->setIsUiItem(true);

--- a/src/notationscene/utilities/percussionutilities.h
+++ b/src/notationscene/utilities/percussionutilities.h
@@ -22,10 +22,11 @@
 
 #pragma once
 
+#include "global/modularity/ioc.h"
 #include "ui/iuiactionsregister.h"
 #include "shortcuts/ishortcutsregister.h"
-
 #include "interactive/iinteractive.h"
+#include "engraving/ipalettescoreprovider.h"
 
 #include "engraving/rendering/isinglerenderer.h"
 
@@ -37,12 +38,11 @@
 namespace mu::notation {
 class PercussionUtilities : public muse::Contextable
 {
+    muse::GlobalInject<mu::engraving::rendering::ISingleRenderer> engravingRender;
     muse::ContextInject<muse::ui::IUiActionsRegister> uiactionsRegister = { this };
     muse::ContextInject<muse::shortcuts::IShortcutsRegister> shortcutsRegister = { this };
-
+    muse::ContextInject<mu::engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
     muse::ContextInject<muse::IInteractive> interactive = { this };
-
-    muse::GlobalInject<mu::engraving::rendering::ISingleRenderer> engravingRender;
 
 public:
 

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -131,7 +131,7 @@ PaletteCellPtr Palette::insertActionIcon(size_t idx, ActionIconType type, Action
 {
     const muse::ui::UiAction& action = actionsRegister()->action(code);
     QString name = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslatedWithoutMnemonic();
-    auto icon = std::make_shared<ActionIcon>(gpaletteScore->dummy());
+    auto icon = std::make_shared<ActionIcon>(paletteScoreProvider()->paletteScore()->dummy());
     icon->setActionType(type);
     icon->setAction(code, static_cast<char16_t>(action.iconCode));
 
@@ -166,7 +166,7 @@ PaletteCellPtr Palette::appendActionIcon(ActionIconType type, ActionCode code, d
 {
     const muse::ui::UiAction& action = actionsRegister()->action(code);
     const QString name = !action.description.isEmpty() ? action.description.str : action.title.raw().str;
-    auto icon = std::make_shared<ActionIcon>(gpaletteScore->dummy());
+    auto icon = std::make_shared<ActionIcon>(paletteScoreProvider()->paletteScore()->dummy());
     icon->setActionType(type);
     icon->setAction(code, static_cast<char16_t>(action.iconCode));
 
@@ -345,7 +345,7 @@ bool Palette::read(XmlReader& e, bool pasteMode)
     }
 
     PaletteCompat::removeOldItemsIfNeeded(*this);
-    PaletteCompat::addNewItemsIfNeeded(*this, gpaletteScore);
+    PaletteCompat::addNewItemsIfNeeded(*this, paletteScoreProvider()->paletteScore());
 
     return true;
 }
@@ -457,7 +457,7 @@ bool Palette::readFromFile(const QString& p)
             QString version = e.attribute("version");
             QStringList sl = version.split('.');
             int mscVersion = sl[0].toInt() * 100 + sl[1].toInt();
-            gpaletteScore->setMscVersion(mscVersion);
+            paletteScoreProvider()->paletteScore()->setMscVersion(mscVersion);
 
             while (e.readNextStartElement()) {
                 if (e.name() == "Palette") {

--- a/src/palette/internal/palette.h
+++ b/src/palette/internal/palette.h
@@ -26,15 +26,15 @@
 
 #include "palettecell.h"
 
+#include "modularity/ioc.h"
+#include "../ipaletteconfiguration.h"
+#include "interactive/iinteractive.h"
 #include "engraving/rendering/isinglerenderer.h"
+#include "engraving/ipalettescoreprovider.h"
 #include "engraving/dom/engravingitem.h"
 
 #include "types/translatablestring.h"
 #include "actions/actiontypes.h"
-
-#include "modularity/ioc.h"
-#include "../ipaletteconfiguration.h"
-#include "interactive/iinteractive.h"
 
 namespace mu::engraving {
 enum class ActionIconType : signed char;
@@ -54,6 +54,7 @@ class Palette : public QObject, public muse::Contextable
     muse::GlobalInject<engraving::rendering::ISingleRenderer> engravingRender;
     muse::ContextInject<muse::ui::IUiActionsRegister> actionsRegister = { this };
     muse::ContextInject<muse::IInteractive> interactive = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     enum class Type {

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -221,8 +221,8 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
             visible = e.readBool();
         } else if (s == "Tremolo") {
             compat::TremoloCompat tc;
-            tc.parent = gpaletteScore->dummy()->chord();
-            rw::RWRegister::reader(gpaletteScore->mscVersion())->readTremoloCompat(&tc, e);
+            tc.parent = paletteScoreProvider()->paletteScore()->dummy()->chord();
+            rw::RWRegister::reader(paletteScoreProvider()->paletteScore()->mscVersion())->readTremoloCompat(&tc, e);
             if (tc.single) {
                 element.reset(tc.single);
             } else if (tc.two) {
@@ -235,11 +235,11 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
                 element->styleChanged();
             }
         } else {
-            element.reset(Factory::createItemByName(s, gpaletteScore->dummy()));
+            element.reset(Factory::createItemByName(s, paletteScoreProvider()->paletteScore()->dummy()));
             if (!element) {
                 e.unknown();
             } else {
-                rw::RWRegister::reader(gpaletteScore->mscVersion())->readItem(element.get(), e);
+                rw::RWRegister::reader(paletteScoreProvider()->paletteScore()->mscVersion())->readItem(element.get(), e);
             }
         }
     }
@@ -247,7 +247,7 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
     setElementTranslated(translateElement);
 
     if (element) {
-        PaletteCompat::migrateOldPaletteCellIfNeeded(this, gpaletteScore);
+        PaletteCompat::migrateOldPaletteCellIfNeeded(this, paletteScoreProvider()->paletteScore());
         element->styleChanged();
 
         if (element->isActionIcon()) {
@@ -325,7 +325,10 @@ PaletteCellPtr PaletteCell::fromElementMimeData(const QByteArray& data, const mu
 {
     PointF dragOffset;
     Fraction duration(1, 4);
-    ElementPtr element(EngravingItem::readMimeData(gpaletteScore, ByteArray::fromQByteArrayNoCopy(data), &dragOffset, &duration));
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { iocCtx };
+    ElementPtr element(EngravingItem::readMimeData(paletteScoreProvider()->paletteScore(),
+                                                   muse::ByteArray::fromQByteArrayNoCopy(data),
+                                                   &dragOffset, &duration));
 
     if (!element) {
         return nullptr;
@@ -336,7 +339,7 @@ PaletteCellPtr PaletteCell::fromElementMimeData(const QByteArray& data, const mu
     }
 
     if (element->isActionIcon()) {
-        muse::Inject<muse::ui::IUiActionsRegister> aregister = { iocCtx };
+        muse::ContextInject<muse::ui::IUiActionsRegister> aregister = { iocCtx };
         ActionIcon* icon = toActionIcon(element.get());
         const muse::ui::UiAction& action = aregister()->action(icon->actionCode());
         if (action.isValid()) {

--- a/src/palette/internal/palettecell.h
+++ b/src/palette/internal/palettecell.h
@@ -28,6 +28,7 @@
 
 #include "modularity/ioc.h"
 #include "ui/iuiactionsregister.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::engraving {
 class XmlReader;
@@ -67,7 +68,7 @@ class PaletteCell : public QObject, public muse::Contextable
 {
     Q_OBJECT
     muse::ContextInject<muse::ui::IUiActionsRegister> actionsRegister = { this };
-
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 public:
     explicit PaletteCell(const muse::modularity::ContextPtr& iocCtx, QObject* parent = nullptr);
     PaletteCell(const muse::modularity::ContextPtr& iocCtx, mu::engraving::ElementPtr e, const QString& _name, qreal _mag = 1.0,

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -141,6 +141,11 @@ std::shared_ptr<C> makeElement(mu::engraving::Score* score, Args&&... args)
     return makeElementImplWrapper<C>::makeElementImpl(score, std::forward<Args>(args)...);
 }
 
+engraving::MasterScore* PaletteCreator::paletteScore() const
+{
+    return paletteScoreProvider()->paletteScore();
+}
+
 PaletteTreePtr PaletteCreator::newMasterPaletteTree()
 {
     PaletteTreePtr tree = std::make_shared<PaletteTree>();
@@ -257,7 +262,7 @@ PalettePtr PaletteCreator::newDynamicsPalette(bool defaultPalette)
     };
 
     for (const char* dynamicType : defaultPalette ? defaultDynamics : masterDynamics) {
-        auto dynamic = makeElement<Dynamic>(mu::engraving::gpaletteScore);
+        auto dynamic = makeElement<Dynamic>(paletteScore());
         dynamic->setDynamicType(String::fromAscii(dynamicType));
         sp->appendElement(dynamic, TConv::userName(dynamic->dynamicType()));
     }
@@ -270,7 +275,7 @@ PalettePtr PaletteCreator::newDynamicsPalette(bool defaultPalette)
     };
 
     for (HairpinType hairpinType : hairpins) {
-        auto hairpin = Factory::makeHairpin(gpaletteScore->dummy());
+        auto hairpin = Factory::makeHairpin(paletteScore()->dummy());
         hairpin->setHairpinType(hairpinType);
         qreal mag = (hairpinType == HairpinType::CRESC_LINE || hairpinType == HairpinType::DIM_LINE) ? 1 : 0.9;
         const QPointF offset = (hairpinType == HairpinType::CRESC_LINE || hairpinType == HairpinType::DIM_LINE)
@@ -291,16 +296,16 @@ PalettePtr PaletteCreator::newKeySigPalette()
     sp->setYOffset(1.0);
 
     for (int i = 0; i < 7; ++i) {
-        auto k = Factory::makeKeySig(mu::engraving::gpaletteScore->dummy()->segment());
+        auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
         k->setKey(Key(i + 1));
         sp->appendElement(k, TConv::userName(Key(i + 1)));
     }
     for (int i = -7; i < 0; ++i) {
-        auto k = Factory::makeKeySig(mu::engraving::gpaletteScore->dummy()->segment());
+        auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
         k->setKey(Key(i));
         sp->appendElement(k, TConv::userName(Key(i)));
     }
-    auto k = Factory::makeKeySig(mu::engraving::gpaletteScore->dummy()->segment());
+    auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
     k->setKey(Key::C);
     sp->appendElement(k, TConv::userName(Key::C));
 
@@ -309,7 +314,7 @@ PalettePtr PaletteCreator::newKeySigPalette()
     nke.setConcertKey(Key::C);
     nke.setCustom(true);
     nke.setMode(KeyMode::NONE);
-    auto nk = Factory::makeKeySig(mu::engraving::gpaletteScore->dummy()->segment());
+    auto nk = Factory::makeKeySig(paletteScore()->dummy()->segment());
     nk->setKeySigEvent(nke);
     sp->appendElement(nk, TConv::userName(Key::C, true));
 
@@ -331,7 +336,7 @@ PalettePtr PaletteCreator::newAccidentalsPalette(bool defaultPalette)
     }
 
     for (int i = int(AccidentalType::FLAT); i < end; ++i) {
-        auto ac = Factory::makeAccidental(gpaletteScore->dummy());
+        auto ac = Factory::makeAccidental(paletteScore()->dummy());
         ac->setAccidentalType(AccidentalType(i));
         if (ac->symId() != SymId::noSym) {
             sp->appendElement(ac, ac->subtypeUserName());
@@ -356,7 +361,7 @@ PalettePtr PaletteCreator::newBarLinePalette(bool defaultPalette)
 
     // bar line styles
     for (const BarLineTableItem& bti : BarLine::barLineTable) {
-        auto b = Factory::makeBarLine(gpaletteScore->dummy()->segment());
+        auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
         b->setBarLineType(bti.type);
         sp->appendElement(b, bti.userName);
     }
@@ -373,7 +378,7 @@ PalettePtr PaletteCreator::newBarLinePalette(bool defaultPalette)
             { BARLINE_SPAN_SHORT2_FROM, BARLINE_SPAN_SHORT2_TO, muse::TranslatableString("engraving/sym", "Short barline 2") }, // Not in SMuFL
         };
         for (auto span : spans) {
-            auto b = Factory::makeBarLine(gpaletteScore->dummy()->segment());
+            auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
             b->setBarLineType(BarLineType::NORMAL);
             b->setSpanFrom(span.from);
             b->setSpanTo(span.to);
@@ -408,7 +413,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     };
 
     for (MeasureRepeatInfo repeat: defaultPalette ? defaultMeasureRepeats : masterMeasureRepeats) {
-        std::shared_ptr<MeasureRepeat> rm = makeElement<MeasureRepeat>(gpaletteScore);
+        std::shared_ptr<MeasureRepeat> rm = makeElement<MeasureRepeat>(paletteScore());
         rm->mutldata()->symId = repeat.id;
         rm->setNumMeasures(repeat.measuresCount);
         sp->appendElement(rm, SymNames::userNameForSymId(repeat.id));
@@ -437,7 +442,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
             continue;
         }
 
-        auto mk = makeElement<Marker>(gpaletteScore);
+        auto mk = makeElement<Marker>(paletteScore());
         mk->setMarkerType(markerType);
         mk->styleChanged();
         sp->appendElement(mk, TConv::userName(markerType));
@@ -453,7 +458,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     };
 
     for (const JumpTypeTableItem& item : (defaultPalette ? defaultJumpTypeTable : jumpTypeTable)) {
-        auto jp = makeElement<Jump>(gpaletteScore);
+        auto jp = makeElement<Jump>(paletteScore());
         jp->setJumpType(item.type);
         sp->appendElement(jp, TConv::userName(item.type));
     }
@@ -468,13 +473,13 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
             continue;
         }
 
-        auto b = Factory::makeBarLine(gpaletteScore->dummy()->segment());
+        auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
         b->setBarLineType(bti.type);
         PaletteCellPtr cell = sp->appendElement(b, bti.userName);
         cell->drawStaff = false;
     }
 
-    auto volta = makeElement<Volta>(gpaletteScore);
+    auto volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::CLOSED);
     volta->setText(u"1.");
     std::vector<int> il;
@@ -482,7 +487,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     volta->setEndings(il);
     sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Prima volta"));
 
-    volta = makeElement<Volta>(gpaletteScore);
+    volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::OPEN);
     volta->setText(u"2.");
     il.clear();
@@ -490,7 +495,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     volta->setEndings(il);
     sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Seconda volta, open"));
 
-    volta = makeElement<Volta>(gpaletteScore);
+    volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::CLOSED);
     volta->setText(u"2.");
     il.clear();
@@ -498,7 +503,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     volta->setEndings(il);
     sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Seconda volta"));
 
-    volta = makeElement<Volta>(gpaletteScore);
+    volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::CLOSED);
     volta->setText(u"3.");
     il.clear();
@@ -507,11 +512,11 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
     sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Terza volta"));
 
     if (!defaultPalette) {
-        auto vibrato = makeElement<Vibrato>(gpaletteScore);
+        auto vibrato = makeElement<Vibrato>(paletteScore());
         vibrato->setVibratoType(VibratoType::VIBRATO_SAWTOOTH);
         sp->appendElement(vibrato, TConv::userName(VibratoType::VIBRATO_SAWTOOTH));
 
-        vibrato = makeElement<Vibrato>(gpaletteScore);
+        vibrato = makeElement<Vibrato>(paletteScore());
         vibrato->setVibratoType(VibratoType::VIBRATO_SAWTOOTH_WIDE);
         sp->appendElement(vibrato, TConv::userName(VibratoType::VIBRATO_SAWTOOTH_WIDE));
     }
@@ -533,13 +538,13 @@ PalettePtr PaletteCreator::newLayoutPalette(bool defaultPalette)
         LayoutBreakType::SECTION,
     };
     for (LayoutBreakType layoutBreakType : layoutBreaks) {
-        auto lb = Factory::makeLayoutBreak(gpaletteScore->dummy()->measure());
+        auto lb = Factory::makeLayoutBreak(paletteScore()->dummy()->measure());
         lb->setLayoutBreakType(layoutBreakType);
         sp->appendElement(lb, TConv::userName(layoutBreakType));
     }
 
     if (!defaultPalette) {
-        auto lb = Factory::makeLayoutBreak(gpaletteScore->dummy()->measure());
+        auto lb = Factory::makeLayoutBreak(paletteScore()->dummy()->measure());
         lb->setLayoutBreakType(LayoutBreakType::NOBREAK);
         sp->appendElement(lb, TConv::userName(LayoutBreakType::NOBREAK));
     }
@@ -552,7 +557,7 @@ PalettePtr PaletteCreator::newLayoutPalette(bool defaultPalette)
         SpacerType::FIXED
     };
     for (SpacerType spacerType : spacers) {
-        auto spacer = Factory::makeSpacer(gpaletteScore->dummy()->measure());
+        auto spacer = Factory::makeSpacer(paletteScore()->dummy()->measure());
         spacer->setSpacerType(spacerType);
         spacer->setGap(3_sp);
         PaletteCellPtr cell = sp->appendElement(spacer, spacer->subtypeUserName());
@@ -580,14 +585,14 @@ PalettePtr PaletteCreator::newFingeringPalette(bool defaultPalette)
 
     const char* finger = "012345";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "Fingering %1"));
     }
 
     finger = "pimac";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->setTextStyleType(TextStyleType::RH_GUITAR_FINGERING);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "RH guitar fingering %1"));
@@ -595,14 +600,14 @@ PalettePtr PaletteCreator::newFingeringPalette(bool defaultPalette)
 
     finger = "012345T";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->setTextStyleType(TextStyleType::LH_GUITAR_FINGERING);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "LH guitar fingering %1"));
     }
     finger = defaultPalette ? "123456" : "0123456789";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->initTextStyleType(TextStyleType::STRING_NUMBER);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "String number %1"));
@@ -618,7 +623,7 @@ PalettePtr PaletteCreator::newFingeringPalette(bool defaultPalette)
     };
     // include additional symbol-based fingerings (temporarily?) implemented as articulations
     for (auto i : defaultPalette ? defaultLute : masterLute) {
-        auto s = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
@@ -634,13 +639,13 @@ PalettePtr PaletteCreator::newTremoloPalette()
     sp->setVisible(false);
 
     for (int i = int(TremoloType::R8); i <= int(TremoloType::BUZZ_ROLL); ++i) {
-        auto tremolo = Factory::makeTremoloSingleChord(gpaletteScore->dummy()->chord());
+        auto tremolo = Factory::makeTremoloSingleChord(paletteScore()->dummy()->chord());
         tremolo->setTremoloType(TremoloType(i));
         sp->appendElement(tremolo, tremolo->subtypeUserName());
     }
 
     for (int i = int(TremoloType::C8); i <= int(TremoloType::C64); ++i) {
-        auto tremolo = Factory::makeTremoloTwoChord(gpaletteScore->dummy()->chord());
+        auto tremolo = Factory::makeTremoloTwoChord(paletteScore()->dummy()->chord());
         tremolo->setTremoloType(TremoloType(i));
         sp->appendElement(tremolo, tremolo->subtypeUserName());
     }
@@ -653,7 +658,7 @@ PalettePtr PaletteCreator::newTremoloPalette()
     };
     // include additional symbol-based tremolo articulations, implemented as articulations
     for (auto i : dots) {
-        auto s = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
@@ -675,7 +680,7 @@ PalettePtr PaletteCreator::newNoteHeadsPalette()
         if (i == int(NoteHeadGroup::HEAD_BREVIS_ALT)) {
             sym = Note::noteHead(0, NoteHeadGroup(i), NoteHeadType::HEAD_BREVIS);
         }
-        auto nh = makeElement<NoteHead>(gpaletteScore);
+        auto nh = makeElement<NoteHead>(paletteScore());
         nh->setSym(sym);
         sp->appendElement(nh, TConv::userName((NoteHeadGroup(i))));
     }
@@ -692,7 +697,7 @@ PalettePtr PaletteCreator::newArticulationsPalette(bool defaultPalette)
     sp->setGridSize(42, 25);
     sp->setDrawGrid(true);
 
-    auto slur = Factory::makeSlur(gpaletteScore->dummy());
+    auto slur = Factory::makeSlur(paletteScore()->dummy());
     sp->appendElement(slur, QT_TRANSLATE_NOOP("palette", "Slur"));
 
     // do not include additional symbol-based fingerings (temporarily?) implemented as articulations
@@ -761,7 +766,7 @@ PalettePtr PaletteCreator::newArticulationsPalette(bool defaultPalette)
     };
 
     for (SymId articulationType : defaultPalette ? defaultArticulations : masterArticulations) {
-        auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
         artic->setSymId(articulationType);
         sp->appendElement(artic, artic->subtypeUserName());
     }
@@ -813,7 +818,7 @@ PalettePtr PaletteCreator::newOrnamentsPalette(bool defaultPalette)
     };
 
     for (auto ornamentType : defaultPalette ? defaultOrnaments : masterOrnaments) {
-        auto ornament = Factory::makeOrnament(gpaletteScore->dummy()->chord());
+        auto ornament = Factory::makeOrnament(paletteScore()->dummy()->chord());
         ornament->setSymId(ornamentType);
         qreal mag = ornament->symId() == SymId::ornamentTrill ? 1.0 : 1.2;
         sp->appendElement(ornament, ornament->subtypeUserName(), mag);
@@ -824,7 +829,7 @@ PalettePtr PaletteCreator::newOrnamentsPalette(bool defaultPalette)
     };
 
     for (TrillType trillType : trillTypes) {
-        auto trill = makeElement<Trill>(gpaletteScore);
+        auto trill = makeElement<Trill>(paletteScore());
         trill->setTrillType(trillType);
 
         qreal mag = (trillType == TrillType::TRILL_LINE || trillType == TrillType::PRALLPRALL_LINE) ? 1.0 : 0.8;
@@ -907,7 +912,7 @@ PalettePtr PaletteCreator::newAccordionPalette()
         SymId::accdnRicochetStem6
     };
     for (auto i : art) {
-        auto s = makeElement<Symbol>(gpaletteScore);
+        auto s = makeElement<Symbol>(paletteScore());
         s->setSym(i);
         sp->appendElement(s, SymNames::userNameForSymId(i));
     }
@@ -930,12 +935,12 @@ PalettePtr PaletteCreator::newBracketsPalette()
         { BracketType::LINE,   QT_TRANSLATE_NOOP("palette", "Line") }
     } };
 
-    static Part* bracketItemOwnerPart = new Part(gpaletteScore);
+    static Part* bracketItemOwnerPart = new Part(paletteScore());
     static Staff* bracketItemOwner = Factory::createStaff(bracketItemOwnerPart);
     bracketItemOwner->setBracketType(types.size() - 1, BracketType::NORMAL);
 
     for (size_t i = 0; i < types.size(); ++i) {
-        auto b1 = Factory::makeBracket(gpaletteScore->dummy());
+        auto b1 = Factory::makeBracket(paletteScore()->dummy());
         auto bi1 = bracketItemOwner->brackets()[i];
         const auto& type = types[i];
         bi1->setBracketType(type.first);
@@ -974,7 +979,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
     // Breaths
 
     for (auto i : defaultPalette ? defaultFermatas : masterFermatas) {
-        auto f = Factory::makeFermata(gpaletteScore->dummy()->segment());
+        auto f = Factory::makeFermata(paletteScore()->dummy()->segment());
         f->setSymIdAndTimeStretch(i);
         sp->appendElement(f, f->subtypeUserName());
     }
@@ -983,7 +988,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
         if ((breath.id == SymId::chantCaesura || breath.id == SymId::caesuraSingleStroke) && defaultPalette) {
             continue;
         }
-        auto a = Factory::makeBreath(gpaletteScore->dummy()->segment());
+        auto a = Factory::makeBreath(paletteScore()->dummy()->segment());
         a->setSymId(breath.id);
         a->setPause(breath.pause);
         sp->appendElement(a, SymNames::userNameForSymId(breath.id));
@@ -1005,13 +1010,13 @@ PalettePtr PaletteCreator::newArpeggioPalette()
             // Deprecated, now handled by CHORD_BRACKET
             continue;
         }
-        auto a = Factory::makeArpeggio(gpaletteScore->dummy()->chord());
+        auto a = Factory::makeArpeggio(paletteScore()->dummy()->chord());
         a->setArpeggioType(ArpeggioType(i));
         sp->appendElement(a, a->arpeggioTypeName());
     }
 
     for (int i = 0; i < 2; ++i) {
-        auto a = makeElement<Glissando>(gpaletteScore);
+        auto a = makeElement<Glissando>(paletteScore());
         a->setGlissandoType(GlissandoType(i));
         if (a->glissandoType() != a->style().styleV(Sid::glissandoType).value<GlissandoType>()) {
             a->setPropertyFlags(Pid::GLISS_TYPE, PropertyFlags::UNSTYLED);
@@ -1029,20 +1034,20 @@ PalettePtr PaletteCreator::newArpeggioPalette()
     };
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(gpaletteScore->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
         cl->setChordLineType(chordLineType);
         sp->appendElement(cl, cl->chordLineTypeName());
     }
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(gpaletteScore->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
         cl->setChordLineType(chordLineType);
         cl->setStraight(true);
         sp->appendElement(cl, cl->chordLineTypeName());
     }
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(gpaletteScore->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
         cl->setChordLineType(chordLineType);
         cl->setStraight(true);
         cl->setWavy(true);
@@ -1077,7 +1082,7 @@ PalettePtr PaletteCreator::newClefsPalette(bool defaultPalette)
     };
 
     for (ClefType clefType : defaultPalette ? clefsDefault : clefsMaster) {
-        auto clef = Factory::makeClef(gpaletteScore->dummy()->segment());
+        auto clef = Factory::makeClef(paletteScore()->dummy()->segment());
         clef->setClefType(ClefTypeList(clefType, clefType));
         sp->appendElement(clef, TConv::userName(clefType));
     }
@@ -1116,7 +1121,7 @@ PalettePtr PaletteCreator::newBagpipeEmbellishmentPalette()
     sp->setVisible(false);
 
     for (size_t i = 0; i < TConv::embellishmentsCount(); ++i) {
-        auto b = makeElement<BagpipeEmbellishment>(gpaletteScore);
+        auto b = makeElement<BagpipeEmbellishment>(paletteScore());
         b->setEmbelType(EmbellishmentType(i));
         // TODO: pass TranslatableString
         sp->appendElement(b, TConv::userName(static_cast<EmbellishmentType>(i)).str);
@@ -1134,7 +1139,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     sp->setDrawGrid(true);
     sp->setVisible(false);
 
-    auto slur = Factory::makeSlur(gpaletteScore->dummy());
+    auto slur = Factory::makeSlur(paletteScore()->dummy());
     sp->appendElement(slur, QT_TRANSLATE_NOOP("palette", "Slur"));
 
     static const std::vector<HairpinType> hairpins {
@@ -1145,12 +1150,12 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     };
 
     for (HairpinType hairpinType : hairpins) {
-        auto hairpin = Factory::makeHairpin(gpaletteScore->dummy());
+        auto hairpin = Factory::makeHairpin(paletteScore()->dummy());
         hairpin->setHairpinType(hairpinType);
         sp->appendElement(hairpin, hairpin->subtypeUserName());
     }
 
-    auto volta = makeElement<Volta>(gpaletteScore);
+    auto volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::CLOSED);
     volta->setText(u"1.");
     std::vector<int> il;
@@ -1159,7 +1164,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Prima volta"));
 
     if (!defaultPalette) {
-        volta = makeElement<Volta>(gpaletteScore);
+        volta = makeElement<Volta>(paletteScore());
         volta->setVoltaType(Volta::Type::CLOSED);
         volta->setText(u"2.");
         il.clear();
@@ -1167,7 +1172,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         volta->setEndings(il);
         sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Seconda volta"));
 
-        volta = makeElement<Volta>(gpaletteScore);
+        volta = makeElement<Volta>(paletteScore());
         volta->setVoltaType(Volta::Type::CLOSED);
         volta->setText(u"3.");
         il.clear();
@@ -1176,7 +1181,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         sp->appendElement(volta, QT_TRANSLATE_NOOP("palette", "Terza volta"));
     }
 
-    volta = makeElement<Volta>(gpaletteScore);
+    volta = makeElement<Volta>(paletteScore());
     volta->setVoltaType(Volta::Type::OPEN);
     volta->setText(u"2.");
     il.clear();
@@ -1198,27 +1203,27 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         OttavaType::OTTAVA_22MB
     };
     for (OttavaType ottavaType : defaultPalette ? ottavasDefault : ottavasMaster) {
-        auto ottava = makeElement<Ottava>(gpaletteScore);
+        auto ottava = makeElement<Ottava>(paletteScore());
         ottava->setOttavaType(ottavaType);
         ottava->styleChanged();
         sp->appendElement(ottava, ottava->subtypeUserName());
     }
 
-    auto pedal = makeElement<Pedal>(gpaletteScore);
+    auto pedal = makeElement<Pedal>(paletteScore());
     pedal->setEndHookType(HookType::HOOK_90);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (with ped and line)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setLineVisible(false);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (with ped and asterisk)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setBeginHookType(HookType::HOOK_90);
     pedal->setEndHookType(HookType::HOOK_90);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1227,7 +1232,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (straight hooks)"));
 
     if (!defaultPalette) {
-        pedal = makeElement<Pedal>(gpaletteScore);
+        pedal = makeElement<Pedal>(paletteScore());
         pedal->setBeginHookType(HookType::HOOK_90);
         pedal->setEndHookType(HookType::HOOK_45);
         pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1235,7 +1240,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
         sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (angled end hook)"));
 
-        pedal = makeElement<Pedal>(gpaletteScore);
+        pedal = makeElement<Pedal>(paletteScore());
         pedal->setBeginHookType(HookType::HOOK_45);
         pedal->setEndHookType(HookType::HOOK_45);
         pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1243,7 +1248,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
         sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (both hooks angled)"));
 
-        pedal = makeElement<Pedal>(gpaletteScore);
+        pedal = makeElement<Pedal>(paletteScore());
         pedal->setBeginHookType(HookType::HOOK_45);
         pedal->setEndHookType(HookType::HOOK_90);
         pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1261,49 +1266,49 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     };
 
     for (TrillType trillType : defaultPalette ? defaultTrills : trillTypes) {
-        auto trill = makeElement<Trill>(gpaletteScore);
+        auto trill = makeElement<Trill>(paletteScore());
         trill->setTrillType(trillType);
         sp->appendElement(trill, TConv::userName(trillType));
     }
 
-    auto staffTextLine = makeElement<TextLine>(gpaletteScore);
+    auto staffTextLine = makeElement<TextLine>(paletteScore());
     staffTextLine->setBeginText(u"Staff");
     staffTextLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(staffTextLine, QT_TRANSLATE_NOOP("palette", "Staff text line"));
 
-    auto systemTextLine = makeElement<TextLine>(gpaletteScore, true);
-    systemTextLine->setLen(12 * gpaletteScore->style().spatium());
+    auto systemTextLine = makeElement<TextLine>(paletteScore(), true);
+    systemTextLine->setLen(12 * paletteScore()->style().spatium());
     systemTextLine->setBeginText(u"System");
     systemTextLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(systemTextLine, QT_TRANSLATE_NOOP("palette", "System text line"));
 
     if (!defaultPalette) {
-        auto textLine = makeElement<TextLine>(gpaletteScore);
+        auto textLine = makeElement<TextLine>(paletteScore());
         textLine->setBeginText(u"VII");
         textLine->setEndHookType(HookType::HOOK_90);
         sp->appendElement(textLine, QT_TRANSLATE_NOOP("palette", "Text line"));
     }
 
-    auto line = makeElement<TextLine>(gpaletteScore);
+    auto line = makeElement<TextLine>(paletteScore());
     line->setDiagonal(true);
     sp->appendElement(line, QT_TRANSLATE_NOOP("palette", "Line"));
 
-    auto rightArrowLine = makeElement<TextLine>(gpaletteScore);
+    auto rightArrowLine = makeElement<TextLine>(paletteScore());
     rightArrowLine->setDiagonal(true);
     rightArrowLine->setEndHookType(HookType::ARROW);
     sp->appendElement(rightArrowLine, QT_TRANSLATE_NOOP("palette", "Line (right arrowhead)"));
 
-    auto leftArrowLine = makeElement<TextLine>(gpaletteScore);
+    auto leftArrowLine = makeElement<TextLine>(paletteScore());
     leftArrowLine->setDiagonal(true);
     leftArrowLine->setBeginHookType(HookType::ARROW);
     sp->appendElement(leftArrowLine, QT_TRANSLATE_NOOP("palette", "Line (left arrowhead)"));
 
     sp->appendActionIcon(ActionIconType::NOTE_ANCHORED_LINE, "add-noteline", 2);
 
-    auto a = Factory::makeAmbitus(gpaletteScore->dummy()->segment());
+    auto a = Factory::makeAmbitus(paletteScore()->dummy()->segment());
     sp->appendElement(a, QT_TRANSLATE_NOOP("palette", "Ambitus"));
 
-    auto letRing = makeElement<LetRing>(gpaletteScore);
+    auto letRing = makeElement<LetRing>(paletteScore());
     sp->appendElement(letRing, QT_TRANSLATE_NOOP("palette", "Let ring"));
 
     static const std::vector<VibratoType> vibratoTable = {
@@ -1316,12 +1321,12 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     };
 
     for (VibratoType vibratoType : defaultPalette ? defaultVibratoTable : vibratoTable) {
-        auto vibrato = makeElement<Vibrato>(gpaletteScore);
+        auto vibrato = makeElement<Vibrato>(paletteScore());
         vibrato->setVibratoType(vibratoType);
         sp->appendElement(vibrato, TConv::userName(vibratoType));
     }
 
-    auto pm = makeElement<PalmMute>(gpaletteScore);
+    auto pm = makeElement<PalmMute>(paletteScore());
     sp->appendElement(pm, QT_TRANSLATE_NOOP("palette", "Palm mute"));
 
     std::array<QString, 3> names = { QT_TRANSLATE_NOOP("palette", "Chord bracket"),
@@ -1329,7 +1334,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
                                      QT_TRANSLATE_NOOP("palette", "Chord bracket (play with right hand)") };
     for (int i = 0; i < 3; ++i) {
         DirectionV hookPos = DirectionV(i);
-        auto c = Factory::makeChordBracket(gpaletteScore->dummy()->chord());
+        auto c = Factory::makeChordBracket(paletteScore()->dummy()->chord());
         c->setProperty(Pid::BRACKET_HOOK_POS, hookPos);
         sp->appendElement(c, names[i]);
     }
@@ -1417,7 +1422,7 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     };
 
     for (TempoPattern tp : tps) {
-        auto tt = makeElement<TempoText>(gpaletteScore);
+        auto tt = makeElement<TempoText>(paletteScore());
         tt->setFollowText(tp.followText);
         tt->setXmlText(tp.pattern);
         if (tp.relative) {
@@ -1454,7 +1459,7 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     };
 
     for (const auto& pair : defaultPalette ? DEFAULT_TEMPO_CHANGE : MASTER_TEMPO_CHANGE) {
-        auto item = makeElement<GradualTempoChange>(gpaletteScore);
+        auto item = makeElement<GradualTempoChange>(paletteScore());
         item->setTempoChangeType(pair.first);
         const String& text = String::fromUtf8(pair.second);
         item->setBeginText(text);
@@ -1463,20 +1468,20 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     }
 
     const char* aTempoStr = QT_TRANSLATE_NOOP("palette", "a tempo");
-    auto aTempoTxt = makeElement<TempoText>(gpaletteScore);
+    auto aTempoTxt = makeElement<TempoText>(paletteScore());
     aTempoTxt->setFollowText(true);
     aTempoTxt->setXmlText(aTempoStr);
     aTempoTxt->setATempo();
     sp->appendElement(aTempoTxt, aTempoStr, 1.3);
 
     const char* tempoPrimoStr = QT_TRANSLATE_NOOP("palette", "tempo primo");
-    auto tempoPrimoTxt = makeElement<TempoText>(gpaletteScore);
+    auto tempoPrimoTxt = makeElement<TempoText>(paletteScore());
     tempoPrimoTxt->setFollowText(true);
     tempoPrimoTxt->setXmlText(tempoPrimoStr);
     tempoPrimoTxt->setTempoPrimo();
     sp->appendElement(tempoPrimoTxt, tempoPrimoStr, 1.3);
 
-    auto stxt = makeElement<SystemText>(gpaletteScore);
+    auto stxt = makeElement<SystemText>(paletteScore());
     stxt->initTextStyleType(TextStyleType::TEMPO);
     stxt->setXmlText(String::fromAscii(QT_TRANSLATE_NOOP("palette", "Swing")));
     stxt->setSwing(true);
@@ -1484,7 +1489,7 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     cell->yoffset = 0.4;
     cell->setElementTranslated(true);
 
-    stxt = makeElement<SystemText>(gpaletteScore);
+    stxt = makeElement<SystemText>(paletteScore());
     stxt->initTextStyleType(TextStyleType::TEMPO);
     /*: System text to switch from swing rhythm back to straight rhythm */
     stxt->setXmlText(QT_TRANSLATE_NOOP("palette", "Straight"));
@@ -1507,36 +1512,36 @@ PalettePtr PaletteCreator::newTextPalette(bool defaultPalette)
     sp->setMag(0.85);
     sp->setDrawGrid(true);
 
-    auto st = makeElement<StaffText>(gpaletteScore);
+    auto st = makeElement<StaffText>(paletteScore());
     st->setXmlText(QT_TRANSLATE_NOOP("palette", "Staff text"));
     sp->appendElement(st, QT_TRANSLATE_NOOP("palette", "Staff text"))->setElementTranslated(true);
 
-    auto staffTextLine = makeElement<TextLine>(gpaletteScore);
+    auto staffTextLine = makeElement<TextLine>(paletteScore());
     staffTextLine->setBeginText(u"Staff");
     staffTextLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(staffTextLine, QT_TRANSLATE_NOOP("palette", "Staff text line"));
 
-    auto stxt = makeElement<SystemText>(gpaletteScore);
+    auto stxt = makeElement<SystemText>(paletteScore());
     stxt->setXmlText(QT_TRANSLATE_NOOP("palette", "System text"));
     sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "System text"))->setElementTranslated(true);
 
-    auto systemTextLine = makeElement<TextLine>(gpaletteScore, true);
-    systemTextLine->setLen(12 * gpaletteScore->style().spatium());
+    auto systemTextLine = makeElement<TextLine>(paletteScore(), true);
+    systemTextLine->setLen(12 * paletteScore()->style().spatium());
     systemTextLine->setBeginText(u"System");
     systemTextLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(systemTextLine, QT_TRANSLATE_NOOP("palette", "System text line"));
 
-    auto expressionText = makeElement<Expression>(gpaletteScore);
+    auto expressionText = makeElement<Expression>(paletteScore());
     expressionText->setTextStyleType(TextStyleType::EXPRESSION);
     expressionText->setXmlText(QT_TRANSLATE_NOOP("palette", "expression"));
     expressionText->setPlacement(PlacementV::BELOW);
     sp->appendElement(expressionText, QT_TRANSLATE_NOOP("palette", "Expression text"))->setElementTranslated(true);
 
-    auto is = makeElement<InstrumentChange>(gpaletteScore);
+    auto is = makeElement<InstrumentChange>(paletteScore());
     is->setXmlText(QT_TRANSLATE_NOOP("palette", "Change instr."));
     sp->appendElement(is, QT_TRANSLATE_NOOP("palette", "Instrument change"))->setElementTranslated(true);
 
-    auto rhm = makeElement<RehearsalMark>(gpaletteScore);
+    auto rhm = makeElement<RehearsalMark>(paletteScore());
     rhm->setXmlText("B1");
     sp->appendElement(rhm, QT_TRANSLATE_NOOP("palette", "Rehearsal mark"));
 
@@ -1564,7 +1569,7 @@ PalettePtr PaletteCreator::newTextPalette(bool defaultPalette)
     };
 
     for (PlayTechAnnotationInfo playTechAnnotation : playTechAnnotations) {
-        auto pta = makeElement<PlayTechAnnotation>(gpaletteScore);
+        auto pta = makeElement<PlayTechAnnotation>(paletteScore());
         if (playTechAnnotation.expressionType) {
             pta->setTextStyleType(TextStyleType::EXPRESSION);
         }
@@ -1578,7 +1583,7 @@ PalettePtr PaletteCreator::newTextPalette(bool defaultPalette)
         // are not copied directly into the score when drop.
         // Instead, they simply set the corresponding measure's MeasureNumberMode to SHOW
         // Because of that, the element shown in the palettes does not have to have any particular formatting.
-        auto meaNum = makeElement<MeasureNumber>(gpaletteScore);
+        auto meaNum = makeElement<MeasureNumber>(paletteScore());
         meaNum->setProperty(Pid::TEXT_STYLE, TextStyleType::STAFF);       // Make the element bigger in the palettes (using the default measure number style makes it too small)
         meaNum->setXmlText(QT_TRANSLATE_NOOP("palette", "Measure number"));
         sp->appendElement(meaNum, QT_TRANSLATE_NOOP("palette", "Measure number"))->setElementTranslated(true);
@@ -1593,7 +1598,7 @@ PalettePtr PaletteCreator::newTextPalette(bool defaultPalette)
         };
 
         for (PlayTechAnnotationInfo playTechAnnotation : playTechAnnotationsMaster) {
-            auto pta = makeElement<PlayTechAnnotation>(gpaletteScore);
+            auto pta = makeElement<PlayTechAnnotation>(paletteScore());
             pta->setXmlText(playTechAnnotation.xmlText);
             pta->setTechniqueType(playTechAnnotation.playTechType);
             sp->appendElement(pta, TConv::userName(playTechAnnotation.playTechType))->setElementTranslated(true);
@@ -1660,7 +1665,7 @@ PalettePtr PaletteCreator::newTimePalette(bool defaultPalette)
     };
 
     for (const TS& timeSignatureType : defaultPalette ? defaultTimeSignatureList : masterTimeSignatureList) {
-        auto timeSignature = Factory::makeTimeSig(gpaletteScore->dummy()->segment());
+        auto timeSignature = Factory::makeTimeSig(paletteScore()->dummy()->segment());
         timeSignature->setSig(Fraction(timeSignatureType.numerator, timeSignatureType.denominator), timeSignatureType.type);
         sp->appendElement(timeSignature, timeSignatureType.name);
     }
@@ -1714,7 +1719,7 @@ PalettePtr PaletteCreator::newFretboardDiagramPalette(bool defaultPalette)
     };
 
     for (const FretDiagramInfo& fretboardDiagram : fretboardDiagrams) {
-        auto fret = Factory::makeFretDiagram(gpaletteScore->dummy()->segment());
+        auto fret = Factory::makeFretDiagram(paletteScore()->dummy()->segment());
 
         if (fretboardDiagram.harmony.empty()) {
             fret->clear();
@@ -1742,18 +1747,18 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
     sp->setDrawGrid(true);
     sp->setVisible(false);
 
-    auto capoLine = makeElement<TextLine>(gpaletteScore);
+    auto capoLine = makeElement<TextLine>(paletteScore());
     capoLine->setBeginText(u"VII");
     capoLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(capoLine, QT_TRANSLATE_NOOP("palette", "Barré line"), 0.8);
 
-    auto pm = makeElement<PalmMute>(gpaletteScore);
+    auto pm = makeElement<PalmMute>(paletteScore());
     sp->appendElement(pm, QT_TRANSLATE_NOOP("palette", "Palm mute"), 0.8);
 
-    auto letRing = makeElement<LetRing>(gpaletteScore);
+    auto letRing = makeElement<LetRing>(paletteScore());
     sp->appendElement(letRing, QT_TRANSLATE_NOOP("palette", "Let ring"), 0.8);
 
-    auto whammyBar = makeElement<WhammyBar>(gpaletteScore);
+    auto whammyBar = makeElement<WhammyBar>(paletteScore());
     sp->appendElement(whammyBar, QT_TRANSLATE_NOOP("palette", "Whammy bar"), 0.8);
 
     static const std::vector<VibratoType> vibratos = {
@@ -1761,7 +1766,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
     };
 
     for (VibratoType vibratoType : vibratos) {
-        auto vibrato = makeElement<Vibrato>(gpaletteScore);
+        auto vibrato = makeElement<Vibrato>(paletteScore());
         vibrato->setVibratoType(vibratoType);
         sp->appendElement(vibrato, TConv::userName(vibratoType));
     }
@@ -1778,7 +1783,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
 
     const char* finger = "pimac";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->setTextStyleType(TextStyleType::RH_GUITAR_FINGERING);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "RH guitar fingering %1"));
@@ -1786,28 +1791,28 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
 
     finger = "012345T";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->setTextStyleType(TextStyleType::LH_GUITAR_FINGERING);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "LH guitar fingering %1"));
     }
     finger = defaultPalette ? "123456" : "0123456789";
     for (unsigned i = 0; i < strlen(finger); ++i) {
-        auto f = makeElement<Fingering>(gpaletteScore);
+        auto f = makeElement<Fingering>(paletteScore());
         f->initTextStyleType(TextStyleType::STRING_NUMBER);
         f->setXmlText(QString(finger[i]));
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "String number %1"));
     }
 
-    auto lhTapping = Factory::makeTapping(gpaletteScore->dummy()->chord());
+    auto lhTapping = Factory::makeTapping(paletteScore()->dummy()->chord());
     lhTapping->setHand(TappingHand::LEFT);
     sp->appendElement(lhTapping, QT_TRANSLATE_NOOP("palette", "Left-hand tapping"), 1.0);
 
-    auto rhTapping = Factory::makeTapping(gpaletteScore->dummy()->chord());
+    auto rhTapping = Factory::makeTapping(paletteScore()->dummy()->chord());
     rhTapping->setHand(TappingHand::RIGHT);
     sp->appendElement(rhTapping, QT_TRANSLATE_NOOP("palette", "Right-hand tapping"), 1.0);
 
-    auto hopo = Factory::makeHammerOnPullOff(gpaletteScore->dummy());
+    auto hopo = Factory::makeHammerOnPullOff(paletteScore()->dummy());
     sp->appendElement(hopo, QT_TRANSLATE_NOOP("palette", "Hammer-on / pull-off"), 0.8);
 
     static const SymIdList luteSymbols {
@@ -1817,16 +1822,16 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
     };
 
     for (auto i : luteSymbols) {
-        auto s = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
 
-    auto capo = makeElement<Capo>(gpaletteScore);
+    auto capo = makeElement<Capo>(paletteScore());
     capo->setXmlText(String::fromAscii(QT_TRANSLATE_NOOP("palette", "Capo")));
     sp->appendElement(capo, QT_TRANSLATE_NOOP("palette", "Capo"), 0.9)->setElementTranslated(true);
 
-    auto stringTunings = makeElement<StringTunings>(gpaletteScore);
+    auto stringTunings = makeElement<StringTunings>(paletteScore());
     stringTunings->setXmlText(u"<sym>guitarString6</sym> - D");
     stringTunings->initTextStyleType(TextStyleType::STRING_TUNINGS);
     sp->appendElement(stringTunings, QT_TRANSLATE_NOOP("palette", "String tunings"), 0.9)->setElementTranslated(true);
@@ -1845,7 +1850,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
     };
 
     for (const PlayTechAnnotationInfo& playTechAnnotation : playTechAnnotations) {
-        auto pta = makeElement<PlayTechAnnotation>(gpaletteScore);
+        auto pta = makeElement<PlayTechAnnotation>(paletteScore());
         pta->setXmlText(playTechAnnotation.xmlText);
         pta->setTechniqueType(playTechAnnotation.playTechType);
         sp->appendElement(pta, TConv::userName(playTechAnnotation.playTechType), 0.8)->setElementTranslated(true);
@@ -1863,21 +1868,21 @@ PalettePtr PaletteCreator::newKeyboardPalette()
     sp->setGridSize(73, 30);
     sp->setDrawGrid(true);
 
-    auto pedal = makeElement<Pedal>(gpaletteScore);
+    auto pedal = makeElement<Pedal>(paletteScore());
     pedal->setLineVisible(false);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (with ped and asterisk)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setEndHookType(HookType::HOOK_90);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (with ped and line)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setBeginHookType(HookType::HOOK_90);
     pedal->setEndHookType(HookType::HOOK_90);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1885,7 +1890,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (straight hooks)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setBeginHookType(HookType::HOOK_90);
     pedal->setEndHookType(HookType::HOOK_45);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1893,7 +1898,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (angled end hook)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setBeginHookType(HookType::HOOK_45);
     pedal->setEndHookType(HookType::HOOK_45);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1901,7 +1906,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
     sp->appendElement(pedal, QT_TRANSLATE_NOOP("palette", "Pedal (both hooks angled)"));
 
-    pedal = makeElement<Pedal>(gpaletteScore);
+    pedal = makeElement<Pedal>(paletteScore());
     pedal->setBeginHookType(HookType::HOOK_45);
     pedal->setEndHookType(HookType::HOOK_90);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
@@ -1914,7 +1919,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
                                      QT_TRANSLATE_NOOP("palette", "Chord bracket (play with right hand)") };
     for (int i = 0; i < 3; ++i) {
         DirectionV hookPos = DirectionV(i);
-        auto c = Factory::makeChordBracket(gpaletteScore->dummy()->chord());
+        auto c = Factory::makeChordBracket(paletteScore()->dummy()->chord());
         c->setProperty(Pid::BRACKET_HOOK_POS, hookPos);
         sp->appendElement(c, names[i]);
     }
@@ -1948,13 +1953,13 @@ PalettePtr PaletteCreator::newPitchPalette(bool defaultPalette)
     };
 
     for (OttavaType ottavaType : defaultPalette ? ottavasDefault : ottavasMaster) {
-        auto ottava = makeElement<Ottava>(gpaletteScore);
+        auto ottava = makeElement<Ottava>(paletteScore());
         ottava->setOttavaType(ottavaType);
         ottava->styleChanged();
         sp->appendElement(ottava, ottava->subtypeUserName());
     }
 
-    auto a = Factory::makeAmbitus(gpaletteScore->dummy()->segment());
+    auto a = Factory::makeAmbitus(paletteScore()->dummy()->segment());
     sp->appendElement(a, QT_TRANSLATE_NOOP("palette", "Ambitus"));
     return sp;
 }
@@ -1967,10 +1972,10 @@ PalettePtr PaletteCreator::newHarpPalette()
     sp->setDrawGrid(true);
     sp->setVisible(false);
 
-    auto pedalDiagram = Factory::makeHarpPedalDiagram(gpaletteScore->dummy()->segment());
+    auto pedalDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy()->segment());
     sp->appendElement(pedalDiagram, QT_TRANSLATE_NOOP("palette", "Harp pedal diagram"));
 
-    auto pedalTextDiagram = Factory::makeHarpPedalDiagram(gpaletteScore->dummy()->segment());
+    auto pedalTextDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy()->segment());
     pedalTextDiagram->setIsDiagram(false);
 
     sp->appendElement(pedalTextDiagram, QT_TRANSLATE_NOOP("palette", "Harp pedal text diagram"));
@@ -2020,20 +2025,20 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
     };
 
     for (SymId symId : standardHandbellsArticSymbols) {
-        auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
         artic->setSymId(symId);
         sp->appendElement(artic, artic->subtypeUserName(),
                           symId == SymId::handbellsGyro ? 0.7 : symId == SymId::handbellsMalletBellSuspended ? 1.4 : 1.0);
     }
 
     for (ArticulationTextType textType : handbellsTextTypes) {
-        auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
         artic->setTextType(textType);
         sp->appendElement(artic, artic->subtypeUserName(), 1.1);
     }
 
     for (const HandbellsPlayTechInfo& info : standardHandbellsPlayTech) {
-        auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+        auto element = makeElement<PlayTechAnnotation>(paletteScore());
         element->setProperty(Pid::TEXT_STYLE, TextStyleType::ARTICULATION);
         element->setXmlText(info.xmlText);
         element->setTechniqueType(info.playTechType);
@@ -2049,7 +2054,7 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
         };
 
         for (SymId symId : additionalHandbellsArticSymbols) {
-            auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
+            auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
             artic->setSymId(symId);
             sp->appendElement(artic, artic->subtypeUserName());
         }
@@ -2060,7 +2065,7 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
         };
 
         for (const HandbellsPlayTechInfo& info : additionalHandbellsPlayTech) {
-            auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+            auto element = makeElement<PlayTechAnnotation>(paletteScore());
             element->setProperty(Pid::TEXT_STYLE, TextStyleType::ARTICULATION);
             element->setXmlText(info.xmlText);
             element->setTechniqueType(info.playTechType);

--- a/src/palette/internal/palettecreator.h
+++ b/src/palette/internal/palettecreator.h
@@ -27,11 +27,13 @@
 
 #include "modularity/ioc.h"
 #include "ipaletteconfiguration.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::palette {
 class PaletteCreator : public muse::Contextable
 {
     muse::GlobalInject<IPaletteConfiguration> configuration;
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
 
@@ -72,6 +74,9 @@ public:
 
     PaletteTreePtr newMasterPaletteTree();
     PaletteTreePtr newDefaultPaletteTree();
+
+private:
+    engraving::MasterScore* paletteScore() const;
 };
 }
 

--- a/src/palette/internal/paletteworkspacesetup.cpp
+++ b/src/palette/internal/paletteworkspacesetup.cpp
@@ -59,7 +59,7 @@ PaletteTreePtr PaletteWorkspaceSetup::readPalette(const ByteArray& data, const m
                 // Versioning workspace palette files started in 4.7. All unversioned files should be treated like 4.6 files
                 mscVersion = 460;
             }
-            engraving::gpaletteScore->setMscVersion(mscVersion);
+            paletteScoreProvider()->paletteScore()->setMscVersion(mscVersion);
 
             PaletteTreePtr tree = std::make_shared<PaletteTree>();
             tree->read(reader, false, iocCtx);
@@ -111,8 +111,8 @@ void PaletteWorkspaceSetup::setup()
         }
         paletteProvider()->setUserPaletteTree(tree);
 
-        if (engraving::gpaletteScore->mscVersion() < engraving::Constants::MSC_VERSION) {
-            LOGD() << "Workspace file found with palette file version " << engraving::gpaletteScore->mscVersion() <<
+        if (paletteScoreProvider()->paletteScore()->mscVersion() < engraving::Constants::MSC_VERSION) {
+            LOGD() << "Workspace file found with palette file version " << paletteScoreProvider()->paletteScore()->mscVersion() <<
                 ". Migrating palette file to " << engraving::Constants::MSC_VERSION;
             saveData();
         }

--- a/src/palette/internal/paletteworkspacesetup.h
+++ b/src/palette/internal/paletteworkspacesetup.h
@@ -26,13 +26,14 @@
 #include "workspace/iworkspacesdataprovider.h"
 #include "ipaletteprovider.h"
 #include "async/asyncable.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::palette {
 class PaletteWorkspaceSetup : public muse::async::Asyncable, public muse::Contextable
 {
     muse::ContextInject<muse::workspace::IWorkspacesDataProvider> workspacesDataProvider = { this };
     muse::ContextInject<IPaletteProvider> paletteProvider = { this };
-
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 public:
 
     explicit PaletteWorkspaceSetup(const muse::modularity::ContextPtr& iocCtx)

--- a/src/palette/widgets/customizekitdialog.cpp
+++ b/src/palette/widgets/customizekitdialog.cpp
@@ -569,7 +569,7 @@ void CustomizeKitDialog::updateExample()
     int v         = m_editedDrumset.voice(pitch);
     DirectionV dir = m_editedDrumset.stemDirection(pitch);
     bool up = (DirectionV::UP == dir) || (DirectionV::AUTO == dir && line > 4);
-    std::shared_ptr<Chord> chord = Factory::makeChord(gpaletteScore->dummy()->segment());
+    std::shared_ptr<Chord> chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy()->segment());
     chord->setDurationType(DurationType::V_QUARTER);
     chord->setStemDirection(dir);
     chord->setTrack(v);
@@ -580,7 +580,7 @@ void CustomizeKitDialog::updateExample()
     note->setPitch(pitch);
     note->setTpcFromPitch();
     note->setLine(line);
-    note->setPos(0.0, gpaletteScore->style().spatium() * .5 * line);
+    note->setPos(0.0, paletteScoreProvider()->paletteScore()->style().spatium() * .5 * line);
     note->setHeadType(NoteHeadType::HEAD_QUARTER);
     note->setHeadGroup(nh);
     note->mutldata()->cachedNoteheadSym.set_value(static_cast<SymId>(quarterCmb->currentData().toInt()));

--- a/src/palette/widgets/customizekitdialog.h
+++ b/src/palette/widgets/customizekitdialog.h
@@ -30,6 +30,7 @@
 #include "notation/inotationconfiguration.h"
 #include "engraving/iengravingfontsprovider.h"
 #include "engraving/rendering/isinglerenderer.h"
+#include "engraving/ipalettescoreprovider.h"
 #include "ui/iuiconfiguration.h"
 
 #include "engraving/dom/drumset.h"
@@ -50,7 +51,7 @@ public:
     muse::GlobalInject<engraving::rendering::ISingleRenderer> engravingRenderer;
     muse::ContextInject<muse::IInteractive> interactive = { this };
     muse::ContextInject<context::IGlobalContext> globalContext = { this };
-
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 public:
     CustomizeKitDialog(QWidget* parent = nullptr);
 

--- a/src/palette/widgets/keycanvas.h
+++ b/src/palette/widgets/keycanvas.h
@@ -29,14 +29,14 @@
 #include "notation/inotationconfiguration.h"
 #include "engraving/iengravingconfiguration.h"
 #include "engraving/rendering/isinglerenderer.h"
-
+#include "engraving/ipalettescoreprovider.h"
 namespace mu::engraving {
 class Accidental;
 class Clef;
 }
 
 namespace mu::palette {
-class KeyCanvas : public QFrame
+class KeyCanvas : public QFrame, public muse::Contextable
 {
     Q_OBJECT
 
@@ -44,6 +44,7 @@ class KeyCanvas : public QFrame
     muse::GlobalInject<notation::INotationConfiguration> notationConfiguration;
     muse::GlobalInject<engraving::IEngravingConfiguration> engravingConfiguration;
     muse::GlobalInject<engraving::rendering::ISingleRenderer> engravingRender;
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
     engraving::Accidental* dragElement = nullptr;
     engraving::Accidental* moveElement = nullptr;

--- a/src/palette/widgets/keyedit.cpp
+++ b/src/palette/widgets/keyedit.cpp
@@ -58,10 +58,11 @@ using namespace mu::palette;
 //---------------------------------------------------------
 
 KeyCanvas::KeyCanvas(QWidget* parent)
-    : QFrame(parent)
+    : QFrame(parent), muse::Contextable(muse::iocCtxForQWidget(this))
 {
     setAcceptDrops(true);
-    qreal mag = configuration()->paletteSpatium() * configuration()->paletteScaling() / gpaletteScore->style().spatium();
+    qreal mag = configuration()->paletteSpatium() * configuration()->paletteScaling()
+                / paletteScoreProvider()->paletteScore()->style().spatium();
     _matrix = QTransform(mag, 0.0, 0.0, mag, 0.0, 0.0);
     imatrix = _matrix.inverted();
     dragElement = 0;
@@ -69,7 +70,7 @@ KeyCanvas::KeyCanvas(QWidget* parent)
     QAction* a = new QAction("delete", this);
     a->setShortcut(Qt::Key_Delete);
     addAction(a);
-    clef = Factory::createClef(gpaletteScore->dummy()->segment());
+    clef = Factory::createClef(paletteScoreProvider()->paletteScore()->dummy()->segment());
     clef->setClefType(ClefType::G);
     connect(a, &QAction::triggered, this, &KeyCanvas::deleteElement);
 }
@@ -115,7 +116,8 @@ void KeyCanvas::paintEvent(QPaintEvent*)
     qreal ww = double(width());
     double y = wh * .5 - 2 * configuration()->paletteSpatium() * extraMag;
 
-    qreal mag  = configuration()->paletteSpatium() * extraMag / gpaletteScore->style().spatium();
+    const double paletteScoreSpatium = paletteScoreProvider()->paletteScore()->style().spatium();
+    qreal mag  = configuration()->paletteSpatium() * extraMag / paletteScoreSpatium;
     _matrix    = QTransform(mag, 0.0, 0.0, mag, 0.0, y);
     imatrix    = _matrix.inverted();
 
@@ -134,23 +136,26 @@ void KeyCanvas::paintEvent(QPaintEvent*)
 
     muse::draw::Pen pen(opt.invertColors ? engravingConfiguration()->scoreInversionColor()
                         : engravingConfiguration()->defaultColor());
-    pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * gpaletteScore->style().spatium());
+    pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(
+                      Sid::staffLineWidth).val() * paletteScoreSpatium);
     painter.setPen(pen);
 
     for (int i = 0; i < 5; ++i) {
-        qreal yy = r.y() + i * gpaletteScore->style().spatium();
+        qreal yy = r.y() + i * paletteScoreSpatium;
         painter.drawLine(LineF(r.x(), yy, r.x() + r.width(), yy));
     }
+
+    const auto paletteRenderer = paletteScoreProvider()->paletteScore()->renderer();
     if (dragElement) {
         painter.save();
         painter.translate(dragElement->pagePos());
-        gpaletteScore->renderer()->drawItem(dragElement, &painter, opt);
+        paletteRenderer->drawItem(dragElement, &painter, opt);
         painter.restore();
     }
     foreach (Accidental* a, accidentals) {
         painter.save();
         painter.translate(a->pagePos());
-        gpaletteScore->renderer()->drawItem(a, &painter, opt);
+        paletteRenderer->drawItem(a, &painter, opt);
         painter.restore();
     }
     clef->setPos(0.0, 0.0);
@@ -158,7 +163,7 @@ void KeyCanvas::paintEvent(QPaintEvent*)
     engravingRender()->layoutItem(clef);
 
     painter.translate(clef->pagePos());
-    gpaletteScore->renderer()->drawItem(clef, &painter, opt);
+    paletteRenderer->drawItem(clef, &painter, opt);
 }
 
 //---------------------------------------------------------
@@ -229,7 +234,7 @@ void KeyCanvas::dragEnterEvent(QDragEnterEvent* event)
         }
 
         event->acceptProposedAction();
-        dragElement = static_cast<Accidental*>(Factory::createItem(type, gpaletteScore->dummy()));
+        dragElement = static_cast<Accidental*>(Factory::createItem(type, paletteScoreProvider()->paletteScore()->dummy()));
         dragElement->resetExplicitParent();
 
         rw::RWRegister::reader()->readItem(dragElement, e);
@@ -280,7 +285,7 @@ void KeyCanvas::dropEvent(QDropEvent*)
 
 void KeyCanvas::snap(Accidental* a)
 {
-    double _spatium = gpaletteScore->style().spatium();
+    double _spatium = paletteScoreProvider()->paletteScore()->style().spatium();
     double spatium2 = _spatium * .5;
     double y = a->ldata()->pos().y();
     double x = KEYEDIT_ACC_ZERO_POINT * _spatium;
@@ -380,7 +385,7 @@ KeyEditor::KeyEditor(QWidget* parent)
 void KeyEditor::addClicked()
 {
     const QList<Accidental*> al = canvas->getAccidentals();
-    double spatium = gpaletteScore->style().spatium();
+    double spatium = paletteScoreProvider()->paletteScore()->style().spatium();
     double xoff = KEYEDIT_ACC_ZERO_POINT * spatium;
 
     KeySigEvent e;
@@ -406,7 +411,7 @@ void KeyEditor::addClicked()
         c.octAlt = static_cast<int>((line - (line >= 0 ? 0 : 6)) / 7);
         e.customKeyDefs().push_back(c);
     }
-    auto ks = Factory::makeKeySig(gpaletteScore->dummy()->segment());
+    auto ks = Factory::makeKeySig(paletteScoreProvider()->paletteScore()->dummy()->segment());
     ks->setKeySigEvent(e);
     m_keySigPaletteWidget->appendElement(ks, "custom");
     m_dirty = true;

--- a/src/palette/widgets/keyedit.h
+++ b/src/palette/widgets/keyedit.h
@@ -28,6 +28,7 @@
 #include "modularity/ioc.h"
 #include "ipaletteconfiguration.h"
 #include "internal/ipaletteprovider.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::palette {
 class PaletteWidget;
@@ -41,6 +42,7 @@ class KeyEditor : public QWidget, Ui::KeyEdit, public muse::Contextable
 
     muse::GlobalInject<IPaletteConfiguration> configuration;
     muse::ContextInject<IPaletteProvider> paletteProvider = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     KeyEditor(QWidget* parent = 0);

--- a/src/palette/widgets/palettewidget.cpp
+++ b/src/palette/widgets/palettewidget.cpp
@@ -559,7 +559,7 @@ QRect PaletteWidget::rectForCellAt(int idx) const
 
 QPixmap PaletteWidget::pixmapForCellAt(int paletteIdx) const
 {
-    qreal _spatium = gpaletteScore->style().spatium();
+    qreal _spatium = paletteScoreProvider()->paletteScore()->style().spatium();
     qreal magS     = configuration()->paletteSpatium() * mag() * paletteScaling();
     qreal mag      = magS / _spatium;
 
@@ -851,7 +851,7 @@ void PaletteWidget::dropEvent(QDropEvent* event)
         QList<QUrl> ul = event->mimeData()->urls();
         QUrl u = ul.front();
         if (u.scheme() == "file") {
-            auto image = std::make_shared<Image>(gpaletteScore->dummy());
+            auto image = std::make_shared<Image>(paletteScoreProvider()->paletteScore()->dummy());
             QString filePath(u.toLocalFile());
             image->loadFromFile(filePath);
             element = image;
@@ -867,11 +867,11 @@ void PaletteWidget::dropEvent(QDropEvent* event)
         ElementType type = EngravingItem::readType(xml, &dragOffset, &duration);
 
         if (type == ElementType::SYMBOL) {
-            auto symbol = std::make_shared<Symbol>(gpaletteScore->dummy());
+            auto symbol = std::make_shared<Symbol>(paletteScoreProvider()->paletteScore()->dummy());
             rw::RWRegister::reader()->readItem(symbol.get(), xml);
             element = symbol;
         } else {
-            element = std::shared_ptr<EngravingItem>(Factory::createItem(type, gpaletteScore->dummy()));
+            element = std::shared_ptr<EngravingItem>(Factory::createItem(type, paletteScoreProvider()->paletteScore()->dummy()));
             if (element) {
                 rw::RWRegister::reader()->readItem(element.get(), xml);
                 element->setTrack(0);
@@ -929,10 +929,11 @@ void PaletteWidget::resizeEvent(QResizeEvent* e)
 
 void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
 {
-    qreal _spatium = gpaletteScore->style().spatium();
+    auto paletteScore = paletteScoreProvider()->paletteScore();
+    qreal _spatium = paletteScore->style().spatium();
     qreal magS     = configuration()->paletteSpatium() * mag() * paletteScaling();
     qreal mag      = magS / _spatium;
-    gpaletteScore->style().setSpatium(gpaletteScore->style().defaultSpatium());
+    paletteScore->style().setSpatium(paletteScore->style().defaultSpatium());
 
     muse::draw::Painter painter(this, "palette");
     painter.setAntialiasing(true);

--- a/src/palette/widgets/palettewidget.h
+++ b/src/palette/widgets/palettewidget.h
@@ -36,6 +36,7 @@
 #include "ui/iuiconfiguration.h"
 #include "context/iglobalcontext.h"
 #include "interactive/iinteractive.h"
+#include "engraving/ipalettescoreprovider.h"
 
 #include "../internal/palette.h"
 #include "../ipaletteconfiguration.h"
@@ -78,6 +79,7 @@ class PaletteWidget : public QWidget, public muse::async::Asyncable, public muse
     muse::ContextInject<context::IGlobalContext> globalContext = { this };
     muse::ContextInject<muse::IInteractive> interactive = { this };
     muse::ContextInject<muse::ui::IMainWindow> mainWindow  = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     PaletteWidget(QWidget* parent = nullptr);

--- a/src/palette/widgets/specialcharactersdialog.cpp
+++ b/src/palette/widgets/specialcharactersdialog.cpp
@@ -666,21 +666,23 @@ void SpecialCharactersDialog::populateCommon()
 {
     m_pCommon->clear();
 
+    auto paletteScore = paletteScoreProvider()->paletteScore();
+
     for (char32_t id : unicodeAccidentals) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(paletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
         m_pCommon->appendElement(fs, QString::fromUcs4(&id, 1));
     }
 
     for (SymId id : commonScoreSymbols) {
-        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore->dummy());
-        s->setSym(id, gpaletteScore->engravingFont());
+        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(paletteScore->dummy());
+        s->setSym(id, paletteScore->engravingFont());
         m_pCommon->appendElement(s, SymNames::translatedUserNameForSymId(id));
     }
 
     for (char32_t id : commonTextSymbols) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(paletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
         m_pCommon->appendElement(fs, QString::fromUcs4(&id, 1));
@@ -698,9 +700,10 @@ void SpecialCharactersDialog::populateSmufl()
     int row = m_lws->currentRow();
     std::vector<SymId> symIds = std::next(Smufl::smuflRanges().begin(), row)->second;
 
+    auto paletteScore = paletteScoreProvider()->paletteScore();
     for (SymId symId : symIds) {
-        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore->dummy());
-        s->setSym(symId, gpaletteScore->engravingFont());
+        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(paletteScore->dummy());
+        s->setSym(symId, paletteScore->engravingFont());
         m_pSmufl->appendElement(s, SymNames::translatedUserNameForSymId(symId));
     }
 }
@@ -714,8 +717,10 @@ void SpecialCharactersDialog::populateUnicode()
     int row = m_lwu->currentItem()->data(Qt::UserRole).toInt();
     const UnicodeRange& range = unicodeRanges[row];
     m_pUnicode->clear();
+
+    auto paletteScore = paletteScoreProvider()->paletteScore();
     for (char32_t code = range.first; code <= range.last; ++code) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(paletteScore->dummy());
         fs->setCode(code);
         fs->setFont(m_font);
         m_pUnicode->appendElement(fs, QString("0x%1").arg(static_cast<int>(code), 5, 16, QLatin1Char('0')));

--- a/src/palette/widgets/specialcharactersdialog.h
+++ b/src/palette/widgets/specialcharactersdialog.h
@@ -28,6 +28,7 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "engraving/ipalettescoreprovider.h"
 
 class QListWidget;
 
@@ -43,7 +44,7 @@ class SpecialCharactersDialog : public muse::uicomponents::TopLevelDialog, publi
     Q_OBJECT
 
     muse::ContextInject<mu::context::IGlobalContext> globalContext = { this };
-
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 public:
     SpecialCharactersDialog(QWidget* parent = nullptr);
 

--- a/src/palette/widgets/symboldialog.cpp
+++ b/src/palette/widgets/symboldialog.cpp
@@ -35,10 +35,6 @@
 using namespace mu::engraving;
 using namespace mu::palette;
 
-namespace mu::engraving {
-extern MasterScore* gpaletteScore;
-}
-
 //---------------------------------------------------------
 //   createSymbolPalette
 //---------------------------------------------------------
@@ -60,11 +56,12 @@ void SymbolDialog::createSymbols()
     // init the font if not done yet
     engravingFonts()->fontByName(f->name());
     m_symbolsWidget->clear();
+    auto paletteScore = paletteScoreProvider()->paletteScore();
     for (SymId symId : Smufl::smuflRanges().at(range)) {
         String symName = SymNames::translatedUserNameForSymId(symId);
         if (search->text().isEmpty()
             || symName.toQString().contains(search->text(), Qt::CaseInsensitive)) {
-            auto s = std::make_shared<Symbol>(gpaletteScore->dummy());
+            auto s = std::make_shared<Symbol>(paletteScore->dummy());
             s->setSym(symId, f);
             m_symbolsWidget->appendElement(s, symName);
         }

--- a/src/palette/widgets/symboldialog.h
+++ b/src/palette/widgets/symboldialog.h
@@ -27,6 +27,7 @@
 
 #include "modularity/ioc.h"
 #include "engraving/iengravingfontsprovider.h"
+#include "engraving/ipalettescoreprovider.h"
 #include "context/iglobalcontext.h"
 
 namespace mu::palette {
@@ -41,6 +42,7 @@ class SymbolDialog : public QWidget, Ui::SymbolDialogBase, public muse::Contexta
     Q_OBJECT
     muse::GlobalInject<engraving::IEngravingFontsProvider> engravingFonts;
     muse::ContextInject<mu::context::IGlobalContext> globalContext = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     SymbolDialog(const QString&, QWidget* parent = 0);

--- a/src/palette/widgets/timedialog.cpp
+++ b/src/palette/widgets/timedialog.cpp
@@ -106,7 +106,7 @@ bool TimeDialog::showTimePalette() const
 
 void TimeDialog::addClicked()
 {
-    auto ts = mu::engraving::Factory::makeTimeSig(gpaletteScore->dummy()->segment());
+    auto ts = mu::engraving::Factory::makeTimeSig(paletteScoreProvider()->paletteScore()->dummy()->segment());
     ts->setSig(Fraction(zNominal->value(), denominator()));
     ts->setGroups(groups->groups());
 

--- a/src/palette/widgets/timedialog.h
+++ b/src/palette/widgets/timedialog.h
@@ -28,6 +28,7 @@
 #include "ipaletteconfiguration.h"
 #include "internal/ipaletteprovider.h"
 #include "engraving/rendering/isinglerenderer.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::palette {
 class PaletteWidget;
@@ -42,6 +43,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase, public muse::Contextable
     muse::GlobalInject<IPaletteConfiguration> configuration;
     muse::GlobalInject<engraving::rendering::ISingleRenderer> engravingRender;
     muse::ContextInject<IPaletteProvider> paletteProvider = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     TimeDialog(QWidget* parent = 0);

--- a/src/palette/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/widgets/timesignaturepropertiesdialog.cpp
@@ -123,7 +123,7 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
         SymId::mensuralProlation11, // tempus imperf., prol. imperfecta, dimin. 5
     };
 
-    IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
+    IEngravingFontPtr symbolFont = paletteScoreProvider()->paletteScore()->engravingFont();
 
     otherCombo->clear();
     otherCombo->setStyleSheet(QString("QComboBox { font-family: \"%1 Text\"; font-size: %2px; max-height: 30px } ")

--- a/src/palette/widgets/timesignaturepropertiesdialog.h
+++ b/src/palette/widgets/timesignaturepropertiesdialog.h
@@ -27,6 +27,7 @@
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "ui/iuiconfiguration.h"
+#include "engraving/ipalettescoreprovider.h"
 
 namespace mu::engraving {
 class TimeSig;
@@ -39,6 +40,7 @@ class TimeSignaturePropertiesDialog : public QDialog, public Ui::TimeSigProperti
 
     muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
     muse::ContextInject<mu::context::IGlobalContext> globalContext = { this };
+    muse::ContextInject<engraving::IPaletteScoreProvider> paletteScoreProvider = { this };
 
 public:
     TimeSignaturePropertiesDialog(QWidget* parent = nullptr);


### PR DESCRIPTION
`Score` itself is context-dependent and can use some services that depend on the context.

The Score for palettes was a global variable—that's a problem. It either should be in the global context, but we currently have a clear separation: services can be either global or contextual. Or it should be made contextual.
This PR makes the Score for palettes contextual. 