### PR TITLE
project: Fix project export not overwriting old file

### DIFF
--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -411,10 +411,21 @@ Ret ExportProjectScenario::doExportLoop(const muse::io::path_t& scorePath, std::
         //! But there is one atypical case:
         //! Export score to unpacked directory - creates a directory and writes files to it
 
+        // Remove previous file because we need to know whether
+        // exportFunctions writes at scorePath
+        Ret ret = fileSystem()->remove(scorePath);
+        if (!ret) {
+            if (askForRetry(filename)) {
+                continue;
+            } else {
+                return make_ret(Ret::Code::Cancel);
+            }
+        }
+
         auto outputBuf = Buffer::opened(IODevice::WriteOnly);
         outputBuf.setMeta("file_path", scorePath.toStdString());
 
-        Ret ret = exportFunction(outputBuf);
+        ret = exportFunction(outputBuf);
         outputBuf.close();
 
         const bool isFileMode = fileSystem()->exists(scorePath);


### PR DESCRIPTION
Resolves: #32670

The `isFileMode` check is true when there is already a file at `scorePath` even though it's intended to check if the export function has written to the file already.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
