### PR TITLE
Fuzzy text search, part 1: algorithm & searching shortcuts

### DIFF
--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -42,6 +42,8 @@ target_sources(muse_global PRIVATE
     profiler.h
     dataformatter.cpp
     dataformatter.h
+    stringsearch.cpp
+    stringsearch.h
     stringutils.cpp
     stringutils.h
     ptrutils.h

--- a/src/framework/global/stringsearch.cpp
+++ b/src/framework/global/stringsearch.cpp
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "stringsearch.h"
+
+#include <algorithm>
+
+bool muse::operator==(const FuzzyMatch& left, const FuzzyMatch& right)
+{
+    return left.beginPos == right.beginPos
+           && left.endPos == right.endPos
+           && left.editDistance == right.editDistance;
+}
+
+bool muse::operator!=(const FuzzyMatch& left, const FuzzyMatch& right)
+{
+    return !(left == right);
+}
+
+namespace muse {
+FuzzyMatcher::FuzzyMatcher(const std::size_t maxDistance)
+    : m_maxDistance{maxDistance}
+{
+}
+
+FuzzyMatcher& FuzzyMatcher::operator()(const std::u32string_view text, const std::u32string_view pattern)
+{
+    return match(text, pattern);
+}
+
+FuzzyMatcher& FuzzyMatcher::match(const std::u32string_view text, const std::u32string_view pattern)
+{
+    m_numPatternPrefixes = pattern.size() + 1;
+    m_numTextPrefixes = text.size() + 1;
+    m_prefixTable.clear();
+    m_prefixTable.resize(m_numPatternPrefixes * m_numTextPrefixes);
+
+    for (std::size_t textSize = 0; textSize < m_numTextPrefixes; ++textSize) {
+        // 0 insertions to transform empty pattern to any text prefix.
+        // This allows the match to start at any position in text.
+        m_prefixTable[index(0, textSize)] = PrefixMatch{ textSize, 0 };
+    }
+
+    for (std::size_t patternSize = 1; patternSize < m_numPatternPrefixes; ++patternSize) {
+        // patternSize deletions to transform any pattern prefix to empty text
+        m_prefixTable[index(patternSize, 0)] = PrefixMatch{ 0, patternSize };
+
+        for (std::size_t textSize = 1; textSize < m_numTextPrefixes; ++textSize) {
+            if (pattern[patternSize - 1] == text[textSize - 1]) {
+                m_prefixTable[index(patternSize, textSize)] = m_prefixTable[index(patternSize - 1, textSize - 1)];
+                continue;
+            }
+
+            const PrefixMatch insertMatch = m_prefixTable[index(patternSize, textSize - 1)];
+            const PrefixMatch replaceMatch = m_prefixTable[index(patternSize - 1, textSize - 1)];
+            const PrefixMatch deleteMatch = m_prefixTable[index(patternSize - 1, textSize)];
+            PrefixMatch minMatch = std::min(insertMatch, std::min(replaceMatch, deleteMatch));
+
+            if (patternSize > 1 && textSize > 1
+                && pattern[patternSize - 1] == text[textSize - 2]
+                && pattern[patternSize - 2] == text[textSize - 1]) {
+                const PrefixMatch transpositionMatch = m_prefixTable[index(patternSize - 2, textSize - 2)];
+                minMatch = std::min(transpositionMatch, minMatch);
+            }
+
+            m_prefixTable[index(patternSize, textSize)] = PrefixMatch{ minMatch.beginPos, minMatch.distance + 1 };
+        }
+    }
+
+    return *this;
+}
+
+std::optional<FuzzyMatch> FuzzyMatcher::findMatch(const std::size_t textEnd) const
+{
+    for (std::size_t textSize = textEnd; textSize < m_numTextPrefixes; ++textSize) {
+        const PrefixMatch match = m_prefixTable[index(m_numPatternPrefixes - 1, textSize)];
+        if (match.distance <= m_maxDistance) {
+            return FuzzyMatch{ match.beginPos, textSize, match.distance };
+        }
+    }
+
+    return std::nullopt;
+}
+
+bool FuzzyMatcher::empty() const
+{
+    return !findMatch(0).has_value();
+}
+
+void FuzzyMatcher::reset(const std::size_t maxDistance)
+{
+    clear();
+    m_maxDistance = maxDistance;
+}
+
+void FuzzyMatcher::clear()
+{
+    m_numPatternPrefixes = 0;
+    m_numTextPrefixes = 0;
+    m_prefixTable.clear();
+}
+
+FuzzyMatcher::const_iterator FuzzyMatcher::begin() const
+{
+    return Iterator(*this);
+}
+
+FuzzyMatcher::const_iterator FuzzyMatcher::end() const
+{
+    return Iterator();
+}
+
+std::size_t FuzzyMatcher::maxDistance() const
+{
+    return m_maxDistance;
+}
+
+std::size_t FuzzyMatcher::index(const std::size_t patternSize, const std::size_t textSize) const
+{
+    return m_numTextPrefixes * patternSize + textSize;
+}
+
+FuzzyMatcher::Iterator::Iterator(const FuzzyMatcher& matcher)
+    : m_matcher{&matcher}
+{
+    next(0);
+}
+
+FuzzyMatcher::Iterator::reference FuzzyMatcher::Iterator::operator*() const
+{
+    return *m_match;
+}
+
+FuzzyMatcher::Iterator::pointer FuzzyMatcher::Iterator::operator->() const
+{
+    return m_match.operator->();
+}
+
+FuzzyMatcher::Iterator& FuzzyMatcher::Iterator::operator++()
+{
+    next(m_match->endPos + 1);
+    return *this;
+}
+
+FuzzyMatcher::Iterator FuzzyMatcher::Iterator::operator++(int)
+{
+    Iterator prev = *this;
+    operator++();
+
+    return prev;
+}
+
+bool FuzzyMatcher::Iterator::operator==(const Iterator& right) const
+{
+    return m_matcher == right.m_matcher && m_match == right.m_match;
+}
+
+bool FuzzyMatcher::Iterator::operator!=(const Iterator& right) const
+{
+    return !(*this == right);
+}
+
+void FuzzyMatcher::Iterator::next(const std::size_t textEnd)
+{
+    m_match = m_matcher->findMatch(textEnd);
+    if (!m_match) {
+        m_matcher = nullptr;
+    }
+}
+}

--- a/src/framework/global/stringsearch.h
+++ b/src/framework/global/stringsearch.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace muse {
+struct FuzzyMatch {
+    std::size_t beginPos = 0;
+    std::size_t endPos = 0;
+    std::size_t editDistance = 0;
+};
+
+bool operator==(const FuzzyMatch&, const FuzzyMatch&);
+bool operator!=(const FuzzyMatch&, const FuzzyMatch&);
+
+class FuzzyMatcher
+{
+public:
+    using value_type = FuzzyMatch;
+
+    static constexpr auto UNLIMITED_DISTANCE = static_cast<std::size_t>(-1);
+
+    explicit FuzzyMatcher(std::size_t maxDistance = UNLIMITED_DISTANCE);
+
+    FuzzyMatcher& operator()(std::u32string_view text, std::u32string_view pattern);
+    FuzzyMatcher& match(std::u32string_view text, std::u32string_view pattern);
+
+    bool empty() const;
+    std::optional<FuzzyMatch> findMatch(std::size_t textEnd) const;
+
+    void reset(std::size_t maxDistance = UNLIMITED_DISTANCE);
+    void clear();
+
+    std::size_t maxDistance() const;
+
+    class Iterator
+    {
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = FuzzyMatcher::value_type;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+        using iterator_category = std::input_iterator_tag;
+
+        Iterator() = default;
+        explicit Iterator(const FuzzyMatcher&);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        Iterator& operator++();
+        Iterator operator++(int);
+
+        bool operator==(const Iterator&) const;
+        bool operator!=(const Iterator&) const;
+
+    private:
+        void next(std::size_t textEnd);
+
+        const FuzzyMatcher* m_matcher = nullptr;
+        std::optional<FuzzyMatch> m_match;
+    };
+
+    using const_iterator = Iterator;
+
+    const_iterator begin() const;
+    const_iterator end() const;
+
+private:
+    struct PrefixMatch {
+        std::size_t beginPos = 0;
+        std::size_t distance = 0;
+
+        friend bool operator<(const PrefixMatch& left, const PrefixMatch& right)
+        {
+            return left.distance < right.distance;
+        }
+    };
+
+    std::size_t index(std::size_t patternSize, std::size_t textSize) const;
+
+    std::size_t m_numPatternPrefixes = 0;
+    std::size_t m_numTextPrefixes = 0;
+    std::size_t m_maxDistance = 0;
+    std::vector<PrefixMatch> m_prefixTable;
+};
+}

--- a/src/framework/global/stringutils.cpp
+++ b/src/framework/global/stringutils.cpp
@@ -19,10 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "stringutils.h"
 
-#include <cctype>
 #include <algorithm>
+#include <cctype>
+#include <iterator>
 
 bool muse::strings::replace(std::string& str, const std::string& from, const std::string& to)
 {
@@ -36,16 +38,7 @@ bool muse::strings::replace(std::string& str, const std::string& from, const std
 
 void muse::strings::split(const std::string& str, std::vector<std::string>& out, const std::string& delim)
 {
-    std::size_t current, previous = 0;
-    current = str.find(delim);
-    std::size_t delimLen = delim.length();
-
-    while (current != std::string::npos) {
-        out.push_back(str.substr(previous, current - previous));
-        previous = current + delimLen;
-        current = str.find(delim, previous);
-    }
-    out.push_back(str.substr(previous, current - previous));
+    split(str, std::back_inserter(out), delim);
 }
 
 std::string muse::strings::join(const std::vector<std::string>& strs, const std::string& sep)

--- a/src/framework/global/stringutils.h
+++ b/src/framework/global/stringutils.h
@@ -19,19 +19,44 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_GLOBAL_STRINGUTILS_H
-#define MUSE_GLOBAL_STRINGUTILS_H
+
+#pragma once
 
 #include <locale>
-#include <string>
-#include <vector>
 #include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "types/string.h"
 
 namespace muse::strings {
 bool replace(std::string& source, const std::string& what, const std::string& to);
+
 void split(const std::string& str, std::vector<std::string>& out, const std::string& delim);
+
+template<typename CharT, typename Traits, typename Allocator, typename OutIt, typename StringViewLike,
+         typename = decltype(*std::declval<OutIt>(), ++std::declval<OutIt>())> // restrict this overload to iterators only
+void split(const std::basic_string<CharT, Traits, Allocator>& str,
+           OutIt out, const StringViewLike& delim)
+{
+    const std::basic_string_view<CharT, Traits> delimStr = delim;
+    const std::size_t delimLen = delimStr.length();
+    const std::size_t extra = delimLen == 0 ? 1 : 0;
+
+    std::size_t begin = 0;
+    std::size_t end = str.find(delimStr);
+    while (end != std::basic_string<CharT, Traits, Allocator>::npos) {
+        *out++ = str.substr(begin, end - begin);
+
+        begin = end + delimLen;
+        end = str.find(delimStr, begin + extra);
+    }
+
+    *out++ = str.substr(begin);
+}
+
 std::string join(const std::vector<std::string>& strs, const std::string& sep = ",");
 
 void ltrim(std::string& s);
@@ -58,5 +83,3 @@ bool lessThanCaseInsensitive(const String& lhs, const String& rhs);
 
 size_t levenshteinDistance(const std::string& s1, const std::string& s2);
 }
-
-#endif // MUSE_GLOBAL_STRINGUTILS_H

--- a/src/framework/global/tests/CMakeLists.txt
+++ b/src/framework/global/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ringqueue_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rpcqueue_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/geometry_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringsearch_tests.cpp
 )
 
 include(SetupGTest)

--- a/src/framework/global/tests/CMakeLists.txt
+++ b/src/framework/global/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/rpcqueue_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/geometry_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/stringsearch_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringutils_tests.cpp
 )
 
 include(SetupGTest)

--- a/src/framework/global/tests/stringsearch_tests.cpp
+++ b/src/framework/global/tests/stringsearch_tests.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "global/stringsearch.h"
+
+using ::testing::ElementsAre;
+
+namespace muse {
+TEST(Global_StringSearchTests, testFuzzySearchEdgeCases)
+{
+    FuzzyMatcher matcher;
+    EXPECT_THAT(matcher(U"", U""), ElementsAre(FuzzyMatch { 0, 0, 0 }));
+    EXPECT_THAT(matcher(U"surgery", U""), ElementsAre(FuzzyMatch { 0, 0, 0 }, FuzzyMatch { 1, 1, 0 },
+                                                      FuzzyMatch { 2, 2, 0 }, FuzzyMatch { 3, 3, 0 },
+                                                      FuzzyMatch { 4, 4, 0 }, FuzzyMatch { 5, 5, 0 },
+                                                      FuzzyMatch { 6, 6, 0 }, FuzzyMatch { 7, 7, 0 }));
+    EXPECT_THAT(matcher(U"", U"survey"), ElementsAre(FuzzyMatch { 0, 0, 6 }));
+}
+
+TEST(Global_StringSearchTests, testFuzzySearch)
+{
+    FuzzyMatcher matcher(2);
+    EXPECT_THAT(matcher(U"surgery", U"survey"), ElementsAre(FuzzyMatch { 0, 5, 2 }, FuzzyMatch { 0, 6, 2 },
+                                                            FuzzyMatch { 0, 7, 2 }));
+
+    // exact
+    matcher.reset(0);
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"needle"), ElementsAre(FuzzyMatch { 6, 12, 0 }));
+
+    matcher.reset(1);
+    // 1 insertion
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"nedle"), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 change
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"nnedle"), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 deletion
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"neoedle"), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 transposition
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"neelde"), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+
+    // multiple matches with different edit distance
+    EXPECT_THAT(matcher(U"haynedlehayneedlehayhayhay", U"needle"),
+                ElementsAre(FuzzyMatch { 3, 8, 1 }, FuzzyMatch { 11, 16, 1 }, FuzzyMatch { 11, 17, 0 },
+                            FuzzyMatch { 11, 18, 1 }));
+    matcher.reset(0);
+    // return best match
+    EXPECT_THAT(matcher(U"haynedlehayneedlehayhayhay", U"needle"), ElementsAre(FuzzyMatch { 11, 17, 0 }));
+    // correct start pos
+    EXPECT_THAT(matcher(U"aaab", U"ab"), ElementsAre(FuzzyMatch { 2, 4, 0 }));
+}
+}

