### PR TITLE
Removed the use of services in the splash screen

### DIFF
--- a/src/appshell/widgets/splashscreen/loadingscreenview.cpp
+++ b/src/appshell/widgets/splashscreen/loadingscreenview.cpp
@@ -26,8 +26,10 @@
 #include <QPainter>
 #include <QScreen>
 #include <QSvgRenderer>
+#include <QFontDatabase>
 
 #include "translation.h"
+#include "global/internal/baseapplication.h"
 
 using namespace mu::appshell;
 
@@ -45,7 +47,7 @@ static const QColor versionNumberColor("#19F3FF");
 static constexpr qreal versionNumberSpacing = 5.0;
 
 LoadingScreenView::LoadingScreenView(QWidget* parent)
-    : QWidget(parent), muse::Contextable(muse::iocCtxForQWidget(parent)),
+    : QWidget(parent),
     m_backgroundRenderer(new QSvgRenderer(imagePath, this))
 {
     setAttribute(Qt::WA_TranslucentBackground);
@@ -73,9 +75,7 @@ void LoadingScreenView::draw(QPainter* painter)
     m_backgroundRenderer->render(painter);
 
     // Draw message
-    QFont font(QString::fromStdString(uiConfiguration()->fontFamily()));
-    font.setPixelSize(uiConfiguration()->fontSize());
-
+    QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
     painter->setFont(font);
 
     QPen pen(messageColor);
@@ -83,8 +83,7 @@ void LoadingScreenView::draw(QPainter* painter)
 
     painter->drawText(messageRect, Qt::AlignTop | Qt::AlignLeft | Qt::TextDontClip, m_message);
 
-    Qt::AlignmentFlag alignment = languagesService()->currentLanguage().direction == Qt::RightToLeft
-                                  ? Qt::AlignLeft : Qt::AlignRight;
+    Qt::AlignmentFlag alignment = layoutDirection() == Qt::RightToLeft ? Qt::AlignLeft : Qt::AlignRight;
 
     // Draw website URL
     QRectF websiteBoundingRect;
@@ -96,5 +95,5 @@ void LoadingScreenView::draw(QPainter* painter)
 
     painter->drawText(websiteRect.translated(0.0, -websiteBoundingRect.height() - versionNumberSpacing),
                       Qt::AlignBottom | alignment | Qt::TextDontClip,
-                      muse::qtrc("appshell", "Version %1").arg(application()->fullVersion().toString()));
+                      muse::qtrc("appshell", "Version %1").arg(muse::BaseApplication::appFullVersion().toString()));
 }

--- a/src/appshell/widgets/splashscreen/loadingscreenview.h
+++ b/src/appshell/widgets/splashscreen/loadingscreenview.h
@@ -24,21 +24,12 @@
 
 #include <QWidget>
 
-#include "modularity/ioc.h"
-#include "ui/iuiconfiguration.h"
-#include "languages/ilanguagesservice.h"
-#include "global/iapplication.h"
-
 class QSvgRenderer;
 
 namespace mu::appshell {
-class LoadingScreenView : public QWidget, public muse::Contextable
+class LoadingScreenView : public QWidget
 {
     Q_OBJECT
-
-    muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
-    muse::GlobalInject<muse::languages::ILanguagesService> languagesService;
-    muse::GlobalInject<muse::IApplication> application;
 
 public:
     explicit LoadingScreenView(QWidget* parent = nullptr);

--- a/src/appshell/widgets/splashscreen/newinstanceloadingscreenview.cpp
+++ b/src/appshell/widgets/splashscreen/newinstanceloadingscreenview.cpp
@@ -25,13 +25,14 @@
 #include <QApplication>
 #include <QPainter>
 #include <QScreen>
+#include <QFontDatabase>
 
 #include "translation.h"
 
 using namespace mu::appshell;
 
 NewInstanceLoadingScreenView::NewInstanceLoadingScreenView(bool forNewScore, const QString& openingFileName, QWidget* parent)
-    : QWidget(parent), muse::Contextable(muse::iocCtxForQWidget(this))
+    : QWidget(parent)
 {
     setAttribute(Qt::WA_TranslucentBackground);
 
@@ -70,17 +71,15 @@ void NewInstanceLoadingScreenView::draw(QPainter* painter)
     painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 
     // Draw background
-    QString bgColorStr = uiConfiguration()->currentTheme().values.value(muse::ui::BACKGROUND_PRIMARY_COLOR).toString();
+    QString bgColorStr = "#00081C";
     painter->fillRect(0, 0, width(), height(), QColor(bgColorStr));
 
     // Draw message
-    QFont font(QString::fromStdString(uiConfiguration()->fontFamily()));
-    font.setPixelSize(uiConfiguration()->fontSize(muse::ui::FontSizeType::BODY_LARGE));
+    QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
     font.setBold(true);
-
     painter->setFont(font);
 
-    QString messageColorStr = uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString();
+    QString messageColorStr = "#F1F1EE";
     QPen pen(messageColorStr);
     painter->setPen(pen);
 

--- a/src/appshell/widgets/splashscreen/newinstanceloadingscreenview.h
+++ b/src/appshell/widgets/splashscreen/newinstanceloadingscreenview.h
@@ -20,24 +20,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_APPSHELL_NEWINSTANCELOADINSCREENVIEW_H
-#define MU_APPSHELL_NEWINSTANCELOADINSCREENVIEW_H
+#pragma once
 
 #include <QWidget>
-
-#include "modularity/ioc.h"
-#include "ui/iuiconfiguration.h"
-#include "languages/ilanguagesservice.h"
 
 class QSvgRenderer;
 
 namespace mu::appshell {
-class NewInstanceLoadingScreenView : public QWidget, public muse::Contextable
+class NewInstanceLoadingScreenView : public QWidget
 {
     Q_OBJECT
-
-    muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
-    muse::GlobalInject<muse::languages::ILanguagesService> languagesService;
 
 public:
     explicit NewInstanceLoadingScreenView(bool forNewScore, const QString& openingFileName, QWidget* parent = nullptr);
@@ -51,5 +43,3 @@ private:
     QSize m_dialogSize;
 };
 }
-
-#endif // MU_APPSHELL_NEWINSTANCELOADINSCREENVIEW_H

--- a/src/appshell/widgets/splashscreen/splashscreen.h
+++ b/src/appshell/widgets/splashscreen/splashscreen.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_APPSHELL_SPLASHSCREEN_H
-#define MU_APPSHELL_SPLASHSCREEN_H
+#pragma once
 
 #include <QWidget>
 
@@ -47,5 +46,3 @@ private:
     QWidget* m_view = nullptr;
 };
 }
-
-#endif // MU_APPSHELL_SPLASHSCREEN_H


### PR DESCRIPTION
Resolves: 
https://github.com/musescore/MuseScore/issues/32875
https://github.com/musescore/MuseScore/issues/32720 


Services can be used after initialization (load lang, init theme)
But if the services are initialized, then the application is ready to work, there is no point in showing a splash screen.

We need to show a splash screen before initializing services. This means we can't use services in a splash screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Loading screens now use the system font and fixed color values instead of external theme/configuration, and determine text alignment from the widget’s layout direction. Version display source was standardized and loading components no longer rely on injected configuration services, producing more consistent startup visuals and fewer external dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->