### PR TITLE
NotationPage. Added compact mode for NotationToolBar

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
@@ -128,9 +128,13 @@ DockPage {
             alignment: DockToolBarAlignment.Center
             contentBottomPadding: 2
 
+            compactPriorityOrder: 1
+
             navigationSection: root.topToolbarKeyNavSec
 
             NotationToolBar {
+                isCompactMode: notationToolBar.isCompact
+
                 navigationPanel.section: notationToolBar.navigationSection
                 navigationPanel.order: 2
             }

--- a/src/appshell/qml/MuseScore/AppShell/PublishPage/PublishPage.qml
+++ b/src/appshell/qml/MuseScore/AppShell/PublishPage/PublishPage.qml
@@ -63,9 +63,13 @@ DockPage {
             alignment: DockToolBarAlignment.Center
             contentBottomPadding: 2
 
+            compactPriorityOrder: 1
+
             navigationSection: root.topToolbarKeyNavSec
 
             NotationToolBar {
+                isCompactMode: notationToolBar.isCompact
+
                 navigationPanel.section: notationToolBar.navigationSection
                 navigationPanel.order: 2
             }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/abstracttoolbarmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/abstracttoolbarmodel.cpp
@@ -331,6 +331,27 @@ ToolBarItem& AbstractToolBarModel::item(const ToolBarItemList& items, const Acti
     return dummy;
 }
 
+bool AbstractToolBarModel::isCompactMode() const
+{
+    return m_isCompactMode;
+}
+
+void AbstractToolBarModel::setIsCompactMode(bool isCompactMode)
+{
+    if (m_isCompactMode == isCompactMode) {
+        return;
+    }
+
+    for (ToolBarItem* item : std::as_const(m_items)) {
+        if (item) {
+            item->setShowTitle(!isCompactMode);
+        }
+    }
+
+    m_isCompactMode = isCompactMode;
+    emit isCompactModeChanged();
+}
+
 void AbstractToolBarModel::updateShortcutsAll()
 {
     for (ToolBarItem* toolBarItem : std::as_const(m_items)) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/abstracttoolbarmodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/abstracttoolbarmodel.h
@@ -60,6 +60,8 @@ class AbstractToolBarModel : public QAbstractListModel, public Contextable, publ
     Q_PROPERTY(int length READ rowCount NOTIFY itemsChanged)
     Q_PROPERTY(QVariantList items READ itemsProperty NOTIFY itemsChanged)
 
+    Q_PROPERTY(bool isCompactMode READ isCompactMode WRITE setIsCompactMode NOTIFY isCompactModeChanged)
+
 public:
     ContextInject<ui::IUiActionsRegister> uiActionsRegister = { this };
     ContextInject<actions::IActionsDispatcher> dispatcher = { this };
@@ -81,9 +83,14 @@ public:
 
     Q_INVOKABLE QVariantMap get(int index);
 
+    bool isCompactMode() const;
+    void setIsCompactMode(bool isCompactMode);
+
 signals:
     void itemsChanged();
-    void itemChanged(uicomponents::ToolBarItem* item);
+    void itemChanged(muse::uicomponents::ToolBarItem* item);
+
+    void isCompactModeChanged();
 
 protected:
     enum Roles {
@@ -124,5 +131,7 @@ private:
     void updateShortcuts(MenuItem* menuItem);
 
     ToolBarItemList m_items;
+
+    bool m_isCompactMode = false;
 };
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/NotationToolBar.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/NotationToolBar.qml
@@ -26,10 +26,16 @@ import Muse.UiComponents
 import MuseScore.NotationScene
 
 StyledToolBarView {
+    property alias isCompactMode: toolBarModel.isCompactMode
+
     navigationPanel.name: "NotationToolBar"
     navigationPanel.accessible.name: qsTrc("notation", "Notation toolbar")
 
     spacing: 2
 
-    model: NotationToolBarModel { }
+    NotationToolBarModel {
+        id: toolBarModel
+    }
+
+    model: toolBarModel
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/notationtoolbarmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationtoolbarmodel.cpp
@@ -43,7 +43,11 @@ void NotationToolBarModel::load()
     ToolBarItemList items;
     for (const ActionCode& code : itemsCodes) {
         ToolBarItem* item = makeItem(code);
-        item->setShowTitle(true);
+        if (!item) {
+            continue;
+        }
+
+        item->setShowTitle(!isCompactMode());
         item->setIsTitleBold(true);
 
         items << item;


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/65d73bb5-e50f-49d3-bbfe-34fe276d4073


After:

https://github.com/user-attachments/assets/fdfc1826-2df5-4448-8015-085fa0349aeb

