### PR TITLE
[4.7] Fix MSVC compiler warnings

### DIFF
--- a/src/framework/media/internal/videoencoder.cpp
+++ b/src/framework/media/internal/videoencoder.cpp
@@ -95,7 +95,11 @@ bool VideoEncoder::open(const muse::io::path_t& fileName, unsigned width, unsign
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 7, 100)
     snprintf(m_ffmpeg->formatCtx->filename, sizeof(m_ffmpeg->formatCtx->filename), "%s", fileName.c_str());
 #else
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
     m_ffmpeg->formatCtx->url = strdup(fileName.c_str());
+#else
+    m_ffmpeg->formatCtx->url = _strdup(fileName.c_str());
+#endif
 #endif
 
     // Add the video stream


### PR DESCRIPTION
* reg.: '=': truncation from 'double' to 'float' (C4305)
* reg.: declaration of 'ret' hides previous local declaration (C4456)
* reg.: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup. See online help for details. (C4996)
