### PR TITLE
Fix #32469: Items surviving repeat ranges / copy-paste ranges [4.7.0]

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -1497,21 +1497,11 @@ bool Score::makeGap1(const Fraction& baseTick, staff_idx_t staffIdx, const Fract
         if (newLen > Fraction(0, 1)) {
             const Fraction endTick = tick + actualTicks(newLen, nullptr, staff(staffIdx)->timeStretch(tick));
 
-            // Delete annotations that require an anchor to the previous segment
-            Segment* s1 = tick2rightSegment(tick);
-            Segment* s2 = tick2rightSegment(endTick);
-            if (s1 && s2 && (*s2) > (*s1)) {
-                for (Segment* s = s1; s && s != s2; s = s->next1()) {
-                    const auto annotations = s->annotations(); // make a copy since we alter the list
-                    for (EngravingItem* annotation : annotations) {
-                        if (!annotation->systemFlag() && !annotation->allowTimeAnchor() && annotation->track() == track) {
-                            deleteItem(annotation);
-                        }
-                    }
-                }
-            }
-
             SelectionFilter filter;
+            // chord symbols can exist without chord/rest so they should not be removed
+            filter.setFiltered(ElementsSelectionFilterTypes::CHORD_SYMBOL, false);
+
+            deleteAnnotationsFromRange(tick2rightSegment(tick), tick2rightSegment(endTick), track, track + 1, filter);
             deleteOrShortenOutSpannersFromRange(tick, endTick, track, track + 1, filter);
         }
 


### PR DESCRIPTION
Partially reverts: #31839
Resolves: #32469

Looks like we now know the answer to [this question](https://github.com/musescore/MuseScore/pull/31839#issuecomment-3773166398) @XiaoMigros @cbjeukendrup  😁

Let me know if this is OK - from what I can tell this specific change was purely made for the sake of consistency and won't affect #26685. This is all going to change anyway when I finally get round to finishing #30178.