### PR TITLE
Fixed a recursive call to the async::processMessages

### DIFF
--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -148,7 +148,6 @@ Ret SoundTrackWriter::generateAudioData()
 
     sendStepProgress(PREPARE_STEP, inputBufferOffset, inputBufferMaxOffset);
 
-    const std::thread::id thisThId = std::this_thread::get_id();
     while (inputBufferOffset < inputBufferMaxOffset && !m_isAborted) {
         m_source->process(m_intermBuffer.data(), m_renderStep);
 
@@ -163,7 +162,6 @@ Ret SoundTrackWriter::generateAudioData()
 
         //! NOTE It is necessary for cancellation to work
         //! and for information about the audio signal to be transmitted.
-        async::processMessages(thisThId);
         rpcChannel()->process();
     }
 

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -37,6 +37,8 @@ using namespace muse::audio;
 using namespace muse::audio::synth;
 using namespace muse::mpe;
 
+static constexpr bool FLUID_DEBUG = false;
+
 static constexpr double FLUID_GLOBAL_VOLUME_GAIN = 4.8;
 static constexpr int DEFAULT_MIDI_VOLUME = 100;
 static constexpr msecs_t MIN_NOTE_LENGTH = 10;
@@ -90,7 +92,9 @@ Ret FluidSynth::init(const OutputSpec& spec)
             LOGI() << message;
         } break;
         case FLUID_DBG:  {
-            LOGD() << message;
+            if (FLUID_DEBUG) {
+                LOGD() << message;
+            }
         } break;
         }
 

--- a/src/framework/global/thirdparty/kors_async/async/async.h
+++ b/src/framework/global/thirdparty/kors_async/async/async.h
@@ -134,12 +134,17 @@ private:
         struct Func : public ICallable
         {
             Call func;
-            Func(const Call& f = nullptr)
-                : func(f) {}
+            Func(const Call& f)
+                : func(f)
+            {
+                assert(func && "callback is nullptr");
+            }
 
             void call(const void*) override
             {
-                func();
+                if (func) {
+                    func();
+                }
             }
         };
 

--- a/src/framework/global/thirdparty/kors_async/async/internal/rpcqueue.h
+++ b/src/framework/global/thirdparty/kors_async/async/internal/rpcqueue.h
@@ -74,6 +74,7 @@ private:
     std::vector<T> m_buffer;
     std::queue<T> m_pending;
     std::function<void(const T&)> m_handler;
+    bool m_isProcessing = false;
 
 public:
 
@@ -93,6 +94,19 @@ public:
         sendPending();
 
         assert(m_connPort);
+
+        assert(!m_isProcessing && "Recursive processing of messages is not allowed");
+
+        if (m_isProcessing) {
+            return;
+        }
+
+        struct Guard {
+            bool& flag;
+            Guard(bool& flag)
+                : flag(flag) { flag = true; }
+            ~Guard() { flag = false; }
+        } guard { m_isProcessing };
 
         // receive messages
         m_buffer.clear();

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 
 #include <QItemSelectionModel>
+#include <QTimer>
 
 #include "async/async.h"
 #include "translation.h"
@@ -425,7 +426,11 @@ bool ExportDialogModel::exportScores()
                    shouldDestinationFolderBeOpenedOnExport() };
 
     std::shared_ptr<IExportProjectScenario> scenario = exportProjectScenario();
-    async::Async::call(nullptr, [scenario, params]() {
+
+    //! NOTE We can't use Async here
+    // because the async::processMessages is called deep within the functions,
+    // and this can't be done in Async's callback.
+    QTimer::singleShot(0, [scenario, params]() {
         scenario->exportScores(params.notations, params.exportPath, params.selectedUnitType, params.openFolderOnExport);
     });
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32819 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy debug logging in the audio engine unless debug is enabled.
  * Added safety checks to async message handling to avoid invoking null callbacks.
  * Introduced a guard to task processing to prevent re-entrancy during message dispatch.
  * Switched export scheduling to the next event-loop iteration for more reliable deferred exports.
  * Simplified audio export generation to rely on channel processing for cancellation and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->