### PR TITLE
Fix EditStaff dialog crash due to null IoC context

### DIFF
--- a/src/framework/global/modularity/ioccontext.cpp
+++ b/src/framework/global/modularity/ioccontext.cpp
@@ -65,8 +65,7 @@ muse::modularity::ContextPtr muse::iocCtxForQmlContext(const QQmlContext* ctx)
 
 muse::modularity::ContextPtr muse::iocCtxForQWidget(const QWidget*)
 {
-    //! TODO
-    return modularity::ContextPtr();
+    return muse::modularity::globalCtx();
 }
 
 #endif


### PR DESCRIPTION
Implement iocCtxForQWidget() to return globalCtx() instead of null. This fixes assertion failures in UiConfiguration::screen() when opening QWidget-based dialogs like Staff Properties.

Resolves: #32749 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