--- a/src/framework/global/tests/stringutils_tests.cpp
+++ b/src/framework/global/tests/stringutils_tests.cpp
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "global/stringutils.h"
+
+using namespace std::literals;
+using ::testing::ElementsAre;
+
+namespace muse::strings {
+TEST(Global_StringUtilsTests, testSplitEdgeCases)
+{
+    std::vector<std::string> parts;
+    split(""s, std::back_inserter(parts), "");
+    EXPECT_THAT(parts, ElementsAre(""s, ""s));
+
+    parts.clear();
+    split("foo"s, std::back_inserter(parts), "");
+    EXPECT_THAT(parts, ElementsAre(""s, "f"s, "o"s, "o"s, ""s));
+
+    parts.clear();
+    split(""s, std::back_inserter(parts), "foo");
+    EXPECT_THAT(parts, ElementsAre(""s));
+
+    parts.clear();
+    split("foo"s, std::back_inserter(parts), ",");
+    EXPECT_THAT(parts, ElementsAre("foo"s));
+}
+
+TEST(Global_StringUtilsTests, testSplit)
+{
+    std::vector<std::string> parts;
+    split("foo,bar,baz"s, std::back_inserter(parts), ",");
+    EXPECT_THAT(parts, ElementsAre("foo"s, "bar"s, "baz"s));
+
+    parts.clear();
+    split(",foo,bar"s, std::back_inserter(parts), ",");
+    EXPECT_THAT(parts, ElementsAre(""s, "foo"s, "bar"s));
+
+    parts.clear();
+    split("foo,bar,"s, std::back_inserter(parts), ",");
+    EXPECT_THAT(parts, ElementsAre("foo"s, "bar"s, ""s));
+
+    parts.clear();
+    split("foo, bar,baz, quux"s, std::back_inserter(parts), ", ");
+    EXPECT_THAT(parts, ElementsAre("foo"s, "bar,baz"s, "quux"s));
+}
+}

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -44,18 +44,27 @@ ValueList {
 
     model: SortFilterProxyModel {
         id: filterModel
-        sourceModel: root.sourceModel
 
+        sourceModel: root.sourceModel
         filters: [
-            FilterValue {
-                roleName: "searchKey"
-                roleValue: root.searchText
-                compareType: CompareType.Contains
-            },
             FilterValue {
                 roleName: "title"
                 roleValue: ""
                 compareType: CompareType.NotEqual
+            },
+            FuzzyFilter {
+                id: fuzzyFilter
+
+                enabled: Boolean(fuzzyPattern)
+                fuzzyPattern: root.searchText
+                roleName: "searchKey"
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        ]
+        sorters: [
+            FuzzyScoreSorter {
+                fuzzyFilter: fuzzyFilter
+                enabled: fuzzyFilter.enabled
             }
         ]
     }

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -39,10 +39,6 @@
 
 #include "imainwindow.h"
 
-#ifdef Q_OS_WIN
-#include <QOperatingSystemVersion>
-#endif
-
 #include "muse_framework_config.h"
 
 #include "log.h"

--- a/src/framework/ui/internal/uicontextconfiguration.cpp
+++ b/src/framework/ui/internal/uicontextconfiguration.cpp
@@ -22,8 +22,12 @@
 
 #include "uicontextconfiguration.h"
 
-#include <QScreen>
 #include <QApplication>
+#include <QScreen>
+
+#ifdef Q_OS_WIN
+#include <QOperatingSystemVersion>
+#endif
 
 using namespace muse::ui;
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -46,6 +46,10 @@ qt_add_qml_module(muse_uicomponents_qml
         filter.h
         filtervalue.cpp
         filtervalue.h
+        fuzzyfilter.cpp
+        fuzzyfilter.h
+        fuzzyscoresorter.cpp
+        fuzzyscoresorter.h
         iconview.cpp
         iconview.h
         internal/focuslistener.cpp

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -42,6 +42,8 @@ qt_add_qml_module(muse_uicomponents_qml
         filepickermodel.h
         filteredflyoutmodel.cpp
         filteredflyoutmodel.h
+        filter.cpp
+        filter.h
         filtervalue.cpp
         filtervalue.h
         iconview.cpp

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -76,6 +76,8 @@ qt_add_qml_module(muse_uicomponents_qml
         selectableitemlistmodel.h
         selectmultipledirectoriesmodel.cpp
         selectmultipledirectoriesmodel.h
+        sorter.cpp
+        sorter.h
         sortervalue.cpp
         sortervalue.h
         sortfilterproxymodel.cpp

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
@@ -81,20 +81,17 @@ Item {
         property real spacing: 4
         property real sideMargin: 30
 
-        function toggleSorter(sorter) {
+        function toggleSorter(sorter: SorterValue) {
             if (!sorter.enabled) {
-                setSorterEnabled(sorter, true)
+                sorter.enabled = true;
+                sorter.sortOrder = Qt.AscendingOrder
             } else if (sorter.sortOrder === Qt.AscendingOrder) {
                 sorter.sortOrder = Qt.DescendingOrder
             } else {
-                setSorterEnabled(sorter, false)
+                sorter.enabled = false
             }
 
             selectionModel.clear()
-        }
-
-        function setSorterEnabled(sorter, enable) {
-            sorter.enabled = enable
         }
     }
 
@@ -187,7 +184,7 @@ Item {
                 }
 
                 prv.toggleSorter(keySorter)
-                prv.setSorterEnabled(valueSorter, false)
+                valueSorter.enabled = false
             }
         }
 
@@ -218,7 +215,7 @@ Item {
                 }
 
                 prv.toggleSorter(valueSorter)
-                prv.setSorterEnabled(keySorter, false)
+                keySorter.enabled = false
             }
         }
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
@@ -28,6 +28,10 @@ Filter::Filter(QObject* parent)
 {
 }
 
+void Filter::invalidate()
+{
+}
+
 bool Filter::enabled() const
 {
     return m_enabled;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "filter.h"
+
+namespace muse::uicomponents {
+Filter::Filter(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool Filter::enabled() const
+{
+    return m_enabled;
+}
+
+void Filter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit dataChanged();
+}
+
+bool Filter::async() const
+{
+    return m_async;
+}
+
+void Filter::setAsync(const bool async)
+{
+    if (m_async == async) {
+        return;
+    }
+
+    m_async = async;
+    emit dataChanged();
+}
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filter.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+class QModelIndex;
+
+namespace muse::uicomponents {
+class SortFilterProxyModel;
+
+class Filter : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
+    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
+
+public:
+    explicit Filter(QObject* parent = nullptr);
+
+    virtual bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) = 0;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    bool async() const;
+    void setAsync(bool async);
+
+signals:
+    void dataChanged();
+
+private:
+    bool m_enabled = true;
+    bool m_async = false;
+};
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
@@ -21,11 +21,36 @@
  */
 #include "filtervalue.h"
 
+#include "sortfilterproxymodel.h"
+
 using namespace muse::uicomponents;
 
 FilterValue::FilterValue(QObject* parent)
-    : QObject(parent)
+    : Filter(parent)
 {
+}
+
+bool FilterValue::acceptsRow(const int sourceRow, const QModelIndex& sourceParent,
+                             const SortFilterProxyModel& proxyModel)
+{
+    const int role = proxyModel.roleFromRoleName(m_roleName);
+    if (role == -1) {
+        return true;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    const QModelIndex index = sourceModel->index(sourceRow, 0, sourceParent);
+    const QVariant data = sourceModel->data(index, role);
+    switch (m_compareType) {
+    case CompareType::Equal:
+        return data == m_roleValue;
+    case CompareType::NotEqual:
+        return data != m_roleValue;
+    case CompareType::Contains:
+        return data.toString().contains(m_roleValue.toString(), Qt::CaseInsensitive);
+    }
+
+    return false;
 }
 
 QString FilterValue::roleName() const
@@ -41,11 +66,6 @@ QVariant FilterValue::roleValue() const
 CompareType::Type FilterValue::compareType() const
 {
     return m_compareType;
-}
-
-bool FilterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void FilterValue::setRoleName(QString roleName)
@@ -75,30 +95,5 @@ void FilterValue::setCompareType(CompareType::Type type)
     }
 
     m_compareType = type;
-    emit dataChanged();
-}
-
-void FilterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-    emit dataChanged();
-}
-
-bool FilterValue::async() const
-{
-    return m_async;
-}
-
-void FilterValue::setAsync(bool async)
-{
-    if (m_async == async) {
-        return;
-    }
-
-    m_async = async;
     emit dataChanged();
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
@@ -22,10 +22,12 @@
 
 #pragma once
 
-#include <qqmlintegration.h>
-
-#include <QObject>
+#include <QString>
 #include <QVariant>
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include "filter.h"
 
 namespace muse::uicomponents {
 namespace CompareType {
@@ -41,44 +43,32 @@ enum Type
 Q_ENUM_NS(Type)
 }
 
-class FilterValue : public QObject
+class FilterValue : public Filter
 {
     Q_OBJECT
-    QML_ELEMENT
-
     Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
     Q_PROPERTY(QVariant roleValue READ roleValue WRITE setRoleValue NOTIFY dataChanged)
     Q_PROPERTY(muse::uicomponents::CompareType::Type compareType READ compareType WRITE setCompareType NOTIFY dataChanged)
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
 
-    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
-    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+    QML_ELEMENT
 
 public:
     explicit FilterValue(QObject* parent = nullptr);
 
+    bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) override;
+
     QString roleName() const;
     QVariant roleValue() const;
     CompareType::Type compareType() const;
-    bool enabled() const;
-
-    bool async() const;
-    void setAsync(bool async);
 
 public slots:
     void setRoleName(QString roleName);
     void setRoleValue(QVariant roleValue);
     void setCompareType(muse::uicomponents::CompareType::Type compareType);
-    void setEnabled(bool enabled);
-
-signals:
-    void dataChanged();
 
 private:
     QString m_roleName;
     QVariant m_roleValue;
     CompareType::Type m_compareType = CompareType::Equal;
-    bool m_enabled = true;
-    bool m_async = false;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "fuzzyfilter.h"
+
+#include "global/stringutils.h"
+
+#include "sortfilterproxymodel.h"
+
+namespace muse::uicomponents {
+FuzzyFilter::FuzzyFilter(QObject* parent)
+    : Filter(parent)
+{
+}
+
+bool FuzzyFilter::acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel& proxyModel)
+{
+    const QModelIndex sourceIndex = proxyModel.sourceModel()->index(sourceRow, 0, sourceParent);
+    const std::optional<double> score = getScore(sourceIndex, proxyModel);
+
+    return score.has_value();
+}
+
+void FuzzyFilter::invalidate()
+{
+    m_scoreCache.clear();
+}
+
+QString FuzzyFilter::fuzzyPattern() const
+{
+    return m_fuzzyPattern;
+}
+
+void FuzzyFilter::setFuzzyPattern(const QString& fuzzyPattern)
+{
+    const QString simplifiedPattern = fuzzyPattern.simplified();
+    if (m_fuzzyPattern == simplifiedPattern) {
+        return;
+    }
+
+    m_fuzzyPattern = simplifiedPattern;
+    compilePattern();
+
+    emit dataChanged();
+}
+
+QString FuzzyFilter::roleName() const
+{
+    return m_roleName;
+}
+
+void FuzzyFilter::setRoleName(const QString& roleName)
+{
+    if (m_roleName == roleName) {
+        return;
+    }
+
+    invalidate();
+
+    m_roleName = roleName;
+    emit dataChanged();
+}
+
+Qt::CaseSensitivity FuzzyFilter::caseSensitivity() const
+{
+    return m_caseSensitivity;
+}
+
+void FuzzyFilter::setCaseSensitivity(const Qt::CaseSensitivity caseSensitivity)
+{
+    if (m_caseSensitivity == caseSensitivity) {
+        return;
+    }
+
+    compilePattern();
+
+    m_caseSensitivity = caseSensitivity;
+    emit dataChanged();
+}
+
+std::optional<double> FuzzyFilter::getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+{
+    auto scoreIt = m_scoreCache.find(sourceIndex);
+    if (scoreIt != m_scoreCache.end()) {
+        return scoreIt.value();
+    }
+
+    std::optional<double> score = calcScore(sourceIndex, proxyModel);
+    // don't cache score of filtered out items because the cache
+    // is always reset before filtering and therefore only used for sorting
+    // already filtered items
+    if (!score) {
+        return score;
+    }
+
+    m_scoreCache.try_emplace(sourceIndex, *score);
+
+    return score;
+}
+
+void FuzzyFilter::compilePattern()
+{
+    invalidate();
+
+    m_patternTokens.clear();
+    const std::u32string pattern = caseSensitivity() == Qt::CaseInsensitive
+                                   ? m_fuzzyPattern.toLower().toStdU32String()
+                                   : m_fuzzyPattern.toStdU32String();
+    strings::split(pattern, std::back_inserter(m_patternTokens), U" ");
+}
+
+std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+{
+    const int role = proxyModel.roleFromRoleName(m_roleName);
+    if (role == -1) {
+        return std::nullopt;
+    }
+
+    const QString rawText = proxyModel.sourceModel()->data(sourceIndex, role)
+                            .toString();
+    const std::u32string text = caseSensitivity() == Qt::CaseInsensitive
+                                ? rawText.toLower().toStdU32String()
+                                : rawText.toStdU32String();
+
+    double score = 0.0;
+    for (const auto& patternToken : m_patternTokens) {
+        const size_t tokenSize = patternToken.size();
+        if (tokenSize == 0) {
+            continue;
+        }
+
+        constexpr size_t MIN_TOKEN_SIZE_FOR_FUZZY_MATCH = 4;
+        constexpr size_t CHARS_PER_ERROR = 8;
+        const size_t maxDistance = tokenSize >= MIN_TOKEN_SIZE_FOR_FUZZY_MATCH
+                                   ? 1 + tokenSize / CHARS_PER_ERROR
+                                   : 0;
+        m_matcher.reset(maxDistance);
+
+        const double inverseTokenSize = 1.0 / tokenSize;
+        std::optional<double> bestTokenScore;
+
+        for (const auto& match : m_matcher(text, patternToken)) {
+            const double matchSimilarity = 1.0 - (match.editDistance * inverseTokenSize);
+            double matchScore = 5.0 * matchSimilarity;
+
+            const bool isMatchStartAtStartOfWord = match.beginPos == 0
+                                                   || text[match.beginPos - 1] == U' ';
+            if (isMatchStartAtStartOfWord) {
+                const bool isMatchEndAtEndOfWord = match.endPos == text.size()
+                                                   || text[match.endPos] == U' ';
+                if (isMatchEndAtEndOfWord) {
+                    matchScore += 2.0 * inverseTokenSize;
+                } else {
+                    matchScore += inverseTokenSize;
+                }
+            }
+
+            if (bestTokenScore < matchScore) {
+                bestTokenScore = matchScore;
+            }
+        }
+
+        // no match for token found -> no score for entire pattern
+        if (!bestTokenScore) {
+            return bestTokenScore;
+        }
+
+        score += *bestTokenScore;
+    }
+
+    return score;
+}
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <QObject>
+#include <QPersistentModelIndex>
+#include <QString>
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include "global/stringsearch.h"
+
+#include "filter.h"
+
+namespace muse::uicomponents {
+// TODO: needs notifications from the model
+class FuzzyFilter : public Filter
+{
+    Q_OBJECT
+    Q_PROPERTY(QString fuzzyPattern READ fuzzyPattern WRITE setFuzzyPattern NOTIFY dataChanged)
+    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+    Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity NOTIFY dataChanged)
+
+    QML_ELEMENT
+
+public:
+    explicit FuzzyFilter(QObject* parent = nullptr);
+
+    bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) override;
+    void invalidate() override;
+
+    QString fuzzyPattern() const;
+    void setFuzzyPattern(const QString&);
+
+    QString roleName() const;
+    void setRoleName(const QString&);
+
+    Qt::CaseSensitivity caseSensitivity() const;
+    void setCaseSensitivity(Qt::CaseSensitivity);
+
+    std::optional<double> getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel&);
+
+private:
+    void compilePattern();
+
+    std::optional<double> calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel&);
+
+    QString m_fuzzyPattern;
+    QString m_roleName;
+    Qt::CaseSensitivity m_caseSensitivity = Qt::CaseSensitive;
+
+    std::vector<std::u32string> m_patternTokens;
+    FuzzyMatcher m_matcher;
+    QHash<QPersistentModelIndex, double> m_scoreCache;
+};
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "fuzzyscoresorter.h"
+
+namespace muse::uicomponents {
+FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
+    : Sorter(parent)
+{
+    setSortOrder(Qt::DescendingOrder);
+}
+
+bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
+                                const SortFilterProxyModel& proxyModel)
+{
+    if (!m_fuzzyFilter) {
+        return sourceLeft < sourceRight;
+    }
+
+    const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft, proxyModel);
+    const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight, proxyModel);
+
+    return leftScore < rightScore;
+}
+
+FuzzyFilter* FuzzyScoreSorter::fuzzyFilter() const
+{
+    return m_fuzzyFilter;
+}
+
+void FuzzyScoreSorter::setFuzzyFilter(FuzzyFilter* fuzzyFilter)
+{
+    if (m_fuzzyFilter == fuzzyFilter) {
+        return;
+    }
+
+    disconnect(m_filterChangedConnection);
+
+    m_fuzzyFilter = fuzzyFilter;
+    emit dataChanged();
+
+    if (m_fuzzyFilter) {
+        m_filterChangedConnection = connect(m_fuzzyFilter, &Filter::dataChanged, this, &Sorter::dataChanged);
+    }
+}
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
@@ -22,42 +22,33 @@
 
 #pragma once
 
