### PR TITLE
Clear destination track before cloning to prevent corruption (#16896):

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -4120,6 +4120,12 @@ bool Score::cmdExplode()
             track_idx_t strack = sTracks[j % VOICES];
             track_idx_t dtrack = dTracks[j % VOICES];
             if (strack != muse::nidx && strack != dtrack && dtrack != muse::nidx) {
+                for (Segment* seg = startSegment; seg && seg->tick() < lTick; seg = seg->next1()) {
+                    EngravingItem* el = seg->element(dtrack);
+                    if (el && el->isChordRest()) {
+                        undoRemoveElement(el);
+                    }
+                }
                 undo(new CloneVoice(startSegment, lTick, startSegment, strack, dtrack, muse::nidx, false));
             }
         }


### PR DESCRIPTION
rests already in dtrack would otherwise coexist with the cloned notes.

Resolves: #16896 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
