### PR TITLE
#32521: Fixed reset button for Text Alignment/Position [4.7]

### DIFF
--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -2371,12 +2371,26 @@ void EditStyle::textStyleChanged(int row)
 
         case TextStylePropertyType::TextAlign:
             textStyleAlign->setAlign(styleValue(a.sid).value<Align>());
-            resetTextStyleAlign->setEnabled(styleValue(a.sid) != defaultStyleValue(a.sid));
+            resetTextStyleAlign->setEnabled(
+                styleValue(a.sid) != defaultStyleValue(a.sid)
+                || [&ts, this]()->bool {    // OR Position is modified
+                const auto& b = std::find_if(ts->begin(), ts->end(), [](const auto& s){
+                    return s.type == TextStylePropertyType::Position;
+                });
+                return b != ts->end() && styleValue(b->sid) != defaultStyleValue(b->sid);
+            }());
             break;
 
         case TextStylePropertyType::Position:
             textStyleAlign->setPosition(styleValue(a.sid).value<AlignH>());
-            resetTextStyleAlign->setEnabled(styleValue(a.sid) != defaultStyleValue(a.sid));
+            resetTextStyleAlign->setEnabled(
+                styleValue(a.sid) != defaultStyleValue(a.sid)
+                || [&ts, this]()->bool { // OR TextAlign is modified
+                const auto& b = std::find_if(ts->begin(), ts->end(), [](const auto& s){
+                    return s.type == TextStylePropertyType::TextAlign;
+                });
+                return b != ts->end() && styleValue(b->sid) != defaultStyleValue(b->sid);
+            }());
             break;
 
         case TextStylePropertyType::Offset:


### PR DESCRIPTION
Resolves: #32521 (style settings only) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Implemented dependent checks for alignment/position reset button state as they share a single reset point. Previously the position condition was overriding any state set by the alignment, ignoring any dependency.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
