### PR TITLE
Expose remaining Part/Staff editing methods to Plugin API

### DIFF
--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -27,6 +27,7 @@
 #include "engraving/dom/factory.h"
 #include "engraving/dom/instrtemplate.h"
 #include "engraving/dom/instrument.h"
+#include "engraving/dom/scoreorder.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/staff.h"
 #include "engraving/dom/stafftype.h"
@@ -1447,5 +1448,77 @@ TEST_F(Engraving_ApiScoreTests, replacePartApi)
     EXPECT_EQ(domScore->parts()[0]->instrumentId(), u"violin");
 
     delete apiPart;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   testSetScoreOrder
+//   Test setting the score order and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, setScoreOrder)
+{
+    // [GIVEN] A score
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    score->appendStaff(Factory::createStaff(part));
+
+    // Create a custom score order
+    ScoreOrder testOrder;
+    testOrder.id = u"test-order";
+    testOrder.name = TranslatableString::untranslatable("Test Order");
+
+    String originalOrderId = score->scoreOrder().id;
+
+    // [WHEN] We set the score order
+    score->startCmd(TranslatableString::untranslatable("Set score order test"));
+    EditPart::setScoreOrder(score, testOrder);
+    score->endCmd();
+
+    // [THEN] The score order should be changed
+    EXPECT_EQ(score->scoreOrder().id, u"test-order");
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] The score order should be back to original
+    EXPECT_EQ(score->scoreOrder().id, originalOrderId);
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testSetScoreOrderApi
+//   Test the Plugin API Score::setScoreOrder() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, setScoreOrderApi)
+{
+    // [GIVEN] A score and an orchestral order available
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    domScore->appendStaff(Factory::createStaff(domPart));
+
+    // Add a test order to the global list for API lookup
+    ScoreOrder testOrder;
+    testOrder.id = u"test-api-order";
+    testOrder.name = TranslatableString::untranslatable("Test API Order");
+    instrumentOrders.push_back(testOrder);
+
+    apiv1::Score apiScore(domScore);
+
+    // [WHEN] We set the score order via API
+    apiScore.setScoreOrder("test-api-order");
+
+    // [THEN] The score order should be changed
+    EXPECT_EQ(domScore->scoreOrder().id, u"test-api-order");
+
+    // Clean up the added test order
+    instrumentOrders.pop_back();
+
     delete domScore;
 }

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1289,3 +1289,163 @@ TEST_F(Engraving_ApiScoreTests, replaceDrumsetApi)
     delete apiPart;
     delete domScore;
 }
+
+//---------------------------------------------------------
+//   testInsertPart
+//   Test inserting a part at a given index and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, insertPart)
+{
+    // [GIVEN] A score with one part
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part1 = new Part(score);
+    score->appendPart(part1);
+    score->appendStaff(Factory::createStaff(part1));
+
+    Instrument instr1;
+    instr1.setId(u"test.first");
+    part1->setInstrument(instr1);
+
+    ASSERT_EQ(score->parts().size(), 1);
+
+    // Load instrument templates so searchTemplate works
+    const InstrumentTemplate* violinTempl = searchTemplate(u"violin");
+    if (!violinTempl) {
+        GTEST_SKIP() << "Instrument templates not loaded";
+    }
+
+    // [WHEN] We insert a part at index 0
+    score->startCmd(TranslatableString::untranslatable("Insert part test"));
+    EditPart::insertPart(score, violinTempl, 0);
+    score->endCmd();
+
+    // [THEN] Two parts should exist, the new one at index 0
+    EXPECT_EQ(score->parts().size(), 2);
+    EXPECT_EQ(score->parts()[0]->instrumentId(), u"violin");
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] Should be back to one part
+    EXPECT_EQ(score->parts().size(), 1);
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testReplacePart
+//   Test replacing a part and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, replacePart)
+{
+    // [GIVEN] A score with one part
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    score->appendStaff(Factory::createStaff(part));
+
+    Instrument instr;
+    instr.setId(u"test.original");
+    part->setInstrument(instr);
+
+    ASSERT_EQ(score->parts().size(), 1);
+
+    const InstrumentTemplate* violinTempl = searchTemplate(u"violin");
+    if (!violinTempl) {
+        GTEST_SKIP() << "Instrument templates not loaded";
+    }
+
+    // [WHEN] We replace the part
+    score->startCmd(TranslatableString::untranslatable("Replace part test"));
+    EditPart::replacePart(score, part, violinTempl);
+    score->endCmd();
+
+    // [THEN] The part should be replaced with violin
+    EXPECT_EQ(score->parts().size(), 1);
+    EXPECT_EQ(score->parts()[0]->instrumentId(), u"violin");
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] Should be back to the original part
+    EXPECT_EQ(score->parts().size(), 1);
+    EXPECT_EQ(score->parts()[0]->instrumentId(), u"test.original");
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testInsertPartApi
+//   Test the Plugin API Score::insertPart() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, insertPartApi)
+{
+    // [GIVEN] A score with one part
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    domScore->appendStaff(Factory::createStaff(domPart));
+
+    ASSERT_EQ(domScore->parts().size(), 1);
+
+    const InstrumentTemplate* violinTempl = searchTemplate(u"violin");
+    if (!violinTempl) {
+        GTEST_SKIP() << "Instrument templates not loaded";
+    }
+
+    apiv1::Score apiScore(domScore);
+
+    // [WHEN] We insert a part via API
+    apiScore.insertPart("violin", 0);
+
+    // [THEN] Two parts should exist
+    EXPECT_EQ(domScore->parts().size(), 2);
+    EXPECT_EQ(domScore->parts()[0]->instrumentId(), u"violin");
+
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   testReplacePartApi
+//   Test the Plugin API Score::replacePart() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, replacePartApi)
+{
+    // [GIVEN] A score with one part
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    domScore->appendStaff(Factory::createStaff(domPart));
+
+    Instrument instr;
+    instr.setId(u"test.original");
+    domPart->setInstrument(instr);
+
+    ASSERT_EQ(domScore->parts().size(), 1);
+
+    const InstrumentTemplate* violinTempl = searchTemplate(u"violin");
+    if (!violinTempl) {
+        GTEST_SKIP() << "Instrument templates not loaded";
+    }
+
+    apiv1::Score apiScore(domScore);
+    apiv1::Part* apiPart = new apiv1::Part(domPart, apiv1::Ownership::SCORE);
+
+    // [WHEN] We replace the part via API
+    apiScore.replacePart(apiPart, "violin");
+
+    // [THEN] The part should be replaced
+    EXPECT_EQ(domScore->parts().size(), 1);
+    EXPECT_EQ(domScore->parts()[0]->instrumentId(), u"violin");
+
+    delete apiPart;
+    delete domScore;
+}

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1140,3 +1140,55 @@ TEST_F(Engraving_ApiScoreTests, appendLinkedStaffApi)
     delete apiPart;
     delete domScore;
 }
