### PR TITLE
fixed EditMidiMappingModel destruction

### DIFF
--- a/src/framework/shortcuts/qml/Muse/Shortcuts/editmidimappingmodel.cpp
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/editmidimappingmodel.cpp
@@ -34,7 +34,9 @@ EditMidiMappingModel::EditMidiMappingModel(QObject* parent)
 
 EditMidiMappingModel::~EditMidiMappingModel()
 {
-    midiRemote()->setIsSettingMode(false);
+    if (m_loaded) {
+        midiRemote()->setIsSettingMode(false);
+    }
 }
 
 void EditMidiMappingModel::load(int originType, int originValue)
@@ -50,6 +52,8 @@ void EditMidiMappingModel::load(int originType, int originValue)
 
     m_event = RemoteEvent(static_cast<RemoteEventType>(originType), originValue);
     emit mappingTitleChanged(mappingTitle());
+
+    m_loaded = true;
 }
 
 QString EditMidiMappingModel::mappingTitle() const

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/editmidimappingmodel.h
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/editmidimappingmodel.h
@@ -57,6 +57,7 @@ signals:
 private:
     QString deviceName(const muse::midi::MidiDeviceID& deviceId) const;
 
+    bool m_loaded = false;
     RemoteEvent m_event;
 };
 }


### PR DESCRIPTION
Resolves: 
https://github.com/musescore/MuseScore/issues/32720
https://github.com/musescore/MuseScore/issues/32735

In the destructor of the Qml object, it is no longer our QmlContext, we cannot get the iocContext.
Solution options:
1. We can check whether we really need to do something in the destructor (as in this PR)
2. We need to call the injectors before calling the destructor, just call them, they will receive the context, receive the service from the IOC, and after that they will no longer figure out the context and access the IOC. 