### PR TITLE
[DRAFT] Force repainting of the main window after removing its transparency

### DIFF
--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -441,8 +441,9 @@ muse::modularity::ContextPtr GuiApp::setupNewContext(const StringList& args)
             m_splashScreen = nullptr;
         }
 
-        // The main window must be shown at this point so KDDockWidgets can read its size correctly
-        // and scale all sizes properly. https://github.com/musescore/MuseScore/issues/21148
+        // The main window must be shown at this point so KDDockWidgets
+        // can read its size correctly and scale all sizes properly.
+        // https://github.com/musescore/MuseScore/issues/21148
         // but before that, let's make the window transparent,
         // otherwise the empty window frame will be visible
         // https://github.com/musescore/MuseScore/issues/29630
@@ -452,7 +453,10 @@ muse::modularity::ContextPtr GuiApp::setupNewContext(const StringList& args)
         ctx.window->setOpacity(0.01);
         ctx.window->setVisible(true);
 
-        startupScenario->runAfterSplashScreen();
+        startupScenario->runAfterSplashScreen([ctx]() {
+            ctx.window->setOpacity(1.0);
+            ctx.window->requestUpdate();
+        });
     }, Qt::QueuedConnection);
 
     return ctxId;

--- a/src/appshell/internal/istartupscenario.h
+++ b/src/appshell/internal/istartupscenario.h
@@ -42,7 +42,7 @@ public:
     virtual void setStartupScoreFile(const std::optional<project::ProjectFile>& file) = 0;
 
     virtual void runOnSplashScreen() = 0;
-    virtual void runAfterSplashScreen() = 0;
+    virtual void runAfterSplashScreen(std::function<void()> startupPageOpenedCallback) = 0;
     virtual bool startupCompleted() const = 0;
 };
 }

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -144,7 +144,7 @@ void StartupScenario::registerAudioPlugins()
     qApp->setQuitLockEnabled(true);
 }
 
-void StartupScenario::runAfterSplashScreen()
+void StartupScenario::runAfterSplashScreen(std::function<void()> startupPageOpenedCallback)
 {
     TRACEFUNC;
 
@@ -183,13 +183,14 @@ void StartupScenario::runAfterSplashScreen()
     }
 
     muse::async::Channel<Uri> opened = interactive()->opened();
-    opened.onReceive(this, [this, opened, modeType](const Uri&) {
+    opened.onReceive(this, [this, opened, modeType, startupPageOpenedCallback](const Uri&) {
         static bool once = false;
         if (once) {
             return;
         }
         once = true;
 
+        startupPageOpenedCallback();
         onStartupPageOpened(modeType);
 
         async::Async::call(this, [this, opened]() {

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -65,7 +65,7 @@ public:
     void setStartupScoreFile(const std::optional<project::ProjectFile>& file) override;
 
     void runOnSplashScreen() override;
-    void runAfterSplashScreen() override;
+    void runAfterSplashScreen(std::function<void()> startupPageOpenedCallback) override;
     bool startupCompleted() const override;
 
 private:

--- a/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
+++ b/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
@@ -43,7 +43,6 @@ DockWindow {
     onPageLoaded: {
         console.log("WindowContent::onPageLoaded")
         interactiveProvider.onPageOpened()
-        window.opacity = 1.0
     }
 
     InteractiveProvider {


### PR DESCRIPTION
Resolves: #31620 

Attempt to resolve an issue on some Linux systems where the main window remains transparent on startup. The proposed fix it to force the main window to repaint as soon as we remove its transparency. I am going to ask the user who submitted the bug to test the PR. I'll mark it as a draft for now.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
