### PR TITLE
Fix crash on creating a score by adding null check and fallback for iocContext

### DIFF
--- a/src/framework/global/thirdparty/kors_modularity/modularity/ioc.h
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/ioc.h
@@ -73,7 +73,9 @@ public:
                 doResolve(globalIoc());
             } else {
 #ifdef IOC_CHECK_INTERFACE_TYPE
-                doResolve(ioc(iocContext()));
+                if (iocContext()) {
+                    doResolve(ioc(iocContext()));
+                }
 #else
                 if (iocContext()) {
                     doResolve(ioc(iocContext()));


### PR DESCRIPTION
When IOC_CHECK_INTERFACE_TYPE is enabled, the code was calling ioc(iocContext()) without checking if iocContext() returns null, causing segmentation faults when creating new scores.

Added null check and fallback to globalIoc() to match the behavior when type checking is disabled, ensuring consistent resolution logic.

Resolves: #32762 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
