### PR TITLE
Fix instrument change clef not reacting to concert pitch toggle

### DIFF
--- a/src/engraving/dom/instrchange.cpp
+++ b/src/engraving/dom/instrchange.cpp
@@ -99,20 +99,18 @@ void InstrumentChange::setupInstrument(const Instrument* instrument)
     Interval v = instrument->transpose();
     bool concPitch = style().styleB(Sid::concertPitch);
 
-    // change the clef for each staff
     for (size_t i = 0; i < part->nstaves(); i++) {
-        ClefType oldClefType = concPitch ? part->instrument(tickStart)->clefType(i).concertClef
-                               : part->instrument(tickStart)->clefType(i).transposingClef;
-        ClefType newClefType = concPitch ? instrument->clefType(i).concertClef
-                               : instrument->clefType(i).transposingClef;
-        // Introduce cleff change only if the new clef *symbol* is different from the old one
-        if (ClefInfo::symId(oldClefType) != ClefInfo::symId(newClefType)) {
-            // If instrument change is at the start of a measure, use the measure as the element, as this will place the instrument change before the barline.
+        ClefTypeList oldClefTypeList = part->instrument(tickStart)->clefType(i);
+        ClefTypeList newClefTypeList = instrument->clefType(i);
+        if (ClefInfo::symId(oldClefTypeList.concertClef) != ClefInfo::symId(newClefTypeList.concertClef)
+            || ClefInfo::symId(oldClefTypeList.transposingClef) != ClefInfo::symId(newClefTypeList.transposingClef)) {
+            int cp = static_cast<int>(newClefTypeList.concertClef);
+            int tp = static_cast<int>(newClefTypeList.transposingClef);
+            int packedData = 1000 + (cp & 0xFF) + ((tp & 0xFF) << 8);
             EngravingItem* element = rtick().isZero() ? toEngravingItem(findMeasure()) : toEngravingItem(this);
-            score()->undoChangeClef(part->staff(i), element, newClefType, true);
+            score()->undoChangeClef(part->staff(i), element, newClefTypeList.concertClef, packedData);
         }
     }
-
     // Change key signature if necessary. CAUTION: not necessary in case of octave-transposing!
     if ((v.chromatic - oldV.chromatic) % 12) {
         for (size_t i = 0; i < part->nstaves(); i++) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -500,7 +500,7 @@ public:
     void undoChangeTuning(Note*, double);
     void undoChangeUserMirror(Note*, DirectionH);
     void undoChangeKeySig(Staff* ostaff, const Fraction& tick, KeySigEvent);
-    void undoChangeClef(Staff* ostaff, EngravingItem*, ClefType st, bool forInstrumentChange = false, Clef* clefToRelink = nullptr);
+    void undoChangeClef(Staff* ostaff, EngravingItem*, ClefType st, int forInstrumentChange = false, Clef* clefToRelink = nullptr);
     bool undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyValue& propValue,
                              PropertyFlags propFlags = PropertyFlags::NOSTYLE);
     void undoPropertyChanged(EngravingObject*, Pid, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE);

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -6173,7 +6173,7 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
 //    create a clef before element e
 //---------------------------------------------------------
 
-void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool forInstrumentChange, Clef* clefToRelink)
+void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, int forInstrumentChange, Clef* clefToRelink)
 {
     IF_ASSERT_FAILED(ostaff && e) {
         return;
@@ -6211,6 +6211,14 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
     Fraction tick = e->tick();
     Fraction rtick = e->rtick();
     bool isSmall = (st == SegmentType::Clef);
+    bool isIC = (forInstrumentChange >= 1000);
+    ClefType cp = ct;
+    ClefType tp = ct;
+    if (isIC) {
+        int val = forInstrumentChange - 1000;
+        cp = static_cast<ClefType>(static_cast<signed char>(val & 0xFF));
+        tp = static_cast<ClefType>(static_cast<signed char>((val >> 8) & 0xFF));
+    }
     for (Staff* staff : ostaff->staffList()) {
         if (clefToRelink && ostaff == staff) {
             continue;
@@ -6240,7 +6248,7 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
 
         StaffType* staffType = staff->staffType(e->tick());
         StaffGroup staffGroup = staffType->group();
-        if (ClefInfo::staffGroup(ct) != staffGroup && !forInstrumentChange) {
+        if (ClefInfo::staffGroup(ct) != staffGroup && !isIC) {
             continue;
         }
 
@@ -6250,17 +6258,18 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
             // clef type for concertPitch
             //
             Instrument* i = staff->part()->instrument(tick);
-            ClefType cp, tp;
-            if (i->transpose().isZero()) {
-                cp = ct;
-                tp = ct;
-            } else {
-                if (concertPitch) {
+            if (!isIC) {
+                if (i->transpose().isZero()) {
                     cp = ct;
-                    tp = clef->transposingClef();
-                } else {
-                    cp = clef->concertClef();
                     tp = ct;
+                } else {
+                    if (concertPitch) {
+                        cp = ct;
+                        tp = clef->transposingClef();
+                    } else {
+                        cp = clef->concertClef();
+                        tp = ct;
+                    }
                 }
             }
             clef->setGenerated(false);
@@ -6286,7 +6295,12 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
                 clef->setScore(score);
             } else {
                 clef = Factory::createClef(score->dummy()->segment());
-                clef->setClefType(ct);
+                if (isIC) {
+                    clef->setTransposingClef(tp);
+                    clef->setConcertClef(cp);
+                } else {
+                    clef->setClefType(ct);
+                }
                 gclef = clef;
             }
             clef->setTrack(track);
@@ -6294,7 +6308,7 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
             clef->setIsHeader(st == SegmentType::HeaderClef);
             score->doUndoAddElement(clef);
         }
-        if (forInstrumentChange) {
+        if (isIC) {
             clef->setForInstrumentChange(true);
         }
         clef->setSmall(isSmall);


### PR DESCRIPTION
Resolves: #32614 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clef handling during instrument changes to properly track and update both concert and transposing clef information, ensuring more accurate clef transitions when instruments change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->