### PR TITLE
Fix instrument memory leaks

### DIFF
--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -81,7 +81,7 @@ TEST_F(Engraving_ApiScoreTests, replaceInstrumentAtDomLevel)
     newInstrument.setTrackName(u"Replaced Instrument");
 
     score->startCmd(TranslatableString::untranslatable("Replace instrument test"));
-    score->undo(new ChangePart(part, new Instrument(newInstrument)));
+    score->undo(new ChangePart(part, newInstrument));
     score->endCmd();
 
     // [THEN] The part's instrument should be changed
@@ -119,7 +119,7 @@ TEST_F(Engraving_ApiScoreTests, replaceInstrumentUndo)
     newInstrument.setTrackName(u"New Instrument");
 
     score->startCmd(TranslatableString::untranslatable("Replace instrument test"));
-    score->undo(new ChangePart(part, new Instrument(newInstrument)));
+    score->undo(new ChangePart(part, newInstrument));
     score->endCmd();
 
     // Verify it changed
@@ -158,7 +158,7 @@ TEST_F(Engraving_ApiScoreTests, replaceInstrumentRedo)
     newInstrument.setId(u"test.replaced");
 
     score->startCmd(TranslatableString::untranslatable("Replace instrument test"));
-    score->undo(new ChangePart(part, new Instrument(newInstrument)));
+    score->undo(new ChangePart(part, newInstrument));
     score->endCmd();
 
     EXPECT_EQ(part->instrumentId(), u"test.replaced");

--- a/src/engraving/dom/instrchange.cpp
+++ b/src/engraving/dom/instrchange.cpp
@@ -71,12 +71,27 @@ InstrumentChange::InstrumentChange(const InstrumentChange& is)
     : TextBase(is)
 {
     m_instrument = new Instrument(*is.m_instrument);
+    m_ownsInstrument = true;  // Copy always owns its instrument
     m_init = is.m_init;
 }
 
 InstrumentChange::~InstrumentChange()
 {
-    delete m_instrument;
+    if (m_ownsInstrument) {
+        delete m_instrument;
+    }
+    m_instrument = nullptr;
+}
+
+void InstrumentChange::setInstrument(Instrument* i)
+{
+    if (m_instrument != i) {
+        if (m_ownsInstrument) {
+            delete m_instrument;
+        }
+        m_instrument = i;
+        m_ownsInstrument = true;
+    }
 }
 
 void InstrumentChange::setInstrument(const Instrument& i)
@@ -134,7 +149,7 @@ void InstrumentChange::setupInstrument(const Instrument* instrument)
     // change instrument in all linked scores
     for (EngravingObject* se : linkList()) {
         InstrumentChange* lic = static_cast<InstrumentChange*>(se);
-        Instrument* newInstrument = new Instrument(*instrument);
+        Instrument newInstrument(*instrument);
         lic->score()->undo(new ChangeInstrument(lic, newInstrument));
     }
 

--- a/src/engraving/dom/instrchange.h
+++ b/src/engraving/dom/instrchange.h
@@ -48,10 +48,12 @@ public:
     InstrumentChange* clone() const override { return new InstrumentChange(*this); }
 
     Instrument* instrument() const { return m_instrument; }
-    void setInstrument(Instrument* i) { m_instrument = i; }
+    void setInstrument(Instrument* i);
     void setInstrument(Instrument&& i) { *m_instrument = i; }
     void setInstrument(const Instrument& i);
     void setupInstrument(const Instrument* instrument);
+    void setNonOwning() { m_ownsInstrument = false; }
+    bool ownsInstrument() const { return m_ownsInstrument; }
 
     std::vector<KeySig*> keySigs(bool all=false) const;
     std::vector<Clef*> clefs() const;
@@ -69,7 +71,8 @@ public:
 
 private:
 
