### PR TITLE
Hook height migration

### DIFF
--- a/src/engraving/compat/engravingcompat.cpp
+++ b/src/engraving/compat/engravingcompat.cpp
@@ -295,10 +295,6 @@ void EngravingCompat::doPostLayoutCompatIfNeeded(MasterScore* score)
 
     int mscVersion = score->mscVersion();
 
-    if (mscVersion < 460) {
-        needRelayout |= resetHookHeightSign(score);
-    }
-
     if (mscVersion < 440) {
         needRelayout |= relayoutUserModifiedCrossStaffBeams(score);
     }
@@ -346,37 +342,5 @@ bool EngravingCompat::relayoutUserModifiedCrossStaffBeams(MasterScore* score)
     }
 
     return found;
-}
-
-bool EngravingCompat::resetHookHeightSign(MasterScore* masterScore)
-{
-    bool needRelayout = false;
-
-    for (Score* score : masterScore->scoreList()) {
-        for (auto pair : score->spanner()) {
-            Spanner* spanner = pair.second;
-            if (spanner->isTextLineBase()) {
-                for (SpannerSegment* spannerSeg : spanner->spannerSegments()) {
-                    TextLineBaseSegment* textLineSeg = static_cast<TextLineBaseSegment*>(spannerSeg);
-                    if (textLineSeg->placeBelow()) {
-                        if (!textLineSeg->isStyled(Pid::BEGIN_HOOK_HEIGHT)) {
-                            Spatium beginHookHeight = textLineSeg->getProperty(Pid::BEGIN_HOOK_HEIGHT).value<Spatium>();
-                            textLineSeg->setProperty(Pid::BEGIN_HOOK_HEIGHT, -beginHookHeight);
-                            spanner->triggerLayout();
-                            needRelayout = true;
-                        }
-                        if (!textLineSeg->isStyled(Pid::END_HOOK_HEIGHT)) {
-                            Spatium endHookHeight = textLineSeg->getProperty(Pid::END_HOOK_HEIGHT).value<Spatium>();
-                            textLineSeg->setProperty(Pid::END_HOOK_HEIGHT, -endHookHeight);
-                            spanner->triggerLayout();
-                            needRelayout = true;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return needRelayout;
 }
 } // namespace mu::engraving::compat

--- a/src/engraving/compat/engravingcompat.h
+++ b/src/engraving/compat/engravingcompat.h
@@ -44,6 +44,5 @@ private:
     static void migrateNoteParens(MasterScore* masterScore);
 
     static bool relayoutUserModifiedCrossStaffBeams(MasterScore* score);
-    static bool resetHookHeightSign(MasterScore* masterScore);
 };
 } // namespace mu::engraving::compat

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -982,6 +982,22 @@ void CompatUtils::setTextLineTextPositionFromAlign(TextLineBase* tl)
     }
 }
 
+void CompatUtils::resetHookHeightSign(TextLineBase* tl)
+{
+    if (!tl->placeBelow()) {
+        return;
+    }
+
+    if (!tl->isStyled(Pid::BEGIN_HOOK_HEIGHT)) {
+        Spatium beginHookHeight = tl->getProperty(Pid::BEGIN_HOOK_HEIGHT).value<Spatium>();
+        tl->setProperty(Pid::BEGIN_HOOK_HEIGHT, -beginHookHeight);
+    }
+    if (!tl->isStyled(Pid::END_HOOK_HEIGHT)) {
+        Spatium endHookHeight = tl->getProperty(Pid::END_HOOK_HEIGHT).value<Spatium>();
+        tl->setProperty(Pid::END_HOOK_HEIGHT, -endHookHeight);
+    }
+}
+
 void mu::engraving::compat::CompatUtils::setMusicSymbolSize470(MStyle& style)
 {
     // Music symbols have their own point size in 4.7

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -49,6 +49,7 @@ public:
     static const std::map<Sid, Sid> ALIGN_VALS_TO_CONVERT;
     static Sid positionStyleFromAlign(Sid align);
     static void setTextLineTextPositionFromAlign(TextLineBase* tl);
+    static void resetHookHeightSign(TextLineBase* tl);
     static void setMusicSymbolSize470(MStyle& style);
     static Spatium convertPre470FrameRadius(double frameRadius);
     static void doMigrateNoteParens(EngravingItem* item);

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1174,6 +1174,7 @@ static void readVolta114(XmlReader& e, ReadContext& ctx, Volta* volta)
     }
     volta->setOffset(PointF());          // ignore offsets
     volta->setAutoplace(true);
+    CompatUtils::resetHookHeightSign(volta);
 }
 
 //---------------------------------------------------------
