### PR TITLE
fixed #32793: Preferences dropdowns unclickable after reset preferences

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
@@ -119,7 +119,7 @@ StyledDialogView {
                 obj.reset()
             }
 
-            preferencesModel.resetFactorySettings()
+            Qt.callLater(preferencesModel.resetFactorySettings)
         }
     }
 


### PR DESCRIPTION
Resolves: #32793