### PR TITLE
Adjust shadow note x-position to account for magnification

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -492,11 +492,6 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
 
     const mu::engraving::Instrument* instr = staff->part()->instrument(tick);
 
-    // in any empty measure, pos will be right next to barline
-    // so pad this by barNoteDistance
-    qreal relX = position.pos.x() - position.segment->measure()->canvasPos().x();
-    position.pos.rx() -= qMin(relX - score()->style().styleAbsolute(mu::engraving::Sid::barNoteDistance) * mag, 0.0);
-
     mu::engraving::NoteHeadGroup noteheadGroup = mu::engraving::NoteHeadGroup::HEAD_NORMAL;
     mu::engraving::NoteHeadType noteHead = params.duration.headType();
 
@@ -562,6 +557,22 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
         shadowNote.setState(symNotehead, params.duration, false, params.position.beyondScore, params.accidentalType,
                             params.articulationIds);
     }
+
+    // if upscaled, note appears by default a distance away from the segment start,
+    // as described in ChordLayout::centreChords
+    if (mag > 1.0) {
+        qreal xOffset = (mag - 1.0) * 0.5 * shadowNote.symWidth(symNotehead);
+        if (shadowNote.computeUp()) {
+            position.pos.rx() += xOffset;
+        } else {
+            position.pos.rx() -= xOffset;
+        }
+    }
+
+    // in any empty measure, pos will be right next to barline
+    // so pad this by barNoteDistance
+    qreal relX = position.pos.x() - position.segment->measure()->canvasPos().x();
+    position.pos.rx() -= qMin(relX - score()->style().styleAbsolute(mu::engraving::Sid::barNoteDistance), 0.0);
 
     score()->renderer()->layoutItem(&shadowNote);
 


### PR DESCRIPTION
Resolves: #14815  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Towards part 7 of that issue (4-6 being presumably satisfied by https://github.com/musescore/MuseScore/pull/32089), this modifies `notationInteraction::doShowShadowNote`'s positioning logic to match the changes resulting from the magnification in ChordLayout::centreChords, which should be closer to what was sought in [previous feedback](https://github.com/musescore/MuseScore/pull/32134#issuecomment-4089755530):
>The point of the ghost note is to show the default position of the note you're about to enter ... the correction for this particular case should happen within the shadow note's logic

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
