### PR TITLE
Added "Repeat Last Action" command

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -899,6 +899,10 @@
     <seq>R</seq>
     </SC>
   <SC>
+    <key>repeat-last-action</key>
+    <seq>Shift+R</seq>
+    </SC>
+  <SC>
     <key>enh-both</key>
     <seq>J</seq>
     </SC>

--- a/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
@@ -395,6 +395,8 @@ MenuItem* AppMenuModel::makeToolsMenu()
     };
 
     MenuItemList toolsItems {
+        makeMenuItem("repeat-last-action"),
+        makeSeparator(),
         makeMenuItem("transpose"),
         makeSeparator(),
         makeMenuItem("explode"),

--- a/src/framework/actions/actiontypes.h
+++ b/src/framework/actions/actiontypes.h
@@ -41,6 +41,12 @@ inline bool containsAction(const ActionCodeList& list, const ActionCode& actionC
     return std::find(list.cbegin(), list.cend(), actionCode) != list.cend();
 }
 
+inline uint64_t nextActionSequence()
+{
+    static uint64_t counter = 0;
+    return ++counter;
+}
+
 inline static ActionCode codeFromQString(const QString& s)
 {
     return s.toStdString();

--- a/src/framework/actions/iactionsdispatcher.h
+++ b/src/framework/actions/iactionsdispatcher.h
@@ -55,6 +55,10 @@ public:
     virtual bool isReg(Actionable* client) const = 0;
     virtual ActionCodeList actionList() const = 0;
 
+    virtual ActionCode lastRepeatableAction() const = 0;
+    virtual uint64_t lastRepeatableActionSequence() const = 0;
+    virtual void repeatLastAction() = 0;
+
     void reg(Actionable* client, const ActionCode& action, const ActionCallBack& call)
     {
         reg(client, action, [call](const ActionCode&, const ActionData&) { call(); });

--- a/src/framework/actions/internal/actionsdispatcher.cpp
+++ b/src/framework/actions/internal/actionsdispatcher.cpp
@@ -133,6 +133,13 @@ void ActionsDispatcher::doDispatch(const Clients& clients, const ActionCode& act
         LOGW() << "More than one client can handle the action, this is not a typical situation.";
     }
 
+    // Track repeatable actions
+    if (isRepeatable(actionCode)) {
+        m_lastRepeatableAction = actionCode;
+        m_lastRepeatableData = data;
+        m_lastRepeatableSequence = nextActionSequence();
+    }
+
     // Notify that we have performed an action.
     m_postDispatch.send(actionCode);
 }
@@ -185,4 +192,90 @@ ActionCodeList ActionsDispatcher::actionList() const
         list.push_back(p.first);
     }
     return list;
+}
+
+ActionCode ActionsDispatcher::lastRepeatableAction() const
+{
+    return m_lastRepeatableAction;
+}
+
+uint64_t ActionsDispatcher::lastRepeatableActionSequence() const
+{
+    return m_lastRepeatableSequence;
+}
+
+void ActionsDispatcher::repeatLastAction()
+{
+    if (m_lastRepeatableAction.empty()) {
+        LOGI() << "no repeatable action to repeat";
+        return;
+    }
+
+    dispatch(m_lastRepeatableAction, m_lastRepeatableData);
+}
+
+bool ActionsDispatcher::isRepeatable(const ActionCode& code) const
+{
+    // Query-style action codes (e.g., "action://...") cannot be safely
+    // re-dispatched with ActionData, so never treat them as repeatable.
+    if (ActionQuery(code).isValid()) {
+        return false;
+    }
+
+    static const std::unordered_set<ActionCode> repeatableActions = {
+        // Articulations
+        "add-marcato", "add-sforzato", "add-tenuto", "add-staccato",
+        // Ornaments
+        "add-turn", "add-turn-inverted", "add-turn-slash",
+        "add-turn-up", "add-turn-inverted-up",
+        "add-trill", "add-short-trill", "add-mordent", "add-haydn",
+        "add-tremblement", "add-prall-mordent", "add-shake",
+        "add-shake-muffat", "add-tremblement-couperin",
+        // Bowing
+        "add-up-bow", "add-down-bow",
+        // Slurs, ties, lines
+        "add-slur", "tie", "chord-tie", "lv", "hammer-on-pull-off",
+        // Hairpins, ottava
+        "add-hairpin", "add-hairpin-reverse", "add-8va", "add-8vb",
+        "add-dynamic", "add-noteline",
+        // Accidentals
+        "sharp2-post", "sharp-post", "nat-post", "flat-post", "flat2-post",
+        "flat2", "flat", "nat", "sharp", "sharp2",
+        // Brackets
+        "add-brackets", "add-parentheses", "add-braces",
+        // Beam modes
+        "beam-auto", "beam-none", "beam-break-left",
+        "beam-break-inner-8th", "beam-break-inner-16th", "beam-join",
+        // Grace notes
+        "acciaccatura", "appoggiatura", "grace4", "grace16", "grace32",
+        "grace8after", "grace16after", "grace32after",
+        // Layout breaks
+        "system-break", "page-break", "section-break",
+        // Visibility
+        "toggle-visible", "set-visible", "unset-visible",
+        // Flip
+        "flip", "flip-horizontally",
+        // Enharmonic
+        "enh-both", "enh-current",
+        // Transposition
+        "transpose-up", "transpose-down",
+        // Text
+        "system-text", "staff-text", "expression-text",
+        "rehearsalmark-text", "tempo", "fingering-text",
+        "sticking-text", "chord-text", "roman-numeral-text",
+        "nashville-number-text", "lyrics",
+        // Guitar bends
+        "standard-bend", "pre-bend", "grace-note-bend", "slight-bend",
+        "dive", "pre-dive", "dip", "scoop",
+        // Pitch
+        "pitch-up", "pitch-down", "pitch-up-octave", "pitch-down-octave",
+        "pitch-up-diatonic", "pitch-down-diatonic",
+        // Misc
+        "toggle-autoplace", "autoplace-enabled", "rest",
+        "toggle-snap-to-previous", "toggle-snap-to-next",
+        "mirror-note", "toggle-mmrest", "toggle-hide-empty",
+        "full-measure-rest",
+    };
+
+    return repeatableActions.find(code) != repeatableActions.end();
 }

