### PR TITLE
fixed assert on cancel audio export

### DIFF
--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -101,7 +101,9 @@ Ret SoundTrackWriter::write()
     m_source->setIsActive(true);
 
     DEFER {
-        m_encoderPtr->end();
+        if (!m_isAborted) {
+            m_encoderPtr->end();
+        }
 
         audioEngine()->setMode(RenderMode::IdleMode);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled audio exports to prevent encoder finalization errors when export operations are aborted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->