### PR TITLE
Fix: Update clef elements when changing default instrument

### DIFF
--- a/src/notationscene/widgets/editstaff.cpp
+++ b/src/notationscene/widgets/editstaff.cpp
@@ -586,6 +586,7 @@ void EditStaff::showReplaceInstrumentDialog()
 
         m_instrument = Instrument::fromTemplate(&val);
         m_staff->setStaffType(m_tick, *staffType);
+        m_staff->setDefaultClefType(m_instrument.clefType(0));
 
         updateInstrument();
         updateStaffType(*staffType);


### PR DESCRIPTION
This fixes a regression introduced by 99b5b5bf ("EditStaff: don't unexpectedly change clef when pressing OK without making changes").

That commit changed applyStaffProperties() to read the clef from m_staff->defaultClefType() instead of m_instrument.clefType(). However, showReplaceInstrumentDialog() never updates m_staff's default clef type when the instrument changes, so on the second apply() call (Apply then OK), applyStaffProperties() sends the stale old clef, reverting the change.

The fix adds m_staff->setDefaultClefType(m_instrument.clefType(0)) in showReplaceInstrumentDialog() to keep m_staff consistent with the selected instrument.

Resolves: #32633 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