--- a/src/framework/actions/internal/actionsdispatcher.h
+++ b/src/framework/actions/internal/actionsdispatcher.h
@@ -23,6 +23,7 @@
 #define MUSE_ACTIONS_ACTIONSDISPATCHER_H
 
 #include <map>
+#include <unordered_set>
 
 #include "../iactionsdispatcher.h"
 #include "async/asyncable.h"
@@ -48,6 +49,10 @@ public:
     bool isReg(Actionable* client) const override;
     ActionCodeList actionList() const override;
 
+    ActionCode lastRepeatableAction() const override;
+    uint64_t lastRepeatableActionSequence() const override;
+    void repeatLastAction() override;
+
 private:
 
     using CallBacks = std::map<ActionCode, ActionCallBackWithNameAndData>;
@@ -57,7 +62,13 @@ private:
 
     void dump() const; // for debug
 
+    bool isRepeatable(const ActionCode& code) const;
+
     std::map<ActionCode, Clients > m_clients;
+
+    ActionCode m_lastRepeatableAction;
+    ActionData m_lastRepeatableData;
+    uint64_t m_lastRepeatableSequence = 0;
 
     async::Channel<ActionCode> m_preDispatch;
     async::Channel<ActionCode> m_postDispatch;

--- a/src/framework/actions/tests/mocks/actionsdispatchermock.h
+++ b/src/framework/actions/tests/mocks/actionsdispatchermock.h
@@ -41,5 +41,9 @@ public:
     MOCK_METHOD(void, reg, (Actionable * client, const ActionQuery& actionQuery, const ActionCallBackWithQuery& call), (override));
     MOCK_METHOD(bool, isReg, (Actionable*), (const, override));
     MOCK_METHOD(ActionCodeList, actionList, (), (const, override));
+
+    MOCK_METHOD(ActionCode, lastRepeatableAction, (), (const, override));
+    MOCK_METHOD(uint64_t, lastRepeatableActionSequence, (), (const, override));
+    MOCK_METHOD(void, repeatLastAction, (), (override));
 };
 }

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -124,6 +124,9 @@ public:
     virtual muse::async::Notification dropChanged() const = 0;
 
     virtual bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) = 0;
+    virtual bool canReapplyLastPaletteElement() const = 0;
+    virtual uint64_t lastPaletteElementSequence() const = 0;
+    virtual bool reapplyLastPaletteElement() = 0;
     virtual void undo() = 0;
     virtual void redo() = 0;
     virtual void undoRedoToIndex(size_t idx) = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -38,6 +38,7 @@
 
 #include "defer.h"
 #include "ptrutils.h"
