### PR TITLE
Get font family of main menu from Qt on Windows as well

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -649,14 +649,6 @@ Notification UiConfiguration::musicalTextFontChanged() const
 
 std::string UiConfiguration::defaultFontFamily() const
 {
-#ifdef Q_OS_WIN
-    static const QString defaultWinFamily = "Segoe UI";
-
-    if (QFontDatabase::hasFamily(defaultWinFamily)) {
-        return defaultWinFamily.toStdString();
-    }
-#endif
-
     return QFontDatabase::systemFont(QFontDatabase::GeneralFont).family().toStdString();
 }
 


### PR DESCRIPTION
Resolves: #32626

<img width="983" height="190" alt="image" src="https://github.com/user-attachments/assets/e3939050-cd5d-4852-90d7-380ea7060545" />

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
