### PR TITLE
fixed show splash screen (setup step by step on event loop)

### DIFF
--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -75,6 +75,13 @@ void ConsoleApp::addModule(modularity::IModuleSetup* module)
     m_modules.push_back(module);
 }
 
+void ConsoleApp::showSplash()
+{
+    std::cout << "================================================" << std::endl;
+    std::cout << "The MuseScore console application is starting..." << std::endl;
+    std::cout << "================================================" << std::endl;
+}
+
 void ConsoleApp::setup()
 {
     const CmdOptions& options = m_options;

--- a/src/app/internal/consoleapp.h
+++ b/src/app/internal/consoleapp.h
@@ -69,6 +69,7 @@ public:
 
     void addModule(muse::modularity::IModuleSetup* module);
 
+    void showSplash() override;
     void setup() override;
     void finish() override;
 

--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -19,18 +19,6 @@
 #include "muse_framework_config.h"
 #include "app_config.h"
 
-#ifdef MUE_ENABLE_SPLASHSCREEN
-#include "appshell/widgets/splashscreen/splashscreen.h"
-#else
-namespace mu::appshell {
-class SplashScreen
-{
-public:
-    void close() {}
-};
-}
-#endif
-
 #ifdef QT_CONCURRENT_SUPPORTED
 #include <QThreadPool>
 #endif
@@ -53,6 +41,45 @@ GuiApp::GuiApp(const CmdOptions& options)
 void GuiApp::addModule(muse::modularity::IModuleSetup* module)
 {
     m_modules.push_back(module);
+}
+
+GuiApp::SplashConfig GuiApp::splashConfig(const CmdOptions& options) const
+{
+    SplashConfig cfg;
+    cfg.type = SplashScreen::Default;
+
+    if (options.startup.type.has_value()) {
+        if (options.startup.type.value() == "start-with-new") {
+            cfg.type = SplashScreen::ForNewInstance;
+            cfg.forNewScore = true;
+        } else if (options.startup.scoreUrl.has_value()) {
+            project::ProjectFile file { options.startup.scoreUrl.value() };
+
+            if (options.startup.scoreDisplayNameOverride.has_value()) {
+                file.displayNameOverride = options.startup.scoreDisplayNameOverride.value();
+            }
+
+            cfg.type = SplashScreen::ForNewInstance;
+            cfg.forNewScore = false;
+            if (file.hasDisplayName()) {
+                cfg.openingFileName = file.displayName(true /* includingExtension */);
+            }
+        } else {
+            cfg.type = SplashScreen::Default;
+        }
+    }
+
+    return cfg;
+}
+
+void GuiApp::showSplash()
+{
+#ifdef MUE_ENABLE_SPLASHSCREEN
+    if (splashConfig(m_options).type == SplashScreen::Default) {
+        m_splashScreen = new SplashScreen(SplashScreen::Default);
+        m_splashScreen->show();
+    }
+#endif
 }
 
 void GuiApp::setup()
@@ -105,38 +132,6 @@ void GuiApp::setup()
         m->onPreInit(runMode);
     }
 
-    // Process all pending events (see IpcSocket::onReadyRead())
-    // so that we can use isFirstWindow() as early as possible
-    muse::async::processMessages();
-
-//! FIXME
-//! The launch scenario is contextual, but there is no context here.
-#undef MUE_ENABLE_SPLASHSCREEN
-
-#ifdef MUE_ENABLE_SPLASHSCREEN
-    if (multiwindowsProvider()->isFirstWindow()) {
-        m_splashScreen = new SplashScreen(SplashScreen::Default);
-    } else {
-        auto startupScenario = muse::modularity::ioc(iocContext())->resolve<IStartupScenario>("app");
-        const project::ProjectFile& file = startupScenario->startupScoreFile();
-        if (file.isValid()) {
-            if (file.hasDisplayName()) {
-                m_splashScreen = new SplashScreen(SplashScreen::ForNewInstance, false, file.displayName(true /* includingExtension */));
-            } else {
-                m_splashScreen = new SplashScreen(SplashScreen::ForNewInstance, false);
-            }
-        } else if (startupScenario->isStartWithNewFileAsSecondaryInstance()) {
-            m_splashScreen = new SplashScreen(SplashScreen::ForNewInstance, true);
-        } else {
-            m_splashScreen = new SplashScreen(SplashScreen::Default);
-        }
-    }
-
-    if (m_splashScreen) {
-        m_splashScreen->show();
-    }
-#endif
-
     // ====================================================
     // Setup modules: onInit
     // ====================================================
@@ -177,11 +172,7 @@ void GuiApp::setup()
     m_delayedInitTimer.start();
 
     // ====================================================
-    // Run
-    // ====================================================
-
-    // ====================================================
-    // Setup Qml Engine
+    // Setup Graphics Api check
     // ====================================================
     //! Needs to be set because we use transparent windows for PopupView.
     //! Needs to be called before any QQuickWindows are shown.
