### PR TITLE
Fix note corruption when instrument change is on lower staff

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -27,6 +27,7 @@
 #include "translation.h"
 
 #include "../editing/editspanner.h"
+#include "../editing/transpose.h"
 #include "types/typesconv.h"
 #include "rendering/score/tlayout.h"
 
@@ -673,6 +674,30 @@ void Segment::checkElement(EngravingItem* el, track_idx_t track)
 }
 
 //---------------------------------------------------------
+//   updateNotesAfterInstrumentChange
+//   Update TPC2 for notes already in segment when instrument changes
+//---------------------------------------------------------
+
+void Segment::updateNotesAfterInstrumentChange(Part* part, const Interval& oldTranspose, const Interval& newTranspose)
+{
+    if (oldTranspose.chromatic == newTranspose.chromatic) {
+        return;
+    }
+
+    for (staff_idx_t staffIdx = part->startTrack() / VOICES; staffIdx < part->endTrack() / VOICES; ++staffIdx) {
+        for (voice_idx_t voice = 0; voice < VOICES; ++voice) {
+            track_idx_t track = staffIdx * VOICES + voice;
+            EngravingItem* e = element(track);
+            if (e && e->isChord()) {
+                for (Note* note : toChord(e)->notes()) {
+                    note->setTpc2(Transpose::transposeTpc(note->tpc1(), newTranspose, true));
+                }
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
 //   add
 //---------------------------------------------------------
 
@@ -742,7 +767,13 @@ void Segment::add(EngravingItem* el)
         if (toStaffState(el)->staffStateType() == StaffStateType::INSTRUMENT) {
             StaffState* ss = toStaffState(el);
             Part* part = el->part();
+            const Instrument* oldInstr = part->instrument(tick());
+            Interval oldTranspose = oldInstr->transpose();
+
             part->setInstrument(ss->instrument(), tick());
+
+            const Instrument* newInstr = part->instrument(tick());
+            updateNotesAfterInstrumentChange(part, oldTranspose, newInstr->transpose());
         }
         m_annotations.push_back(el);
         break;
@@ -750,7 +781,14 @@ void Segment::add(EngravingItem* el)
     case ElementType::INSTRUMENT_CHANGE: {
         InstrumentChange* is = toInstrumentChange(el);
         Part* part = is->part();
+        const Instrument* oldInstr = part->instrument(tick());
+        Interval oldTranspose = oldInstr->transpose();
+
         part->setInstrument(is->instrument(), tick());
+
+        const Instrument* newInstr = part->instrument(tick());
+        updateNotesAfterInstrumentChange(part, oldTranspose, newInstr->transpose());
+
         m_annotations.push_back(el);
         break;
     }

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -31,6 +31,7 @@ class Segment;
 class ChordRest;
 class Spanner;
 class System;
+struct Interval;
 
 //-------------------------------------------------------------------
 //   SegmentType
@@ -359,6 +360,7 @@ private:
 
     void init();
     void checkElement(EngravingItem*, track_idx_t track);
+    void updateNotesAfterInstrumentChange(Part* part, const Interval& oldTranspose, const Interval& newTranspose);
     void setEmpty(bool val) const { setFlag(ElementFlag::EMPTY, val); }
 
     SegmentType m_segmentType = SegmentType::Invalid;


### PR DESCRIPTION
When a multi-staff part has an InstrumentChange on the lower staff, notes on upper staves at the same tick were using incorrect TPC values after reopening the file. This occurred because during file reading, notes on upper staves were processed before the InstrumentChange on the lower staff updated the Part's instrument map.

The fix ensures that when an InstrumentChange (or StaffState with instrument type) is added to a segment, it recalculates TPC2 values for any notes already present in that segment across all staves of the same part, using the new instrument's transposition.

Resolves: #24488 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
