### PR TITLE
[4.7] fixed #32793: Preferences dropdowns unclickable after reset preferences

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
@@ -119,7 +119,7 @@ StyledDialogView {
                 obj.reset()
             }
 
-            preferencesModel.resetFactorySettings()
+            Qt.callLater(preferencesModel.resetFactorySettings)
         }
     }
 


### PR DESCRIPTION
Resolves: #32793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when resetting preferences to factory defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->