+
+//---------------------------------------------------------
+//   testSetVoiceVisibleOnMainScore
+//   Test that setVoiceVisible returns false on main score
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, setVoiceVisibleOnMainScore)
+{
+    // [GIVEN] A main score (not an excerpt)
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    Staff* staff = Factory::createStaff(part);
+    score->appendStaff(staff);
+
+    // [WHEN] We try to set voice visible on the main score
+    bool result = EditPart::setVoiceVisible(score, staff, 0, false);
+
+    // [THEN] It should return false (only works on excerpts)
+    EXPECT_FALSE(result);
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testSetVoiceVisibleApi
+//   Test the Plugin API Score::setVoiceVisible() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, setVoiceVisibleApi)
+{
+    // [GIVEN] A main score (not an excerpt)
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    Staff* domStaff = Factory::createStaff(domPart);
+    domScore->appendStaff(domStaff);
+
+    apiv1::Score apiScore(domScore);
+    apiv1::Staff* apiStaff = new apiv1::Staff(domStaff, apiv1::Ownership::SCORE);
+
+    // [WHEN] We try to set voice visible via API on main score
+    bool result = apiScore.setVoiceVisible(apiStaff, 0, false);
+
+    // [THEN] It should return false
+    EXPECT_FALSE(result);
+
+    delete apiStaff;
+    delete domScore;
+}

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1008,3 +1008,135 @@ TEST_F(Engraving_ApiScoreTests, staffPropertiesApi)
 
     delete domScore;
 }
+
+//---------------------------------------------------------
+//   testAppendStaff
+//   Test appending a new staff to a part and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, appendStaff)
+{
+    // [GIVEN] A score with a part containing one staff
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    score->appendStaff(Factory::createStaff(part));
+
+    ASSERT_EQ(part->nstaves(), 1);
+
+    // [WHEN] We append a new staff
+    score->startCmd(TranslatableString::untranslatable("Append staff test"));
+    Staff* newStaff = EditPart::appendStaff(score, part);
+    score->endCmd();
+
+    // [THEN] The part should have 2 staves
+    ASSERT_NE(newStaff, nullptr);
+    EXPECT_EQ(part->nstaves(), 2);
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] The part should have 1 staff again
+    EXPECT_EQ(part->nstaves(), 1);
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testAppendLinkedStaff
+//   Test appending a linked staff and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, appendLinkedStaff)
+{
+    // [GIVEN] A score with a part containing one staff
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    Staff* sourceStaff = Factory::createStaff(part);
+    score->appendStaff(sourceStaff);
+
+    ASSERT_EQ(part->nstaves(), 1);
+
+    // [WHEN] We append a linked staff
+    score->startCmd(TranslatableString::untranslatable("Append linked staff test"));
+    Staff* linkedStaff = EditPart::appendLinkedStaff(score, sourceStaff, part);
+    score->endCmd();
+
+    // [THEN] The part should have 2 staves
+    ASSERT_NE(linkedStaff, nullptr);
+    EXPECT_EQ(part->nstaves(), 2);
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] The part should have 1 staff again
+    EXPECT_EQ(part->nstaves(), 1);
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testAppendStaffApi
+//   Test the Plugin API Score::appendStaff() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, appendStaffApi)
+{
+    // [GIVEN] A score with a part containing one staff
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    domScore->appendStaff(Factory::createStaff(domPart));
+
+    ASSERT_EQ(domPart->nstaves(), 1);
+
+    apiv1::Score apiScore(domScore);
+    apiv1::Part* apiPart = new apiv1::Part(domPart, apiv1::Ownership::SCORE);
+
+    // [WHEN] We append a staff via API
+    apiv1::Staff* apiStaff = apiScore.appendStaff(apiPart);
+
+    // [THEN] The part should have 2 staves
+    EXPECT_NE(apiStaff, nullptr);
+    EXPECT_EQ(domPart->nstaves(), 2);
+
+    delete apiPart;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   testAppendLinkedStaffApi
+//   Test the Plugin API Score::appendLinkedStaff() method
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, appendLinkedStaffApi)
+{
+    // [GIVEN] A score with a part containing one staff
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    Staff* domStaff = Factory::createStaff(domPart);
+    domScore->appendStaff(domStaff);
+
+    ASSERT_EQ(domPart->nstaves(), 1);
+
+    apiv1::Score apiScore(domScore);
+    apiv1::Part* apiPart = new apiv1::Part(domPart, apiv1::Ownership::SCORE);
+    apiv1::Staff* apiSourceStaff = new apiv1::Staff(domStaff, apiv1::Ownership::SCORE);
+
+    // [WHEN] We append a linked staff via API
+    apiv1::Staff* apiLinkedStaff = apiScore.appendLinkedStaff(apiSourceStaff, apiPart);
+
+    // [THEN] The part should have 2 staves
+    EXPECT_NE(apiLinkedStaff, nullptr);
+    EXPECT_EQ(domPart->nstaves(), 2);
+
+    delete apiSourceStaff;
+    delete apiPart;
+    delete domScore;
+}

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include "engraving/compat/scoreaccess.h"
+#include "engraving/dom/drumset.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/instrtemplate.h"
 #include "engraving/dom/instrument.h"
