### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/score/parenthesislayout.cpp
+++ b/src/engraving/rendering/score/parenthesislayout.cpp
@@ -87,6 +87,7 @@ void ParenthesisLayout::layoutChordParentheses(const Chord* chord, const LayoutC
 void ParenthesisLayout::layoutParentheses(Parenthesis* leftParen, Parenthesis* rightParen, Shape& dummyItemShape, bool itemAddToSkyline,
                                           const LayoutContext& ctx)
 {
+    UNUSED(ctx);
     if (!leftParen || !rightParen) {
         // 1 parenthesis
         Parenthesis* paren = leftParen ? leftParen : rightParen;


### PR DESCRIPTION
reg.: 'ctx': unreferenced parameter (C4100)