@@ -1216,6 +1217,8 @@ static void readOttava114(XmlReader& e, ReadContext& ctx, Ottava* ottava)
             e.unknown();
         }
     }
+
+    CompatUtils::resetHookHeightSign(ottava);
 }
 
 //---------------------------------------------------------
@@ -1295,6 +1298,8 @@ static void readTextLine114(XmlReader& e, ReadContext& ctx, TextLine* textLine)
             e.unknown();
         }
     }
+
+    CompatUtils::resetHookHeightSign(textLine);
 }
 
 //---------------------------------------------------------
@@ -1388,6 +1393,8 @@ static void readPedal114(XmlReader& e, ReadContext& ctx, Pedal* pedal)
     } else if (pedal->endText() == pedal->propertyDefault(Pid::END_TEXT).value<String>()) {
         pedal->setPropertyFlags(Pid::END_TEXT, PropertyFlags::STYLED);
     }
+
+    CompatUtils::resetHookHeightSign(pedal);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2193,6 +2193,7 @@ static bool readTextLineProperties(XmlReader& e, ReadContext& ctx, TextLineBase*
     } else if (!read400::TRead::readProperties(tl, e, ctx)) {
         return false;
     }
+
     return true;
 }
 
@@ -2223,6 +2224,7 @@ static void readVolta206(XmlReader& e, ReadContext& ctx, Volta* volta)
         LOGW("Correcting volta anchor type from %d to %d", int(volta->anchor()), int(Volta::VOLTA_ANCHOR));
         volta->setAnchor(Volta::VOLTA_ANCHOR);
     }
+    CompatUtils::resetHookHeightSign(volta);
     adjustPlacement(volta);
 }
 
@@ -2268,6 +2270,7 @@ static void readPedal(XmlReader& e, ReadContext& ctx, Pedal* pedal)
         pedal->setPropertyFlags(Pid::END_TEXT, PropertyFlags::STYLED);
     }
 
+    CompatUtils::resetHookHeightSign(pedal);
     adjustPlacement(pedal);
 }
 
@@ -2302,6 +2305,7 @@ static void readOttava(XmlReader& e, ReadContext& ctx, Ottava* ottava)
         }
     }
     ottava->styleChanged();
+    CompatUtils::resetHookHeightSign(ottava);
     adjustPlacement(ottava);
 }
 
@@ -2344,6 +2348,7 @@ void Read206::readHairpin206(XmlReader& e, ReadContext& ctx, Hairpin* h)
         h->setContinueText(u"");
         h->setEndText(u"");
     }
+    CompatUtils::resetHookHeightSign(h);
     adjustPlacement(h);
 }
 
@@ -2379,6 +2384,7 @@ void Read206::readTextLine206(XmlReader& e, ReadContext& ctx, TextLineBase* tlb)
             e.unknown();
         }
     }
+    CompatUtils::resetHookHeightSign(tlb);
     adjustPlacement(tlb);
 }
 

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2652,6 +2652,7 @@ void TRead::read(GradualTempoChange* c, XmlReader& xml, ReadContext& ctx)
             xml.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(c);
     compat::CompatUtils::setTextLineTextPositionFromAlign(c);
 }
 
