### PR TITLE
32612: Remove the code that makes the window non-transparent once it has loaded

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
+++ b/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
@@ -43,7 +43,6 @@ DockWindow {
     onPageLoaded: {
         console.log("WindowContent::onPageLoaded")
         interactiveProvider.onPageOpened()
-        window.opacity = 1.0
     }
 
     InteractiveProvider {


### PR DESCRIPTION
Resolves: #32612 
Resolves: #31620 
Need to retest #29630

In [MF/PR15](https://github.com/musescore/muse_framework/pull/15) we stopped making the main window transparent on startup. Those changes were consumed into MSS in [MuseScore/PR33374](https://github.com/musescore/MuseScore/pull/33374) (at that moment there was a check that was forcing the MF submodule to always point at the latest commit). This PR deletes the code that removes the transparency on the main window once it has loaded as it is not longer needed.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
