### PR TITLE
ci: Fix concurrency groups

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -42,7 +42,9 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
+  # which is the same for all workflows called in that run, hence we must add a unique suffix here.
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }} backend
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -49,7 +49,9 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
+  # which is the same for all workflows called in that run, hence we must add a unique suffix here.
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }} linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -40,7 +40,9 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
+  # which is the same for all workflows called in that run, hence we must add a unique suffix here.
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }} macos
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -17,7 +17,9 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
+  # which is the same for all workflows called in that run, hence we must add a unique suffix here.
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }} wasm
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -48,13 +48,16 @@ on:
         type: string
         required: false
 
+concurrency:
+  # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
+  # which is the same for all workflows called in that run, hence we must add a unique suffix here.
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }} windows
+  cancel-in-progress: true
+
 jobs:
   windows_x64:
     if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_x64')
     runs-on: windows-2025
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-native
-      cancel-in-progress: true
     steps:
     - name: Clone repository
       uses: actions/checkout@v6
@@ -245,9 +248,6 @@ jobs:
       github.event_name != 'pull_request' &&
       (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_portable'))
     runs-on: windows-2025
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-portable
-      cancel-in-progress: true
     steps:
     - name: Clone repository
       uses: actions/checkout@v6

--- a/.github/workflows/build_without_qt.yml
+++ b/.github/workflows/build_without_qt.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -13,7 +13,7 @@ on:
     - cron: "0 3 * * 4" # Every Thursday night at 03:00 for master branch
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }} ${{ github.event_name }} ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Resolves: #32865 

Reused workflows inherit `${{ github.workflow }}` from its callee, meaning all of them evaluate to "Build: All" when used from that workflow.

This PR fixes this by giving them fixed names. Also, make `cancel-in-progress` only true for PR runs.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI concurrency/grouping to reduce redundant runs across build targets (backend, Linux, macOS, Windows, WebAssembly, Qt-less) and tests.
  * Centralized concurrency for Windows builds.
  * Made cancellation behavior conditional for visual tests to limit unnecessary background jobs and speed feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->