@@ -2701,6 +2702,7 @@ void TRead::read(Hairpin* h, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(h);
     compat::CompatUtils::setTextLineTextPositionFromAlign(h);
 
     h->styleChanged();
@@ -2870,6 +2872,7 @@ void TRead::read(LetRing* r, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(r);
     compat::CompatUtils::setTextLineTextPositionFromAlign(r);
 }
 
@@ -3208,6 +3211,7 @@ void TRead::read(Ottava* o, XmlReader& e, ReadContext& ctx)
     while (e.readNextStartElement()) {
         readProperties(o, e, ctx);
     }
+    compat::CompatUtils::resetHookHeightSign(o);
     compat::CompatUtils::setTextLineTextPositionFromAlign(o);
     if (o->ottavaType() != OttavaType::OTTAVA_8VA || o->numbersOnly() != o->propertyDefault(Pid::NUMBERS_ONLY).toBool()) {
         o->styleChanged();
@@ -3274,6 +3278,7 @@ void TRead::read(PalmMute* p, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(p);
     compat::CompatUtils::setTextLineTextPositionFromAlign(p);
 }
 
@@ -3452,6 +3457,7 @@ void TRead::read(Pedal* p, XmlReader& e, ReadContext& ctx)
         p->setPropertyFlags(Pid::END_TEXT, PropertyFlags::STYLED);
     }
 
+    compat::CompatUtils::resetHookHeightSign(p);
     compat::CompatUtils::setTextLineTextPositionFromAlign(p);
 }
 
@@ -3988,6 +3994,7 @@ void TRead::read(TextLineBase* b, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(b);
     compat::CompatUtils::setTextLineTextPositionFromAlign(b);
 }
 
@@ -4343,6 +4350,7 @@ void TRead::read(Volta* v, XmlReader& e, ReadContext& ctx)
         }
     }
 
+    compat::CompatUtils::resetHookHeightSign(v);
     compat::CompatUtils::setTextLineTextPositionFromAlign(v);
 }
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2804,6 +2804,7 @@ void TRead::read(GradualTempoChange* c, XmlReader& xml, ReadContext& ctx)
         }
     }
 
+    compat::CompatUtils::resetHookHeightSign(c);
     compat::CompatUtils::setTextLineTextPositionFromAlign(c);
 }
 
@@ -2909,6 +2910,7 @@ void TRead::read(Hairpin* h, XmlReader& e, ReadContext& ctx)
         }
     }
 
+    compat::CompatUtils::resetHookHeightSign(h);
     compat::CompatUtils::setTextLineTextPositionFromAlign(h);
 
     h->styleChanged();
@@ -3077,6 +3079,7 @@ void TRead::read(LetRing* r, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(r);
     compat::CompatUtils::setTextLineTextPositionFromAlign(r);
 }
 
@@ -3406,6 +3409,7 @@ void TRead::read(Ottava* o, XmlReader& e, ReadContext& ctx)
     while (e.readNextStartElement()) {
         readProperties(o, e, ctx);
     }
+    compat::CompatUtils::resetHookHeightSign(o);
     compat::CompatUtils::setTextLineTextPositionFromAlign(o);
     if (o->ottavaType() != OttavaType::OTTAVA_8VA || o->numbersOnly() != o->propertyDefault(Pid::NUMBERS_ONLY).toBool()) {
         o->styleChanged();
@@ -3461,6 +3465,7 @@ void TRead::read(PalmMute* p, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(p);
     compat::CompatUtils::setTextLineTextPositionFromAlign(p);
 }
 
@@ -3608,6 +3613,7 @@ void TRead::read(Pedal* p, XmlReader& e, ReadContext& ctx)
             p->setPropertyFlags(Pid::END_TEXT, PropertyFlags::STYLED);
         }
     }
+    compat::CompatUtils::resetHookHeightSign(p);
     compat::CompatUtils::setTextLineTextPositionFromAlign(p);
 }
 
@@ -4134,6 +4140,8 @@ void TRead::read(TextLineBase* b, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+
+    compat::CompatUtils::resetHookHeightSign(b);
     compat::CompatUtils::setTextLineTextPositionFromAlign(b);
 }
 
