### PR TITLE
fixed com init for audio. 4.7

### DIFF
--- a/src/framework/audio/driver/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/win/wasapiaudiodriver.cpp
@@ -243,10 +243,9 @@ std::string WasapiAudioDriver::name() const
 void WasapiAudioDriver::init()
 {
     LOGI() << "begin driver init";
-    CoUninitialize();
-    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    HRESULT hr = CoInitialize(nullptr);
     if (FAILED(hr)) {
-        LOGE() << "failed CoInitializeEx, error: " << hrToString(hr);
+        LOGE() << "failed CoInitialize, error: " << hrToString(hr);
     }
 
     hr = CoCreateInstance(
@@ -425,6 +424,12 @@ bool WasapiAudioDriver::open(const Spec& spec, Spec* activeSpec)
 
 void WasapiAudioDriver::th_audioThread()
 {
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (FAILED(hr)) {
+        LOGE() << "failed CoInitializeEx, error: " << hrToString(hr);
+        return;
+    }
+
     m_opened = th_audioInitialize();
     m_activeSpecChanged.send(m_activeSpec);
 
@@ -439,6 +444,8 @@ void WasapiAudioDriver::th_audioThread()
             break;
         }
     }
+
+    CoUninitialize();
 }
 
 bool WasapiAudioDriver::th_audioInitialize()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32430

The [previous fix](https://github.com/musescore/MuseScore/pull/32474) didn't work; an error arose from within the Qt.
This is the new fix.

@krasko78 FYI