-    Instrument* m_instrument = nullptr;     // Staff holds ownership if part of score
+    Instrument* m_instrument = nullptr;     // Instrument pointer (shared with Part when non-owning)
+    bool m_ownsInstrument = true;           // False when pointer is shared with Part's InstrumentList
     bool m_init = false;                    // Set if the instrument has been set by the user, as there is no other way to tell.
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/instrument.cpp
+++ b/src/engraving/dom/instrument.cpp
@@ -1041,8 +1041,14 @@ Instrument* InstrumentList::instrument(int tick)
 
 void InstrumentList::setInstrument(Instrument* instr, int tick)
 {
-    if (!insert({ tick, instr }).second) {
-        (*this)[tick] = instr;
+    auto result = insert({ tick, instr });
+    if (!result.second) {
+        // Key already exists, delete old instrument and replace
+        Instrument* oldInstr = (*this)[tick];
+        if (oldInstr != instr) {
+            delete oldInstr;
+            (*this)[tick] = instr;
+        }
     }
 }
 

--- a/src/engraving/dom/part.cpp
+++ b/src/engraving/dom/part.cpp
@@ -62,6 +62,18 @@ Part::Part(Score* s)
 }
 
 //---------------------------------------------------------
+//   ~Part
+//---------------------------------------------------------
+
+Part::~Part()
+{
+    // Delete all instruments owned by this Part
+    for (auto it = m_instruments.begin(); it != m_instruments.end(); ++it) {
+        delete it->second;
+    }
+}
+
+//---------------------------------------------------------
 //   initFromInstrTemplate
 //---------------------------------------------------------
 
@@ -349,10 +361,18 @@ void Part::setInstrument(const Instrument& i, Fraction tick)
 
 void Part::setInstruments(const InstrumentList& instruments)
 {
+    // Delete old instruments only if they won't appear in the new list.
+    // Callers may shallow-copy the map before calling setInstruments({}),
+    // so we must not delete when the new list is empty.
+    if (!instruments.empty()) {
+        for (auto it = m_instruments.begin(); it != m_instruments.end(); ++it) {
+            delete it->second;
+        }
+    }
     m_instruments.clear();
 
     for (auto it = instruments.begin(); it != instruments.end(); ++it) {
-        m_instruments.setInstrument(it->second, it->first);
+        m_instruments.setInstrument(new Instrument(*it->second), it->first);
     }
 }
 
@@ -367,6 +387,7 @@ void Part::removeInstrument(const Fraction& tick)
         LOGD("Part::removeInstrument: not found at tick %d", tick.ticks());
         return;
     }
+    delete i->second;  // Delete the instrument before erasing
     m_instruments.erase(i);
 }
 
@@ -379,6 +400,7 @@ void Part::removeNonPrimaryInstruments()
     auto it = m_instruments.begin();
     while (it != m_instruments.end()) {
         if (it->first != -1) {
+            delete it->second;  // Delete the instrument before erasing
             it = m_instruments.erase(it);
             continue;
         }

--- a/src/engraving/dom/part.h
+++ b/src/engraving/dom/part.h
@@ -67,6 +67,7 @@ public:
     static const int DEFAULT_COLOR = 0x3399ff;
 
     Part(Score* score = nullptr);
+    ~Part();
     void initFromInstrTemplate(const InstrumentTemplate*);
 
     const muse::ID& id() const;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1469,6 +1469,7 @@ void Score::addElement(EngravingItem* element)
     case ElementType::INSTRUMENT_CHANGE: {
         InstrumentChange* ic = toInstrumentChange(element);
         ic->part()->setInstrument(ic->instrument(), ic->segment()->tick());
+        ic->setNonOwning();
         addLayoutFlags(LayoutFlag::REBUILD_MIDI_MAPPING);
         cmdState().instrumentsChanged = true;
     }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -742,7 +742,7 @@ void Segment::add(EngravingItem* el)
         if (toStaffState(el)->staffStateType() == StaffStateType::INSTRUMENT) {
             StaffState* ss = toStaffState(el);
             Part* part = el->part();
-            part->setInstrument(ss->instrument(), tick());
+            part->setInstrument(*ss->instrument(), tick());
         }
         m_annotations.push_back(el);
         break;
@@ -751,6 +751,7 @@ void Segment::add(EngravingItem* el)
         InstrumentChange* is = toInstrumentChange(el);
         Part* part = is->part();
         part->setInstrument(is->instrument(), tick());
+        is->setNonOwning();
         m_annotations.push_back(el);
         break;
     }