@@ -4470,6 +4478,7 @@ void TRead::read(Volta* v, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
+    compat::CompatUtils::resetHookHeightSign(v);
     compat::CompatUtils::setTextLineTextPositionFromAlign(v);
 }
 

--- a/src/engraving/tests/compat114_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat114_data/hairpin-ref.mscx
@@ -130,6 +130,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>O_O</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/compat114_data/pedal-ref.mscx
+++ b/src/engraving/tests/compat114_data/pedal-ref.mscx
@@ -100,7 +100,7 @@
           <Spanner type="Pedal">
             <Pedal>
               <continueText>&lt;font size=&quot;11&quot;/&gt;</continueText>
-              <endHookHeight>-1.5</endHookHeight>
+              <endHookHeight>1.5</endHookHeight>
               <eid>I_I</eid>
               </Pedal>
             <next>

--- a/src/engraving/tests/compat206_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat206_data/hairpin-ref.mscx
@@ -104,6 +104,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>H_H</eid>
               </HairPin>
             <next>
@@ -732,6 +734,8 @@
             <Spanner type="HairPin">
               <HairPin>
                 <subtype>0</subtype>
+                <beginHookHeight>-1.9</beginHookHeight>
+                <endHookHeight>-1.9</endHookHeight>
                 <eid>5B_5B</eid>
                 </HairPin>
               <next>

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -576,8 +576,6 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
-              <beginHookHeight>-1.2</beginHookHeight>
-              <endHookHeight>-1.2</endHookHeight>
               <eid>AB_AB</eid>
               </Pedal>
             <next>

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -283,6 +283,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>i_i</eid>
               </HairPin>
             <next>
@@ -642,6 +644,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>ZB_ZB</eid>
               </HairPin>
             <next>
@@ -1110,6 +1114,8 @@
             <Spanner type="HairPin">
               <HairPin>
                 <subtype>0</subtype>
+                <beginHookHeight>-1.9</beginHookHeight>
+                <endHookHeight>-1.9</endHookHeight>
                 <eid>bC_bC</eid>
                 <linkedTo>i_i</linkedTo>
                 </HairPin>
@@ -1516,6 +1522,8 @@
             <Spanner type="HairPin">
               <HairPin>
                 <subtype>0</subtype>
+                <beginHookHeight>-1.9</beginHookHeight>
+                <endHookHeight>-1.9</endHookHeight>
                 <eid>SD_SD</eid>
                 <linkedTo>ZB_ZB</linkedTo>
                 </HairPin>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
@@ -194,6 +194,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>J_J</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
@@ -194,6 +194,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>J_J</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/implode_explode_data/implodeScore01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeScore01-ref.mscx
@@ -290,6 +290,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>N_N</eid>
               </HairPin>
             <next>
@@ -871,6 +873,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>8B_8B</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/implode_explode_data/implodeScore02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeScore02-ref.mscx
@@ -336,6 +336,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>8B_8B</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/implode_explode_data/undoExplode01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoExplode01-ref.mscx
@@ -321,6 +321,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>W_W</eid>
               </HairPin>
             <next>
@@ -538,6 +540,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>4_4</eid>
               </HairPin>
             <next>
@@ -754,6 +758,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>ZB_ZB</eid>
               </HairPin>
             <next>
@@ -970,6 +976,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>6B_6B</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/implode_explode_data/undoExplode02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoExplode02-ref.mscx
@@ -387,6 +387,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>W_W</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/join_data/join03-ref.mscx
+++ b/src/engraving/tests/join_data/join03-ref.mscx
@@ -96,6 +96,8 @@
             <HairPin>
               <subtype>0</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>K_K</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/join_data/join07-ref.mscx
+++ b/src/engraving/tests/join_data/join07-ref.mscx
@@ -123,6 +123,8 @@
             <HairPin>
               <subtype>0</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>Q_Q</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/join_data/join09-ref.mscx
+++ b/src/engraving/tests/join_data/join09-ref.mscx
@@ -128,6 +128,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>K_K</eid>
               </HairPin>
             <next>
