### PR TITLE
Fix ASIO buffer sizes 8, 16, 32 not working on Windows

### DIFF
--- a/src/framework/audio/driver/platform/win/asio/asioaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/win/asio/asioaudiodriver.cpp
@@ -614,7 +614,7 @@ std::vector<samples_t> AsioAudioDriver::availableOutputDeviceBufferSizes() const
     std::vector<samples_t> result;
 
     samples_t n = s_adata.deviceMetrics.maxSize;
-    samples_t min = s_adata.deviceMetrics.minSize;
+    samples_t min = std::max(s_adata.deviceMetrics.minSize, (long)64);
 
     while (n >= min) {
         result.push_back(n);


### PR DESCRIPTION
### Description
This PR fixes an issue where ASIO buffer sizes of 8, 16, and 32 samples were offered in the audio settings but did not function properly on Windows, causing playback problems.

### Changes
- Modified `AsioAudioDriver::availableOutputDeviceBufferSizes()` to enforce a minimum buffer size of 64 samples
- Small buffer sizes (8, 16, 32) are now filtered out and will no longer appear as options in the preferences

### Technical Details
The fix uses `std::max()` to ensure the minimum buffer size is at least 64, even if the ASIO device reports a lower minimum capability. This prevents users from selecting non-functional buffer sizes.

**File changed:**
- `src/framework/audio/driver/platform/win/asio/asioaudiodriver.cpp` (line 617)

### Testing
Tested with ASIO-compatible audio devices on Windows. Buffer sizes below 64 are no longer available for selection, preventing the crash/malfunction scenario.

##
Resolves: #32653 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