@@ -35,6 +36,7 @@
 #include "engraving/api/v1/score.h"
 #include "engraving/api/v1/part.h"
 #include "engraving/api/v1/elements.h"
+#include "engraving/api/v1/instrument.h"
 #include "engraving/api/v1/apistructs.h"
 
 using namespace mu::engraving;
@@ -1190,5 +1192,100 @@ TEST_F(Engraving_ApiScoreTests, setVoiceVisibleApi)
     EXPECT_FALSE(result);
 
     delete apiStaff;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   testReplaceDrumset
+//   Test replacing a drumset and undo
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, replaceDrumset)
+{
+    // [GIVEN] A score with a percussion part
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* part = new Part(score);
+    score->appendPart(part);
+    score->appendStaff(Factory::createStaff(part));
+
+    // Set up a percussion instrument with a drumset
+    Instrument percInstrument;
+    percInstrument.setId(u"drumset");
+    Drumset ds;
+    ds.drum(36).name = u"Bass Drum";
+    ds.drum(36).notehead = NoteHeadGroup::HEAD_NORMAL;
+    ds.drum(36).line = 7;
+    ds.drum(36).voice = 0;
+    ds.drum(36).stemDirection = DirectionV::DOWN;
+    percInstrument.setDrumset(&ds);
+    part->setInstrument(percInstrument);
+
+    EXPECT_EQ(part->instrument()->drumset()->name(36), u"Bass Drum");
+
+    // [WHEN] We replace the drumset with modified values
+    Drumset newDs(ds);
+    newDs.drum(36).name = u"Kick Drum";
+
+    score->startCmd(TranslatableString::untranslatable("Replace drumset test"));
+    EditPart::replaceDrumset(score, part, u"drumset", newDs);
+    score->endCmd();
+
+    // [THEN] The drumset should have the new name
+    EXPECT_EQ(part->instrument()->drumset()->name(36), u"Kick Drum");
+
+    // [WHEN] We undo
+    score->undoRedo(true, nullptr);
+
+    // [THEN] The drumset should be back to original
+    EXPECT_EQ(part->instrument()->drumset()->name(36), u"Bass Drum");
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   testReplaceDrumsetApi
+//   Test the Plugin API replaceDrumset workflow
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, replaceDrumsetApi)
+{
+    // [GIVEN] A score with a percussion part
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Part* domPart = new Part(domScore);
+    domScore->appendPart(domPart);
+    domScore->appendStaff(Factory::createStaff(domPart));
+
+    // Set up a percussion instrument with a drumset
+    Instrument percInstrument;
+    percInstrument.setId(u"drumset");
+    Drumset ds;
+    ds.drum(36).name = u"Bass Drum";
+    ds.drum(36).notehead = NoteHeadGroup::HEAD_NORMAL;
+    ds.drum(36).line = 7;
+    ds.drum(36).voice = 0;
+    ds.drum(36).stemDirection = DirectionV::DOWN;
+    percInstrument.setDrumset(&ds);
+    domPart->setInstrument(percInstrument);
+
+    EXPECT_EQ(domPart->instrument()->drumset()->name(36), u"Bass Drum");
+
+    apiv1::Score apiScore(domScore);
+    apiv1::Part* apiPart = new apiv1::Part(domPart, apiv1::Ownership::SCORE);
+
+    // [WHEN] We clone the drumset via API, modify it, and replace
+    apiv1::Instrument apiInstr(domPart->instrument(), domPart);
+    apiv1::Drumset* cloned = apiInstr.cloneDrumset();
+    ASSERT_NE(cloned, nullptr);
+
+    cloned->setName(36, "Kick Drum");
+    apiScore.replaceDrumset(apiPart, cloned);
+
+    // [THEN] The drumset should have the new name
+    EXPECT_EQ(domPart->instrument()->drumset()->name(36), u"Kick Drum");
+
+    delete cloned;
+    delete apiPart;
     delete domScore;
 }

--- a/src/engraving/api/v1/instrument.cpp
+++ b/src/engraving/api/v1/instrument.cpp
@@ -105,6 +105,57 @@ QVariantList StringData::stringList() const
 }
 
 //---------------------------------------------------------
+//   Drumset setters
+//   These allow modifying a cloned drumset before passing
+//   it to Score::replaceDrumset(). The Drumset obtained
+//   from an Instrument is read-only; Instrument::cloneDrumset()
+//   returns a writable copy that can be modified with these
+//   setters and then applied to the score.
+//---------------------------------------------------------
+
+void Drumset::setName(int pitch, const QString& name)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).name = name;
+    }
+}
+
+void Drumset::setNoteHead(int pitch, int noteHead)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).notehead = mu::engraving::NoteHeadGroup(noteHead);
+    }
+}
+
+void Drumset::setLine(int pitch, int line)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).line = line;
+    }
+}
+
+void Drumset::setVoice(int pitch, int voice)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).voice = voice;
+    }
+}
+
+void Drumset::setStemDirection(int pitch, int stemDirection)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).stemDirection = mu::engraving::DirectionV(stemDirection);
+    }
+}
+
+void Drumset::setShortcut(int pitch, const QString& shortcut)
+{
+    if (pitch >= 0 && pitch <= 127) {
+        m_drumset->drum(pitch).shortcut = shortcut;
+    }
+}
+
+//---------------------------------------------------------
 //   Drumset::variants
 //---------------------------------------------------------
 
@@ -175,6 +226,16 @@ QString Instrument::shortName() const
 //---------------------------------------------------------
 //   Instrument::channels
 //---------------------------------------------------------
