### PR TITLE
Fix #32016: Prevent UI overlap in Beams style page on window resize

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
@@ -50,7 +50,6 @@ StyledFlickable {
 
             RadioButtonGroup {
                 Layout.preferredHeight: 70
-                Layout.minimumWidth: 300
                 spacing: 12
 
                 model: [
@@ -155,6 +154,7 @@ StyledFlickable {
 
                 RadioButtonGroup {
                     Layout.fillWidth: true
+                    Layout.minimumWidth: 300
 
                     spacing: 12
                     orientation: ListView.Vertical


### PR DESCRIPTION
When shrinking the application window, the UI elements in the Beams style page would overlap each other because the layout lacked minimum width constraints and scrollability.

This commit wraps the page content in a StyledFlickable and enforces a Layout.minimumWidth of 500 on the main components. Now, instead of breaking the layout, the page gracefully introduces a horizontal scrollbar when the window becomes too narrow, matching the behavior of other dense pages like Chord Symbols.

Resolves: #32016

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)