+#include <QMetaObject>
 #include <QObject>
+#include <QPointer>
 
 #include <QtQmlIntegration/qqmlintegration.h>
 
-class QModelIndex;
+#include "fuzzyfilter.h"
+#include "sorter.h"
 
 namespace muse::uicomponents {
-class SortFilterProxyModel;
-
-class Filter : public QObject
+class FuzzyScoreSorter : public Sorter
 {
     Q_OBJECT
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
-    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
-    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+    Q_PROPERTY(muse::uicomponents::FuzzyFilter * fuzzyFilter READ fuzzyFilter WRITE setFuzzyFilter NOTIFY dataChanged REQUIRED)
 
-    QML_ELEMENT;
-    QML_UNCREATABLE("")
+    QML_ELEMENT
 
 public:
-    explicit Filter(QObject* parent = nullptr);
+    explicit FuzzyScoreSorter(QObject* parent = nullptr);
 
-    virtual bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) = 0;
-    virtual void invalidate();
+    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
 
-    bool enabled() const;
-    void setEnabled(bool enabled);
-
-    bool async() const;
-    void setAsync(bool async);
-
-signals:
-    void dataChanged();
+    FuzzyFilter* fuzzyFilter() const;
+    void setFuzzyFilter(FuzzyFilter*);
 
 private:
-    bool m_enabled = true;
-    bool m_async = false;
+    QPointer<FuzzyFilter> m_fuzzyFilter;
+    QMetaObject::Connection m_filterChangedConnection;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,33 +20,41 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include <QString>
-
-#include <QtQmlIntegration/qqmlintegration.h>
-
 #include "sorter.h"
 
 namespace muse::uicomponents {
-class SorterValue : public Sorter
+Sorter::Sorter(QObject* parent)
+    : QObject(parent)
 {
-    Q_OBJECT
-    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+}
 
-    QML_ELEMENT
+Qt::SortOrder Sorter::sortOrder() const
+{
+    return m_sortOrder;
+}
 
-public:
-    explicit SorterValue(QObject* parent = nullptr);
+void Sorter::setSortOrder(const Qt::SortOrder sortOrder)
+{
+    if (m_sortOrder == sortOrder) {
+        return;
+    }
 
-    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
+    m_sortOrder = sortOrder;
+    emit dataChanged();
+}
 
-    QString roleName() const;
+bool Sorter::enabled() const
+{
+    return m_enabled;
+}
 
-public slots:
-    void setRoleName(QString roleName);
+void Sorter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
 
-private:
-    QString m_roleName;
-};
+    m_enabled = enabled;
+    emit dataChanged();
+}
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sorter.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sorter.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,31 +22,40 @@
 
 #pragma once
 
