### PR TITLE
Add ability to have an icon for dropdown

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
@@ -21,6 +21,7 @@
  */
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import Muse.Ui
 import Muse.UiComponents
@@ -35,6 +36,7 @@ Item {
     property int count: Boolean(model) ? model.length : 0
     property string textRole: "text"
     property string valueRole: "value"
+    property Component contentItem: null
 
     property int currentIndex: -1
 
@@ -50,9 +52,6 @@ Item {
     property string indeterminateText: "--"
 
     property int popupItemsCount: 18
-
-    property alias dropIcon: mainItem.dropIcon
-    property alias label: mainItem.label
 
     property alias navigation: mainItem.navigation
 
@@ -123,9 +122,6 @@ Item {
         property bool selected: false
         property bool insideDropdownList: false
 
-        property alias label: labelItem
-        property alias dropIcon: dropIconItem
-
         property color hoveredColor: backgroundItem.color
 
         property alias navigation: navCtrl
@@ -136,7 +132,7 @@ Item {
             name: mainItem.objectName != "" ? mainItem.objectName : "Dropdown"
             enabled: mainItem.enabled && mainItem.visible
             accessible.role: MUAccessible.ComboBox
-            accessible.name: labelItem.text
+            accessible.name: root.displayText
 
             onActiveChanged: {
                 if (!mainItem.activeFocus) {
@@ -159,25 +155,50 @@ Item {
             NavigationFocusBorder { navigationCtrl: navCtrl }
         }
 
-        StyledTextLabel {
-            id: labelItem
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.right: dropIconItem.left
-            anchors.leftMargin: 12
-            anchors.rightMargin: 6
-            horizontalAlignment: Text.AlignLeft
-            text: root.displayText
-        }
+        Loader {
+            id: contentLoader
 
-        StyledIconLabel {
-            id: dropIconItem
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.right
-            anchors.rightMargin: 8
+            anchors.fill: parent
 
-            iconCode: IconCode.SMALL_ARROW_DOWN
+            sourceComponent: root.contentItem ?? defaultContentComponent
+
+            onLoaded: {
+                const item = contentLoader.item
+                if (!item) {
+                    return
+                }
+
+                if (item.text !== undefined) {
+                    item.text = Qt.binding(function() { return root.displayText })
+                }
+            }
+
+            Component {
+                id: defaultContentComponent
+
+                RowLayout {
+                    property alias labelItem: labelItem
+
+                    anchors.fill: parent
+                    anchors.leftMargin: 12
+                    anchors.rightMargin: 8
+                    spacing: 6
+
+                    StyledTextLabel {
+                        id: labelItem
+
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignVCenter
+                        horizontalAlignment: Text.AlignLeft
+                        text: root.displayText
+                    }
+
+                    StyledIconLabel {
+                        Layout.alignment: Qt.AlignVCenter
+                        iconCode: IconCode.SMALL_ARROW_DOWN
+                    }
+                }
+            }
         }
 
         MouseArea {
@@ -190,12 +211,13 @@ Item {
             onClicked: mainItem.clicked()
 
             onContainsMouseChanged: {
-                if (!labelItem.truncated) {
+                const defaultLabel = contentLoader.item ? contentLoader.item.labelItem : null
+                if (!defaultLabel || !defaultLabel.truncated) {
                     return
                 }
 
                 if (mouseAreaItem.containsMouse) {
-                    ui.tooltip.show(mainItem, labelItem.text)
+                    ui.tooltip.show(mainItem, root.displayText)
                 } else {
                     ui.tooltip.hide(mainItem)
                 }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
@@ -149,8 +149,34 @@ Item {
                 width: 86
                 height: 24
 
-                label.anchors.leftMargin: 8
-                dropIcon.anchors.rightMargin: 4
+                contentItem: Item {
+                    property string text: ""
+                    property alias labelItem: labelItem
+
+                    StyledTextLabel {
+                        id: labelItem
+
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        anchors.left: parent.left
+                        anchors.right: dropIconItem.left
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 6
+
+                        horizontalAlignment: Text.AlignLeft
+                        text: parent.text
+                    }
+
+                    StyledIconLabel {
+                        id: dropIconItem
+
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: 4
+
+                        iconCode: IconCode.SMALL_ARROW_DOWN
+                    }
+                }
 
                 visible: traitsBox.count > 1
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8576

Allow to set an icon for a dropdown item:
<img width="851" height="173" alt="dropdown2" src="https://github.com/user-attachments/assets/dd382891-2283-4a94-ab8f-6fc6683ec65b" />
<img width="828" height="103" alt="dropdown" src="https://github.com/user-attachments/assets/5e46a4f4-a1b6-4d8e-8049-486aac4cd42d" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

QA:
- [ ] there should be no visual change in dropdowns in MU4