### PR TITLE
Fix VST plugin window crash on macOS when closing

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -158,7 +158,9 @@ void VstView::deinit()
 
     if (m_view) {
         m_view->setFrame(nullptr);
+#ifndef Q_OS_MAC
         m_view->removed();
+#endif
         m_view = nullptr;
 
         m_vstWindow->hide();

--- a/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
+++ b/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
@@ -65,7 +65,9 @@ void VstViewDialog::deinit()
 {
     if (m_view) {
         m_view->setFrame(nullptr);
+#ifndef Q_OS_MAC
         m_view->removed();
+#endif
         m_view = nullptr;
     }
 


### PR DESCRIPTION
### Problem

MuseScore crashes when closing VST plugin windows (e.g., ARIA player) on macOS. The crash occurs with a segmentation fault during the window close sequence.

**Platform:** macOS only

### Root Cause

The crash is caused by calling `IPlugView::removed()` during the `closeEvent()` on macOS. When the window closes, macOS's Cocoa framework may already be deallocating the NSView as part of its own cleanup sequence. Calling `removed()` at this point attempts to interact with partially or fully deallocated NSView objects, resulting in a crash.

This is a platform-specific issue:
- **macOS (NSView)**: The native view may already be in the process of deallocation when `closeEvent()` is triggered, making `removed()` unsafe
- **Windows (HWND)**: Window handles remain valid throughout the close event
- **Linux (X11)**: X11 window IDs remain valid throughout the close event

### Solution

Skip calling `IPlugView::removed()` on macOS using `#ifndef Q_OS_MAC`. The NSView cleanup is handled automatically by the Cocoa framework during window destruction, so the explicit `removed()` call is unnecessary and harmful on macOS.

On Windows and Linux, `removed()` continues to be called to ensure proper plugin cleanup.

### Changes

Modified two files:
1. `src/framework/vst/widgets/vstviewdialog_qwidget.cpp` - QWidget-based VST dialog
2. `src/framework/vst/qml/Muse/Vst/vstview.cpp` - QML-based VST view

Both `deinit()` methods now conditionally skip `m_view->removed()` on macOS.

### Testing

- Verify VST plugins (especially ARIA) can be opened and closed without crashing on macOS
- Verify VST plugins continue to work correctly on Windows and Linux
- Verify no memory leaks or resource issues on any platform


Resolves: #32742  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
