### PR TITLE
Fix crash on video export

### DIFF
--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -83,7 +83,7 @@ muse::Ret VideoWriter::write(INotationPtr notation, muse::io::IODevice& device, 
     encoderOptions.gop = cfg.fps / 2;
     encoderOptions.fps = cfg.fps;
 
-    if (!encoder->open(finalPath, encoderOptions)) {
+    if (!encoder || !encoder->open(finalPath, encoderOptions)) {
         LOGE() << "failed to open video encoder";
         return make_ret(muse::Ret::Code::UnknownError);
     }


### PR DESCRIPTION
Might resolve: #32570
At least fixes one potential crash, one that happens to me, independantly of whether having FFMPEG installed or not ?!?
Actually when not having **located** the FFMPEG libs (seems I'm unable to locate the FFMPEG libs, regardless that Audacity sees them).