-#include <QString>
+#include <QObject>
 
 #include <QtQmlIntegration/qqmlintegration.h>
 
-#include "sorter.h"
+class QModelIndex;
 
 namespace muse::uicomponents {
-class SorterValue : public Sorter
+class SortFilterProxyModel;
+
+class Sorter : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY dataChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
 
-    QML_ELEMENT
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
 
 public:
-    explicit SorterValue(QObject* parent = nullptr);
+    explicit Sorter(QObject* parent = nullptr);
 
-    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
+    virtual bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) = 0;
 
-    QString roleName() const;
+    Qt::SortOrder sortOrder() const;
+    void setSortOrder(Qt::SortOrder sortOrder);
 
-public slots:
-    void setRoleName(QString roleName);
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+signals:
+    void dataChanged();
 
 private:
-    QString m_roleName;
+    Qt::SortOrder m_sortOrder = Qt::AscendingOrder;
+    bool m_enabled = false;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
@@ -19,28 +19,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortervalue.h"
+
+#include "sortfilterproxymodel.h"
 
 using namespace muse::uicomponents;
 
 SorterValue::SorterValue(QObject* parent)
-    : QObject(parent)
+    : Sorter(parent)
 {
+}
+
+bool SorterValue::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
+                           const SortFilterProxyModel& proxyModel)
+{
+    const int role = proxyModel.roleFromRoleName(m_roleName);
+    if (role == -1) {
+        return sourceLeft < sourceRight;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    const QVariant leftData = sourceModel->data(sourceLeft, role);
+    const QVariant rightData = sourceModel->data(sourceRight, role);
+    const QPartialOrdering ordering = QVariant::compare(leftData, rightData);
+    if (ordering == QPartialOrdering::Unordered || ordering == QPartialOrdering::Equivalent) {
+        return sourceLeft < sourceRight;
+    }
+
+    return ordering == QPartialOrdering::Less;
 }
 
 QString SorterValue::roleName() const
 {
     return m_roleName;
-}
-
-Qt::SortOrder SorterValue::sortOrder() const
-{
-    return m_sortOrder;
-}
-
-bool SorterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void SorterValue::setRoleName(QString roleName)
@@ -50,30 +62,5 @@ void SorterValue::setRoleName(QString roleName)
     }
 
     m_roleName = roleName;
