### PR TITLE
Fix #17793: Apply swing to chord symbol playback

### DIFF
--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -76,10 +76,11 @@ static void applySwingIfNeed(const Harmony* chordSymbol,
 
     const Swing::ChordDurationAdjustment swingDurationAdjustment = Swing::applySwing(chord, swing);
     const duration_t nominalDuration = timestampFromTicks(score, positionTickWithOffset + chord->actualTicks().ticks()) - eventTimestamp;
+    const duration_t additionalDuration = duration - nominalDuration;
     const timestamp_t swingOffset = static_cast<timestamp_t>(nominalDuration * swingDurationAdjustment.remainingDurationMultiplier);
 
     eventTimestamp += swingOffset;
-    duration -= swingOffset;
+    duration = static_cast<duration_t>(nominalDuration * swingDurationAdjustment.durationMultiplier) + additionalDuration;
 }
 
 static ArticulationMap makeStandardArticulationMap(const ArticulationsProfilePtr profile, timestamp_t timestamp, duration_t duration)

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -27,7 +27,9 @@
 #include "dom/chord.h"
 #include "dom/harmony.h"
 #include "dom/note.h"
+#include "dom/segment.h"
 #include "dom/sig.h"
+#include "dom/swing.h"
 #include "dom/tempo.h"
 #include "dom/staff.h"
 #include "dom/utils.h"
@@ -44,6 +46,41 @@
 using namespace mu::engraving;
 using namespace muse;
 using namespace muse::mpe;
+
+static const Chord* findChordAtHarmony(const Harmony* chordSymbol)
+{
+    const EngravingItem* parent = chordSymbol->parentItem();
+    if (!parent || !parent->isSegment()) {
+        return nullptr;
+    }
+
+    const EngravingItem* el = toSegment(parent)->element(chordSymbol->track());
+    return el && el->isChord() ? toChord(el) : nullptr;
+}
+
+static void applySwingIfNeed(const Harmony* chordSymbol,
+                             const Score* score,
+                             int positionTickWithOffset,
+                             timestamp_t& eventTimestamp,
+                             duration_t& duration)
+{
+    const SwingParameters swing = chordSymbol->staff()->swing(chordSymbol->tick());
+    if (!swing.isOn()) {
+        return;
+    }
+
+    const Chord* chord = findChordAtHarmony(chordSymbol);
+    if (!chord || chord->tuplet()) {
+        return;
+    }
+
+    const Swing::ChordDurationAdjustment swingDurationAdjustment = Swing::applySwing(chord, swing);
+    const duration_t nominalDuration = timestampFromTicks(score, positionTickWithOffset + chord->actualTicks().ticks()) - eventTimestamp;
+    const timestamp_t swingOffset = static_cast<timestamp_t>(nominalDuration * swingDurationAdjustment.remainingDurationMultiplier);
+
+    eventTimestamp += swingOffset;
+    duration -= swingOffset;
+}
 
 static ArticulationMap makeStandardArticulationMap(const ArticulationsProfilePtr profile, timestamp_t timestamp, duration_t duration)
 {
@@ -143,10 +180,13 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
     int positionTickWithOffset = positionTick + ticksPositionOffset;
 
     timestamp_t eventTimestamp = timestampFromTicks(score, positionTickWithOffset);
-    PlaybackEventList& events = result[eventTimestamp];
 
     int durationTicks = realized.getActualDuration(positionTickWithOffset).ticks();
     duration_t duration = timestampFromTicks(score, positionTickWithOffset + durationTicks) - eventTimestamp;
+
+    applySwingIfNeed(chordSymbol, score, positionTickWithOffset, eventTimestamp, duration);
+
+    PlaybackEventList& events = result[eventTimestamp];
 
     voice_layer_idx_t voiceIdx = static_cast<voice_layer_idx_t>(chordSymbol->voice());
     staff_layer_idx_t staffIdx = static_cast<staff_layer_idx_t>(chordSymbol->staffIdx());


### PR DESCRIPTION
Resolves: #17793, where when swing is enabled, chord symbols placed on offbeat eighth notes are played back straight, causing them to be played out of sync with the notes they are attached to (notes are correctly swung but chord symbols are not).

Fixed by updating `PlaybackEventsRenderer::renderChordSymbol` to call a new helper `applySwingIfNeed`, which adjusts the event timestamp and duration using logic based on the existing [NoteRenderer::applySwingIfNeed](https://github.com/musescore/MuseScore/blob/4e25547c8b9f37c8caefcc3d93403eac2ca82cf2/src/engraving/playback/renderers/noterenderer.cpp#L299-L316).


<!-- Add a short description of and motivation for the changes here -->

**Fixed playback:**

https://github.com/user-attachments/assets/7b11ae21-4aa6-485d-8989-89bb2acdebe0

**Before (master):**

https://github.com/user-attachments/assets/a910be67-2993-4442-900e-31b0670df872




<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
