### PR TITLE
Update Qt to 6.11.2

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -106,11 +106,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
 
     - name: Setup environment

--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -106,11 +106,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
 
     - name: Setup environment

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -225,11 +225,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: ${{ matrix.qt-host }}
         target: 'desktop'
         arch: ${{ matrix.qt-arch }}
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -227,11 +227,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: ${{ matrix.qt-host }}
         target: 'desktop'
         arch: ${{ matrix.qt-arch }}
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -205,16 +205,16 @@ jobs:
           bash ./buildscripts/ci/tools/setup_ccache_config.sh
 
     - name: Install Qt
-      # uses: jurplel/install-qt-action@v4
-      # with:
-      #   version: 6.10.2
-      #   host: 'mac'
-      #   target: 'desktop'
-      #   arch: 'clang_64'
-      #   modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
-      #   cache: true
-      run: |
-        bash ./buildscripts/ci/macos/install_qt.sh
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.11.1
+        host: 'mac'
+        target: 'desktop'
+        arch: 'clang_64'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
+        cache: true
+      # run: |
+      #   bash ./buildscripts/ci/macos/install_qt.sh
 
     - parallel:
       - name: Generate _en.ts files

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -211,16 +211,16 @@ jobs:
           bash ./buildscripts/ci/tools/setup_ccache_config.sh
 
     - name: Install Qt
-      # uses: jurplel/install-qt-action@v4
-      # with:
-      #   version: 6.10.2
-      #   host: 'mac'
-      #   target: 'desktop'
-      #   arch: 'clang_64'
-      #   modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
-      #   cache: true
-      run: |
-        bash ./buildscripts/ci/macos/install_qt.sh
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.11.2
+        host: 'mac'
+        target: 'desktop'
+        arch: 'clang_64'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
+        cache: true
+      # run: |
+      #   bash ./buildscripts/ci/macos/install_qt.sh
 
     - parallel:
       - name: Generate _en.ts files

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -67,11 +67,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: all_os
         target: 'wasm'
         arch: wasm_singlethread
-        modules: 'qt5compat qtshadertools'
+        modules: 'qt5compat qtcanvaspainter qtshadertools qttasktree qtwebsockets'
         cache: true
 
     - name: Setup environment

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -67,11 +67,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: all_os
         target: 'wasm'
         arch: wasm_singlethread
-        modules: 'qt5compat qtshadertools'
+        modules: 'qt5compat qtcanvaspainter qtshadertools qttasktree qtwebsockets'
         cache: true
 
     - name: Setup environment

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -209,6 +209,8 @@ jobs:
           arch: 'win64_msvc2022_64'
           modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
+          # https://github.com/miurahr/aqtinstall/pull/1000#issuecomment-4109913885
+          aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
       - name: Setup environment
         run: |
           buildscripts\ci\windows\setup.bat
@@ -374,6 +376,8 @@ jobs:
           arch: 'win64_msvc2022_64'
           modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
+          # https://github.com/miurahr/aqtinstall/pull/1000#issuecomment-4109913885
+          aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
       - name: Setup environment
         run: |
           buildscripts\ci\windows\setup.bat --portable ON

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -203,11 +203,11 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.1
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
-          modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+          modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
       - name: Setup environment
         run: |
@@ -368,11 +368,11 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.1
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
-          modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+          modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
       - name: Setup environment
         run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -205,11 +205,11 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.2
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
-          modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+          modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
       - name: Setup environment
         run: |
@@ -392,11 +392,11 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.2
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
-          modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+          modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
       - name: Setup environment
         run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -211,6 +211,8 @@ jobs:
           arch: 'win64_msvc2022_64'
           modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
+          # https://github.com/miurahr/aqtinstall/pull/1000#issuecomment-4109913885
+          aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
       - name: Setup environment
         run: |
           buildscripts\ci\windows\setup.bat
@@ -398,6 +400,8 @@ jobs:
           arch: 'win64_msvc2022_64'
           modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
           cache: true
+          # https://github.com/miurahr/aqtinstall/pull/1000#issuecomment-4109913885
+          aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
       - name: Setup environment
         run: |
           buildscripts\ci\windows\setup.bat --portable ON

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -58,11 +58,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -58,11 +58,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -88,11 +88,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |
@@ -155,11 +155,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.1
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -88,11 +88,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |
@@ -155,11 +155,11 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10.2
+        version: 6.11.2
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
-        modules: 'qt5compat qtnetworkauth qtshadertools qtwebsockets'
+        modules: 'qt5compat qtcanvaspainter qtnetworkauth qtshadertools qttasktree qtwebsockets'
         cache: true
     - name: Setup environment
       run: |

