### PR TITLE
Allow selecting multiple files in interactive dialog

### DIFF
--- a/src/framework/autobot/internal/autobotinteractive.cpp
+++ b/src/framework/autobot/internal/autobotinteractive.cpp
@@ -112,6 +112,12 @@ io::path_t AutobotInteractive::selectOpeningFileSync(const std::string& title, c
     return m_real->selectOpeningFileSync(title, dir, filter, options);
 }
 
+io::paths_t AutobotInteractive::selectOpeningFilesSync(const std::string& title, const io::path_t& dir,
+                                                       const std::vector<std::string>& filter, const int options)
+{
+    return m_real->selectOpeningFilesSync(title, dir, filter, options);
+}
+
 io::path_t AutobotInteractive::selectSavingFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                                     bool confirmOverwrite)
 {

--- a/src/framework/autobot/internal/autobotinteractive.h
+++ b/src/framework/autobot/internal/autobotinteractive.h
@@ -76,6 +76,8 @@ public:
                                                          const std::vector<std::string>& filter) override;
     io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                      const int options = 0) override;
+    io::paths_t selectOpeningFilesSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                       const int options = 0) override;
     io::path_t selectSavingFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                     bool confirmOverwrite = true) override;
 

--- a/src/framework/interactive/iinteractive.h
+++ b/src/framework/interactive/iinteractive.h
@@ -219,6 +219,8 @@ public:
                                                          const std::vector<std::string>& filter) = 0;
     virtual io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                              const int options = 0) = 0;
+    virtual io::paths_t selectOpeningFilesSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                               const int options = 0) = 0;
     virtual io::path_t selectSavingFileSync(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
                                             bool confirmOverwrite = true) = 0;
 

--- a/src/framework/interactive/internal/interactive.cpp
+++ b/src/framework/interactive/internal/interactive.cpp
@@ -314,6 +314,7 @@ void Interactive::showProgress(const std::string& title, Progress progress)
 // see QQuickPlatformFileDialog::FileMode
 enum class FileDialogMode {
     OpenFile = 0,
+    OpenFiles = 1,
     SaveFile = 2
 };
 
@@ -331,7 +332,7 @@ static UriQuery makeSelectFileQuery(FileDialogMode mode, const std::string& titl
     q.set("nameFilters", filterList);
     q.set("fileMode", static_cast<int>(mode));
     q.set("options", options);
-    if (mode == FileDialogMode::OpenFile) {
+    if (mode == FileDialogMode::OpenFile || mode == FileDialogMode::OpenFiles) {
         q.set("selectExisting", true);
         q.set("folder", QUrl::fromLocalFile(current.toQString()).toString().toStdString());
     } else if (mode == FileDialogMode::SaveFile) {
@@ -420,6 +421,27 @@ io::path_t Interactive::selectOpeningFileSync(const std::string& title, const io
     }
 
     return QUrl::fromUserInput(rv.val.toQString()).toLocalFile();
+#endif
+}
+
+io::paths_t Interactive::selectOpeningFilesSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                                const int options)
+{
+#ifndef Q_OS_LINUX
+    const QFileDialog::Options qoptions = QFileDialog::Options::fromInt(options);
+    const QStringList result = QFileDialog::getOpenFileNames(nullptr, QString::fromStdString(title), dir.toQString(), filterToString(
+                                                                 filter), nullptr, qoptions);
+
+    io::paths_t paths;
+    paths.reserve(result.size());
+    for (const QString& path : result) {
+        paths.emplace_back(path);
+    }
+
+    return paths;
+#else
+    NOT_SUPPORTED;
+    return io::paths_t{ selectOpeningFileSync(title, dir, filter, options) };
 #endif
 }
 

--- a/src/framework/interactive/internal/interactive.h
+++ b/src/framework/interactive/internal/interactive.h
@@ -95,6 +95,8 @@ public:
                                                  const std::vector<std::string>& filter) override;
     io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                      const int options) override;
+    io::paths_t selectOpeningFilesSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                       const int options) override;
     io::path_t selectSavingFileSync(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
                                     bool confirmOverwrite = true) override;
 

--- a/src/framework/interactive/internal/platform/web/webinteractive.cpp
+++ b/src/framework/interactive/internal/platform/web/webinteractive.cpp
@@ -213,6 +213,21 @@ io::path_t WebInteractive::selectOpeningFileSync(const std::string& title, const
 #endif
 }
 
+muse::io::paths_t WebInteractive::selectOpeningFilesSync(const std::string& title, const muse::io::path_t& dir,
+                                                         const std::vector<std::string>& filter, const int options)
+{
+#ifdef Q_OS_WASM
+    UNUSED(title);
+    UNUSED(dir);
+    UNUSED(filter);
+    UNUSED(options);
+    NOT_SUPPORTED;
+    return muse::io::paths_t();
+#else
+    return m_origin->selectOpeningFilesSync(title, dir, filter, options);
+#endif
+}
+
 io::path_t WebInteractive::selectSavingFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                                 bool confirmOverwrite)
 {

--- a/src/framework/interactive/internal/platform/web/webinteractive.h
+++ b/src/framework/interactive/internal/platform/web/webinteractive.h
@@ -71,6 +71,8 @@ public:
                                                              const std::vector<std::string>& filter) override;
     muse::io::path_t selectOpeningFileSync(const std::string& title, const muse::io::path_t& dir, const std::vector<std::string>& filter,
                                            const int options = 0) override;
+    muse::io::paths_t selectOpeningFilesSync(const std::string& title, const muse::io::path_t& dir, const std::vector<std::string>& filter,
+                                             const int options = 0) override;
 
     muse::io::path_t selectSavingFileSync(const std::string& title, const muse::io::path_t& path, const std::vector<std::string>& filter,
                                           bool confirmOverwrite = true) override;

--- a/src/framework/interactive/qml/Muse/Interactive/FileDialog.qml
+++ b/src/framework/interactive/qml/Muse/Interactive/FileDialog.qml
@@ -42,7 +42,12 @@ QtPlatform.FileDialog {
     }
 
     onAccepted: {
-        root.ret = { "errcode": 0, "value":  root.currentFile.toString() }
+        if (root.fileMode === FileDialog.OpenFiles) {
+            const selectedUrls = root.fileUrls || []
+            root.ret = { "errcode": 0, "value": selectedUrls }
+        } else {
+            root.ret = { "errcode": 0, "value": root.currentFile.toString() }
+        }
         root.close()
         root.closed()
     }

--- a/src/framework/interactive/tests/mocks/interactivemock.h
+++ b/src/framework/interactive/tests/mocks/interactivemock.h
@@ -60,6 +60,8 @@ public:
                                                                 const std::vector<std::string>& filter), (override));
     MOCK_METHOD(io::path_t, selectOpeningFileSync, (const std::string&, const io::path_t&, const std::vector<std::string>&, const int),
                 (override));
+    MOCK_METHOD(io::paths_t, selectOpeningFilesSync, (const std::string&, const io::path_t&, const std::vector<std::string>&, const int),
+                (override));
     MOCK_METHOD(io::path_t, selectSavingFileSync, (const std::string&, const io::path_t&, const std::vector<std::string>&, bool),
                 (override));
     MOCK_METHOD(io::path_t, selectDirectory, (const std::string&, const io::path_t&), (override));


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10265

Added a function allowing to select multiple files in interactive dialog

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