+#include "actions/actiontypes.h"
 #include "containers.h"
 
 #include "draw/painter.h"
@@ -2361,7 +2362,29 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
 
     checkAndShowError();
 
+    m_lastPaletteElement.reset(element->clone());
+    m_lastPaletteElementSequence = muse::actions::nextActionSequence();
+
     return true;
+}
+
+bool NotationInteraction::canReapplyLastPaletteElement() const
+{
+    return m_lastPaletteElement != nullptr;
+}
+
+uint64_t NotationInteraction::lastPaletteElementSequence() const
+{
+    return m_lastPaletteElementSequence;
+}
+
+bool NotationInteraction::reapplyLastPaletteElement()
+{
+    if (!m_lastPaletteElement) {
+        return false;
+    }
+
+    return applyPaletteElement(m_lastPaletteElement.get());
 }
 
 void NotationInteraction::applyPaletteElementToList(EngravingItem* element, mu::engraving::Score* score,

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -143,6 +143,9 @@ public:
     muse::async::Notification dropChanged() const override;
 
     bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) override;
+    bool canReapplyLastPaletteElement() const override;
+    uint64_t lastPaletteElementSequence() const override;
+    bool reapplyLastPaletteElement() override;
     void undo() override;
     void redo() override;
     void undoRedoToIndex(size_t idx) override;
@@ -576,6 +579,8 @@ private:
     mu::engraving::Lasso* m_lasso = nullptr;
 
     bool m_notifyAboutDropChanged = false;
+    mu::engraving::ElementPtr m_lastPaletteElement;
+    uint64_t m_lastPaletteElementSequence = 0;
     HitElementContext m_hitElementContext;
 
     muse::async::Channel<ShowItemRequest> m_showItemRequested;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -89,6 +89,9 @@ public:
     MOCK_METHOD(muse::async::Notification, dropChanged, (), (const, override));
 
     MOCK_METHOD(bool, applyPaletteElement, (mu::engraving::EngravingItem*, Qt::KeyboardModifiers), (override));
+    MOCK_METHOD(bool, canReapplyLastPaletteElement, (), (const, override));
+    MOCK_METHOD(uint64_t, lastPaletteElementSequence, (), (const, override));
+    MOCK_METHOD(bool, reapplyLastPaletteElement, (), (override));
     MOCK_METHOD(void, undo, (), (override));
     MOCK_METHOD(void, redo, (), (override));
     MOCK_METHOD(void, undoRedoToIndex, (size_t idx), (override));

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -245,6 +245,18 @@ void NotationActionController::init()
     registerAction(UNDO_ACTION_CODE, &Interaction::undo, &Controller::canUndo);
     registerAction(REDO_ACTION_CODE, &Interaction::redo, &Controller::canRedo);
 
+    registerAction("repeat-last-action", [this]() {
+        uint64_t actionSeq = dispatcher()->lastRepeatableActionSequence();
+        auto notation = currentNotation();
+        uint64_t paletteSeq = notation ? notation->interaction()->lastPaletteElementSequence() : 0;
+
+        if (paletteSeq > actionSeq && notation && notation->interaction()->canReapplyLastPaletteElement()) {
+            notation->interaction()->reapplyLastPaletteElement();
+        } else {
+            dispatcher()->repeatLastAction();
+        }
+    });
+
     registerAction("select-similar", &Controller::selectAllSimilarElements, &Controller::hasSelection);
     registerAction("select-similar-staff", &Controller::selectAllSimilarElementsInStaff, &Controller::hasSelection);
     registerAction("select-similar-range", &Controller::selectAllSimilarElementsInRange, &Controller::hasSelection);

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1658,6 +1658,12 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Repeat selection"),
              TranslatableString("action", "Repeat selection")
              ),
+    UiAction("repeat-last-action",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Repeat last action"),
+             TranslatableString("action", "Repeat the last notation action")
+             ),
     UiAction("toggle-score-lock",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,


### PR DESCRIPTION
Hi!

This PR basically lets redo the last action done. I find it annoying to have to go to the palette to choose again the same articulation or have to find some menu to re-apply some action to some bar or selection, specially when I have to do it many-many times for the same composition or arrangement I'm working on at many different points. With these changes, now I only need to do "Shift + R" for my new selection and it makes it much more efficient for my workflow. Hopefully it's also useful for somebody else.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
