### PR TITLE
Fix 17557: backspace can now deletes multiple chords

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -425,6 +425,10 @@
     <seq>Alt+Up</seq>
     </SC>
   <SC>
+    <key>notation-backspace</key>
+    <seq>Backspace</seq>
+    </SC>
+  <SC>
     <key>top-chord</key>
     <seq>Ctrl+Alt+Up</seq>
     </SC>

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -233,6 +233,7 @@ void NotationActionController::init()
     registerAction("notation-paste-special", [this]() { pasteSelection(PastingType::Special); });
     registerAction("notation-swap", &Interaction::swapSelection, &Controller::hasSelection);
     registerAction("action://notation/delete", &Interaction::deleteSelection, &Controller::hasSelection);
+    registerAction("notation-backspace", &Controller::deleteAndSelectPrev, &Controller::hasSelection);
 
     registerAction("flip", &Interaction::flipSelection, &Controller::hasSelection);
     registerAction("flip-horizontally", &Interaction::flipSelectionHorizontally, &Controller::hasSelection);
@@ -900,6 +901,19 @@ void NotationActionController::putNote(const ActionData& args)
     Ret ret = noteInput->putNote(pos, replace, insert);
     if (ret) {
         seekAndPlaySelectedElement();
+    }
+}
+
+void NotationActionController::deleteAndSelectPrev()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+    interaction->deleteSelection();
+    auto selected = interaction->selection();
+    if (selected && selected->elementsSelected(engraving::ElementTypeSet { ElementType::REST })) {
+        interaction->moveSelection(MoveDirection::Left, MoveSelectionType::Chord);
     }
 }
 

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -96,6 +96,7 @@ private:
     void doubleNoteInputDuration();
     void halveNoteInputDuration();
     void realtimeAdvance();
+    void deleteAndSelectPrev();
 
     void toggleAccidental(AccidentalType type);
     void toggleArticulation(SymbolId articulationSymbolId);

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -125,6 +125,11 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Remove note")
              ),
+    UiAction("notation-backspace",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "delete selected elements and select the element before them")
+             ),
     UiAction("next-element",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,


### PR DESCRIPTION
Resolves: #17557 
<!-- Add a short description of and motivation for the changes here -->

Added 'notation-backspace' ui action and registered a handler for it, in the notationscene module.
Bound it to the Backspace key in shortcuts.xml.

The logic for backspace now is that, after deletion, if the selected element is a rest
the selection moves to the previous chord. 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x]  Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