@@ -950,6 +951,10 @@ void Segment::remove(EngravingItem* el)
         if (!isMMRestSegment()) {
             InstrumentChange* is = toInstrumentChange(el);
             Part* part = is->part();
+            // Reclaim ownership before Part deletes the shared instrument
+            if (!is->ownsInstrument()) {
+                is->setInstrument(new Instrument(*is->instrument()));
+            }
             part->removeInstrument(tick());
         }
     }

--- a/src/engraving/editing/editinstrumentchange.cpp
+++ b/src/engraving/editing/editinstrumentchange.cpp
@@ -38,20 +38,22 @@ using namespace mu::engraving;
 
 void ChangeInstrument::flip(EditData*)
 {
-    Part* part = is->staff()->part();
-    Fraction tickStart = is->segment()->tick();
-    Instrument* oi = is->instrument();    //new Instrument(*is->instrument());
+    Instrument curInstrument = *is->instrument();
 
-    // set instrument in both part and instrument change element
-    is->setInstrument(instrument);        //*instrument
-    part->setInstrument(instrument, tickStart);
+    // Modify the shared instrument in-place. Since IC is non-owning,
+    // its pointer is the same as Part's InstrumentList entry, so both
+    // are updated by this single call. No need to call part->setInstrument
+    // which would create a redundant copy and orphan the shared pointer.
+    is->setInstrument(instrument);
 
-    // update score
-    is->masterScore()->rebuildMidiMapping();
-    is->masterScore()->updateChannel();
+    // Only rebuild MIDI mapping from master score to avoid race conditions
+    // when excerpts are processed in parallel (e.g., during save)
+    if (is->score()->isMaster()) {
+        is->masterScore()->rebuildMidiMapping();
+        is->masterScore()->updateChannel();
+    }
     is->score()->setInstrumentsChanged(true);
     is->triggerLayoutAll();
 
-    // remember original instrument
-    instrument = oi;
+    instrument = std::move(curInstrument);
 }

--- a/src/engraving/editing/editinstrumentchange.h
+++ b/src/engraving/editing/editinstrumentchange.h
@@ -33,12 +33,12 @@ class ChangeInstrument : public UndoCommand
     OBJECT_ALLOCATOR(engraving, ChangeInstrument)
 
     InstrumentChange* is = nullptr;
-    Instrument* instrument = nullptr;
+    Instrument instrument;  // Value copy: stores old instrument for undo/redo
 
     void flip(EditData*) override;
 
 public:
-    ChangeInstrument(InstrumentChange* _is, Instrument* i)
+    ChangeInstrument(InstrumentChange* _is, const Instrument& i)
         : is(_is), instrument(i) {}
 
     UNDO_TYPE(CommandType::ChangeInstrument)

--- a/src/engraving/editing/editmeasures.cpp
+++ b/src/engraving/editing/editmeasures.cpp
@@ -116,7 +116,9 @@ void InsertRemoveMeasures::insertMeasures()
         for (Segment* s = fs; s && s != ls; s = s->next1()) {
             for (EngravingItem* e : s->annotations()) {
                 if (e->isInstrumentChange()) {
-                    e->part()->setInstrument(toInstrumentChange(e)->instrument(), s->tick());
+                    InstrumentChange* ic = toInstrumentChange(e);
+                    e->part()->setInstrument(ic->instrument(), s->tick());
+                    ic->setNonOwning();
                 }
             }
         }

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -126,15 +126,14 @@ void SetSoloist::redo(EditData*)
 //   ChangePart
 //---------------------------------------------------------
 
-ChangePart::ChangePart(Part* _part, Instrument* i)
+ChangePart::ChangePart(Part* _part, const Instrument& i)
+    : part(_part), instrument(i)
 {
-    instrument = i;
-    part       = _part;
 }
 
 void ChangePart::flip(EditData*)
 {
-    Instrument* oi = part->instrument(); //tick?
+    Instrument curInstrument = *part->instrument();
     part->setInstrument(instrument);
 
     part->updateHarmonyChannels(false);
@@ -144,18 +143,9 @@ void ChangePart::flip(EditData*)
     score->setInstrumentsChanged(true);
     score->setPlaylistDirty();
 
-    // check if notes need to be updated
-    // true if changing into or away from TAB or from one TAB type to another
-
     score->setLayoutAll();
 
-    instrument = oi;
-}
-
-void ChangePart::cleanup(bool)
-{
-    delete instrument;
-    instrument = nullptr;
+    instrument = std::move(curInstrument);
 }
 
 //---------------------------------------------------------
