### PR TITLE
fix Braille hairpins one note too late

### DIFF
--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2924,7 +2924,7 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
     // This needs to be accounted when using examples from MBC2015 for tests
     QString result = QString();
     for (Hairpin* hairpin : hairpins) {
-        if (!hairpin || chordRest->tick() + chordRest->actualTicks() != hairpin->tick2()) {
+        if (!hairpin || chordRest->endTick() != hairpin->tick2()) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2924,7 +2924,7 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
     // This needs to be accounted when using examples from MBC2015 for tests
     QString result = QString();
     for (Hairpin* hairpin : hairpins) {
-        if (!hairpin || hairpin->endCR() != chordRest) {
+        if (!hairpin || chordRest->tick() + chordRest->actualTicks() != hairpin->tick2()) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2912,14 +2912,15 @@ QString Braille::brailleHairpinBefore(ChordRest* chordRest, const std::vector<Ha
     return result;
 }
 
-bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest)
+bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest, Hairpin* endingHairpin)
 {
-    if (!chordRest || !chordRest->segment() || !chordRest->segment()->next1()) {
+    if (!chordRest || !endingHairpin || endingHairpin->endCR() != chordRest
+        || !chordRest->segment() || !chordRest->segment()->next1()) {
         return false;
     }
 
     ChordRest* nextCR = chordRest->segment()->next1()->nextChordRest(chordRest->track());
-    if (!nextCR) {
+    if (!nextCR || nextCR->measure() != chordRest->measure()) {
         return false;
     }
 
@@ -2928,10 +2929,14 @@ bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest)
         return false;
     }
 
-    // Check if there's a hairpin starting on the next ChordRest
+    // Check if there's a related hairpin starting on the immediate next ChordRest
     std::vector<Hairpin*> nextCRHairpins = hairpins(nextCR);
     for (Hairpin* hairpin : nextCRHairpins) {
-        if (hairpin && hairpin->startCR() == nextCR) {
+        if (!hairpin || hairpin->startCR() != nextCR) {
+            continue;
+        }
+
+        if (hairpin == endingHairpin || hairpin->hairpinType() == endingHairpin->hairpinType()) {
             return true;
         }
     }
@@ -2954,7 +2959,7 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
         if (!hairpin || chordRest->endTick() != hairpin->tick2()) {
             continue;
         }
-        if (hasImmediateHairpinStartOnNextCR(chordRest)) {
+        if (hasImmediateHairpinStartOnNextCR(chordRest, hairpin)) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2912,6 +2912,33 @@ QString Braille::brailleHairpinBefore(ChordRest* chordRest, const std::vector<Ha
     return result;
 }
 
+bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest)
+{
+    if (!chordRest || !chordRest->segment() || !chordRest->segment()->next1()) {
+        return false;
+    }
+
+    ChordRest* nextCR = chordRest->segment()->next1()->nextChordRest(chordRest->track());
+    if (!nextCR) {
+        return false;
+    }
+
+    // Check if the next ChordRest is directly adjacent in time
+    if (nextCR->tick() != chordRest->tick() + chordRest->actualTicks()) {
+        return false;
+    }
+
+    // Check if there's a hairpin starting on the next ChordRest
+    std::vector<Hairpin*> nextCRHairpins = hairpins(nextCR);
+    for (Hairpin* hairpin : nextCRHairpins) {
+        if (hairpin && hairpin->startCR() == nextCR) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpins)
 {
     if (!chordRest) {
@@ -2925,6 +2952,9 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
     QString result = QString();
     for (Hairpin* hairpin : hairpins) {
         if (!hairpin || chordRest->endTick() != hairpin->tick2()) {
+            continue;
+        }
+        if (hasImmediateHairpinStartOnNextCR(chordRest)) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2912,15 +2912,14 @@ QString Braille::brailleHairpinBefore(ChordRest* chordRest, const std::vector<Ha
     return result;
 }
 
-bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest, Hairpin* endingHairpin)
+bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest)
 {
-    if (!chordRest || !endingHairpin || endingHairpin->endCR() != chordRest
-        || !chordRest->segment() || !chordRest->segment()->next1()) {
+    if (!chordRest || !chordRest->segment() || !chordRest->segment()->next1()) {
         return false;
     }
 
     ChordRest* nextCR = chordRest->segment()->next1()->nextChordRest(chordRest->track());
-    if (!nextCR || nextCR->measure() != chordRest->measure()) {
+    if (!nextCR) {
         return false;
     }
 
@@ -2929,14 +2928,10 @@ bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest, Hairpin* en
         return false;
     }
 
-    // Check if there's a related hairpin starting on the immediate next ChordRest
+    // Check if there's a hairpin starting on the next ChordRest
     std::vector<Hairpin*> nextCRHairpins = hairpins(nextCR);
     for (Hairpin* hairpin : nextCRHairpins) {
-        if (!hairpin || hairpin->startCR() != nextCR) {
-            continue;
-        }
-
-        if (hairpin == endingHairpin || hairpin->hairpinType() == endingHairpin->hairpinType()) {
+        if (hairpin && hairpin->startCR() == nextCR) {
             return true;
         }
     }
@@ -2959,7 +2954,7 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
         if (!hairpin || chordRest->endTick() != hairpin->tick2()) {
             continue;
         }
-        if (hasImmediateHairpinStartOnNextCR(chordRest, hairpin)) {
+        if (hasImmediateHairpinStartOnNextCR(chordRest)) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2939,6 +2939,30 @@ bool Braille::hasImmediateHairpinStartOnNextCR(ChordRest* chordRest)
     return false;
 }
 
+bool Braille::hasImmediateDynamicOnNextCR(ChordRest* chordRest)
+{
+    if (!chordRest || !chordRest->segment() || !chordRest->segment()->next1()) {
+        return false;
+    }
+
+    ChordRest* nextCR = chordRest->segment()->next1()->nextChordRest(chordRest->track());
+    if (!nextCR) {
+        return false;
+    }
+
+    if (nextCR->tick() != chordRest->tick() + chordRest->actualTicks()) {
+        return false;
+    }
+
+    for (EngravingItem* annotation : nextCR->segment()->annotations()) {
+        if (annotation->isDynamic() && annotation->staffIdx() == chordRest->staffIdx()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpins)
 {
     if (!chordRest) {
@@ -2954,7 +2978,7 @@ QString Braille::brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hai
         if (!hairpin || chordRest->endTick() != hairpin->tick2()) {
             continue;
         }
-        if (hasImmediateHairpinStartOnNextCR(chordRest)) {
+        if (hasImmediateHairpinStartOnNextCR(chordRest) || hasImmediateDynamicOnNextCR(chordRest)) {
             continue;
         }
         switch (hairpin->hairpinType()) {

--- a/src/braille/internal/braille.h
+++ b/src/braille/internal/braille.h
@@ -231,7 +231,7 @@ private:
     QString brailleVolta(Measure* measure, Volta* volta, int staffCount);
 
     QString brailleHairpinBefore(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
-    bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest);
+    bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest, Hairpin* endingHairpin);
     QString brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
     QString brailleSlurBefore(ChordRest* chordRest, const std::vector<Slur*>& slur);
     QString brailleSlurAfter(ChordRest* chordRest, const std::vector<Slur*>& slur);

--- a/src/braille/internal/braille.h
+++ b/src/braille/internal/braille.h
@@ -231,6 +231,7 @@ private:
     QString brailleVolta(Measure* measure, Volta* volta, int staffCount);
 
     QString brailleHairpinBefore(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
+    bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest);
     QString brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
     QString brailleSlurBefore(ChordRest* chordRest, const std::vector<Slur*>& slur);
     QString brailleSlurAfter(ChordRest* chordRest, const std::vector<Slur*>& slur);

--- a/src/braille/internal/braille.h
+++ b/src/braille/internal/braille.h
@@ -231,7 +231,7 @@ private:
     QString brailleVolta(Measure* measure, Volta* volta, int staffCount);
 
     QString brailleHairpinBefore(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
-    bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest, Hairpin* endingHairpin);
+    bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest);
     QString brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
     QString brailleSlurBefore(ChordRest* chordRest, const std::vector<Slur*>& slur);
     QString brailleSlurAfter(ChordRest* chordRest, const std::vector<Slur*>& slur);

--- a/src/braille/internal/braille.h
+++ b/src/braille/internal/braille.h
@@ -232,6 +232,7 @@ private:
 
     QString brailleHairpinBefore(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
     bool hasImmediateHairpinStartOnNextCR(ChordRest* chordRest);
+    bool hasImmediateDynamicOnNextCR(ChordRest* chordRest);
     QString brailleHairpinAfter(ChordRest* chordRest, const std::vector<Hairpin*>& hairpin);
     QString brailleSlurBefore(ChordRest* chordRest, const std::vector<Slur*>& slur);
     QString brailleSlurAfter(ChordRest* chordRest, const std::vector<Slur*>& slur);

--- a/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
+++ b/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
@@ -5,5 +5,5 @@ composer ,composer
 #a ,piano
 
 a >#l%#c4 >c_:EcDc>3^JI \\_FE 
-c >d_?DcJc>4^IH q: >c^FGHIJD>3 >d_:W\>4 
+c >d_?DcJc>4^IH q: >c^FGHIJD >d_:W\>4 
 g >p^[EFGI >d^rv>4<K 

--- a/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
+++ b/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
@@ -4,6 +4,6 @@ composer ,composer
 
 #a ,piano
 
-a >#l%#c4 >c_:EcDcJ>3^I \\_FE 
-c >d_?DcJcI>4^H q: >c^FGHIJD >d_:>3^W\ 
-g >p^[>4^EFGI >d^rv<K 
+a >#l%#c4 >c_:EcDc>3^JI \\_FE 
+c >d_?DcJc>4^IH q: >c^FGHIJD>3 >d_:W\>4 
+g >p^[EFGI >d^rv>4<K 

--- a/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
+++ b/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
@@ -5,5 +5,5 @@ composer ,composer
 #a ,piano
 
 a >#l%#c4 >c_:EcDc>3^JI \\_FE 
-c >d_?DcJc>4^IH q: >c^FGHIJD >d_:W\>4 
+c >d_?DcJc>4^IH q: >c^FGHIJD>3 >d_:W\>4 
 g >p^[EFGI >d^rv>4<K 

--- a/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
+++ b/src/braille/tests/data/testHairpins_Example_22.3.3.2_MBC2015_ref.brf
@@ -5,5 +5,5 @@ composer ,composer
 #a ,piano
 
 a >#l%#c4 >c_:EcDc>3^JI \\_FE 
-c >d_?DcJc>4^IH q: >c^FGHIJD >d_:W\>4 
+c >d_?DcJc>4^IH q: >c^FGHIJD >d_:W\ 
 g >p^[EFGI >d^rv>4<K 


### PR DESCRIPTION
Not sure if there was already a GitHub issue concerning this bug, couldn't find any.
Currently, hairpins in Braille finished one note too late, and not on the actual note where the line ends. This PR fixes that.


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
