### PR TITLE
Refactor EditStaff::apply() to use m_orgStaff for undo stack access

### DIFF
--- a/src/notationscene/widgets/editstaff.cpp
+++ b/src/notationscene/widgets/editstaff.cpp
@@ -361,10 +361,10 @@ void EditStaff::bboxClicked(QAbstractButton* button)
 
 void EditStaff::apply()
 {
-    size_t index = m_staff->score()->undoStack()->currentIndex();
+    size_t index = m_orgStaff->score()->undoStack()->currentIndex();
     applyStaffProperties();
     applyPartProperties();
-    m_staff->score()->undoStack()->mergeCommands(index);
+    m_orgStaff->score()->undoStack()->mergeCommands(index);
 }
 
 void EditStaff::minPitchAClicked()


### PR DESCRIPTION
Use m_orgStaff->score()->undoStack() instead of m_staff->score()->undoStack() for better code clarity and semantic correctness.

While both references point to the same undo stack (since m_staff and m_orgStaff share the same Part), using m_orgStaff makes the intent clearer: we're accessing the undo stack of the score containing the staff being modified, not the temporary UI copy used for staging changes.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
