### PR TITLE
fix issue #32496 CMake configuration of mnx_w3c

### DIFF
--- a/src/importexport/mnx/CMakeLists.txt
+++ b/src/importexport/mnx/CMakeLists.txt
@@ -16,10 +16,15 @@ if(MUE_COMPILE_USE_SYSTEM_MNXDOM)
     target_compile_definitions(iex_mnx PRIVATE MNXDOM_SYSTEM)
     message(STATUS "Using system-installed mnxdom")
 else()
+    set(_mnxdom_patch_script ${CMAKE_CURRENT_LIST_DIR}/cmake/patch_mnxdom_download_timestamp.cmake)
+
     FetchContent_Declare(
         mnxdom
         GIT_REPOSITORY https://github.com/rpatters1/mnxdom.git
         GIT_TAG        1557afd19d47b7935ddda2b69131f5c62efab84c
+        PATCH_COMMAND  ${CMAKE_COMMAND}
+                       -Dmnxdom_SOURCE_DIR=<SOURCE_DIR>
+                       -P ${_mnxdom_patch_script}
     )
     FetchContent_MakeAvailable(mnxdom)
     set(MNXDOM_LIB mnxdom)

--- a/src/importexport/mnx/cmake/patch_mnxdom_download_timestamp.cmake
+++ b/src/importexport/mnx/cmake/patch_mnxdom_download_timestamp.cmake
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT DEFINED mnxdom_SOURCE_DIR)
+    message(FATAL_ERROR "mnxdom_SOURCE_DIR is not set")
+endif()
+
+set(_target_file "${mnxdom_SOURCE_DIR}/CMakeLists.txt")
+if(NOT EXISTS "${_target_file}")
+    message(FATAL_ERROR "mnxdom patch: file not found: ${_target_file}")
+endif()
+
+file(READ "${_target_file}" _content)
+set(_original "${_content}")
+
+string(REPLACE "        DOWNLOAD_EXTRACT_TIMESTAMP TRUE\n" "" _content "${_content}")
+string(REPLACE "        DOWNLOAD_EXTRACT_TIMESTAMP TRUE\r\n" "" _content "${_content}")
+
+if(_content STREQUAL _original)
+    message(STATUS "mnxdom patch: DOWNLOAD_EXTRACT_TIMESTAMP lines already removed")
+else()
+    file(WRITE "${_target_file}" "${_content}")
+    message(STATUS "mnxdom patch: removed DOWNLOAD_EXTRACT_TIMESTAMP from mnxdom CMakeLists.txt")
+endif()


### PR DESCRIPTION
Resolves: #32496 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
I really don't know how those lines ended up being wrong but this patch script removes them and unblocks me. I don't really think this is the right approach in the long run, but perhaps it can unblock someone else encountering the issue. Likely someone needs to dig in and find out where these faulty DOWNLOAD_EXTRACT_TIMESTAMP lines came from in the first place, and fix it at the source. However, the patch also does no harm as an interim solution.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

I believe unit test / vtest is not applicable to this change.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
