### PR TITLE
Take the size of the default font from Qt

### DIFF
--- a/src/framework/ui/api/themeapi.cpp
+++ b/src/framework/ui/api/themeapi.cpp
@@ -420,8 +420,7 @@ void ThemeApi::setupUiFonts()
         font->setWeight(fontConfig.weight);
     }
 
-    m_defaultFont.setFamily(QString::fromStdString(configuration()->defaultFontFamily()));
-    m_defaultFont.setPixelSize(configuration()->defaultFontSize());
+    m_defaultFont = configuration()->defaultFont();
 }
 
 void ThemeApi::setupIconsFont()

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -93,13 +93,13 @@ void UiConfiguration::init()
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
     settings()->setDefaultValue(UI_CUSTOM_COLORS_KEY, Val(readLegacyCustomColors()));
     settings()->setDefaultValue(UI_FOLLOW_SYSTEM_THEME_KEY, Val(false));
-    settings()->setDefaultValue(UI_FONT_FAMILY_KEY, Val(defaultFontFamily()));
-    settings()->setDefaultValue(UI_FONT_SIZE_KEY, Val(defaultFontSize()));
+    settings()->setDefaultValue(UI_FONT_FAMILY_KEY, Val(defaultFont().family()));
+    settings()->setDefaultValue(UI_FONT_SIZE_KEY, Val(12));
     settings()->setDefaultValue(UI_ICONS_FONT_FAMILY_KEY, Val("MusescoreIcon"));
     settings()->setDefaultValue(UI_MUSICAL_FONT_FAMILY_KEY, Val("Leland"));
     settings()->setDefaultValue(UI_MUSICAL_FONT_SIZE_KEY, Val(24));
     settings()->setDefaultValue(UI_MUSICAL_TEXT_FONT_FAMILY_KEY, Val("Leland Text"));
-    settings()->setDefaultValue(UI_MUSICAL_TEXT_FONT_SIZE_KEY, Val(defaultFontSize()));
+    settings()->setDefaultValue(UI_MUSICAL_TEXT_FONT_SIZE_KEY, Val(12));
     settings()->setDefaultValue(UI_THEMES_KEY, Val(""));
 
     settings()->valueChanged(UI_THEMES_KEY).onReceive(this, [this](const Val&) {
@@ -175,7 +175,7 @@ void UiConfiguration::correctUserFontIfNeeded()
 {
     QString userFontFamily = QString::fromStdString(fontFamily());
     if (!QFontDatabase::hasFamily(userFontFamily)) {
-        std::string fallbackFontFamily = defaultFontFamily();
+        std::string fallbackFontFamily = defaultFont().family().toStdString();
         LOGI() << "The user font " << userFontFamily << " is missing, we will use the fallback font " << fallbackFontFamily;
 
         setFontFamily(fallbackFontFamily);
@@ -639,14 +639,9 @@ Notification UiConfiguration::musicalTextFontChanged() const
     return m_musicalTextFontChanged;
 }
 
-std::string UiConfiguration::defaultFontFamily() const
+QFont UiConfiguration::defaultFont() const
 {
-    return QFontDatabase::systemFont(QFontDatabase::GeneralFont).family().toStdString();
-}
-
-int UiConfiguration::defaultFontSize() const
-{
-    return 12;
+    return QFontDatabase::systemFont(QFontDatabase::GeneralFont);
 }
 
 void UiConfiguration::resetFonts()

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -88,8 +88,7 @@ public:
     int musicalTextFontSize() const override;
     async::Notification musicalTextFontChanged() const override;
 
-    std::string defaultFontFamily() const override;
-    int defaultFontSize() const override;
+    QFont defaultFont() const override;
 
     void resetFonts() override;
 

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -87,8 +87,7 @@ public:
     virtual int musicalTextFontSize() const = 0;
     virtual async::Notification musicalTextFontChanged() const = 0;
 
-    virtual std::string defaultFontFamily() const = 0;
-    virtual int defaultFontSize() const = 0;
+    virtual QFont defaultFont() const = 0;
 
     virtual void resetFonts() = 0;
 

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -71,8 +71,7 @@ public:
     MOCK_METHOD(int, musicalTextFontSize, (), (const, override));
     MOCK_METHOD(async::Notification, musicalTextFontChanged, (), (const, override));
 
-    MOCK_METHOD(std::string, defaultFontFamily, (), (const, override));
-    MOCK_METHOD(int, defaultFontSize, (), (const, override));
+    MOCK_METHOD(QFont, defaultFont, (), (const, override));
 
     MOCK_METHOD(void, resetFonts, (), (override));
 

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -184,7 +184,7 @@ Item {
 
         // Fixed width prevents items from jumping around; but we
         // scale it according to the font size to prevent clipping
-        readonly property real tempoViewWidth: 60 * (ui.theme.bodyFont.pixelSize / ui.theme.defaultFont.pixelSize)
+        readonly property real tempoViewWidth: 5 * ui.theme.bodyFont.pixelSize
 
         sourceComponent: root.floating ? tempoViewComponent : tempoButtonComponent
 


### PR DESCRIPTION
Resolves: #32631

Should wait for [PR32627](https://github.com/musescore/MuseScore/pull/32627) otherwise it is a breaking change and will need a different approach (change only the size but not the family).

P.S. Now that PR32627 was approved and merged, I am marking this PR as ready for review.

**Areas affected by this PR:**
The default font is used:
- for the main menu bar (but not the main menus themselves)
- for the window title (between the main menu bar and the buttons for minimize, maximize and close)
- to scale the tempo button in the Playback toolbar so its contents are not clipped

Since currently the default font size is fixed at 12px (note it is px and not pt), I expect on many systems the font size returned by Qt to be larger. Therefore for many users the size of the main menu and the title to the right of it will increase with this PR. This should be a good thing, though, because 12px is rather small and many people have complained about it. This PR should normalize it to a size that the user is much more accustomed to (same or similar to that of other apps).

**Changes:**
1. The default font's size will now be taken from Qt. Since we are also taking the font family from Qt, I've combined the two in a single call. I figured this is much easier than still getting both separately from `UiConfiguration`. The latter would require more changes since the default font size in `UiConfiguration` is used for other purposes too.

2. It is unclear to me why the width of the tempo button in the Playback toolbar was made to depend on the default font size. Anyway, since the default font size was fixed at 12px and is going to change now, I've updated the formula so the width of the tempo button is not affected.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
