### PR TITLE
Fix Instrument change text should show full instrument name

### DIFF
--- a/src/engraving/dom/instrchange.cpp
+++ b/src/engraving/dom/instrchange.cpp
@@ -152,7 +152,7 @@ void InstrumentChange::setupInstrument(const Instrument* instrument)
     }
 
     //: The text of an "instrument change" marking. It is an instruction to the player to switch to another instrument.
-    const String newInstrChangeText = muse::mtrc("engraving", "To %1").arg(instrument->trackName());
+    const String newInstrChangeText = muse::mtrc("engraving", "To %1").arg(instrument->trackNameWithTrait());
     undoChangeProperty(Pid::TEXT, TextBase::plainToXmlText(newInstrChangeText));
 }
 

--- a/src/engraving/dom/instrument.cpp
+++ b/src/engraving/dom/instrument.cpp
@@ -22,6 +22,8 @@
 
 #include "instrument.h"
 
+#include "translation.h"
+
 #include "drumset.h"
 #include "instrtemplate.h"
 #include "masterscore.h"
@@ -1063,6 +1065,14 @@ bool InstrumentList::contains(const String& instrumentId) const
 
 String Instrument::trackName() const
 {
+    return m_trackName;
+}
+
+String Instrument::trackNameWithTrait() const
+{
+    if (m_trait.type == TraitType::Transposition && !m_trait.isHiddenOnScore) {
+        return muse::mtrc("engraving", "%1 in %2").arg(m_trackName, m_trait.name);
+    }
     return m_trackName;
 }
 

--- a/src/engraving/dom/instrument.h
+++ b/src/engraving/dom/instrument.h
@@ -348,6 +348,7 @@ public:
     String musicXmlId() const;
 
     String trackName() const;
+    String trackNameWithTrait() const;
     void setTrackName(const String& s);
     String nameAsXmlText() const;
     String nameAsPlainText() const;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -48,19 +48,6 @@ using namespace mu::engraving;
 
 static const mu::engraving::Fraction DEFAULT_TICK = mu::engraving::Fraction(0, 1);
 
-static String formatInstrumentTitleOnScore(const String& instrumentName, const Trait& trait)
-{
-    // Comments for translators start with //:
-
-    if (trait.type == TraitType::Transposition && !trait.isHiddenOnScore) {
-        //: %1=name ("Horn"), %2=transposition ("C alto"). Example: "Horn in C alto"
-        return muse::qtrc("notation", "%1 in %2", "Transposing instrument displayed in the score")
-               .arg(instrumentName, trait.name);
-    }
-
-    return instrumentName; // Example: "Flute"
-}
-
 NotationParts::NotationParts(IGetScore* getScore, INotationInteractionPtr interaction, INotationUndoStackPtr undoStack)
     : m_getScore(getScore), m_undoStack(undoStack), m_interaction(interaction)
 {


### PR DESCRIPTION
Resolves: #32588 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent instrument name display to ensure transposition information appears consistently across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->