+
+Drumset* Instrument::cloneDrumset()
+{
+    const mu::engraving::Drumset* ds = instrument()->drumset();
+    if (!ds) {
+        return nullptr;
+    }
+
+    return new Drumset(new mu::engraving::Drumset(*ds), true, this);
+}
 
 ChannelListProperty Instrument::channels()
 {

--- a/src/engraving/api/v1/instrument.cpp
+++ b/src/engraving/api/v1/instrument.cpp
@@ -115,44 +115,50 @@ QVariantList StringData::stringList() const
 
 void Drumset::setName(int pitch, const QString& name)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).name = name;
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).name = name;
 }
 
 void Drumset::setNoteHead(int pitch, int noteHead)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).notehead = mu::engraving::NoteHeadGroup(noteHead);
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).notehead = mu::engraving::NoteHeadGroup(noteHead);
 }
 
 void Drumset::setLine(int pitch, int line)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).line = line;
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).line = line;
 }
 
 void Drumset::setVoice(int pitch, int voice)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).voice = voice;
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).voice = voice;
 }
 
 void Drumset::setStemDirection(int pitch, int stemDirection)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).stemDirection = mu::engraving::DirectionV(stemDirection);
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).stemDirection = mu::engraving::DirectionV(stemDirection);
 }
 
 void Drumset::setShortcut(int pitch, const QString& shortcut)
 {
-    if (pitch >= 0 && pitch <= 127) {
-        m_drumset->drum(pitch).shortcut = shortcut;
+    IF_ASSERT_FAILED(pitch >= 0 && pitch < DRUM_INSTRUMENTS) {
+        return;
     }
+    m_drumset->drum(pitch).shortcut = shortcut;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/instrument.h
+++ b/src/engraving/api/v1/instrument.h
@@ -204,11 +204,22 @@ class Drumset : public QObject
     Q_OBJECT
 
     mu::engraving::Drumset* m_drumset;
+    bool m_owned = false;
 
 public:
     /// \cond MS_INTERNAL
     Drumset(mu::engraving::Drumset* d, QObject* parent = nullptr)
         : QObject(parent), m_drumset(d) {}
+
+    Drumset(mu::engraving::Drumset* d, bool owned, QObject* parent = nullptr)
+        : QObject(parent), m_drumset(d), m_owned(owned) {}
+
+    ~Drumset() override
+    {
+        if (m_owned) {
+            delete m_drumset;
+        }
+    }
 
     mu::engraving::Drumset* drumset() { return m_drumset; }
     const mu::engraving::Drumset* drumset() const { return m_drumset; }
@@ -297,6 +308,45 @@ public:
     /// \param pitch The pitch from which to find the previous used pitch from.
     Q_INVOKABLE int prevPitch(int pitch) { return drumset()->prevPitch(pitch); }
 
+    /// Sets the name of the drum note at the given pitch.
+    /// These setters allow modifying a cloned drumset before passing it
+    /// to Score.replaceDrumset(). The Drumset obtained from an Instrument
+    /// is read-only; use Instrument.cloneDrumset() to get a writable copy.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param name The new name for this drum note.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setName(int pitch, const QString& name);
+
+    /// Sets the notehead group for the drum note at the given pitch.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param noteHead The notehead group (NoteHeadGroup value).
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setNoteHead(int pitch, int noteHead);
+
+    /// Sets the staff line for the drum note at the given pitch.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param line The staff line for this note.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setLine(int pitch, int line);
+
+    /// Sets the voice for the drum note at the given pitch.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param voice The voice index (0 to 3).
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setVoice(int pitch, int voice);
+
+    /// Sets the stem direction for the drum note at the given pitch.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param stemDirection The stem direction (Direction value).
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setStemDirection(int pitch, int stemDirection);
+
+    /// Sets the keyboard shortcut for the drum note at the given pitch.
+    /// \param pitch The MIDI pitch (0 to 127).
+    /// \param shortcut The keyboard shortcut character.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setShortcut(int pitch, const QString& shortcut);
+
     /// Checks whether two drumsets represent the same object.
     Q_INVOKABLE bool is(apiv1::Drumset* other) { return other && drumset() == other->drumset(); }
 };
@@ -377,6 +427,13 @@ public:
 
     ChannelListProperty channels();
     /// \endcond
+
+    /// Creates and returns a copy of this instrument's drumset.
+    /// The returned Drumset is owned by the caller and can be modified
+    /// without affecting the original instrument until replaceDrumset is called.
+    /// Returns null if the instrument has no drumset.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE apiv1::Drumset* cloneDrumset();
 
     /// Checks whether two instruments represent the same object.
     Q_INVOKABLE bool is(apiv1::Instrument* other) { return other && instrument() == other->instrument(); }

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -344,6 +344,32 @@ void Score::moveSystemObjects(apiv1::Staff* sourceStaff, apiv1::Staff* destinati
     mu::engraving::EditPart::moveSystemObjects(score(), sourceStaff->staff(), destinationStaff->staff());
 }
 
+Staff* Score::appendStaff(Part* destinationPart)
+{
+    if (!destinationPart) {
+        LOGW("appendStaff: destinationPart is null");
+        return nullptr;
+    }
+
+    mu::engraving::Staff* staff = mu::engraving::EditPart::appendStaff(score(), destinationPart->part());
+    return staff ? wrap<Staff>(staff, Ownership::SCORE) : nullptr;
+}
+
+Staff* Score::appendLinkedStaff(Staff* sourceStaff, Part* destinationPart)
+{
+    if (!sourceStaff) {
+        LOGW("appendLinkedStaff: sourceStaff is null");
+        return nullptr;
+    }
+    if (!destinationPart) {
+        LOGW("appendLinkedStaff: destinationPart is null");
+        return nullptr;
+    }
+
+    mu::engraving::Staff* staff = mu::engraving::EditPart::appendLinkedStaff(score(), sourceStaff->staff(), destinationPart->part());
+    return staff ? wrap<Staff>(staff, Ownership::SCORE) : nullptr;
+}
+
 //---------------------------------------------------------
 //   Score::firstSegment
 //---------------------------------------------------------

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -410,6 +410,33 @@ void Score::replaceDrumset(Part* part, Drumset* drumset)
     mu::engraving::EditPart::replaceDrumset(score(), part->part(), instrumentId, *drumset->drumset());
 }
 
