### PR TITLE
Allow unisons in note sets

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -3510,7 +3510,14 @@ void Score::cmdAddBracket()
 struct NoteComparator {
     bool operator()(const Note* n1, const Note* n2) const
     {
-        return noteIsBefore(n1, n2);
+        if (noteIsBefore(n1, n2)) {
+            return true;
+        }
+        if (noteIsBefore(n2, n1)) {
+            return false;
+        }
+        // tiebreak by pointer address so we can have unison notes in the set
+        return n1 < n2;
     }
 };
 


### PR DESCRIPTION
Resolves: #32451 

Add a case to the note set comparator to allow 2 different notes with the same pitch in the set.