### PR TITLE
Remove functions without definitions

### DIFF
--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -354,8 +354,6 @@ public:
 
     void scanElements(std::function<void(EngravingItem*)> func) override;
 
-    void dumpScoreTree();  // for debugging purposes
-
     RootItem* rootItem() const { return m_rootItem; }
     compat::DummyElement* dummy() const { return m_rootItem->dummy(); }
 
@@ -638,7 +636,6 @@ public:
                                                StaffAccepted staffAccepted = StaffAccepted()) const;
 
     void appendPart(const InstrumentTemplate*);
-    void updateStaffIndex();
     void sortSystemObjects(std::vector<staff_idx_t>& dst);
     void sortStaves(std::vector<staff_idx_t>& dst);
 
@@ -1110,10 +1107,6 @@ private:
     ChordRest* findChordRestEndingBeforeTickInStaffAndVoice(const Fraction& tick, staff_idx_t staffIdx, bool forceVoice,
                                                             voice_idx_t voice) const;
 
-    void addTempo();
-    void addMetronome();
-
-    void checkSlurs();
     void checkScore();
 
     bool rewriteMeasures(Measure* fm, Measure* lm, const Fraction&, staff_idx_t staffIdx);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -7787,9 +7787,7 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
         }
     } else {
         // add new text if no existing element to edit
-        // TODO: for tempo text, mscore->addTempo() could be called
-        // but it pre-fills the text
-        // would be better to create empty tempo element
+        // TODO: for tempo text, would be better to create empty tempo element
         if (type != ElementType::TEMPO_TEXT) {
             addTextToItem(textStyleType, el);
         }


### PR DESCRIPTION
Several functions in `score.h` do not have definitions and warnings are issued for them. Click on the links below to view the search results for the functions.

[dumpScoreTree](https://github.com/search?q=repo%3Amusescore%2FMuseScore%20dumpScoreTree&type=code)
[updateStaffIndex](https://github.com/search?q=repo%3Amusescore%2FMuseScore+updateStaffIndex&type=code)
[addTempo](https://github.com/search?q=repo%3Amusescore%2FMuseScore+addTempo&type=code)
[addMetronome](https://github.com/search?q=repo%3Amusescore%2FMuseScore+addMetronome&type=code)
[checkSlurs](https://github.com/search?q=repo%3Amusescore%2FMuseScore+checkSlurs&type=code)

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