@@ -199,6 +201,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>U_U</eid>
               </HairPin>
             <next>
@@ -211,6 +215,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>V_V</eid>
               </HairPin>
             <next>
@@ -358,6 +364,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>n_n</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/join_data/join10-ref.mscx
+++ b/src/engraving/tests/join_data/join10-ref.mscx
@@ -128,6 +128,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>K_K</eid>
               </HairPin>
             <next>
@@ -206,6 +208,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>V_V</eid>
               </HairPin>
             <next>
@@ -217,6 +221,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>W_W</eid>
               </HairPin>
             <next>
@@ -352,6 +358,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>n_n</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/measure_data/measure-4-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-4-ref.mscx
@@ -80,6 +80,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>I_I</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/measure_data/measure-5-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-5-ref.mscx
@@ -90,6 +90,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>K_K</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/measure_data/measure-6-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-6-ref.mscx
@@ -78,6 +78,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>I_I</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/measure_data/measure-7-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-7-ref.mscx
@@ -80,6 +80,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>I_I</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/measure_data/measure-9-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-9-ref.mscx
@@ -81,6 +81,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>I_I</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/parts_data/voices-ref.mscx
+++ b/src/engraving/tests/parts_data/voices-ref.mscx
@@ -259,6 +259,8 @@
             <HairPin>
               <subtype>0</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <beginText>cresc.</beginText>
               <continueText>(cresc.)</continueText>
               <eid>c_c</eid>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter1-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter1-base-ref.xml
@@ -19,6 +19,8 @@
       <HairPin>
         <subtype>0</subtype>
         <veloChange>10</veloChange>
+        <beginHookHeight>-1.9</beginHookHeight>
+        <endHookHeight>-1.9</endHookHeight>
         <ticks_f>2/4</ticks_f>
         </HairPin>
       <next>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter1-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter1-ref.xml
@@ -15,6 +15,8 @@
       <HairPin>
         <subtype>0</subtype>
         <veloChange>10</veloChange>
+        <beginHookHeight>-1.9</beginHookHeight>
+        <endHookHeight>-1.9</endHookHeight>
         <ticks_f>2/4</ticks_f>
         </HairPin>
       <next>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter22-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter22-base-ref.xml
@@ -19,6 +19,8 @@
       <HairPin>
         <subtype>0</subtype>
         <veloChange>10</veloChange>
+        <beginHookHeight>-1.9</beginHookHeight>
+        <endHookHeight>-1.9</endHookHeight>
         <ticks_f>2/4</ticks_f>
         </HairPin>
       <next>

--- a/src/engraving/tests/split_data/split03-ref.mscx
+++ b/src/engraving/tests/split_data/split03-ref.mscx
@@ -97,6 +97,8 @@
             <HairPin>
               <subtype>0</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>K_K</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/split_data/split07-ref.mscx
+++ b/src/engraving/tests/split_data/split07-ref.mscx
@@ -129,6 +129,8 @@
             <HairPin>
               <subtype>0</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>R_R</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/split_data/split295207-ref.mscx
+++ b/src/engraving/tests/split_data/split295207-ref.mscx
@@ -109,6 +109,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>N_N</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/timesig_data/timesig-03-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-03-ref.mscx
@@ -234,6 +234,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>q_q</eid>
               </HairPin>
             <next>

--- a/src/engraving/tests/timesig_data/timesig-05-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-05-ref.mscx
@@ -72,6 +72,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>F_F</eid>
               </HairPin>
             <next>
@@ -328,6 +330,8 @@
             <HairPin>
               <subtype>1</subtype>
               <veloChange>10</veloChange>
+              <beginHookHeight>-1.9</beginHookHeight>
+              <endHookHeight>-1.9</endHookHeight>
               <eid>2_2</eid>
               </HairPin>
             <next>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33348
This PR migrates hook height signs (<4.6) on file read to avoid an additional score layout. 

It also fixes a bug in ornament cue note layout order covered up by this second layout. 