### PR TITLE
not updating dead notes for transposition

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -184,6 +184,7 @@ void StringData::fretChords(Chord* chord) const
     };
 
     int strings = static_cast<int>(this->strings());
+    const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
 
     // we need the notes sorted in order of string (from highest to lowest) and then pitch
     std::map<int, Note*> sortedNotes;
@@ -246,7 +247,7 @@ void StringData::fretChords(Chord* chord) const
         nString = nNewString = note->string();
         nFret   = nNewFret   = note->fret();
         note->setFretConflict(false);           // assume no conflicts on this note
-        if (note->deadNote()) {
+        if (skipDeadNotes && note->deadNote()) {
             continue;
         }
         // if no fretting (any invalid fretting has been erased by sortChordNotes() )
@@ -305,7 +306,7 @@ void StringData::fretChords(Chord* chord) const
     // check for any remaining fret conflict
     for (auto& p : sortedNotes) {
         Note* note = p.second;
-        if (note->deadNote()) {
+        if (skipDeadNotes && note->deadNote()) {
             continue;
         }
         if (!note->negativeFretUsed() && (note->string() == -1 || bUsed[note->string()] > 1)) {
@@ -524,13 +525,14 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
 {
     int capoFret = chord->staff()->capo(chord->tick()).fretPosition;
+    const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
 
     bool anyReset = false;
     for (Note* note : chord->notes()) {
         if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
             continue;
         }
-        if (note->deadNote()) {
+        if (skipDeadNotes && note->deadNote()) {
             continue;
         }
         if (note->string() < 0 || note->fret() < 0) {
@@ -553,7 +555,7 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
             if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
                 continue;
             }
-            if (note->deadNote()) {
+            if (skipDeadNotes && note->deadNote()) {
                 continue;
             }
             note->setString(INVALID_STRING_INDEX);
@@ -576,6 +578,7 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
 void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* chord, int* count) const
 {
     bool useSameString = chord->configuration()->preferSameStringForTranspose();
+    const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
     int transp = chord->staff() ? chord->part()->instrument(chord->tick())->transpose().chromatic : 0;
     int pitchOffset = -transp + chord->staff()->pitchOffset(chord->segment()->tick());
 
@@ -594,8 +597,9 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
         int pitch = getPitch(string, noteFret, pitchOffsetAt(chord->staff(), chord->tick(), string));
         // if note not fretted yet or current fretting no longer valid,
         // use most convenient string as key
-        if (!note->deadNote() && !note->negativeFretUsed() && (string <= INVALID_STRING_INDEX || noteFret <= INVALID_FRET_INDEX
-                                                               || (pitchIsValid(pitch) && pitch != note->pitch()))) {
+        if (!(skipDeadNotes && note->deadNote()) && !note->negativeFretUsed()
+            && (string <= INVALID_STRING_INDEX || noteFret <= INVALID_FRET_INDEX
+                || (pitchIsValid(pitch) && pitch != note->pitch()))) {
             note->setString(INVALID_STRING_INDEX);
             note->setFret(INVALID_FRET_INDEX);
         }

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -246,6 +246,9 @@ void StringData::fretChords(Chord* chord) const
         nString = nNewString = note->string();
         nFret   = nNewFret   = note->fret();
         note->setFretConflict(false);           // assume no conflicts on this note
+        if (note->deadNote()) {
+            continue;
+        }
         // if no fretting (any invalid fretting has been erased by sortChordNotes() )
         if (nString == INVALID_STRING_INDEX /*|| nFret == INVALID_FRET_INDEX || getPitch(nString, nFret) != note->pitch()*/) {
             const CapoParams& capo = note->staff()->capo(note->tick());
@@ -302,6 +305,9 @@ void StringData::fretChords(Chord* chord) const
     // check for any remaining fret conflict
     for (auto& p : sortedNotes) {
         Note* note = p.second;
+        if (note->deadNote()) {
+            continue;
+        }
         if (!note->negativeFretUsed() && (note->string() == -1 || bUsed[note->string()] > 1)) {
             note->setFretConflict(true);
         }
@@ -509,6 +515,12 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
     return fret;
 }
 
+//---------------------------------------------------------
+//   sortChordNotesUseSameString
+//    Tries to keep each note on its currently assigned string when the
+//    chord's pitches are transposed, updating only the fret.
+//---------------------------------------------------------
+
 void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
 {
     int capoFret = chord->staff()->capo(chord->tick()).fretPosition;
@@ -516,6 +528,9 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
     bool anyReset = false;
     for (Note* note : chord->notes()) {
         if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
+            continue;
+        }
+        if (note->deadNote()) {
             continue;
         }
         if (note->string() < 0 || note->fret() < 0) {
@@ -536,6 +551,9 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
     if (anyReset) {
         for (Note* note : chord->notes()) {
             if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
+                continue;
+            }
+            if (note->deadNote()) {
                 continue;
             }
             note->setString(INVALID_STRING_INDEX);
@@ -576,8 +594,8 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
         int pitch = getPitch(string, noteFret, pitchOffsetAt(chord->staff(), chord->tick(), string));
         // if note not fretted yet or current fretting no longer valid,
         // use most convenient string as key
-        if (!note->negativeFretUsed() && (string <= INVALID_STRING_INDEX || noteFret <= INVALID_FRET_INDEX
-                                          || (pitchIsValid(pitch) && pitch != note->pitch()))) {
+        if (!note->deadNote() && !note->negativeFretUsed() && (string <= INVALID_STRING_INDEX || noteFret <= INVALID_FRET_INDEX
+                                                               || (pitchIsValid(pitch) && pitch != note->pitch()))) {
             note->setString(INVALID_STRING_INDEX);
             note->setFret(INVALID_FRET_INDEX);
         }

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -538,6 +538,10 @@ Interval Transpose::keydiff2Interval(Key oKey, Key nKey, TransposeDirection dir)
 bool Transpose::transposeNote(Note* note, TransposeMode mode, int transposeInterval, bool trKeys, bool useDoubleSharpsFlats,
                               Interval interval)
 {
+    if (note->deadNote()) {
+        return true;
+    }
+
     if (mode == TransposeMode::DIATONICALLY) {
         return note->transposeDiatonic(transposeInterval, trKeys, useDoubleSharpsFlats);
     }

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -538,7 +538,7 @@ Interval Transpose::keydiff2Interval(Key oKey, Key nKey, TransposeDirection dir)
 bool Transpose::transposeNote(Note* note, TransposeMode mode, int transposeInterval, bool trKeys, bool useDoubleSharpsFlats,
                               Interval interval)
 {
-    if (note->deadNote()) {
+    if (note->deadNote() && note->configuration()->keepDeadNotesUnchangedOnTranspose()) {
         return true;
     }
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -141,5 +141,6 @@ public:
     virtual bool specificSlursLayoutWorkaround() const = 0;
     virtual bool preferSameStringForTranspose() const = 0;
     virtual void setPreferSameStringForTranspose(bool preferSameString) = 0;
+    virtual bool keepDeadNotesUnchangedOnTranspose() const = 0;
 };
 }

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -478,3 +478,8 @@ bool EngravingConfiguration::preferSameStringForTranspose() const
 void EngravingConfiguration::setPreferSameStringForTranspose(bool /*preferSameString*/)
 {
 }
+
+bool EngravingConfiguration::keepDeadNotesUnchangedOnTranspose() const
+{
+    return false;
+}

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -116,6 +116,7 @@ public:
     bool specificSlursLayoutWorkaround() const override;
     bool preferSameStringForTranspose() const override;
     void setPreferSameStringForTranspose(bool preferSameString) override;
+    bool keepDeadNotesUnchangedOnTranspose() const override;
 
 private:
     muse::async::Channel<voice_idx_t, Color> m_voiceColorChanged;

--- a/src/engraving/tests/CMakeLists.txt
+++ b/src/engraving/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/timesig_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tools_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transpose_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tab_transpose_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tuplet_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/unrollrepeats_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/changevisibility_tests.cpp

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -103,5 +103,6 @@ public:
     MOCK_METHOD(bool, specificSlursLayoutWorkaround, (), (const, override));
     MOCK_METHOD(bool, preferSameStringForTranspose, (), (const, override));
     MOCK_METHOD(void, setPreferSameStringForTranspose, (bool), (override));
+    MOCK_METHOD(bool, keepDeadNotesUnchangedOnTranspose, (), (const, override));
 };
 }

--- a/src/engraving/tests/tab_transpose_data/dead_notes.mscx
+++ b/src/engraving/tests/tab_transpose_data/dead_notes.mscx
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              <fret>5</fret>
+              <string>3</string>
+            </Note>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>0</fret>
+              <string>4</string>
+            </Note>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <head>cross</head>
+              <fret>7</fret>
+              <string>1</string>
+              <dead>1</dead>
+            </Note>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <head>cross</head>
+              <fret>7</fret>
+              <string>4</string>
+              <dead>1</dead>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -115,6 +115,7 @@ protected:
         if (m_mock) {
             ON_CALL(*m_mock, preferSameStringForTranspose()).WillByDefault(::testing::Return(false));
             ON_CALL(*m_mock, negativeFretsAllowed()).WillByDefault(::testing::Return(false));
+            ON_CALL(*m_mock, keepDeadNotesUnchangedOnTranspose()).WillByDefault(::testing::Return(false));
         }
     }
 
@@ -123,6 +124,12 @@ protected:
         ASSERT_NE(m_mock, nullptr);
         ON_CALL(*m_mock, preferSameStringForTranspose()).WillByDefault(::testing::Return(preferSameStringForTranspose));
         ON_CALL(*m_mock, negativeFretsAllowed()).WillByDefault(::testing::Return(negativeFretsAllowed));
+    }
+
+    void setKeepDeadNotes(bool keep)
+    {
+        ASSERT_NE(m_mock, nullptr);
+        ON_CALL(*m_mock, keepDeadNotesUnchangedOnTranspose()).WillByDefault(::testing::Return(keep));
     }
 
     ECMock* m_mock = nullptr;
@@ -196,11 +203,13 @@ static void assertDeadNotesUnchangedByTransposeImpl(MasterScore* score)
     }
 }
 
-// Dead notes must be completely ignored during transpose — their string,
-// fret, and pitch must not change. Verify for both the typical configuration
-// (flags false) and the alternate behavior (flags true).
+// When keepDeadNotesUnchangedOnTranspose is enabled, dead notes must be
+// completely ignored — their string, fret, and pitch must not change.
+// Verify across both fretting-flag combinations.
 TEST_F(Engraving_TabTransposeTests, deadNotesUnchangedByTranspose)
 {
+    setKeepDeadNotes(true);
+
     struct FlagCase {
         bool preferSameString;
         bool negativeFretsAllowed;
@@ -216,4 +225,43 @@ TEST_F(Engraving_TabTransposeTests, deadNotesUnchangedByTranspose)
         assertDeadNotesUnchangedByTransposeImpl(score);
         delete score;
     }
+}
+
+// With the default configuration (keepDeadNotesUnchangedOnTranspose disabled),
+// dead notes are transposed like any other note
+TEST_F(Engraving_TabTransposeTests, deadNotesTransposedWithNormalFlow)
+{
+    // keepDeadNotesUnchangedOnTranspose defaults to false — no explicit setup needed.
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "dead_notes.mscx");
+    ASSERT_TRUE(score);
+
+    auto notesBefore = collectTabNotes(score);
+    std::vector<int> deadPitchesBefore;
+    for (const auto& n : notesBefore) {
+        if (n.dead) {
+            deadPitchesBefore.push_back(n.pitch);
+        }
+    }
+    ASSERT_EQ(deadPitchesBefore.size(), 2u) << "fixture must contain 2 dead notes";
+
+    constexpr int kSemitones = 2;
+    transposeScore(score, kSemitones);
+
+    auto notesAfter = collectTabNotes(score);
+    std::vector<int> deadPitchesAfter;
+    for (const auto& n : notesAfter) {
+        if (n.dead) {
+            deadPitchesAfter.push_back(n.pitch);
+        }
+    }
+    ASSERT_EQ(deadPitchesAfter.size(), 2u);
+
+    std::sort(deadPitchesBefore.begin(), deadPitchesBefore.end());
+    std::sort(deadPitchesAfter.begin(),  deadPitchesAfter.end());
+    for (size_t i = 0; i < deadPitchesBefore.size(); ++i) {
+        EXPECT_EQ(deadPitchesAfter[i], deadPitchesBefore[i] + kSemitones)
+            << "dead note pitch should change with default (MuseScore) configuration";
+    }
+
+    delete score;
 }

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "engraving/dom/chord.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/measure.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/segment.h"
+#include "engraving/editing/transpose.h"
+
+#include "mocks/engravingconfigurationmock.h"
+
+#include "utils/scorerw.h"
+
+#include "global/modularity/ioc.h"
+
+using namespace mu::engraving;
+using ECMock = ::testing::NiceMock<EngravingConfigurationMock>;
+
+static const String DATA_DIR("tab_transpose_data/");
+
+struct TabNote {
+    int string = -1;
+    int fret = -1;
+    int pitch = -1;
+    bool dead = false;
+};
+
+static std::vector<TabNote> collectTabNotes(MasterScore* score)
+{
+    std::vector<TabNote> result;
+    Measure* m = score->firstMeasure();
+    if (!m) {
+        return result;
+    }
+    for (Segment& seg : m->segments()) {
+        if (!seg.isChordRestType()) {
+            continue;
+        }
+        for (track_idx_t trk = 0; trk < VOICES; ++trk) {
+            EngravingItem* el = seg.element(trk);
+            if (!el || !el->isChord()) {
+                continue;
+            }
+            Chord* chord = toChord(el);
+            for (Note* note : chord->notes()) {
+                result.push_back({ note->string(), note->fret(), note->pitch(), note->deadNote() });
+            }
+        }
+    }
+    return result;
+}
+
+static void transposeScore(MasterScore* score, int semitones)
+{
+    // allIntervals indices for semitones 0-11: P1 m2 M2 m3 M3 P4 TT P5 m6 M6 m7 M7
+    // Mirrors the internal lookup table used by Interval::chromatic2diatonic.
+    static constexpr int kIntervalIdx[12] = { 0, 3, 4, 7, 8, 11, 12, 14, 17, 18, 21, 22 };
+
+    score->cmdSelectAll();
+    score->startCmd(TranslatableString::untranslatable("fretting test"));
+
+    const TransposeDirection dir = semitones < 0 ? TransposeDirection::DOWN : TransposeDirection::UP;
+    const int abs = std::abs(semitones);
+    const int remainder = abs % 12;
+    const int octaves = abs / 12;
+
+    if (remainder != 0) {
+        Transpose::transpose(score, TransposeMode::BY_INTERVAL, dir, Key::C,
+                             kIntervalIdx[remainder], true, true, true);
+    }
+    for (int i = 0; i < octaves; i++) {
+        Transpose::transpose(score, TransposeMode::BY_INTERVAL, dir, Key::C, 25, true, true, true);
+    }
+
+    score->endCmd();
+    score->doLayout();
+}
+
+class Engraving_TabTransposeTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        auto mock = muse::modularity::globalIoc()->resolve<IEngravingConfiguration>("utests");
+        m_mock = dynamic_cast<ECMock*>(mock.get());
+        ASSERT_NE(m_mock, nullptr);
+    }
+
+    void TearDown() override
+    {
+        if (m_mock) {
+            ON_CALL(*m_mock, preferSameStringForTranspose()).WillByDefault(::testing::Return(false));
+            ON_CALL(*m_mock, negativeFretsAllowed()).WillByDefault(::testing::Return(false));
+        }
+    }
+
+    void setFrettingFlags(bool preferSameStringForTranspose, bool negativeFretsAllowed)
+    {
+        ASSERT_NE(m_mock, nullptr);
+        ON_CALL(*m_mock, preferSameStringForTranspose()).WillByDefault(::testing::Return(preferSameStringForTranspose));
+        ON_CALL(*m_mock, negativeFretsAllowed()).WillByDefault(::testing::Return(negativeFretsAllowed));
+    }
+
+    ECMock* m_mock = nullptr;
+};
+
+static void assertDeadNotesUnchangedByTransposeImpl(MasterScore* score)
+{
+    ASSERT_TRUE(score);
+
+    auto notesBefore = collectTabNotes(score);
+    ASSERT_EQ(notesBefore.size(), 4u);
+
+    // Snapshot all dead notes before transpose.
+    std::vector<TabNote> deadBefore;
+    std::vector<TabNote> liveBefore;
+    for (const auto& n : notesBefore) {
+        if (n.dead) {
+            deadBefore.push_back(n);
+        } else {
+            liveBefore.push_back(n);
+        }
+    }
+    ASSERT_EQ(deadBefore.size(), 2u) << "fixture must contain 2 dead notes";
+    ASSERT_EQ(liveBefore.size(), 2u) << "fixture must contain 2 live notes";
+
+    constexpr int kSemitones = 2;
+    transposeScore(score, kSemitones);
+
+    auto notesAfter = collectTabNotes(score);
+    ASSERT_EQ(notesAfter.size(), 4u);
+
+    // All dead notes must still exist and remain unchanged.
+    std::vector<TabNote> deadAfter;
+    std::vector<TabNote> liveAfter;
+    for (const auto& n : notesAfter) {
+        if (n.dead) {
+            deadAfter.push_back(n);
+        } else {
+            liveAfter.push_back(n);
+        }
+    }
+    ASSERT_EQ(deadAfter.size(), deadBefore.size()) << "dead notes count changed after transpose";
+    ASSERT_EQ(liveAfter.size(), liveBefore.size()) << "live notes count changed after transpose";
+
+    std::vector<TabNote> deadAfterRemaining = deadAfter;
+    for (const auto& db : deadBefore) {
+        auto it = std::find_if(deadAfterRemaining.begin(), deadAfterRemaining.end(), [&](const TabNote& da) {
+            return da.string == db.string && da.fret == db.fret && da.pitch == db.pitch && da.dead == db.dead;
+        });
+        EXPECT_NE(it, deadAfterRemaining.end())
+            << "dead note changed or disappeared after transpose (string=" << db.string
+            << ", fret=" << db.fret << ", pitch=" << db.pitch << ")";
+        if (it != deadAfterRemaining.end()) {
+            deadAfterRemaining.erase(it);
+        }
+    }
+
+    // Live notes must all be transposed by the expected interval.
+    std::vector<int> livePitchesBefore, livePitchesAfter;
+    for (const auto& n : liveBefore) {
+        livePitchesBefore.push_back(n.pitch);
+    }
+    for (const auto& n : liveAfter) {
+        livePitchesAfter.push_back(n.pitch);
+    }
+    std::sort(livePitchesBefore.begin(), livePitchesBefore.end());
+    std::sort(livePitchesAfter.begin(),  livePitchesAfter.end());
+    for (size_t i = 0; i < livePitchesBefore.size(); ++i) {
+        EXPECT_EQ(livePitchesAfter[i], livePitchesBefore[i] + kSemitones)
+            << "live note pitch did not change by expected transpose interval";
+    }
+}
+
+// Dead notes must be completely ignored during transpose — their string,
+// fret, and pitch must not change. Verify for both the typical configuration
+// (flags false) and the alternate behavior (flags true).
+TEST_F(Engraving_TabTransposeTests, deadNotesUnchangedByTranspose)
+{
+    struct FlagCase {
+        bool preferSameString;
+        bool negativeFretsAllowed;
+    };
+    constexpr FlagCase flagCases[] = {
+        { false, false },
+        { true,  true },
+    };
+
+    for (const auto& c : flagCases) {
+        setFrettingFlags(c.preferSameString, c.negativeFretsAllowed);
+        MasterScore* score = ScoreRW::readScore(DATA_DIR + "dead_notes.mscx");
+        assertDeadNotesUnchangedByTransposeImpl(score);
+        delete score;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dead (inactive) notes are now skipped during transposition, preventing inadvertent pitch/TPC changes.
  * Dead notes are excluded from accidental-state updates, avoiding accidental removal or forced state changes.
  * Dead notes no longer participate in chord fretting or string/fret conflict resolution, preventing incorrect reassignments and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->