+void Score::insertPart(const QString& instrumentId, int index)
+{
+    const InstrumentTemplate* t = searchTemplate(instrumentId);
+    if (!t) {
+        LOGW("insertPart: <%s> not found", qPrintable(instrumentId));
+        return;
+    }
+
+    mu::engraving::EditPart::insertPart(score(), t, static_cast<size_t>(index));
+}
+
+void Score::replacePart(Part* part, const QString& instrumentId)
+{
+    if (!part) {
+        LOGW("replacePart: part is null");
+        return;
+    }
+
+    const InstrumentTemplate* t = searchTemplate(instrumentId);
+    if (!t) {
+        LOGW("replacePart: <%s> not found", qPrintable(instrumentId));
+        return;
+    }
+
+    mu::engraving::EditPart::replacePart(score(), part->part(), t);
+}
+
 //---------------------------------------------------------
 //   Score::firstSegment
 //---------------------------------------------------------

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -26,6 +26,7 @@
 #include "dom/factory.h"
 #include "dom/instrtemplate.h"
 #include "dom/measure.h"
+#include "dom/scoreorder.h"
 #include "dom/part.h"
 #include "dom/score.h"
 #include "dom/masterscore.h"
@@ -435,6 +436,20 @@ void Score::replacePart(Part* part, const QString& instrumentId)
     }
 
     mu::engraving::EditPart::replacePart(score(), part->part(), t);
+}
+
+void Score::setScoreOrder(const QString& orderId)
+{
+    muse::String id = muse::String::fromQString(orderId);
+
+    for (const mu::engraving::ScoreOrder& order : mu::engraving::instrumentOrders) {
+        if (order.id == id) {
+            mu::engraving::EditPart::setScoreOrder(score(), order);
+            return;
+        }
+    }
+
+    LOGW("setScoreOrder: <%s> not found", qPrintable(orderId));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -370,6 +370,16 @@ Staff* Score::appendLinkedStaff(Staff* sourceStaff, Part* destinationPart)
     return staff ? wrap<Staff>(staff, Ownership::SCORE) : nullptr;
 }
 
+bool Score::setVoiceVisible(Staff* staff, int voiceIndex, bool visible)
+{
+    if (!staff) {
+        LOGW("setVoiceVisible: staff is null");
+        return false;
+    }
+
+    return mu::engraving::EditPart::setVoiceVisible(score(), staff->staff(), voiceIndex, visible);
+}
+
 //---------------------------------------------------------
 //   Score::firstSegment
 //---------------------------------------------------------

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -41,6 +41,7 @@
 #include "apistructs.h"
 #include "cursor.h"
 #include "elements.h"
+#include "instrument.h"
 #include "apitypes.h"
 
 using namespace mu::engraving::apiv1;
@@ -378,6 +379,35 @@ bool Score::setVoiceVisible(Staff* staff, int voiceIndex, bool visible)
     }
 
     return mu::engraving::EditPart::setVoiceVisible(score(), staff->staff(), voiceIndex, visible);