--- a/.github/workflows/translate_lupdate.yml
+++ b/.github/workflows/translate_lupdate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.1
           host: "linux"
           target: "desktop"
           arch: "linux_gcc_64"

--- a/.github/workflows/translate_lupdate.yml
+++ b/.github/workflows/translate_lupdate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.2
           host: "linux"
           target: "desktop"
           arch: "linux_gcc_64"

--- a/.github/workflows/translate_tx_pull_to_s3.yml
+++ b/.github/workflows/translate_tx_pull_to_s3.yml
@@ -74,7 +74,7 @@ jobs:
         if: steps.configure.outputs.DO_PUSH_TO_S3 == 'true'
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.1
           host: "linux"
           target: "desktop"
           arch: "linux_gcc_64"

--- a/.github/workflows/translate_tx_pull_to_s3.yml
+++ b/.github/workflows/translate_tx_pull_to_s3.yml
@@ -74,7 +74,7 @@ jobs:
         if: steps.configure.outputs.DO_PUSH_TO_S3 == 'true'
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.10.2
+          version: 6.11.2
           host: "linux"
           target: "desktop"
           arch: "linux_gcc_64"

--- a/.vscode_template/README.md
+++ b/.vscode_template/README.md
@@ -28,7 +28,7 @@ sudo apt install lldb
 
 Edit `$HOME/.bashrc`, specify the current Qt, for example
 ```
-export QT_DIR=$HOME/Qt/6.10.1/gcc_64
+export QT_DIR=$HOME/Qt/6.11.1/gcc_64
 
 export PATH=$HOME/Qt/Tools/CMake/bin:$PATH
 export PATH=$HOME/Qt/Tools/Ninja:$PATH
@@ -59,4 +59,3 @@ Don't use the `flatpak` version because it has limited permissions; for example,
 * There will be a choice of cmake preset, select `Qt Clang Debug`.
 * There will be buttons on the bottom panel: Build, Debug, Run
 * Enjoy!
-

--- a/.vscode_template/README.md
+++ b/.vscode_template/README.md
@@ -28,7 +28,7 @@ sudo apt install lldb
 
 Edit `$HOME/.bashrc`, specify the current Qt, for example
 ```
-export QT_DIR=$HOME/Qt/6.10.1/gcc_64
+export QT_DIR=$HOME/Qt/6.11.2/gcc_64
 
 export PATH=$HOME/Qt/Tools/CMake/bin:$PATH
 export PATH=$HOME/Qt/Tools/Ninja:$PATH
@@ -59,4 +59,3 @@ Don't use the `flatpak` version because it has limited permissions; for example,
 * There will be a choice of cmake preset, select `Qt Clang Debug`.
 * There will be buttons on the bottom panel: Build, Debug, Run
 * Enjoy!
-

--- a/buildscripts/ci/linux/setup.sh
+++ b/buildscripts/ci/linux/setup.sh
@@ -29,7 +29,7 @@ BUILD_TOOLS=$HOME/build_tools
 ENV_FILE=$BUILD_TOOLS/environment.sh
 PACKARCH="x86_64" # x86_64, aarch64, wasm
 COMPILER="gcc" # gcc, clang
-EMSDK_VERSION="4.0.7" # for Qt 6.10
+EMSDK_VERSION="4.0.7" # for Qt 6.11.1
 BUILD_PIPEWIRE=
 
 while [[ "$#" -gt 0 ]]; do

--- a/buildscripts/ci/linux/setup.sh
+++ b/buildscripts/ci/linux/setup.sh
@@ -29,7 +29,7 @@ BUILD_TOOLS=$HOME/build_tools
 ENV_FILE=$BUILD_TOOLS/environment.sh
 PACKARCH="x86_64" # x86_64, aarch64, wasm
 COMPILER="gcc" # gcc, clang
-EMSDK_VERSION="4.0.7" # for Qt 6.10
+EMSDK_VERSION="4.0.7" # for Qt 6.11.2 (https://doc.qt.io/qt-6/wasm.html)
 BUILD_PIPEWIRE=
 
 while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
Important: this bumps the minimum supported macOS version from 10.15.4 all the way to 13.0. We can discuss backporting Qt to an older macOS version than that, but 10.15.4 is likely becoming too difficult.