### PR TITLE
Fix EditStaff dialog crash on startup

### DIFF
--- a/src/notationscene/widgets/editstaff.cpp
+++ b/src/notationscene/widgets/editstaff.cpp
@@ -64,8 +64,6 @@ EditStaff::EditStaff(QWidget* parent)
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setModal(true);
 
-    initStaff();
-
     editStaffTypeDialog = new EditStaffType(this);
     editStaffTypeDialog->setWindowModality(Qt::WindowModal);
 
@@ -166,6 +164,7 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
 
 void EditStaff::showEvent(QShowEvent* event)
 {
+    initStaff();
     WidgetStateStore::restoreGeometry(this);
     QDialog::showEvent(event);
 }
@@ -443,6 +442,10 @@ INotationPartsPtr EditStaff::masterNotationParts() const
 
 void EditStaff::initStaff()
 {
+    if (!globalContext()) {
+        return;
+    }
+
     const INotationPtr notation = this->notation();
     const INotationInteractionPtr interaction = notation ? notation->interaction() : nullptr;
     auto context = interaction ? interaction->hitElementContext() : INotationInteraction::HitElementContext();
@@ -522,8 +525,10 @@ void EditStaff::applyPartProperties()
     String _lsn = longStaffName->toPlainText();
     if (!mu::engraving::Text::validateText(_sn) || !mu::engraving::Text::validateText(_ln)
         || !mu::engraving::Text::validateText(_ssn) || !mu::engraving::Text::validateText(_lsn)) {
-        interactive()->warning(muse::trc("notation/staffpartproperties", "Invalid instrument name"),
-                               muse::trc("notation/staffpartproperties", "The instrument name is invalid."));
+        if (interactive()) {
+            interactive()->warning(muse::trc("notation/staffpartproperties", "Invalid instrument name"),
+                                   muse::trc("notation/staffpartproperties", "The instrument name is invalid."));
+        }
         return;
     }
     QString sn = _sn;
@@ -577,6 +582,10 @@ void EditStaff::applyPartProperties()
 
 void EditStaff::showReplaceInstrumentDialog()
 {
+    if (!selectInstrumentsScenario()) {
+        return;
+    }
+
     async::Promise<InstrumentTemplate> templ = selectInstrumentsScenario()->selectInstrument(m_instrumentKey);
     templ.onResolve(this, [this](const InstrumentTemplate& val) {
         const StaffType* staffType = val.staffTypePreset;


### PR DESCRIPTION
The crash occurred because initStaff() was called in the constructor before the context injection system was fully initialized. After the MUSE_MULTICONTEXT_WIP removal, globalContext() returns null during construction, causing a segfault when notation() is called.

Fixed by moving initStaff() from the constructor to showEvent(), ensuring the context is ready before accessing it.

Resolves: #32743  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
