### PR TITLE
Fix duplicate clefs in parts after undo/redo near repeat barlines

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -826,16 +826,16 @@ void Measure::add(EngravingItem* e)
         }
         while (s && s->rtick() == t) {
             if (!seg->isChordRestType() && (seg->segmentType() == s->segmentType())) {
-                if (seg->isType(SegmentType::BarLineType)) {
-                    // Barline segments are regenerated every layout
-                    // We need to remove the regenerated segment when undoing to ensure the original element is added back to the score
+                if (seg->isType(SegmentType::BarLineType | SegmentType::Clef | SegmentType::HeaderClef)) {
+                    // Barline segments are regenerated every layout.
+                    // Clef segments collide when the undo system and layout
+                    // independently create them (see #32162, #25257).
+                    // Remove the layout-generated duplicate so the undo system's
+                    // segment becomes authoritative.
                     m_segments.remove(s);
                     s = s->next();
                     continue;
                 }
-                /// HACK: REMOVED to prevent crash in 4.4.3.
-                /// Adding multiple identical segments may cause problems, so we should resolve this properly
-                // return;
             }
             if (seg->goesBefore(s)) {
                 break;


### PR DESCRIPTION
**Resolves:** #32162

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
