### PR TITLE
Fix/autosave background write

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -49,6 +49,8 @@
 #include "projectfileinfoprovider.h"
 #include "projecterrors.h"
 
+#include "global/concurrency/concurrent.h"
+
 #include "defer.h"
 #include "log.h"
 
@@ -700,6 +702,35 @@ Ret NotationProject::doSave(const muse::io::path_t& path, engraving::MscIoMode i
         }
 
         if (maybeOutBuf) {
+#ifdef MUSE_THREADS_SUPPORT
+            if (isAutosave) {
+                // For autosave, write to disk on a background thread to avoid stuttering.
+                // The buffer is fully serialized at this point so it's safe to move off the main thread.
+                muse::ByteArray data = maybeOutBuf->data();
+                QString savePathCopy = savePath;
+                QString targetContainerPathCopy = targetContainerPath;
+                muse::io::path_t targetMainFilePathCopy = targetMainFilePath;
+                auto fs = fileSystem();
+                Concurrent::run([fs, savePathCopy, targetContainerPathCopy, targetMainFilePathCopy, data]() {
+                    Ret writeRet = fs->writeFile(savePathCopy, data);
+                    if (!writeRet) {
+                        LOGE() << "Autosave: failed to write project file: " << writeRet.toString();
+                        return;
+                    }
+                    Ret copyRet = fs->copy(savePathCopy, targetContainerPathCopy, true);
+                    if (!copyRet) {
+                        LOGE() << "Autosave: failed to copy to target: " << copyRet.toString();
+                        return;
+                    }
+                    fs->remove(savePathCopy);
+                    QFile::setPermissions(targetMainFilePathCopy.toQString(),
+                                          QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther);
+                    LOGD() << "Autosave: background write complete: " << targetContainerPathCopy;
+                });
+                return make_ret(Ret::Code::Ok);
+            }
+#endif
+
             ret = fileSystem()->writeFile(savePath, maybeOutBuf->data());
             if (!ret) {
                 LOGE() << "Failed to write project file";


### PR DESCRIPTION
Resolves: #31596 (Maybe) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

# Move autosave file I/O to background thread to reduce UI stutter

## Problem

Autosave runs entirely on the main thread via a `QTimer`. The file I/O steps — `writeFile`, `copy`, and `remove` — are blocking operations that stutter the UI mid-editing, which is disruptive to workflow.

## Solution

After serialization completes on the main thread (unchanged), move the file I/O steps to a background thread using `Concurrent::run` when `MUSE_THREADS_SUPPORT` is available.

The serialization itself stays on the main thread because:
- It's read-only on the score data
- It writes to an in-memory `Buffer`, not disk
- The buffer is fully complete before the background thread starts, so no locking is needed

When threads are not supported, autosave falls back to the existing synchronous behavior.

## What is not changed

- Manual save, SaveAs, SaveCopy — all unchanged
- Serialization logic — unchanged
- Backup generation — not applicable for autosave
- Corruption check — not applicable for autosave

## How to test

1. Open a large score with multiple parts
2. Edit the score and wait for autosave to trigger
3. Verify no UI stutter occurs during autosave
4. Verify the autosave file is written correctly and can be recovered

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
