### PR TITLE
[4.7] Fix empty articulations from MEI

### DIFF
--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1716,6 +1716,12 @@ bool MeiImporter::readArtic(pugi::xml_node articNode, Chord* chord)
 
     Convert::articFromMEI(articulation, meiArtic, warning);
 
+    if (articulation->symId() == SymId::noSym) {
+        // remove the articulation if it has no symbol
+        chord->remove(articulation);
+        delete articulation;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
This contains only the fix from #32615 to prevent adding empty articulations from importing MEI, which was happening since the addition of text articulations.

Possibly fixes #29440