@@ -264,6 +255,17 @@ std::vector<muse::modularity::ContextPtr> GuiApp::contexts() const
 size_t GuiApp::contextCount() const
 {
     return m_contexts.size();
+}
+
+void GuiApp::showContextSplash()
+{
+#ifdef MUE_ENABLE_SPLASHSCREEN
+    SplashConfig cfg = splashConfig(m_options);
+    if (cfg.type == SplashScreen::ForNewInstance) {
+        m_splashScreen = new SplashScreen(cfg.type, cfg.forNewScore, cfg.openingFileName);
+        m_splashScreen->show();
+    }
+#endif
 }
 
 muse::modularity::ContextPtr GuiApp::setupNewContext(const StringList& args)
@@ -397,11 +399,13 @@ muse::modularity::ContextPtr GuiApp::setupNewContext(const StringList& args)
     startupScenario->runOnSplashScreen();
 
     QMetaObject::invokeMethod(qApp, [this, ctxId, obj, startupScenario]() {
+#ifdef MUE_ENABLE_SPLASHSCREEN
         if (m_splashScreen) {
             m_splashScreen->close();
             delete m_splashScreen;
             m_splashScreen = nullptr;
         }
+#endif
 
         // The main window must be shown at this point so KDDockWidgets can read its size correctly
         // and scale all sizes properly. https://github.com/musescore/MuseScore/issues/21148

--- a/src/app/internal/guiapp.h
+++ b/src/app/internal/guiapp.h
@@ -17,11 +17,9 @@
 #include "appshell/iappshellconfiguration.h"
 #include "importexport/guitarpro/iguitarproconfiguration.h"
 
-class QQuickWindow;
+#include "appshell/widgets/splashscreen/splashscreen.h"
 
-namespace mu::appshell {
-class SplashScreen;
-}
+class QQuickWindow;
 
 namespace mu::app {
 class GuiApp : public muse::BaseApplication, public std::enable_shared_from_this<GuiApp>
@@ -35,15 +33,26 @@ public:
 
     void addModule(muse::modularity::IModuleSetup* module);
 
+    void showSplash() override;
     void setup() override;
     void finish() override;
 
+    void showContextSplash() override;
     muse::modularity::ContextPtr setupNewContext(const muse::StringList& args = {}) override;
     void destroyContext(const muse::modularity::ContextPtr& ctx) override;
     size_t contextCount() const override;
     std::vector<muse::modularity::ContextPtr> contexts() const override;
 
 private:
+
+    struct SplashConfig {
+        appshell::SplashScreen::SplashScreenType type = appshell::SplashScreen::SplashScreenType::Default;
+        bool forNewScore = false;
+        QString openingFileName;
+    };
+
+    SplashConfig splashConfig(const CmdOptions& options) const;
+
     void applyCommandLineOptions(const CmdOptions& options);
 
     struct Context {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -158,12 +158,29 @@ int main(int argc, char** argv)
     opt.runMode = IApplication::RunMode::GuiApp;
 #endif
 
-    AppFactory f;
-    std::shared_ptr<muse::IApplication> app = f.newApp(opt);
+    // ====================================================
+    // Setup application
+    // ====================================================
 
-    app->setup();
+    //! NOTE: We immediately launch the application's event loop
+    // to be able to show a splash screen (on Linux, splash screen won't show without event loop).
+    // All subsequent initialization steps will be executed as events in the event loop.
 
-    app->setupNewContext();
+    std::shared_ptr<muse::IApplication> app;
+    QMetaObject::invokeMethod(qapp, [qapp, &app, &opt]() {
+        AppFactory f;
+        app = f.newApp(opt);
+        app->showSplash();
+        QMetaObject::invokeMethod(qapp, [qapp, &app]() {
+            app->setup();
+            QMetaObject::invokeMethod(qapp, [qapp, &app]() {
+                app->showContextSplash();
+                QMetaObject::invokeMethod(qapp, [&app]() {
+                    app->setupNewContext();
+                }, Qt::QueuedConnection);
+            }, Qt::QueuedConnection);
+        }, Qt::QueuedConnection);
+    }, Qt::QueuedConnection);
 
     // ====================================================
     // Run main loop
@@ -174,7 +191,9 @@ int main(int argc, char** argv)
     // Quit
     // ====================================================
 
-    app->finish();
+    if (app) {
+        app->finish();
+    }
 
     delete qapp;
 

--- a/src/framework/global/iapplication.h
+++ b/src/framework/global/iapplication.h
@@ -64,10 +64,12 @@ public:
     virtual RunMode runMode() const = 0;
     virtual bool noGui() const = 0;
 
+    virtual void showSplash() {}
     virtual void setup() = 0;
     virtual void finish() = 0;
     virtual void restart() = 0;
 
+    virtual void showContextSplash() {}
     virtual modularity::ContextPtr setupNewContext(const StringList& args = {}) = 0;
     virtual void destroyContext(const modularity::ContextPtr& ctx) = 0;
     virtual size_t contextCount() const = 0;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32720 

Not fixed:
* Show splash screen when opening the next window in single-proc mode 
* The launch scenario itself doesn't work yet.  