@@ -348,7 +338,7 @@ void EditPart::replacePartInstrument(Score* score, Part* part, const Instrument&
         return;
     }
 
-    score->undo(new ChangePart(part, new Instrument(newInstrument)));
+    score->undo(new ChangePart(part, newInstrument));
 
     // Update clefs and staff type for all staves in the part
     for (staff_idx_t staffIdx = 0; staffIdx < part->nstaves(); ++staffIdx) {

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -89,13 +89,12 @@ class ChangePart : public UndoCommand
     OBJECT_ALLOCATOR(engraving, ChangePart)
 
     Part* part = nullptr;
-    Instrument* instrument = nullptr;
+    Instrument instrument;
 
     void flip(EditData*) override;
 
 public:
-    ChangePart(Part*, Instrument*);
-    void cleanup(bool) override;
+    ChangePart(Part*, const Instrument&);
 
     UNDO_TYPE(CommandType::ChangePart)
     UNDO_NAME("ChangePart")

--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -41,10 +41,25 @@ void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
         return;
     }
 
+    // Check for idempotent registration (same item, same EID)
+    auto it = m_itemToEid.find(const_cast<EngravingObject*>(item));
+    if (it != m_itemToEid.end() && it->second == eid) {
+        return;
+    }
+
     bool inserted = m_eidToItem.emplace(eid, const_cast<EngravingObject*>(item)).second;
     assert(inserted);
 
-    inserted = m_itemToEid.emplace(const_cast<EngravingObject*>(item), eid).second;
+    // If the pointer is already registered with a different EID, the previous
+    // object at this address was deleted and the memory reused.
+    // Clean up the stale EID entry.
+    if (it != m_itemToEid.end()) {
+        m_eidToItem.erase(it->second);
+        it->second = eid;
+        inserted = true;
+    } else {
+        inserted = m_itemToEid.emplace(const_cast<EngravingObject*>(item), eid).second;
+    }
     assert(inserted);
 
     if (MScore::testMode) {

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -232,7 +232,11 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::Writ
     ctx.setCurTrack(0);
 
     // Let's decide: write midi mapping to a file or not
-    score->masterScore()->checkMidiMapping();
+    // Only check from master score to avoid thread-safety issues
+    // when excerpts are serialized in parallel
+    if (score->isMaster()) {
+        score->masterScore()->checkMidiMapping();
+    }
 
     auto shouldWritePart = [&ctx, score, staffStart, staffEnd](const Part* part) {
         if (!ctx.shouldWriteRange()) {

--- a/src/engraving/tests/instrumentchange_tests.cpp
+++ b/src/engraving/tests/instrumentchange_tests.cpp
@@ -98,10 +98,9 @@ TEST_F(Engraving_InstrumentChangeTests, testChange)
     Segment* s           = m->first(SegmentType::ChordRest);
     InstrumentChange* ic = toInstrumentChange(s->annotations()[0]);
     Instrument* ni       = score->staff(1)->part()->instrument();
-    ic->setInstrument(new Instrument(*ni));
     score->startCmd(TranslatableString::untranslatable("Instrument change tests"));
     ic->setXmlText("Instrument Oboe");
-    score->undo(new ChangeInstrument(ic, ic->instrument()));
+    score->undo(new ChangeInstrument(ic, *ni));
     score->endCmd();
     score->doLayout();
     test_post(score, u"change");


### PR DESCRIPTION
Resolves: #32722 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated instrument-related tests to match revised undo/redo handling.

* **Bug Fixes / Chores**
  * Fixed instrument ownership and memory handling to prevent leaks and double-frees during edits, part/segment updates, and undo/redo.
  * Instrument-change items now correctly track ownership to avoid improper deletions when moving or restoring instruments.
  * Save/export skips MIDI-mapping checks for non-master/excerpt scores to reduce unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->