### PR TITLE
Fix #26174: Prevent grid lines from overlapping scrollbar in Accidentals

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/MoreElementsPopup.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/MoreElementsPopup.qml
@@ -230,7 +230,9 @@ StyledPopupView {
                                 )
                     width: parent.contentWidth
 
-                    ScrollBar.vertical: StyledScrollBar {}
+                    ScrollBar.vertical: StyledScrollBar {
+                        z : 100
+                    }
 
                     // TODO: change settings to "hidden" model?
                     cellSize: root.cellSize

--- a/src/palette/qml/MuseScore/Palette/internal/MoreElementsPopup.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/MoreElementsPopup.qml
@@ -230,9 +230,7 @@ StyledPopupView {
                                 )
                     width: parent.contentWidth
 
-                    ScrollBar.vertical: StyledScrollBar {
-                        z : 100
-                    }
+                    ScrollBar.vertical: StyledScrollBar {}
 
                     // TODO: change settings to "hidden" model?
                     cellSize: root.cellSize

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
@@ -143,63 +143,6 @@ StyledGridView {
         horizontalAlignment: Text.AlignLeft
     }
 
-    Rectangle {
-        id: moreButtonRect
-
-        anchors.bottom: parent.bottom
-        anchors.right: parent.right
-        implicitWidth: 64
-        width: {
-            if (paletteView.empty) {
-                return implicitWidth;
-            }
-
-            // align to the left border of some palette cell
-            var addition = (parent.width - implicitWidth) % paletteView.cellWidth - 1; // -1 allows to fit into a cell if palette grid is visible
-            if (addition < 0) {
-                addition += paletteView.cellWidth;
-            }
-
-            return implicitWidth + addition;
-        }
-
-        height: paletteView.cellHeight - (paletteView.oneRow ? 0 : 1)
-        visible: paletteView.showMoreButton
-        color: background.color
-
-        z: 1
-
-        FlatButton {
-            id: moreButton
-
-            anchors.fill: parent
-
-            visible: paletteView.isInVisibleArea
-
-            navigation.panel: paletteView.navigationPanel
-            //! NOTE Just Up/Down navigation now
-            navigation.row: paletteView.ncells + paletteView.navigationRow
-            navigation.column: 1
-
-            onActiveFocusChanged: {
-                if (activeFocus) {
-                    paletteView.setCurrentTreeItemRequested(this);
-
-                    if (ui.keyboardModifiers() === Qt.NoModifier) {
-                        paletteView.selectionModel.clearSelection();
-                    }
-                }
-            }
-
-            //: Caption of a button to reveal more elements
-            text: qsTrc("palette", "More")
-
-            transparent: true
-            accentButton: true
-
-            onClicked: paletteView.moreButtonClicked(moreButton)
-        }
-    }
 
     PlaceholderManager {
         id: placeholder
@@ -699,5 +642,61 @@ StyledGridView {
         offsetY: parent.contentY
         cellWidth: parent.cellWidth
         cellHeight: parent.cellHeight
+    }
+
+    Rectangle {
+        id: moreButtonRect
+
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        implicitWidth: 64
+        width: {
+            if (paletteView.empty) {
+                return implicitWidth;
+            }
+
+            // align to the left border of some palette cell
+            var addition = (parent.width - implicitWidth) % paletteView.cellWidth - 1; // -1 allows to fit into a cell if palette grid is visible
+            if (addition < 0) {
+                addition += paletteView.cellWidth;
+            }
+
+            return implicitWidth + addition;
+        }
+
+        height: paletteView.cellHeight - (paletteView.oneRow ? 0 : 1)
+        visible: paletteView.showMoreButton
+        color: background.color
+
+        FlatButton {
+            id: moreButton
+
+            anchors.fill: parent
+
+            visible: paletteView.isInVisibleArea
+
+            navigation.panel: paletteView.navigationPanel
+            //! NOTE Just Up/Down navigation now
+            navigation.row: paletteView.ncells + paletteView.navigationRow
+            navigation.column: 1
+
+            onActiveFocusChanged: {
+                if (activeFocus) {
+                    paletteView.setCurrentTreeItemRequested(this);
+
+                    if (ui.keyboardModifiers() === Qt.NoModifier) {
+                        paletteView.selectionModel.clearSelection();
+                    }
+                }
+            }
+
+            //: Caption of a button to reveal more elements
+            text: qsTrc("palette", "More")
+
+            transparent: true
+            accentButton: true
+
+            onClicked: paletteView.moreButtonClicked(moreButton)
+        }
     }
 }

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
@@ -167,7 +167,7 @@ StyledGridView {
         visible: paletteView.showMoreButton
         color: background.color
 
-        z: grid.z + 1
+        z: 1
 
         FlatButton {
             id: moreButton
@@ -211,126 +211,114 @@ StyledGridView {
         interval: 400
     }
 
-    PaletteGridLinesCanvas {
-        id: grid
-        z: 1
+    DropArea {
+        id: paletteDropArea
         anchors.fill: parent
-        drawGrid: parent.drawGrid && !parent.empty
-        stretchWidth: paletteView.stretchWidth
-        offsetX: parent.contentX
-        offsetY: parent.contentY
-        cellWidth: parent.cellWidth
-        cellHeight: parent.cellHeight
 
-        DropArea {
-            id: paletteDropArea
-            anchors.fill: parent
+        property var action
+        property int proposedAction: Qt.IgnoreAction
+        property bool internal: false
 
-            property var action
-            property int proposedAction: Qt.IgnoreAction
-            property bool internal: false
-
-            function onDrag(drag) {
-                if (drag.proposedAction !== proposedAction) {
-                    onEntered(drag);
-                    return;
-                }
-
-                if (drag.source.dragged) {
-                    drag.source.internalDrag = internal;
-                    drag.source.dragCopy = action === Qt.CopyAction;
-                    paletteView.state = "drag";
-                    drag.source.paletteDrag = true;
-                } else if (typeof drag.source.paletteDrag !== "undefined") { // if this is a palette and not, e.g., scoreview
-                    return;
-                }
-
-                drag.accept(action); // confirm we accept the action we determined inside onEntered
-
-                var idx = paletteView.indexAt(drag.x, drag.y);
-                if (idx === -1) {
-                    idx = paletteView.paletteModel.rowCount(paletteView.paletteRootIndex) - (internal ? 1 : 0);
-                }
-
-                if (placeholder.active && placeholder.index === idx) {
-                    return;
-                }
-
-                placeholder.makePlaceholder(idx, { decoration: ui.theme.textFieldColor, toolTip: "placeholder", accessibleText: "", cellActive: false, mimeData: {} });
+        function onDrag(drag) {
+            if (drag.proposedAction !== proposedAction) {
+                onEntered(drag);
+                return;
             }
 
-            onEntered: function(drag) {
+            if (drag.source.dragged) {
+                drag.source.internalDrag = internal;
+                drag.source.dragCopy = action === Qt.CopyAction;
+                paletteView.state = "drag";
+                drag.source.paletteDrag = true;
+            } else if (typeof drag.source.paletteDrag !== "undefined") { // if this is a palette and not, e.g., scoreview
+                return;
+            }
+
+            drag.accept(action); // confirm we accept the action we determined inside onEntered
+
+            var idx = paletteView.indexAt(drag.x, drag.y);
+            if (idx === -1) {
+                idx = paletteView.paletteModel.rowCount(paletteView.paletteRootIndex) - (internal ? 1 : 0);
+            }
+
+            if (placeholder.active && placeholder.index === idx) {
+                return;
+            }
+
+            placeholder.makePlaceholder(idx, { decoration: ui.theme.textFieldColor, toolTip: "placeholder", accessibleText: "", cellActive: false, mimeData: {} });
+        }
+
+        onEntered: function(drag) {
+            onDragOverPaletteFinished();
+
+            // first check if controller allows dropping this item here
+            const mimeData = PaletteUtils.dropEventMimeData(drag);
+            internal = (drag.source.parentModelIndex === paletteView.paletteRootIndex);
+            action = paletteView.paletteController.dropAction(mimeData, drag.proposedAction, paletteView.paletteRootIndex, internal);
+            proposedAction = drag.proposedAction;
+
+            if (action !== Qt.MoveAction) {
+                internal = false;
+            }
+
+            const accept = (action & drag.supportedActions) && (internal || !paletteView.externalDropBlocked);
+
+            if (accept) {
+                drag.accept(action);
+            } else {
+                drag.accepted = false;
+            }
+
+            // If event is accepted, process the drag in a usual way
+            if (drag.accepted) {
+                onDrag(drag);
+            }
+        }
+
+        onPositionChanged: function(drag) {
+            onDrag(drag)
+        }
+
+        function onDragOverPaletteFinished() {
+            if (placeholder.active) {
+                placeholder.removePlaceholder();
+                paletteView.state = "default";
+            }
+
+            if (drag.source && drag.source.parentModelIndex === paletteView.paletteRootIndex) {
+                drag.source.internalDrag = false;
+            }
+        }
+
+        onExited: onDragOverPaletteFinished();
+
+        onDropped: function(drop) {
+            if (!action) {
                 onDragOverPaletteFinished();
-
-                // first check if controller allows dropping this item here
-                const mimeData = PaletteUtils.dropEventMimeData(drag);
-                internal = (drag.source.parentModelIndex === paletteView.paletteRootIndex);
-                action = paletteView.paletteController.dropAction(mimeData, drag.proposedAction, paletteView.paletteRootIndex, internal);
-                proposedAction = drag.proposedAction;
-
-                if (action !== Qt.MoveAction) {
-                    internal = false;
-                }
-
-                const accept = (action & drag.supportedActions) && (internal || !paletteView.externalDropBlocked);
-
-                if (accept) {
-                    drag.accept(action);
-                } else {
-                    drag.accepted = false;
-                }
-
-                // If event is accepted, process the drag in a usual way
-                if (drag.accepted) {
-                    onDrag(drag);
-                }
+                return;
             }
 
-            onPositionChanged: function(drag) {
-                onDrag(drag)
+            const destIndex = placeholder.active ? placeholder.index : paletteView.paletteModel.rowCount(paletteView.paletteRootIndex);
+            onDragOverPaletteFinished();
+
+            // Moving cells here causes Drag.onDragFinished be not called properly.
+            // Therefore record the necessary information to move cells later.
+            const data = {
+                action: action,
+                srcParentModelIndex: drag.source.parentModelIndex,
+                srcRowIndex: drag.source.rowIndex,
+                paletteView: paletteView,
+                destIndex: destIndex,
+                mimeData: PaletteUtils.dropEventMimeData(drop)
+            };
+
+            if (typeof data.srcParentModelIndex !== "undefined") {
+                drag.source.dropData = data;
+            } else {
+                data.paletteView.insertCell(data.destIndex, data.mimeData, data.action);
             }
 
-            function onDragOverPaletteFinished() {
-                if (placeholder.active) {
-                    placeholder.removePlaceholder();
-                    paletteView.state = "default";
-                }
-
-                if (drag.source && drag.source.parentModelIndex === paletteView.paletteRootIndex) {
-                    drag.source.internalDrag = false;
-                }
-            }
-
-            onExited: onDragOverPaletteFinished();
-
-            onDropped: function(drop) {
-                if (!action) {
-                    onDragOverPaletteFinished();
-                    return;
-                }
-
-                const destIndex = placeholder.active ? placeholder.index : paletteView.paletteModel.rowCount(paletteView.paletteRootIndex);
-                onDragOverPaletteFinished();
-
-                // Moving cells here causes Drag.onDragFinished be not called properly.
-                // Therefore record the necessary information to move cells later.
-                const data = {
-                    action: action,
-                    srcParentModelIndex: drag.source.parentModelIndex,
-                    srcRowIndex: drag.source.rowIndex,
-                    paletteView: paletteView,
-                    destIndex: destIndex,
-                    mimeData: PaletteUtils.dropEventMimeData(drop)
-                };
-
-                if (typeof data.srcParentModelIndex !== "undefined") {
-                    drag.source.dropData = data;
-                } else {
-                    data.paletteView.insertCell(data.destIndex, data.mimeData, data.action);
-                }
-
-                drop.accept(action);
-            }
+            drop.accept(action);
         }
     }
 
@@ -683,7 +671,7 @@ StyledGridView {
 
             function endDrag() {
                 draggedIcon.visible = false
-                draggedIcon.parent = grid
+                draggedIcon.parent = paletteView
                 draggedIcon.x = 0
                 draggedIcon.y = 0
             }
@@ -701,4 +689,15 @@ StyledGridView {
             */
         } // end ListItemBlank
     } // end DelegateModel
+
+    PaletteGridLinesCanvas {
+        id: grid
+        anchors.fill: parent
+        drawGrid: parent.drawGrid && !parent.empty
+        stretchWidth: paletteView.stretchWidth
+        offsetX: parent.contentX
+        offsetY: parent.contentY
+        cellWidth: parent.cellWidth
+        cellHeight: parent.cellHeight
+    }
 }

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
@@ -143,63 +143,6 @@ StyledGridView {
         horizontalAlignment: Text.AlignLeft
     }
 
-    Rectangle {
-        id: moreButtonRect
-
-        anchors.bottom: parent.bottom
-        anchors.right: parent.right
-        implicitWidth: 64
-        width: {
-            if (paletteView.empty) {
-                return implicitWidth;
-            }
-
-            // align to the left border of some palette cell
-            var addition = (parent.width - implicitWidth) % paletteView.cellWidth - 1; // -1 allows to fit into a cell if palette grid is visible
-            if (addition < 0) {
-                addition += paletteView.cellWidth;
-            }
-
-            return implicitWidth + addition;
-        }
-
-        height: paletteView.cellHeight - (paletteView.oneRow ? 0 : 1)
-        visible: paletteView.showMoreButton
-        color: background.color
-
-        z: grid.z + 1
-
-        FlatButton {
-            id: moreButton
-
-            anchors.fill: parent
-
-            visible: paletteView.isInVisibleArea
-
-            navigation.panel: paletteView.navigationPanel
-            //! NOTE Just Up/Down navigation now
-            navigation.row: paletteView.ncells + paletteView.navigationRow
-            navigation.column: 1
-
-            onActiveFocusChanged: {
-                if (activeFocus) {
-                    paletteView.setCurrentTreeItemRequested(this);
-
-                    if (ui.keyboardModifiers() === Qt.NoModifier) {
-                        paletteView.selectionModel.clearSelection();
-                    }
-                }
-            }
-
-            //: Caption of a button to reveal more elements
-            text: qsTrc("palette", "More")
-
-            transparent: true
-            accentButton: true
-
-            onClicked: paletteView.moreButtonClicked(moreButton)
-        }
-    }
 
     PlaceholderManager {
         id: placeholder
@@ -211,126 +154,114 @@ StyledGridView {
         interval: 400
     }
 
-    PaletteGridLinesCanvas {
-        id: grid
-        z: 1
+    DropArea {
+        id: paletteDropArea
         anchors.fill: parent
-        drawGrid: parent.drawGrid && !parent.empty
-        stretchWidth: paletteView.stretchWidth
-        offsetX: parent.contentX
-        offsetY: parent.contentY
-        cellWidth: parent.cellWidth
-        cellHeight: parent.cellHeight
 
-        DropArea {
-            id: paletteDropArea
-            anchors.fill: parent
+        property var action
+        property int proposedAction: Qt.IgnoreAction
+        property bool internal: false
 
-            property var action
-            property int proposedAction: Qt.IgnoreAction
-            property bool internal: false
-
-            function onDrag(drag) {
-                if (drag.proposedAction !== proposedAction) {
-                    onEntered(drag);
-                    return;
-                }
-
-                if (drag.source.dragged) {
-                    drag.source.internalDrag = internal;
-                    drag.source.dragCopy = action === Qt.CopyAction;
-                    paletteView.state = "drag";
-                    drag.source.paletteDrag = true;
-                } else if (typeof drag.source.paletteDrag !== "undefined") { // if this is a palette and not, e.g., scoreview
-                    return;
-                }
-
-                drag.accept(action); // confirm we accept the action we determined inside onEntered
-
-                var idx = paletteView.indexAt(drag.x, drag.y);
-                if (idx === -1) {
-                    idx = paletteView.paletteModel.rowCount(paletteView.paletteRootIndex) - (internal ? 1 : 0);
-                }
-
-                if (placeholder.active && placeholder.index === idx) {
-                    return;
-                }
-
-                placeholder.makePlaceholder(idx, { decoration: ui.theme.textFieldColor, toolTip: "placeholder", accessibleText: "", cellActive: false, mimeData: {} });
+        function onDrag(drag) {
+            if (drag.proposedAction !== proposedAction) {
+                onEntered(drag);
+                return;
             }
 
-            onEntered: function(drag) {
+            if (drag.source.dragged) {
+                drag.source.internalDrag = internal;
+                drag.source.dragCopy = action === Qt.CopyAction;
+                paletteView.state = "drag";
+                drag.source.paletteDrag = true;
+            } else if (typeof drag.source.paletteDrag !== "undefined") { // if this is a palette and not, e.g., scoreview
+                return;
+            }
+
+            drag.accept(action); // confirm we accept the action we determined inside onEntered
+
+            var idx = paletteView.indexAt(drag.x, drag.y);
+            if (idx === -1) {
+                idx = paletteView.paletteModel.rowCount(paletteView.paletteRootIndex) - (internal ? 1 : 0);
+            }
+
+            if (placeholder.active && placeholder.index === idx) {
+                return;
+            }
+
+            placeholder.makePlaceholder(idx, { decoration: ui.theme.textFieldColor, toolTip: "placeholder", accessibleText: "", cellActive: false, mimeData: {} });
+        }
+
+        onEntered: function(drag) {
+            onDragOverPaletteFinished();
+
+            // first check if controller allows dropping this item here
+            const mimeData = PaletteUtils.dropEventMimeData(drag);
+            internal = (drag.source.parentModelIndex === paletteView.paletteRootIndex);
+            action = paletteView.paletteController.dropAction(mimeData, drag.proposedAction, paletteView.paletteRootIndex, internal);
+            proposedAction = drag.proposedAction;
+
+            if (action !== Qt.MoveAction) {
+                internal = false;
+            }
+
+            const accept = (action & drag.supportedActions) && (internal || !paletteView.externalDropBlocked);
+
+            if (accept) {
+                drag.accept(action);
+            } else {
+                drag.accepted = false;
+            }
+
+            // If event is accepted, process the drag in a usual way
+            if (drag.accepted) {
+                onDrag(drag);
+            }
+        }
+
+        onPositionChanged: function(drag) {
+            onDrag(drag)
+        }
+
+        function onDragOverPaletteFinished() {
+            if (placeholder.active) {
+                placeholder.removePlaceholder();
+                paletteView.state = "default";
+            }
+
+            if (drag.source && drag.source.parentModelIndex === paletteView.paletteRootIndex) {
+                drag.source.internalDrag = false;
+            }
+        }
+
+        onExited: onDragOverPaletteFinished();
+
+        onDropped: function(drop) {
+            if (!action) {
                 onDragOverPaletteFinished();
-
-                // first check if controller allows dropping this item here
-                const mimeData = PaletteUtils.dropEventMimeData(drag);
-                internal = (drag.source.parentModelIndex === paletteView.paletteRootIndex);
-                action = paletteView.paletteController.dropAction(mimeData, drag.proposedAction, paletteView.paletteRootIndex, internal);
-                proposedAction = drag.proposedAction;
-
-                if (action !== Qt.MoveAction) {
-                    internal = false;
-                }
-
-                const accept = (action & drag.supportedActions) && (internal || !paletteView.externalDropBlocked);
-
-                if (accept) {
-                    drag.accept(action);
-                } else {
-                    drag.accepted = false;
-                }
-
-                // If event is accepted, process the drag in a usual way
-                if (drag.accepted) {
-                    onDrag(drag);
-                }
+                return;
             }
 
-            onPositionChanged: function(drag) {
-                onDrag(drag)
+            const destIndex = placeholder.active ? placeholder.index : paletteView.paletteModel.rowCount(paletteView.paletteRootIndex);
+            onDragOverPaletteFinished();
+
+            // Moving cells here causes Drag.onDragFinished be not called properly.
+            // Therefore record the necessary information to move cells later.
+            const data = {
+                action: action,
+                srcParentModelIndex: drag.source.parentModelIndex,
+                srcRowIndex: drag.source.rowIndex,
+                paletteView: paletteView,
+                destIndex: destIndex,
+                mimeData: PaletteUtils.dropEventMimeData(drop)
+            };
+
+            if (typeof data.srcParentModelIndex !== "undefined") {
+                drag.source.dropData = data;
+            } else {
+                data.paletteView.insertCell(data.destIndex, data.mimeData, data.action);
             }
 
-            function onDragOverPaletteFinished() {
-                if (placeholder.active) {
-                    placeholder.removePlaceholder();
-                    paletteView.state = "default";
-                }
-
-                if (drag.source && drag.source.parentModelIndex === paletteView.paletteRootIndex) {
-                    drag.source.internalDrag = false;
-                }
-            }
-
-            onExited: onDragOverPaletteFinished();
-
-            onDropped: function(drop) {
-                if (!action) {
-                    onDragOverPaletteFinished();
-                    return;
-                }
-
-                const destIndex = placeholder.active ? placeholder.index : paletteView.paletteModel.rowCount(paletteView.paletteRootIndex);
-                onDragOverPaletteFinished();
-
-                // Moving cells here causes Drag.onDragFinished be not called properly.
-                // Therefore record the necessary information to move cells later.
-                const data = {
-                    action: action,
-                    srcParentModelIndex: drag.source.parentModelIndex,
-                    srcRowIndex: drag.source.rowIndex,
-                    paletteView: paletteView,
-                    destIndex: destIndex,
-                    mimeData: PaletteUtils.dropEventMimeData(drop)
-                };
-
-                if (typeof data.srcParentModelIndex !== "undefined") {
-                    drag.source.dropData = data;
-                } else {
-                    data.paletteView.insertCell(data.destIndex, data.mimeData, data.action);
-                }
-
-                drop.accept(action);
-            }
+            drop.accept(action);
         }
     }
 
@@ -683,7 +614,7 @@ StyledGridView {
 
             function endDrag() {
                 draggedIcon.visible = false
-                draggedIcon.parent = grid
+                draggedIcon.parent = paletteView
                 draggedIcon.x = 0
                 draggedIcon.y = 0
             }
@@ -701,4 +632,71 @@ StyledGridView {
             */
         } // end ListItemBlank
     } // end DelegateModel
+
+    PaletteGridLinesCanvas {
+        id: grid
+        anchors.fill: parent
+        drawGrid: parent.drawGrid && !parent.empty
+        stretchWidth: paletteView.stretchWidth
+        offsetX: parent.contentX
+        offsetY: parent.contentY
+        cellWidth: parent.cellWidth
+        cellHeight: parent.cellHeight
+    }
+
+    Rectangle {
+        id: moreButtonRect
+
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        implicitWidth: 64
+        width: {
+            if (paletteView.empty) {
+                return implicitWidth;
+            }
+
+            // align to the left border of some palette cell
+            var addition = (parent.width - implicitWidth) % paletteView.cellWidth - 1; // -1 allows to fit into a cell if palette grid is visible
+            if (addition < 0) {
+                addition += paletteView.cellWidth;
+            }
+
+            return implicitWidth + addition;
+        }
+
+        height: paletteView.cellHeight - (paletteView.oneRow ? 0 : 1)
+        visible: paletteView.showMoreButton
+        color: background.color
+
+        FlatButton {
+            id: moreButton
+
+            anchors.fill: parent
+
+            visible: paletteView.isInVisibleArea
+
+            navigation.panel: paletteView.navigationPanel
+            //! NOTE Just Up/Down navigation now
+            navigation.row: paletteView.ncells + paletteView.navigationRow
+            navigation.column: 1
+
+            onActiveFocusChanged: {
+                if (activeFocus) {
+                    paletteView.setCurrentTreeItemRequested(this);
+
+                    if (ui.keyboardModifiers() === Qt.NoModifier) {
+                        paletteView.selectionModel.clearSelection();
+                    }
+                }
+            }
+
+            //: Caption of a button to reveal more elements
+            text: qsTrc("palette", "More")
+
+            transparent: true
+            accentButton: true
+
+            onClicked: paletteView.moreButtonClicked(moreButton)
+        }
+    }
 }


### PR DESCRIPTION
When opening the "More" popup for Accidentals, the grid lines separating the elements would visually render on top of the vertical scrollbar.

This commit explicitly sets a `z: 100` property on the vertical StyledScrollBar within the popup's view. Now, instead of being obscured by the separator lines, the scrollbar correctly renders above the grid elements.

Resolves: #26174 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)