### PR TITLE
Fix part 'always hide' to respect individual staff emptiness

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -587,7 +587,7 @@ static StaffHideMode computeHideMode(const System* system, const Staff* staff, c
     AutoOnOff partHideMode = staff->part()->hideWhenEmpty();
     switch (partHideMode) {
     case AutoOnOff::ON:
-        break;
+        return StaffHideMode::HIDE_WHEN_STAFF_EMPTY;
     case AutoOnOff::OFF:
         return StaffHideMode::ALWAYS_SHOW;
     case AutoOnOff::AUTO:


### PR DESCRIPTION
Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
