### PR TITLE
allow loading multi-component vst3 effects

### DIFF
--- a/src/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
+++ b/src/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
@@ -56,23 +56,27 @@ PluginScanResult RegisterAudioPluginsScenario::scanPlugins() const
 
     PluginScanResult result;
 
-    std::map<io::path_t, audio::AudioResourceId> registered;
+    //! NOTE: A single plugin path can map to multiple resource IDs (multi-component bundles),
+    //! so we track all IDs per path.
+    std::map<io::path_t, std::vector<audio::AudioResourceId> > pathToIds;
     for (const auto& info : knownPluginsRegister()->pluginInfoList()) {
-        registered[info.path] = info.meta.id;
+        pathToIds[info.path].push_back(info.meta.id);
     }
 
     for (const auto& scanner : scannerRegister()->scanners()) {
         for (const auto& path : scanner->scanPlugins()) {
-            if (auto it = registered.find(path); it != registered.end()) {
-                registered.erase(it);
+            if (auto it = pathToIds.find(path); it != pathToIds.end()) {
+                pathToIds.erase(it);
             } else {
                 result.newPluginPaths.push_back(path);
             }
         }
     }
 
-    for (const auto& [path, id] : registered) {
-        result.missingPluginIds.push_back(id);
+    for (const auto& [path, ids] : pathToIds) {
+        for (const auto& id : ids) {
+            result.missingPluginIds.push_back(id);
+        }
     }
 
     return result;

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -109,14 +109,18 @@ void VstPluginInstance::load()
 
         const auto& factory = m_module->getFactory();
 
+        //! NOTE: For multi-component bundles, the resource ID is the component name or UID.
+        //! Match by name or UID against the factory's audio effect components.
         for (const ClassInfo& classInfo : factory.classInfos()) {
             if (classInfo.category() != kVstAudioEffectClass) {
                 continue;
             }
 
-            m_pluginProvider = std::make_unique<VstPluginProvider>(factory, classInfo);
-            m_classInfo = classInfo;
-            break;
+            if (classInfo.name() == m_resourceId || classInfo.ID().toString() == m_resourceId) {
+                m_pluginProvider = std::make_unique<VstPluginProvider>(factory, classInfo);
+                m_classInfo = classInfo;
+                break;
+            }
         }
 
         if (!m_pluginProvider) {

--- a/src/framework/vst/internal/vstpluginmetareader.cpp
+++ b/src/framework/vst/internal/vstpluginmetareader.cpp
@@ -49,26 +49,49 @@ RetVal<AudioResourceMetaList> VstPluginMetaReader::readMeta(const io::path_t& pl
     }
 
     const auto& factory = module->getFactory();
-    AudioResourceMetaList result;
 
+    std::vector<ClassInfo> audioEffects;
     for (const ClassInfo& classInfo : factory.classInfos()) {
-        if (classInfo.category() != kVstAudioEffectClass) {
-            continue;
+        if (classInfo.category() == kVstAudioEffectClass) {
+            audioEffects.push_back(classInfo);
+        }
+    }
+
+    if (audioEffects.empty()) {
+        return make_ret(Err::NoAudioEffect);
+    }
+
+    std::string baseName = io::completeBasename(pluginPath).toStdString();
+    bool multiComponent = audioEffects.size() > 1;
+
+    AudioResourceMetaList result;
+    std::set<std::string> usedIds;
+
+    for (size_t i = 0; i < audioEffects.size(); ++i) {
+        const ClassInfo& classInfo = audioEffects[i];
+
+        std::string id;
+        if (multiComponent) {
+            id = classInfo.name();
+            if (id.empty()) {
+                id = baseName + " " + std::to_string(i + 1);
+            }
+            if (muse::contains(usedIds, id)) {
+                id = classInfo.ID().toString();
+            }
+            usedIds.insert(id);
+        } else {
+            id = baseName;
         }
 
         muse::audio::AudioResourceMeta meta;
-        meta.id = io::completeBasename(pluginPath).toStdString();
+        meta.id = std::move(id);
         meta.type = muse::audio::AudioResourceType::VstPlugin;
         meta.attributes.emplace(muse::audio::CATEGORIES_ATTRIBUTE, String::fromStdString(classInfo.subCategoriesString()));
         meta.vendor = classInfo.vendor();
         meta.hasNativeEditorSupport = true;
 
         result.emplace_back(std::move(meta));
-        break;
-    }
-
-    if (result.empty()) {
-        return make_ret(Err::NoAudioEffect);
     }
 
     return RetVal<AudioResourceMetaList>::make_ok(result);


### PR DESCRIPTION
Some rare VST3 effects contain more than one effect within a single bundle. Before this change, only the first effect could be used.

Example effect pack: Linux Studio Plugins (lsp-plugins):
- Not available on windows
- you can install it from your linux distro repository
- or from here for mac: https://github.com/kryksyh/lsp-plugins/releases/tag/1.2.29-mac
 
 MSS 4.6.5: 
<img width="510" height="699" alt="image" src="https://github.com/user-attachments/assets/2e3fa6f0-ee64-44e8-bcd2-f030c3e16985" />

This PR:
<img width="731" height="736" alt="image" src="https://github.com/user-attachments/assets/64fa5dd5-0e67-40c5-abd1-c52559ca6246" />

 
<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
