### PR TITLE
fix #17557: Backspace key only deletes one note in Note-input mode

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -109,6 +109,9 @@
     <SC>
         <key>action://delete</key>
         <seq>Del</seq>
+    </SC>
+    <SC>
+        <key>action://backspace</key>
         <seq>Backspace</seq>
     </SC>
     <SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -109,6 +109,9 @@
     <SC>
         <key>action://delete</key>
         <seq>Del</seq>
+    </SC>
+    <SC>
+        <key>action://backspace</key>
         <seq>Backspace</seq>
     </SC>
     <SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -109,6 +109,9 @@
     <SC>
         <key>action://delete</key>
         <seq>Del</seq>
+    </SC>
+    <SC>
+        <key>action://backspace</key>
         <seq>Backspace</seq>
     </SC>
     <SC>

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -81,6 +81,7 @@ void ApplicationActionController::init()
     dispatcher()->reg(this, "action://undo", this, &ApplicationActionController::doGlobalUndo);
     dispatcher()->reg(this, "action://redo", this, &ApplicationActionController::doGlobalRedo);
     dispatcher()->reg(this, "action://delete", this, &ApplicationActionController::doGlobalDelete);
+    dispatcher()->reg(this, "action://backspace", this, &ApplicationActionController::doGlobalBackspace);
     dispatcher()->reg(this, "action://cancel", this, &ApplicationActionController::doGlobalCancel);
 }
 
@@ -435,6 +436,15 @@ void ApplicationActionController::doGlobalDelete()
 {
     if (hasProjectAndIsFocused()) {
         dispatcher()->dispatch("action://notation/delete");
+    } else {
+        // resolve other actions
+    }
+}
+
+void ApplicationActionController::doGlobalBackspace()
+{
+    if (hasProjectAndIsFocused()) {
+        dispatcher()->dispatch("action://notation/backspace");
     } else {
         // resolve other actions
     }

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -119,6 +119,7 @@ private:
     void doGlobalUndo();
     void doGlobalRedo();
     void doGlobalDelete();
+    void doGlobalBackspace();
     void doGlobalCancel();
 
     bool m_quiting = false;

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -278,6 +278,14 @@ const UiActionList ApplicationUiActions::m_actions = {
              TranslatableString("action", "Delete"),
              IconCode::Code::DELETE_TANK
              ),
+    UiAction("action://backspace",
+             { "action://notation/backspace" },
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Backspace"),
+             TranslatableString("action", "Backspace"),
+             IconCode::Code::NONE
+             ),
     UiAction("action://cancel",
              { "action://notation/cancel" },
              mu::context::UiCtxAny,

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -232,6 +232,7 @@ void NotationActionController::init()
     registerAction("notation-paste-double", [this]() { pasteSelection(PastingType::Double); });
     registerAction("notation-paste-special", [this]() { pasteSelection(PastingType::Special); });
     registerAction("notation-swap", &Interaction::swapSelection, &Controller::hasSelection);
+    registerAction("action://notation/backspace", &Controller::backspace, &Controller::isNotationPage);
     registerAction("action://notation/delete", &Interaction::deleteSelection, &Controller::hasSelection);
 
     registerAction("flip", &Interaction::flipSelection, &Controller::hasSelection);
@@ -1299,6 +1300,35 @@ void NotationActionController::cutSelection()
     }
     interaction->copySelection();
     interaction->deleteSelection();
+}
+
+void NotationActionController::backspace()
+{
+    TRACEFUNC;
+
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    auto noteInput = interaction->noteInput();
+    if (!noteInput || !noteInput->isNoteInputMode()) {
+        if (!interaction->selection()->isNone()) {
+            interaction->deleteSelection();
+        }
+        return;
+    }
+
+    if (interaction->selection()->isNone()) {
+        interaction->moveSelection(MoveDirection::Left, MoveSelectionType::Chord);
+    }
+
+    if (!interaction->selection()->isNone()) {
+        interaction->deleteSelection();
+    }
+
+    interaction->moveSelection(MoveDirection::Left, MoveSelectionType::Chord);
+    seekSelectedElement();
 }
 
 void NotationActionController::repeatSelection()

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -115,6 +115,7 @@ private:
     void changeVoice(voice_idx_t voiceIndex);
 
     void cutSelection();
+    void backspace();
     void repeatSelection();
     void addTie();
     void chordTie();

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -110,6 +110,12 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Delete"),
              IconCode::Code::DELETE_TANK
              ),
+    UiAction("action://notation/backspace",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_DISABLED,
+             TranslatableString("action", "Backspace"),
+             TranslatableString("action", "Backspace")
+             ),
     UiAction("action://notation/cancel",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_DISABLED


### PR DESCRIPTION
Made backspace an individual command and implemented the intended behaviour, which was to delete the selected note and move the cursor to the left. Now it is possible to continuously delete notes by pressing the backspace key.

Resolves: #17557 

<!-- Add a short description of and motivation for the changes here --> The delete and backspace keys were mapped to the same functionality in shortcuts.xml. The intended backspace behaviour was implemented, so that this key can delete not just the last note when in note input mode.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