+}
+
+void Score::replaceDrumset(Part* part, Drumset* drumset)
+{
+    if (!part) {
+        LOGW("replaceDrumset: part is null");
+        return;
+    }
+    if (!drumset) {
+        LOGW("replaceDrumset: drumset is null");
+        return;
+    }
+
+    // Find the instrumentId from the part's first instrument that has a drumset
+    mu::engraving::String instrumentId;
+    for (auto pair : part->part()->instruments()) {
+        mu::engraving::Instrument* instr = pair.second;
+        if (instr && instr->drumset()) {
+            instrumentId = instr->id();
+            break;
+        }
+    }
+
+    if (instrumentId.isEmpty()) {
+        LOGW("replaceDrumset: no percussion instrument found in part");
+        return;
+    }
+
+    mu::engraving::EditPart::replaceDrumset(score(), part->part(), instrumentId, *drumset->drumset());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -673,6 +673,18 @@ public:
     Q_INVOKABLE apiv1::Staff* appendLinkedStaff(apiv1::Staff* sourceStaff, apiv1::Part* destinationPart);
 
     /** APIDOC
+     * Sets the visibility of a voice on a staff.
+     * This method only works on excerpt (linked part) scores, not on the main score.
+     * @method
+     * @param {Engraving.Staff} staff The Staff object.
+     * @param {Number} voiceIndex The voice index (0 to 3).
+     * @param {Boolean} visible Whether the voice should be visible.
+     * @return {Boolean} True if successful, false if not an excerpt or voice cannot be disabled.
+     * @since 4.7
+    */
+    Q_INVOKABLE bool setVoiceVisible(apiv1::Staff* staff, int voiceIndex, bool visible);
+
+    /** APIDOC
      * Creates and returns a cursor to be used to navigate in the score
      * @method
      * @returns {Cursor} cursor

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -718,6 +718,15 @@ public:
     Q_INVOKABLE void replacePart(apiv1::Part* part, const QString& instrumentId);
 
     /** APIDOC
+     * Sets the score order (e.g. "orchestral", "marching-band").
+     * Score orders define the standard ordering of instruments and bracket/barline groupings.
+     * @method
+     * @param {String} orderId The ID of the score order (e.g. "orchestral", "marching-band", "jazz-combo").
+     * @since 4.7
+    */
+    Q_INVOKABLE void setScoreOrder(const QString& orderId);
+
+    /** APIDOC
      * Creates and returns a cursor to be used to navigate in the score
      * @method
      * @returns {Cursor} cursor

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -697,6 +697,27 @@ public:
     Q_INVOKABLE void replaceDrumset(apiv1::Part* part, apiv1::Drumset* drumset);
 
     /** APIDOC
+     * Inserts a part with the instrument defined by `instrumentId` at the given index.
+     * @method
+     * @param {String} instrumentId ID of the instrument to be added,
+     * as listed in {@link https://github.com/musescore/MuseScore/blob/master/share/instruments/instruments.xml|instruments.xml}
+     * @param {Number} index The position to insert the part at (0 = first).
+     * @since 4.7
+    */
+    Q_INVOKABLE void insertPart(const QString& instrumentId, int index);
+
+    /** APIDOC
+     * Replaces a part with a new instrument, keeping the same position.
+     * This removes the old part and inserts a new one with the given instrument.
+     * @method
+     * @param {Engraving.Part} part The Part to replace.
+     * @param {String} instrumentId ID of the new instrument,
+     * as listed in {@link https://github.com/musescore/MuseScore/blob/master/share/instruments/instruments.xml|instruments.xml}
+     * @since 4.7
+    */
+    Q_INVOKABLE void replacePart(apiv1::Part* part, const QString& instrumentId);
+
+    /** APIDOC
      * Creates and returns a cursor to be used to navigate in the score
      * @method
      * @returns {Cursor} cursor

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -653,6 +653,26 @@ public:
     Q_INVOKABLE void moveSystemObjects(apiv1::Staff* sourceStaff, apiv1::Staff* destinationStaff);
 
     /** APIDOC
+     * Creates and appends a new default staff to the given part.
+     * @method
+     * @param {Engraving.Part} destinationPart The Part to append the staff to.
+     * @return {Engraving.Staff} The newly created Staff, or null on failure.
+     * @since 4.7
+    */
+    Q_INVOKABLE apiv1::Staff* appendStaff(apiv1::Part* destinationPart);
+
+    /** APIDOC
+     * Creates a staff linked to a source staff and appends it to the given part.
+     * The linked staff will share content with the source staff.
+     * @method
+     * @param {Engraving.Staff} sourceStaff The Staff to link from.
+     * @param {Engraving.Part} destinationPart The Part to append the linked staff to.
+     * @return {Engraving.Staff} The newly created linked Staff, or null on failure.
+     * @since 4.7
+    */
+    Q_INVOKABLE apiv1::Staff* appendLinkedStaff(apiv1::Staff* sourceStaff, apiv1::Part* destinationPart);
+
+    /** APIDOC
      * Creates and returns a cursor to be used to navigate in the score
      * @method
      * @returns {Cursor} cursor

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -51,6 +51,7 @@ class System;
 class Selection;
 class Score;
 class Staff;
+class Drumset;
 class Lyrics;
 class Spanner;
 
@@ -683,6 +684,17 @@ public:
      * @since 4.7
     */
     Q_INVOKABLE bool setVoiceVisible(apiv1::Staff* staff, int voiceIndex, bool visible);
+
+    /** APIDOC
+     * Replaces the drumset of a part's percussion instrument.
+     * Use Instrument.cloneDrumset() to get a modifiable copy, then call Drumset.setDrum()
+     * to modify entries, and finally pass the modified drumset to this method.
+     * @method
+     * @param {Engraving.Part} part The Part object.
+     * @param {Engraving.Drumset} drumset The new Drumset to apply.
+     * @since 4.7
+    */
+    Q_INVOKABLE void replaceDrumset(apiv1::Part* part, apiv1::Drumset* drumset);
 
     /** APIDOC
      * Creates and returns a cursor to be used to navigate in the score

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "editpart.h"
+#include "editscoreproperties.h"
 #include "editstaff.h"
 #include "transpose.h"
 
@@ -28,6 +29,7 @@
 #include "../dom/factory.h"
 #include "../dom/instrchange.h"
 #include "../dom/instrtemplate.h"
+#include "../dom/scoreorder.h"
 #include "../dom/masterscore.h"
 #include "../dom/mscore.h"
 #include "../dom/part.h"
@@ -750,4 +752,15 @@ void EditPart::replaceDrumset(Score* score, Part* part, const String& instrument
             score->undo(new ChangeDrumset(instrument, newDrumset, part));
         }
     }
+}
+
+void EditPart::setScoreOrder(Score* score, const ScoreOrder& order)
+{
+    if (!score) {
+        return;
+    }
+
+    score->undo(new ChangeScoreOrder(score, order));
+    ScoreOrder mutableOrder = order;
+    mutableOrder.setBracketsAndBarlines(score);
 }

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -704,3 +704,17 @@ bool EditPart::setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool 
     score->excerpt()->setVoiceVisible(staff, voiceIndex, visible);
     return true;
 }
+
+void EditPart::replaceDrumset(Score* score, Part* part, const String& instrumentId, const Drumset& newDrumset)
+{
+    if (!score || !part) {
+        return;
+    }
+
+    for (auto pair : part->instruments()) {
+        Instrument* instrument = pair.second;
+        if (instrument && instrument->drumset() && instrument->id() == instrumentId) {
+            score->undo(new ChangeDrumset(instrument, newDrumset, part));
+        }
+    }
+}

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -686,3 +686,21 @@ Staff* EditPart::appendLinkedStaff(Score* score, Staff* sourceStaff, Part* desti
 
     return staff;
 }
+
+bool EditPart::setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool visible)
+{
+    if (!score || !staff) {
+        return false;
+    }
+
+    if (!score->excerpt()) {
+        return false;
+    }
+
+    if (!visible && !staff->canDisableVoice()) {
+        return false;
+    }
+
+    score->excerpt()->setVoiceVisible(staff, voiceIndex, visible);
+    return true;
+}

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -25,6 +25,7 @@
 #include "transpose.h"
 
 #include "../dom/excerpt.h"
+#include "../dom/factory.h"
 #include "../dom/instrchange.h"
 #include "../dom/masterscore.h"
 #include "../dom/mscore.h"
@@ -636,4 +637,52 @@ void EditPart::moveSystemObjects(Score* score, Staff* sourceStaff, Staff* destin
             item->undoChangeProperty(Pid::TRACK, staff2track(dstStaffIdx, item->voice()));
         }
     }
+}
+
+void EditPart::doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests)
+{
+    if (!score || !staff || !destinationPart) {
+        return;
+    }
+
+    staff_idx_t staffLocalIndex = destinationPart->nstaves();
+    KeyList keyList = *destinationPart->staff(staffLocalIndex - 1)->keyList();
+
+    staff->setScore(score);
+    staff->setPart(destinationPart);
+
+    score->undoInsertStaff(staff, staffLocalIndex, createRests);
+
+    staff_idx_t staffGlobalIndex = staff->idx();
+    score->adjustKeySigs(staffGlobalIndex, staffGlobalIndex + 1, keyList);
+
+    score->updateBracesAndBarlines(destinationPart, staffLocalIndex);
+
+    destinationPart->instrument()->setClefType(staffLocalIndex, staff->defaultClefType());
+}
+
+Staff* EditPart::appendStaff(Score* score, Part* destinationPart)
+{
+    if (!score || !destinationPart) {
+        return nullptr;
+    }
+
+    Staff* staff = Factory::createStaff(destinationPart);
+    doAppendStaff(score, staff, destinationPart);
+    return staff;
+}
+
+Staff* EditPart::appendLinkedStaff(Score* score, Staff* sourceStaff, Part* destinationPart)
+{
+    if (!score || !sourceStaff || !destinationPart) {
+        return nullptr;
+    }
+
+    Staff* staff = Factory::createStaff(destinationPart);
+    doAppendStaff(score, staff, destinationPart, false);
+
+    staff->setLinks(nullptr);
+    Excerpt::cloneStaff(sourceStaff, staff);
+
+    return staff;
 }

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -27,6 +27,7 @@
 #include "../dom/excerpt.h"
 #include "../dom/factory.h"
 #include "../dom/instrchange.h"
+#include "../dom/instrtemplate.h"
 #include "../dom/masterscore.h"
 #include "../dom/mscore.h"
 #include "../dom/part.h"
@@ -703,6 +704,38 @@ bool EditPart::setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool 
 
     score->excerpt()->setVoiceVisible(staff, voiceIndex, visible);
     return true;
+}
+
+void EditPart::insertPart(Score* score, const InstrumentTemplate* templ, size_t index)
+{
+    if (!score || !templ) {
+        return;
+    }
+
+    Part* part = new Part(score);
+    part->initFromInstrTemplate(templ);
+
+    for (staff_idx_t i = 0; i < templ->staffCount; ++i) {
+        Staff* staff = Factory::createStaff(part);
+        StaffType* stt = staff->staffType(Fraction(0, 1));
+        staff->init(templ, stt, int(i));
+        score->undoInsertStaff(staff, i);
+    }
+
+    score->undoInsertPart(part, index);
+    score->setUpTempoMapLater();
+    score->masterScore()->rebuildMidiMapping();
+}
+
+void EditPart::replacePart(Score* score, Part* oldPart, const InstrumentTemplate* templ)
+{
+    if (!score || !oldPart || !templ) {
+        return;
+    }
+
+    size_t partIndex = muse::indexOf(score->parts(), oldPart);
+    score->cmdRemovePart(oldPart);
+    insertPart(score, templ, partIndex);
 }
 
 void EditPart::replaceDrumset(Score* score, Part* part, const String& instrumentId, const Drumset& newDrumset)

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -239,6 +239,8 @@ public:
 
     static bool setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool visible);
 
+    static void replaceDrumset(Score* score, Part* part, const String& instrumentId, const Drumset& newDrumset);
+
 private:
     static void doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests = true);
 };

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -233,5 +233,11 @@ public:
     static void addSystemObjects(Score* score, const std::vector<Staff*>& staves);
     static void removeSystemObjects(Score* score, const std::vector<Staff*>& staves);
     static void moveSystemObjects(Score* score, Staff* sourceStaff, Staff* destinationStaff);
+
+    static Staff* appendStaff(Score* score, Part* destinationPart);
+    static Staff* appendLinkedStaff(Score* score, Staff* sourceStaff, Part* destinationPart);
+
+private:
+    static void doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests = true);
 };
 }

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -206,6 +206,7 @@ public:
 };
 
 class InstrumentTemplate;
+struct ScoreOrder;
 class Staff;
 class StaffType;
 enum class PreferSharpFlat : char;
@@ -244,6 +245,8 @@ public:
 
     static void insertPart(Score* score, const InstrumentTemplate* templ, size_t index);
     static void replacePart(Score* score, Part* oldPart, const InstrumentTemplate* templ);
+
+    static void setScoreOrder(Score* score, const ScoreOrder& order);
 
 private:
     static void doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests = true);

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -205,6 +205,7 @@ public:
     UNDO_NAME("SetUserBankController")
 };
 
+class InstrumentTemplate;
 class Staff;
 class StaffType;
 enum class PreferSharpFlat : char;
@@ -240,6 +241,9 @@ public:
     static bool setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool visible);
 
     static void replaceDrumset(Score* score, Part* part, const String& instrumentId, const Drumset& newDrumset);
+
+    static void insertPart(Score* score, const InstrumentTemplate* templ, size_t index);
+    static void replacePart(Score* score, Part* oldPart, const InstrumentTemplate* templ);
 
 private:
     static void doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests = true);

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -237,6 +237,8 @@ public:
     static Staff* appendStaff(Score* score, Part* destinationPart);
     static Staff* appendLinkedStaff(Score* score, Staff* sourceStaff, Part* destinationPart);
 
+    static bool setVoiceVisible(Score* score, Staff* staff, int voiceIndex, bool visible);
+
 private:
     static void doAppendStaff(Score* score, Staff* staff, Part* destinationPart, bool createRests = true);
 };

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -404,7 +404,7 @@ void NotationParts::updatePartsAndSystemObjectStaves(const mu::engraving::ScoreC
 
 void NotationParts::doSetScoreOrder(const ScoreOrder& order)
 {
-    score()->undo(new mu::engraving::ChangeScoreOrder(score(), order));
+    EditPart::setScoreOrder(score(), order);
 
     m_scoreOrderChanged.notify();
 }

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -468,16 +468,8 @@ bool NotationParts::setVoiceVisible(const ID& staffId, int voiceIndex, bool visi
 {
     TRACEFUNC;
 
-    if (!score()->excerpt()) {
-        return false;
-    }
-
     Staff* staff = staffModifiable(staffId);
     if (!staff) {
-        return false;
-    }
-
-    if (!visible && !staff->canDisableVoice()) {
         return false;
     }
 
@@ -487,7 +479,11 @@ bool NotationParts::setVoiceVisible(const ID& staffId, int voiceIndex, bool visi
 
     startEdit(actionName);
 
-    score()->excerpt()->setVoiceVisible(staff, voiceIndex, visible);
+    bool result = EditPart::setVoiceVisible(score(), staff, voiceIndex, visible);
+    if (!result) {
+        rollback();
+        return false;
+    }
 
     //! HACK: Excerpt::setVoiceVisible recreates the staff,
     //! so later in listenUndoStackChanges() we will call notifyAboutStaffRemoved() and notifyAboutStaffAdded(),

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -718,15 +718,9 @@ void NotationParts::replaceDrumset(const InstrumentKey& instrumentKey, const Dru
         return;
     }
 
-    // Update all identical drumsets in the part...
     if (undoable) {
         startEdit(TranslatableString("undoableAction", "Edit drumset"));
-        for (auto pair : part->instruments()) {
-            Instrument* instrument = pair.second;
-            if (instrument && instrument->drumset() && instrument->id() == instrumentKey.instrumentId) {
-                score()->undo(new mu::engraving::ChangeDrumset(instrument, newDrumset, part));
-            }
-        }
+        EditPart::replaceDrumset(score(), part, instrumentKey.instrumentId, newDrumset);
         apply();
     } else {
         for (auto pair : part->instruments()) {


### PR DESCRIPTION
Related to: #31201
Follow-up to: #31205, #32185

## Summary

This is the third and final PR for exposing `NotationParts` methods to the Plugin API (issue #31201). It implements the 7 methods that were deferred in PR #32185 due to prerequisite work.

All new methods follow the established pattern: shared static methods in `EditPart` (used by both the Plugin API and `NotationParts`), with `Q_INVOKABLE` wrappers on the `Score` API class. `NotationParts` is refactored to delegate to `EditPart`, eliminating logic duplication.

### Changes

#### Commit 1: appendStaff and appendLinkedStaff
- `appendStaff(destinationPart)` : Creates and appends a new default staff to a part, returns the new staff
- `appendLinkedStaff(sourceStaff, destinationPart)` : Creates a staff linked to a source staff, appends it to a part, returns the new staff
- Private helper `doAppendStaff` extracted from `NotationParts` for shared use

#### Commit 2: setVoiceVisible
- `setVoiceVisible(staff, voiceIndex, visible)` : Shows or hides a voice in an excerpt score. Returns false if called on a main score (excerpt only limitation)
- Refactors `NotationParts::setVoiceVisible` to delegate to `EditPart`

#### Commit 3: replaceDrumset
- `replaceDrumset(part, drumset)` : Applies a modified drumset to all matching instruments in a part (undoable)
- `Instrument::cloneDrumset()` : Creates a writable copy of an instrument's drumset
- Drumset individual setters for modifying cloned drumsets: `setName`, `setNoteHead`, `setLine`, `setVoice`, `setStemDirection`, `setShortcut`
- Drumset ownership model (`m_owned` flag) for safe lifecycle of cloned drumsets
- Refactors `NotationParts::replaceDrumset` undoable path to delegate to `EditPart`

#### Commit 4: insertPart and replacePart
- `insertPart(instrumentId, index)` : Creates a new part from an instrument template and inserts it at the given index
- `replacePart(part, instrumentId)` : Replaces an existing part with a new one created from an instrument template

#### Commit 5: setScoreOrder
- `setScoreOrder(orderId)` : Sets the score order (e.g. "orchestral", "marching-band") which controls part ordering and bracket/barline layout
- Refactors `NotationParts::doSetScoreOrder` to delegate to `EditPart`

### Implementation checklist

Completed in PR #31205:
- [x] `replaceInstrument(part, instrumentId)`

Completed in PR #32185:
- [x] `setPartVisible(part, visible)`
- [x] `setPartSharpFlat(part, sharpFlat)`
- [x] `setInstrumentName(part, tick, name)`
- [x] `setInstrumentAbbreviature(part, tick, abbreviature)`
- [x] `setStaffType(staff, staffTypeId)`
- [x] `removeParts(parts)`
- [x] `removeStaves(staves)`
- [x] `moveParts(sourceParts, destinationPart, mode)`
- [x] `moveStaves(sourceStaves, destinationStaff, mode)`
- [x] `addSystemObjects(staves)`
- [x] `removeSystemObjects(staves)`
- [x] `moveSystemObjects(sourceStaff, destinationStaff)`
- [x] Staff writable properties via Pid (`visible`, `cutaway`, `hideSystemBarLine`, `mergeMatchingRests`, `reflectTranspositionInLinkedTab`)

Completed in this PR:
- [x] `appendStaff(destinationPart)`
- [x] `appendLinkedStaff(sourceStaff, destinationPart)`
- [x] `setVoiceVisible(staff, voiceIndex, visible)`
- [x] `replaceDrumset(part, drumset)`
- [x] `insertPart(instrumentId, index)`
- [x] `replacePart(part, instrumentId)`
- [x] `setScoreOrder(orderId)`

### Usage examples

```javascript
curScore.startCmd("Append staff");

// Append a new staff to the first part
var newStaff = curScore.appendStaff(curScore.parts[0]);

// Append a linked staff (content mirrors the source)
var linked = curScore.appendLinkedStaff(curScore.staves[0], curScore.parts[0]);

curScore.endCmd();
```

```javascript
curScore.startCmd("Edit drumset");

// Clone the drumset, modify entries, and apply
var instrument = curScore.parts[0].instrumentAtTick(0);
var drumset = instrument.cloneDrumset();
drumset.setName(36, "Kick Drum");
drumset.setLine(36, 4);
drumset.setVoice(36, 1);
drumset.setStemDirection(36, 1);
curScore.replaceDrumset(curScore.parts[0], drumset);

curScore.endCmd();
```

```javascript
curScore.startCmd("Insert and replace parts");

// Insert a flute at position 0
curScore.insertPart("flute", 0);

// Replace the last part with a cello
var lastPart = curScore.parts[curScore.parts.length - 1];
curScore.replacePart(lastPart, "cello");

// Set orchestral score order
curScore.setScoreOrder("orchestral");

curScore.endCmd();
```

---

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
