### PR TITLE
Fix #27279: Preserve accidental brackets when copying and pasting

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1768,7 +1768,7 @@ EngravingItem* Note::drop(EditData& data)
         return e;
 
     case ElementType::ACCIDENTAL:
-        EditNote::changeAccidental(score(), this, toAccidental(e)->accidentalType());
+        EditNote::changeAccidental(score(), this, toAccidental(e)->accidentalType(), toAccidental(e)->bracket());
         break;
 
     case ElementType::BEND:

--- a/src/engraving/editing/editnote.cpp
+++ b/src/engraving/editing/editnote.cpp
@@ -23,6 +23,7 @@
 #include "editnote.h"
 #include "editchord.h"
 
+#include <optional>
 #include <set>
 
 #include "dom/accidental.h"
@@ -328,7 +329,7 @@ void EditNote::changeAccidental2(Note* n, int pitch, int tpc)
 ///   note \a note.
 //---------------------------------------------------------
 
-void EditNote::changeAccidental(Score* score, Note* note, AccidentalType accidental)
+void EditNote::changeAccidental(Score* score, Note* note, AccidentalType accidental, std::optional<AccidentalBracket> bracket)
 {
     Chord* chord = note ? note->chord() : nullptr;
     if (!chord) {
@@ -387,6 +388,12 @@ void EditNote::changeAccidental(Score* score, Note* note, AccidentalType acciden
              || Accidental::isMicrotonal(accidental)) {
         forceAdd = true;
     }
+    // since Note::updateAccidental doesn't have
+    // enough context to pick the correct parenthesis
+    // the accidental needs to be added here
+    else if (bracket.has_value()) {
+        forceAdd = true;
+    }
 
     for (EngravingObject* se : note->linkList()) {
         Note* ln = toNote(se);
@@ -407,6 +414,10 @@ void EditNote::changeAccidental(Score* score, Note* note, AccidentalType acciden
                 score->undoRemoveElement(a);
             }
             Accidental* a1 = Factory::createAccidental(ln);
+
+            if (bracket.has_value()) {
+                a1->setBracket(bracket.value());
+            }
             a1->setParent(ln);
             a1->setAccidentalType(accidental);
             a1->setRole(AccidentalRole::USER);

--- a/src/engraving/editing/editnote.h
+++ b/src/engraving/editing/editnote.h
@@ -42,7 +42,7 @@ public:
     static void toggleAccidental(Score* score, AccidentalType at);
     static void applyAccidentalToInputNotes(Score* score, AccidentalType accidentalType);
     static void changeAccidental(Score* score, AccidentalType idx);
-    static void changeAccidental(Score* score, Note* note, AccidentalType accidental);
+    static void changeAccidental(Score* score, Note* note, AccidentalType accidental, std::optional<AccidentalBracket> = std::nullopt);
     static void undoChangePitch(Score* score, Note* note, int pitch, int tpc1, int tpc2);
     static void undoChangeFretting(Score* score, Note* note, int pitch, int string, int fret, int tpc1, int tpc2);
     static void upDown(Score* score, bool up, UpDownMode mode);

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -838,3 +838,23 @@ TEST_F(Engraving_NoteTests, RepitchInVoiceTwoDoesNotAffectVoiceOneLyrics)
 
     delete score;
 }
+//---------------------------------------------------------
+///   changeAccidentalBracket
+///   test changeAccidental with bracket argument
+//---------------------------------------------------------
+
+TEST_F(Engraving_NoteTests, changeAccidentalWithBracket)
+{
+    MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + u"altered-unison.mscx");
+    Measure* m = score->firstMeasure();
+    Chord* c = m->findChord(Fraction(0, 1), 0);
+    Note* note = c->upNote();
+
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
+    EditNote::changeAccidental(score, note, AccidentalType::SHARP, AccidentalBracket::BRACKET);
+    score->endCmd();
+
+    EXPECT_TRUE(note->accidental());
+    EXPECT_EQ(note->accidental()->accidentalType(), AccidentalType::SHARP);
+    EXPECT_EQ(note->accidental()->bracket(), AccidentalBracket::BRACKET);
+}


### PR DESCRIPTION
add optional bracket parameter to Score::changeAccidental

update related Score::changeAccidental call

add unit test "changeAccidentalWithBracket"

Resolves: #27279

## Cause of the bug
From what I could gather, an accidental is added to a note in two steps:

- `Score::changeAccidental` is called and changes the tpc
- Later, `Note::updateAccidental` is called, looks at the tpc, determines that an accidental is required and adds it accordingly

Since the accidental is computed from the ground up, `Note::updateAccidental`, doesn’t have enough information to determine whether or not it had brackets, leading to the bug.

## Fix
Simply force-add the accidental directly in the `Score::changeAccidental` with the brackets.

## Notes
- I added the brackets as an optional argument because the function was called in other places without a known bracket.
- I only added the bracket argument in the call that lead to the bug.
- I added a default argument so as to change as little code as possible, but simply adding std::nullopt to all the calls is also a choice.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
