### PR TITLE
Added missing preferences focus handlers

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/AdvancedPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/AdvancedPreferencesPage.qml
@@ -59,6 +59,12 @@ PreferencesPage {
             onResetToDefaultRequested: {
                 preferencesModel.resetToDefault()
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         ValueList {

--- a/src/preferences/qml/MuseScore/Preferences/AudioMidiPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/AudioMidiPreferencesPage.qml
@@ -51,6 +51,12 @@ PreferencesPage {
             onCurrentAudioApiIndexChangeRequested: function(newIndex) {
                 audioMidiModel.currentAudioApiIndex = newIndex
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -78,6 +84,12 @@ PreferencesPage {
             onUseMIDI20OutputChangeRequested: function(use) {
                 audioMidiModel.useMIDI20Output = use
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -90,6 +102,12 @@ PreferencesPage {
 
             onMuteHiddenInstrumentsChangeRequested: function(mute) {
                 audioMidiModel.muteHiddenInstruments = mute
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
 
@@ -117,6 +135,12 @@ PreferencesPage {
 
             onProgressBarModeChangeRequired: function(mode) {
                 audioMidiModel.onlineSoundsShowProgressBarMode = mode
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
 

--- a/src/preferences/qml/MuseScore/Preferences/BraillePreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/BraillePreferencesPage.qml
@@ -51,6 +51,12 @@ PreferencesPage {
             onBraillePanelEnabledChangeRequested: function(val) {
                 preferencesModel.braillePanelEnabled = val;
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height));
+                }
+            }
         }
 
         SeparatorLine { }

--- a/src/preferences/qml/MuseScore/Preferences/CanvasPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/CanvasPreferencesPage.qml
@@ -60,6 +60,12 @@ PreferencesPage {
             onMouseZoomPrecisionChangeRequested: function(zoomPrecision) {
                 preferencesModel.mouseZoomPrecision = zoomPrecision
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -78,6 +84,12 @@ PreferencesPage {
             onLimitScrollAreaChangeRequested: function(limit) {
                 preferencesModel.limitScrollArea = limit
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -90,6 +102,12 @@ PreferencesPage {
 
             onSelectionProximityChangeRequested: function(proximity) {
                 preferencesModel.selectionProximity = proximity
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
     }

--- a/src/preferences/qml/MuseScore/Preferences/FoldersPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/FoldersPreferencesPage.qml
@@ -46,6 +46,12 @@ PreferencesPage {
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 1
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
     }
 }

--- a/src/preferences/qml/MuseScore/Preferences/GeneralPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/GeneralPreferencesPage.qml
@@ -63,6 +63,12 @@ PreferencesPage {
             onCheckForUpdateRequested: {
                 preferencesModel.checkUpdateForCurrentLanguage()
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -72,6 +78,12 @@ PreferencesPage {
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 2
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -81,6 +93,12 @@ PreferencesPage {
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 3
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         /*

--- a/src/preferences/qml/MuseScore/Preferences/ImportPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/ImportPreferencesPage.qml
@@ -150,6 +150,12 @@ PreferencesPage {
             onMeiImportLayoutChangeRequested: function(meiImportLayout) {
                 importPreferencesModel.meiImportLayout = meiImportLayout
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }

--- a/src/preferences/qml/MuseScore/Preferences/ImportPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/ImportPreferencesPage.qml
@@ -147,6 +147,9 @@ PreferencesPage {
         MeiSection {
             meiImportLayout: importPreferencesModel.meiImportLayout
 
+            navigation.section: root.navigationSection
+            navigation.order: root.navigationOrderStart + 5
+
             onMeiImportLayoutChangeRequested: function(meiImportLayout) {
                 importPreferencesModel.meiImportLayout = meiImportLayout
             }
@@ -164,7 +167,7 @@ PreferencesPage {
             requireExactSchemaValidation: importPreferencesModel.mnxRequireExactSchemaValidation
 
             navigation.section: root.navigationSection
-            navigation.order: root.navigationOrderStart + 5
+            navigation.order: root.navigationOrderStart + 6
 
             onRequireExactSchemaValidationChangeRequested: function(value) {
                 importPreferencesModel.mnxRequireExactSchemaValidation = value

--- a/src/preferences/qml/MuseScore/Preferences/NoteInputPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/NoteInputPreferencesPage.qml
@@ -62,6 +62,12 @@ PreferencesPage {
             onUseNoteInputCursorInInputByDurationChangeRequested: function(use) {
                 noteInputModel.useNoteInputCursorInInputByDuration = use
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -89,6 +95,12 @@ PreferencesPage {
 
             onDelayBetweenNotesChangeRequested: function(delay) {
                 noteInputModel.delayBetweenNotesInRealTimeModeMilliseconds = delay
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
 
@@ -142,6 +154,12 @@ PreferencesPage {
             onUseMidiVelocityAndDurationDuringNoteInputChangeRequested: function(use) {
                 noteInputModel.useMidiVelocityAndDurationDuringNoteInput = use
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -157,6 +175,12 @@ PreferencesPage {
             onDynamicsApplyToAllVoicesChangeRequested: function(value) {
                 noteInputModel.dynamicsApplyToAllVoices = value
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -171,6 +195,12 @@ PreferencesPage {
 
             onAutoUpdateFretboardDiagramsChangeRequested: function(update) {
                 noteInputModel.autoUpdateFretboardDiagrams = update
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
 
@@ -191,6 +221,12 @@ PreferencesPage {
 
             onWarnGuitarBendsChangeRequested: function(warn) {
                 noteInputModel.warnGuitarBends = warn
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
     }

--- a/src/preferences/qml/MuseScore/Preferences/PercussionPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PercussionPreferencesPage.qml
@@ -122,6 +122,12 @@ PreferencesPage {
                     percussionPreferencesModel.autoClosePercussionPanel = !autoCloseCheckBox.checked
                 }
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine {}
@@ -157,6 +163,12 @@ PreferencesPage {
 
                 onToggled: {
                     percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+                }
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
                 }
             }
         }

--- a/src/preferences/qml/MuseScore/Preferences/SaveAndPublishPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/SaveAndPublishPreferencesPage.qml
@@ -55,6 +55,12 @@ PreferencesPage {
             onIntervalChanged: function(minutes) {
                 preferencesModel.autoSaveInterval = minutes
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -62,6 +68,12 @@ PreferencesPage {
         SaveToCloudSection {
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 2
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
 
         SeparatorLine { }
@@ -74,6 +86,12 @@ PreferencesPage {
 
             onAlsoShareAudioComChangeRequested: function(share) {
                 preferencesModel.alsoShareAudioCom = share;
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
             }
         }
     }

--- a/src/preferences/qml/MuseScore/Preferences/ScorePreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/ScorePreferencesPage.qml
@@ -44,5 +44,11 @@ PreferencesPage {
 
         navigation.section: root.navigationSection
         navigation.order: root.navigationOrderStart + 1
+
+        onFocusChanged: {
+            if (activeFocus) {
+                root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+            }
+        }
     }
 }

--- a/src/preferences/qml/MuseScore/Preferences/UpdatePreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/UpdatePreferencesPage.qml
@@ -53,6 +53,12 @@ PreferencesPage {
             onNeedCheckForNewAppVersionChangeRequested: function(check) {
                 updateModel.needCheckForNewAppVersion = check
             }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Added missing preferences focus handlers (so it auto scrolls when using navigation).
Fixed Import->MEI navigation section (it wasn't possible to navigate to it)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
