### PR TITLE
Recognize `dim.` as diminished chord

### DIFF
--- a/src/engraving/dom/chordlist.cpp
+++ b/src/engraving/dom/chordlist.cpp
@@ -543,7 +543,7 @@ void ParsedChord::configure(const ChordList* cl)
     // TODO: allow this to be parameterized via chord list
     m_major << u"ma" << u"maj" << u"major" << u"t" << u"^";
     m_minor << u"mi" << u"min" << u"minor" << u"-" << u"=";
-    m_diminished << u"dim" << u"o";
+    m_diminished << u"dim" << u"dim." << u"o";
     m_augmented << u"aug" << u"+";
     m_lower << u"b" << u"-" << u"dim";
     m_raise << u"#" << u"+" << u"aug";


### PR DESCRIPTION
Resolves: #32785

`dim.` is recognized as diminished when parsing chord symbols (in addition to `dim` and `o`).

<img width="621" height="349" alt="Screenshot from 2026-03-25 16-28-20" src="https://github.com/user-attachments/assets/86b4cf54-e29d-4738-bfe1-6884fb899d3d" />
