### PR TITLE
Fix element stacking during partial layout

### DIFF
--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -518,6 +518,8 @@ public:
             m_mask.reset();
             //! NOTE Temporary removed, have problems, need investigation
             //m_pos.reset();
+            autoplace.offsetChanged = OffsetChange::NONE;
+            autoplace.changedPos = PointF();
         }
 
         virtual bool isValid() const { return m_shape.has_value() && m_shape.value().bbox().isValid(); }


### PR DESCRIPTION
Elements (text, dynamics) were stacking on top of each other after edits, only returning to correct positions after save/reload. This occurred because partial layout reset only affected the edited measure range while skyline collision detection processed entire systems, creating mixed stale/fresh data.

Changes:
- Enable position reset in LayoutData::reset() to force clean recalculation
- Reset autoplace state to ensure proper collision detection
- Expand PassResetLayoutData to reset all measures in affected systems, not just the edited range

Fixes the mismatch between partial reset scope and full system processing.

Resolves: #32756
 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
