### PR TITLE
Fix Corruption when input notes and switching between score and part

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -1395,7 +1395,7 @@ Fraction Score::makeGap(Segment* segment, track_idx_t track, const Fraction& _sd
             tuplet = 0;
         } else {
             if (seg != firstSegment || !keepChord) {
-                undoRemoveElement(cr);
+                undoRemoveElement(cr, false);
             }
             // even if there was a tuplet, we didn't remove it
             ltuplet = 0;

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -7476,6 +7476,14 @@ void Score::undoAddCR(ChordRest* cr, Measure* measure, const Fraction& tick)
             toRest(newcr)->setGap(false);
         }
 
+        if (staff != ostaff) {
+            if (EngravingItem* existing = seg->element(linkedTrack)) {
+                if (!existing->findLinkedInStaff(ostaff)) {
+                    doUndoRemoveElement(existing);
+                }
+            }
+        }
+
         doUndoAddElement(newcr);
     }
 }

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -67,7 +67,10 @@ void VstSynthesiser::init(const OutputSpec& spec)
         m_vstAudioClient->setOutputSpec(m_outputSpec);
         m_vstAudioClient->loadSupportedParams();
         m_sequencer.init(m_vstAudioClient->paramsMapping(SUPPORTED_CONTROLLERS), m_useDynamicEvents);
-        m_inited = true;
+        if (m_vstAudioClient->isActive()) {
+            m_inited = true;
+            m_pluginPtr->setViewAllowed(true);
+        }
     };
 
     if (m_pluginPtr->isLoaded()) {

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -461,8 +461,12 @@ void VstAudioClient::ensureActivity()
         return;
     }
 
-    component->setActive(true);
-    processor->setProcessing(true);
+    if (component->setActive(true) != Steinberg::kResultOk) {
+        return;
+    }
+    if (processor->setProcessing(true) != Steinberg::kResultOk) {
+        return;
+    }
 
     m_isActive = true;
 }

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -37,6 +37,7 @@ public:
     void loadSupportedParams();
 
     void setIsActive(const bool isActive);
+    bool isActive() const { return m_isActive; }
     void setOutputSpec(const audio::OutputSpec& spec);
     void setProcessMode(VstProcessMode mode);
     void setVolumeGain(const muse::audio::gain_t newVolumeGain);

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -191,7 +191,7 @@ PluginViewPtr VstPluginInstance::createView() const
 
     std::lock_guard lock(m_mutex);
 
-    if (!m_pluginProvider) {
+    if (!m_pluginProvider || !m_viewAllowed) {
         return nullptr;
     }
 

--- a/src/framework/vst/internal/vstplugininstance.h
+++ b/src/framework/vst/internal/vstplugininstance.h
@@ -54,6 +54,7 @@ public:
     VstPluginInstanceId id() const override;
 
     PluginViewPtr createView() const override;
+    void setViewAllowed(bool allowed) override { m_viewAllowed = allowed; }
 
     PluginControllerPtr controller() const override;
     PluginComponentPtr component() const override;
@@ -91,6 +92,7 @@ private:
     mutable async::Channel<muse::audio::AudioUnitConfig> m_pluginSettingsChanges;
 
     std::atomic_bool m_isLoaded = false;
+    std::atomic_bool m_viewAllowed = false;
     async::Notification m_loadingCompleted;
 
     mutable std::mutex m_mutex;

--- a/src/framework/vst/ivstplugininstance.h
+++ b/src/framework/vst/ivstplugininstance.h
@@ -41,6 +41,7 @@ public:
     virtual async::Notification loadingCompleted() const = 0;
 
     virtual PluginViewPtr createView() const = 0;
+    virtual void setViewAllowed(bool allowed) = 0;
     virtual PluginControllerPtr controller() const = 0;
     virtual PluginComponentPtr component() const = 0;
     virtual PluginMidiMappingPtr midiMapping() const = 0;


### PR DESCRIPTION
Resolves: #18437 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
