### PR TITLE
Fix stale item selection UI after clearing selection

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/selectableitemlistmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/selectableitemlistmodel.cpp
@@ -34,7 +34,16 @@ SelectableItemListModel::Item::Item(QObject* parent)
 SelectableItemListModel::SelectableItemListModel(QObject* parent)
     : QAbstractListModel(parent), m_selection(new ItemMultiSelectionModel(this))
 {
-    connect(m_selection, &ItemMultiSelectionModel::selectionChanged, [this]() {
+    connect(m_selection, &ItemMultiSelectionModel::selectionChanged, this,
+            [this](const QItemSelection& selected, const QItemSelection& deselected) {
+        QModelIndexList changedIndexes;
+        changedIndexes << selected.indexes();
+        changedIndexes << deselected.indexes();
+
+        for (const QModelIndex& idx : changedIndexes) {
+            emit dataChanged(idx, idx, { RoleIsSelected });
+        }
+
         emit selectionChanged();
         onUpdateOperationsAvailability();
     });
@@ -88,8 +97,6 @@ void SelectableItemListModel::selectRow(int row)
     TRACEFUNC;
 
     m_selection->select(index(row));
-
-    emit dataChanged(index(0), index(rowCount() - 1), { RoleIsSelected });
 }
 
 void SelectableItemListModel::moveSelectionUp()


### PR DESCRIPTION
Resolves: #32645  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)