-    emit dataChanged();
-}
-
-void SorterValue::setSortOrder(Qt::SortOrder sortOrder)
-{
-    if (m_sortOrder == sortOrder) {
-        return;
-    }
-
-    m_sortOrder = sortOrder;
-    emit dataChanged();
-}
-
-void SorterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-
-    if (!enabled) {
-        m_sortOrder = Qt::AscendingOrder;
-    }
-
     emit dataChanged();
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -19,18 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortfilterproxymodel.h"
 
 #include <QTimer>
 
-#include "defer.h"
-#include "types/val.h"
+#include "global/defer.h"
+#include "global/types/val.h"
 
-#include "view/modelutils.h"
+#include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
 
-static const int INVALID_KEY = -1;
+static constexpr int INVALID_KEY = -1;
 
 SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     : QSortFilterProxyModel(parent), m_filters(this), m_sorters(this)
@@ -161,12 +162,6 @@ void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
     }
 }
 
-void SortFilterProxyModel::refresh()
-{
-    setFilterFixedString(filterRegularExpression().pattern());
-    setSortCaseSensitivity(sortCaseSensitivity());
-}
-
 bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
 {
     if (m_alwaysIncludeIndices.contains(sourceRow)) {
@@ -178,31 +173,25 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
     }
 
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-
-    QHashIterator<int, FilterValue*> it(m_roleIdToFilterValueHash);
-    while (it.hasNext()) {
-        it.next();
-
-        QVariant data = sourceModel()->data(index, it.key());
-        FilterValue* value = it.value();
-
-        if (!value->enabled()) {
+    for (const auto& [role, filter] : m_roleIdToFilterValueHash.asKeyValueRange()) {
+        if (!filter->enabled()) {
             continue;
         }
 
-        switch (value->compareType()) {
+        QVariant data = sourceModel()->data(index, role);
+        switch (filter->compareType()) {
         case CompareType::Equal:
-            if (data != value->roleValue()) {
+            if (data != filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::NotEqual:
-            if (data == value->roleValue()) {
+            if (data == filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::Contains:
-            if (!data.toString().contains(value->roleValue().toString(), Qt::CaseInsensitive)) {
+            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
                 return false;
             }
             break;
@@ -227,13 +216,6 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
     return leftData < rightData;
 }
 
-void SortFilterProxyModel::reset()
-{
-    beginResetModel();
-    resetInternalData();
-    endResetModel();
-}
-
 void SortFilterProxyModel::fillRoleIds()
 {
     beginFilterChange();
@@ -248,30 +230,24 @@ void SortFilterProxyModel::fillRoleIds()
 
     m_roleIdToFilterValueHash.clear();
 
-    if (!sourceModel()) {
-        return;
+    const QList<FilterValue*> filterList = m_filters.list();
+    QHash<QByteArray, FilterValue*> roleNameToValueHash;
+    for (FilterValue* filter : filterList) {
+        roleNameToValueHash.insert(filter->roleName().toUtf8(), filter);
     }
 
-    QHash<QString, FilterValue*> roleNameToValueHash;
-    QList<FilterValue*> filterList = m_filters.list();
-    for (FilterValue* filter : std::as_const(filterList)) {
-        roleNameToValueHash.insert(filter->roleName(), filter);
-    }
-
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    QHash<int, QByteArray>::const_iterator it = roles.constBegin();
-    while (it != roles.constEnd()) {
-        if (roleNameToValueHash.contains(it.value())) {
-            m_roleIdToFilterValueHash.insert(it.key(), roleNameToValueHash[it.value()]);
+    const QHash<int, QByteArray> roles = roleNames();
+    for (const auto& [role, roleName] : roles.asKeyValueRange()) {
+        if (roleNameToValueHash.contains(roleName)) {
+            m_roleIdToFilterValueHash.insert(role, roleNameToValueHash[roleName]);
         }
-        ++it;
     }
 }
 
 SorterValue* SortFilterProxyModel::currentSorterValue() const
 {
-    QList<SorterValue*> sorterList = m_sorters.list();
-    for (SorterValue* sorter : std::as_const(sorterList)) {
+    const QList<SorterValue*> sorterList = m_sorters.list();
+    for (SorterValue* sorter : sorterList) {
         if (sorter->enabled()) {
             return sorter;
         }
@@ -282,12 +258,5 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
 
 int SortFilterProxyModel::roleKey(const QString& roleName) const
 {
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    for (auto it = roles.begin(); it != roles.end(); ++it) {
-        if (roleName == QString(it.value())) {
-            return it.key();
-        }
-    }
-
-    return INVALID_KEY;
+    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -24,6 +24,7 @@
 
 #include <QTimer>
 
+#include "global/log.h"
 #include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
@@ -145,7 +146,7 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
 
 int SortFilterProxyModel::roleFromRoleName(const QString& roleName) const
 {
-    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+    return m_roles.value(roleName.toUtf8(), INVALID_KEY);
 }
 
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
@@ -165,11 +166,16 @@ void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
 
     QSortFilterProxyModel::setSourceModel(sourceModel);
 
+    updateRoleMap();
+
     emit sourceModelRoleNamesChanged();
 
     if (auto sourceSortFilterModel = qobject_cast<SortFilterProxyModel*>(sourceModel)) {
         m_subSourceModelConnection = connect(sourceSortFilterModel, &SortFilterProxyModel::sourceModelRoleNamesChanged,
-                                             this, &SortFilterProxyModel::sourceModelRoleNamesChanged);
+                                             this, [this] {
+            updateRoleMap();
+            emit sourceModelRoleNamesChanged();
+        });
     }
 }
 
@@ -217,4 +223,13 @@ Sorter* SortFilterProxyModel::currentSorter() const
     }
 
     return nullptr;
+}
+
+void SortFilterProxyModel::updateRoleMap()
+{
+    m_roles.clear();
+    for (const auto& [role, roleName] : roleNames().asKeyValueRange()) {
+        const auto[it, didInsert] = m_roles.try_emplace(roleName, role);
+        DO_ASSERT(didInsert);
+    }
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -24,7 +24,6 @@
 
 #include <QTimer>
 
-#include "global/defer.h"
 #include "global/types/val.h"
 
 #include "uicomponents/view/modelutils.h"
@@ -38,13 +37,19 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 {
     ModelUtils::connectRowCountChangedSignal(this, &SortFilterProxyModel::rowCountChanged);
 
-    auto onFilterChanged = [this](FilterValue* changedFilterValue) {
+    const auto invalidateRows = [this]() {
+        beginFilterChange();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+    };
+    const auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
         if (changedFilterValue->async()) {
-            QTimer::singleShot(0, this, [this](){
-                fillRoleIds();
-            });
+            QTimer::singleShot(0, this, invalidateRows);
         } else {
-            fillRoleIds();
+            invalidateRows();
         }
     };
 
@@ -79,7 +84,6 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
         invalidate();
-        fillRoleIds();
     });
 }
 
@@ -173,8 +177,14 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
     }
 
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-    for (const auto& [role, filter] : m_roleIdToFilterValueHash.asKeyValueRange()) {
+    const QList<FilterValue*> filters = m_filters.list();
+    for (auto* filter : filters) {
         if (!filter->enabled()) {
+            continue;
+        }
+
+        const int role = roleKey(filter->roleName());
+        if (role == INVALID_KEY) {
             continue;
         }
 
@@ -214,34 +224,6 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
     Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
 
     return leftData < rightData;
-}
-
-void SortFilterProxyModel::fillRoleIds()
-{
-    beginFilterChange();
-
-    DEFER {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        endFilterChange(QSortFilterProxyModel::Direction::Rows);
-#else
-        invalidateFilter();
-#endif
-    };
-
-    m_roleIdToFilterValueHash.clear();
-
-    const QList<FilterValue*> filterList = m_filters.list();
-    QHash<QByteArray, FilterValue*> roleNameToValueHash;
-    for (FilterValue* filter : filterList) {
-        roleNameToValueHash.insert(filter->roleName().toUtf8(), filter);
-    }
-
-    const QHash<int, QByteArray> roles = roleNames();
-    for (const auto& [role, roleName] : roles.asKeyValueRange()) {
-        if (roleNameToValueHash.contains(roleName)) {
-            m_roleIdToFilterValueHash.insert(role, roleNameToValueHash[roleName]);
-        }
-    }
 }
 
 SorterValue* SortFilterProxyModel::currentSorterValue() const

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -160,13 +160,20 @@ QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
 
 void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
 {
-    if (m_subSourceModelConnection) {
-        disconnect(m_subSourceModelConnection);
-    }
+    disconnect(m_subSourceModelConnection);
+    disconnect(m_sourceModelAboutToBeResetConnection);
+    disconnect(m_sourceDataChangedConnection);
 
     QSortFilterProxyModel::setSourceModel(sourceModel);
 
     updateRoleMap();
+
+    if (sourceModel) {
+        m_sourceDataChangedConnection = connect(sourceModel, &QAbstractItemModel::dataChanged,
+                                                this, &SortFilterProxyModel::invalidateFilters);
+        m_sourceModelAboutToBeResetConnection = connect(sourceModel, &QAbstractItemModel::modelAboutToBeReset,
+                                                        this, &SortFilterProxyModel::invalidateFilters);
+    }
 
     emit sourceModelRoleNamesChanged();
 
@@ -223,6 +230,14 @@ Sorter* SortFilterProxyModel::currentSorter() const
     }
 
     return nullptr;
+}
+
+void SortFilterProxyModel::invalidateFilters() const
+{
+    const QList<Filter*> filters = m_filters.list();
+    for (auto* filter : filters) {
+        filter->invalidate();
+    }
 }
 
 void SortFilterProxyModel::updateRoleMap()

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -45,8 +45,8 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
         invalidateFilter();
 #endif
     };
-    const auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
-        if (changedFilterValue->async()) {
+    const auto onFilterChanged = [this, invalidateRows](Filter* changedFilter) {
+        if (changedFilter->async()) {
             QTimer::singleShot(0, this, invalidateRows);
         } else {
             invalidateRows();
@@ -54,13 +54,13 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     };
 
     connect(m_filters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onFilterChanged](int index) {
-        FilterValue* filter = m_filters.at(index);
+        Filter* filter = m_filters.at(index);
 
         if (filter->enabled()) {
             onFilterChanged(filter);
         }
 
-        connect(filter, &FilterValue::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
+        connect(filter, &Filter::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
     });
 
     auto onSortersChanged = [this] {
@@ -87,7 +87,7 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 }
 
-QQmlListProperty<FilterValue> SortFilterProxyModel::filters()
+QQmlListProperty<Filter> SortFilterProxyModel::filters()
 {
     return m_filters.property();
 }
@@ -141,6 +141,11 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
     emit alwaysExcludeIndicesChanged();
 }
 
+int SortFilterProxyModel::roleFromRoleName(const QString& roleName) const
+{
+    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+}
+
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
 {
     if (!sourceModel()) {
@@ -176,35 +181,14 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
         return false;
     }
 
-    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-    const QList<FilterValue*> filters = m_filters.list();
+    const QList<Filter*> filters = m_filters.list();
     for (auto* filter : filters) {
         if (!filter->enabled()) {
             continue;
         }
 
-        const int role = roleKey(filter->roleName());
-        if (role == INVALID_KEY) {
-            continue;
-        }
-
-        QVariant data = sourceModel()->data(index, role);
-        switch (filter->compareType()) {
-        case CompareType::Equal:
-            if (data != filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::NotEqual:
-            if (data == filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::Contains:
-            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
-                return false;
-            }
-            break;
+        if (!filter->acceptsRow(sourceRow, sourceParent, *this)) {
+            return false;
         }
     }
 
@@ -218,7 +202,7 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
         return false;
     }
 
-    int sorterRoleKey = roleKey(sorter->roleName());
+    const int sorterRoleKey = roleFromRoleName(sorter->roleName());
 
     Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
     Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
@@ -236,9 +220,4 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
     }
 
     return nullptr;
-}
-
-int SortFilterProxyModel::roleKey(const QString& roleName) const
-{
-    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -24,8 +24,6 @@
 
 #include <QTimer>
 
-#include "global/types/val.h"
-
 #include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
@@ -64,10 +62,11 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 
     auto onSortersChanged = [this] {
-        SorterValue* sorter = currentSorterValue();
+        Sorter* sorter = currentSorter();
         invalidate();
 
         if (!sorter) {
+            sort(-1, Qt::AscendingOrder);
             return;
         }
 
@@ -77,9 +76,12 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     };
 
     connect(m_sorters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onSortersChanged](int index) {
-        onSortersChanged();
+        Sorter* sorter = m_sorters.at(index);
+        if (sorter->enabled()) {
+            onSortersChanged();
+        }
 
-        connect(m_sorters.at(index), &SorterValue::dataChanged, this, onSortersChanged);
+        connect(sorter, &Sorter::dataChanged, this, onSortersChanged);
     });
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
@@ -92,7 +94,7 @@ QQmlListProperty<Filter> SortFilterProxyModel::filters()
     return m_filters.property();
 }
 
-QQmlListProperty<SorterValue> SortFilterProxyModel::sorters()
+QQmlListProperty<Sorter> SortFilterProxyModel::sorters()
 {
     return m_sorters.property();
 }
@@ -197,23 +199,18 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
-    SorterValue* sorter = currentSorterValue();
+    Sorter* sorter = currentSorter();
     if (!sorter) {
         return false;
     }
 
-    const int sorterRoleKey = roleFromRoleName(sorter->roleName());
-
-    Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
-    Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
-
-    return leftData < rightData;
+    return sorter->lessThan(left, right, *this);
 }
 
-SorterValue* SortFilterProxyModel::currentSorterValue() const
+Sorter* SortFilterProxyModel::currentSorter() const
 {
-    const QList<SorterValue*> sorterList = m_sorters.list();
-    for (SorterValue* sorter : sorterList) {
+    const QList<Sorter*> sorterList = m_sorters.list();
+    for (Sorter* sorter : sorterList) {
         if (sorter->enabled()) {
             return sorter;
         }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -77,6 +77,7 @@ protected:
 
 private:
     Sorter* currentSorter() const;
+    void invalidateFilters() const;
     void updateRoleMap();
 
     QHash<QByteArray, int> m_roles;
@@ -88,5 +89,7 @@ private:
     QList<int> m_alwaysExcludeIndices;
 
     QMetaObject::Connection m_subSourceModelConnection;
+    QMetaObject::Connection m_sourceDataChangedConnection;
+    QMetaObject::Connection m_sourceModelAboutToBeResetConnection;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -30,8 +30,8 @@
 #include <QtQmlIntegration/qqmlintegration.h>
 
 #include "filter.h"
-#include "sortervalue.h"
 #include "qmllistproperty.h"
+#include "sorter.h"
 
 namespace muse::uicomponents {
 class SortFilterProxyModel : public QSortFilterProxyModel
@@ -39,7 +39,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
     Q_OBJECT
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Sorter> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
 
@@ -49,7 +49,7 @@ public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
     QQmlListProperty<Filter> filters();
-    QQmlListProperty<SorterValue> sorters();
+    QQmlListProperty<Sorter> sorters();
 
     QList<int> alwaysIncludeIndices() const;
     void setAlwaysIncludeIndices(const QList<int>& indices);
@@ -75,10 +75,10 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    SorterValue* currentSorterValue() const;
+    Sorter* currentSorter() const;
 
     QmlListProperty<Filter> m_filters;
-    QmlListProperty<SorterValue> m_sorters;
+    QmlListProperty<Sorter> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;
     QList<int> m_alwaysExcludeIndices;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -29,7 +29,7 @@
 
 #include <QtQmlIntegration/qqmlintegration.h>
 
-#include "filtervalue.h"
+#include "filter.h"
 #include "sortervalue.h"
 #include "qmllistproperty.h"
 
@@ -38,7 +38,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
@@ -48,7 +48,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
-    QQmlListProperty<FilterValue> filters();
+    QQmlListProperty<Filter> filters();
     QQmlListProperty<SorterValue> sorters();
 
     QList<int> alwaysIncludeIndices() const;
@@ -57,6 +57,7 @@ public:
     QList<int> alwaysExcludeIndices() const;
     void setAlwaysExcludeIndices(const QList<int>& indices);
 
+    int roleFromRoleName(const QString&) const;
     QHash<int, QByteArray> roleNames() const override;
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
@@ -75,9 +76,8 @@ protected:
 
 private:
     SorterValue* currentSorterValue() const;
-    int roleKey(const QString& roleName) const;
 
-    QmlListProperty<FilterValue> m_filters;
+    QmlListProperty<Filter> m_filters;
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -19,11 +19,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
-#include <qqmlintegration.h>
-
+#include <QHash>
+#include <QList>
+#include <QMetaObject>
 #include <QSortFilterProxyModel>
+
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "filtervalue.h"
 #include "sortervalue.h"
@@ -33,14 +37,13 @@ namespace muse::uicomponents {
 class SortFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
-    QML_ELEMENT
-
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
+
+    QML_ELEMENT
 
 public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
@@ -58,12 +61,8 @@ public:
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
 
-    Q_INVOKABLE void refresh();
-
 signals:
     void rowCountChanged();
-
-    void filtersChanged(QQmlListProperty<muse::uicomponents::FilterValue> filters);
 
     void alwaysIncludeIndicesChanged();
     void alwaysExcludeIndicesChanged();
@@ -75,9 +74,7 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void reset();
     void fillRoleIds();
-
     SorterValue* currentSorterValue() const;
     int roleKey(const QString& roleName) const;
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -74,13 +74,10 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void fillRoleIds();
     SorterValue* currentSorterValue() const;
     int roleKey(const QString& roleName) const;
 
     QmlListProperty<FilterValue> m_filters;
-    QHash<int, FilterValue*> m_roleIdToFilterValueHash;
-
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QHash>
 #include <QList>
 #include <QMetaObject>
@@ -76,6 +77,9 @@ protected:
 
 private:
     Sorter* currentSorter() const;
+    void updateRoleMap();
+
+    QHash<QByteArray, int> m_roles;
 
     QmlListProperty<Filter> m_filters;
     QmlListProperty<Sorter> m_sorters;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULE_TEST muse_uicomponents_qml_tests)
 
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/doubleinputvalidator_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sortfilterproxymodel_tests.cpp
     )
 
 set(MODULE_TEST_LINK

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <QString>
+#include <QStringList>
+#include <QStringListModel>
+
+#include "uicomponents/qml/Muse/UiComponents/filtervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h"
+
+using namespace Qt::StringLiterals;
+
+namespace muse::uicomponents {
+class UiComponents_SortFilterProxyModelTests : public ::testing::Test
+{
+public:
+    UiComponents_SortFilterProxyModelTests()
+    {
+        QStringList modelData;
+        modelData << u"hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay needle hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay hay"_s;
+        m_model->setStringList(modelData);
+    }
+
+    QAbstractListModel* listModel() const
+    {
+        return m_model.get();
+    }
+
+private:
+    std::unique_ptr<QStringListModel> m_model = std::make_unique<QStringListModel>();
+};
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* filter = new FilterValue(proxyModel.get());
+    filter->setCompareType(CompareType::Equal);
+    filter->setRoleName(u"display"_s);
+    filter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, filter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 2);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(3));
+
+    filter->setCompareType(CompareType::NotEqual);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(0));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(4));
+
+    filter->setCompareType(CompareType::Contains);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(3));
+
+    filter->setEnabled(false);
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValueMultiple)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* hayFilter = new FilterValue(proxyModel.get());
+    hayFilter->setCompareType(CompareType::Contains);
+    hayFilter->setRoleName(u"display"_s);
+    hayFilter->setRoleValue(u"hay"_s);
+
+    FilterValue* needleFilter = new FilterValue(proxyModel.get());
+    needleFilter->setCompareType(CompareType::Contains);
+    needleFilter->setRoleName(u"display"_s);
+    needleFilter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, hayFilter);
+    filters.append(&filters, needleFilter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 1);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(2));
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testSorterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    SorterValue* sorter = new SorterValue(proxyModel.get());
+    sorter->setRoleName(u"display"_s);
+
+    QQmlListProperty<Sorter> sorters = proxyModel->sorters();
+    ASSERT_TRUE(sorters.append);
+    sorters.append(&sorters, sorter);
+
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+    for (int row = 0; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+        EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(row, 0)), model->index(row));
+    }
+
+    sorter->setEnabled(true);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Less || ordering == QPartialOrdering::Equivalent);
+    }
+
+    sorter->setSortOrder(Qt::DescendingOrder);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Greater || ordering == QPartialOrdering::Equivalent);
+    }
+}
+}


### PR DESCRIPTION
Part of: #15983 

This PR implements a reusable fuzzy search proxy model and adds fuzzy search support to the shortcuts list in preferences.

### Overview of the Algorithm
1. Split the user input into words (words are assumed to be separated by whitespace)
2. Try to find a fuzzy match of each individual word within every candidate item. Matches have an error budget of 1 when the searched word is 4 characters or longer. An additional error is added to the budget every 8 characters.
3. The resulting items are then sorted by match similarity (amount of errors between the user input and the item). If the amount of errors is equal they are sorted further by whether the match spans a whole word or starts at a word in the item.
An error can be a missing character, an excess character, different characters, and swapped characters.

The implemented fuzzy search algorithm is an extended version of [Seller's variant for string search of the Wagner-Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm#Seller's_variant_for_string_search) (this is the algorithm that is used in our implementation of `muse::string::levenshteinDistance`). It is extended to also allow transposition errors (Damerau-Levenshtein distance).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
