### PR TITLE
Paste multiline text properly

### DIFF
--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -926,13 +926,19 @@ void TextBase::paste(EditData& ed, const String& txt)
                     sym += c;
                 } else {
                     deleteSelectedText(ed);
-                    static_cast<TextEditData*>(ed.getData(this).get())->cursor()->setFormat(format);
+                    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
+                    TextCursor* cursor = ted->cursor();
+                    cursor->setFormat(format);
                     if (c.isHighSurrogate()) {
                         Char highSurrogate = c;
                         assert(i + 1 < txt.size());
                         i++;
                         Char lowSurrogate = txt.at(i);
                         insertText(ed, String::fromUcs4(Char::surrogateToUcs4(highSurrogate, lowSurrogate)));
+                    } else if (c == '\r') {
+                        continue;
+                    } else if (c == '\n') {
+                        score()->undo(new SplitText(cursor), &ed);
                     } else {
                         insertText(ed, String(c));
                     }


### PR DESCRIPTION
Resolves: #32593 

The fix is borrowed from the handling of the Enter/Return key (lines 471-476).

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
