### PR TITLE
[4.7.0] Audio API section: various fixes

### DIFF
--- a/src/framework/audio/driver/platform/win/asio/asioaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/win/asio/asioaudiodriver.cpp
@@ -422,12 +422,18 @@ AudioDeviceID AsioAudioDriver::defaultDevice() const
 
 bool AsioAudioDriver::open(const Spec& spec, Spec* activeSpec)
 {
-    LOGI() << "try open: " << spec.deviceId;
     IF_ASSERT_FAILED(!spec.deviceId.empty()) {
         return false;
     }
 
-    const char* name = spec.deviceId.c_str();
+    AudioDeviceID deviceId = spec.deviceId;
+    if (deviceId == DEFAULT_DEVICE_ID) {
+        deviceId = defaultDevice();
+    }
+
+    LOGI() << "try to open: " << deviceId;
+
+    const char* name = deviceId.c_str();
     bool ok = s_adata.drivers->loadDriver(const_cast<char*>(name));
     if (!ok) {
         LOGE() << "failed load driver: " << name;
@@ -471,6 +477,7 @@ bool AsioAudioDriver::open(const Spec& spec, Spec* activeSpec)
 
     // Set active
     s_adata.activeSpec = spec;
+    s_adata.activeSpec.deviceId = deviceId;
     OutputSpec& active = s_adata.activeSpec.output;
     active.audioChannelCount = 2;
 

--- a/src/framework/audio/main/internal/audiodrivercontroller.cpp
+++ b/src/framework/audio/main/internal/audiodrivercontroller.cpp
@@ -218,16 +218,17 @@ void AudioDriverController::changeCurrentAudioApi(const std::string& name)
     IAudioDriverPtr driver = createDriver(name);
     setNewDriver(driver);
     m_audioDriver->init();
-    LOGI() << "Used " << m_audioDriver->name() << " audio driver";
+    LOGI() << "Used audio driver: " << m_audioDriver->name();
 
     // reset to default
     IAudioDriver::Spec spec = defaultSpec();
     spec.callback = m_callback;
 
     if (!spec.deviceId.empty()) {
+        spec.deviceId = DEFAULT_DEVICE_ID;
         m_audioDriver->open(spec, nullptr);
     } else {
-        LOGW() << "no devices for " << name;
+        LOGW() << "No devices for " << name;
     }
 
     configuration()->setCurrentAudioApi(name);

--- a/src/preferences/qml/MuseScore/Preferences/audiomidipreferencesmodel.cpp
+++ b/src/preferences/qml/MuseScore/Preferences/audiomidipreferencesmodel.cpp
@@ -22,6 +22,7 @@
 
 #include "audiomidipreferencesmodel.h"
 
+#include "translation.h"
 #include "log.h"
 
 using namespace mu::preferences;
@@ -49,6 +50,29 @@ void AudioMidiPreferencesModel::setCurrentAudioApiIndex(int index)
     if (index < 0 || index >= static_cast<int>(apiList.size())) {
         return;
     }
+
+    std::string fallbackApi = audioDriverController()->currentAudioApi();
+
+    audioDriverController()->availableOutputDevicesChanged().onNotify(this, [this, fallbackApi]() {
+        audioDriverController()->availableOutputDevicesChanged().disconnect(this);
+
+        if (!audioDriverController()->availableOutputDevices().empty()) {
+            return;
+        }
+
+        auto promise = interactive()->warning(
+            muse::trc("preferences", "No audio devices available"),
+            muse::qtrc("preferences", "The selected audio driver does not have any available audio devices. "
+                                      "MuseScore Studio will use the default audio driver instead. "
+                                      "To use %1, ensure your hardware is set up correctly, "
+                                      "then restart MuseScore Studio and try again.")
+            .arg(QString::fromStdString(audioDriverController()->currentAudioApi())).toStdString());
+
+        promise.onResolve(this, [this, fallbackApi](const muse::IInteractive::Result&) {
+            audioDriverController()->changeCurrentAudioApi(fallbackApi);
+            emit currentAudioApiIndexChanged(currentAudioApiIndex());
+        });
+    }, Asyncable::Mode::SetReplace);
 
     audioDriverController()->changeCurrentAudioApi(apiList.at(index));
     emit currentAudioApiIndexChanged(index);
@@ -147,9 +171,11 @@ bool AudioMidiPreferencesModel::onlineSoundsSectionVisible() const
 
 QVariantList AudioMidiPreferencesModel::midiInputDevices() const
 {
-    QVariantList result;
-
     std::vector<MidiDevice> devices = midiInPort()->availableDevices();
+
+    QVariantList result;
+    result.reserve(devices.size());
+
     for (const MidiDevice& device : devices) {
         QVariantMap obj;
         obj["value"] = QString::fromStdString(device.id);
@@ -163,9 +189,11 @@ QVariantList AudioMidiPreferencesModel::midiInputDevices() const
 
 QVariantList AudioMidiPreferencesModel::midiOutputDevices() const
 {
-    QVariantList result;
-
     std::vector<MidiDevice> devices = midiOutPort()->availableDevices();
+
+    QVariantList result;
+    result.reserve(devices.size());
+
     for (const MidiDevice& device : devices) {
         QVariantMap obj;
         obj["value"] = QString::fromStdString(device.id);

--- a/src/preferences/qml/MuseScore/Preferences/audiomidipreferencesmodel.h
+++ b/src/preferences/qml/MuseScore/Preferences/audiomidipreferencesmodel.h
@@ -27,12 +27,14 @@
 
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+
 #include "audio/main/iaudioconfiguration.h"
 #include "audio/iaudiodrivercontroller.h"
 #include "midi/imidiconfiguration.h"
 #include "midi/imidioutport.h"
 #include "midi/imidiinport.h"
 #include "playback/iplaybackconfiguration.h"
+#include "global/iinteractive.h"
 
 namespace mu::preferences {
 class AudioMidiPreferencesModel : public QObject, public muse::Contextable, public muse::async::Asyncable
@@ -66,6 +68,7 @@ class AudioMidiPreferencesModel : public QObject, public muse::Contextable, publ
     muse::ContextInject<muse::audio::IAudioDriverController> audioDriverController = { this };
     muse::ContextInject<muse::midi::IMidiOutPort> midiOutPort = { this };
     muse::ContextInject<muse::midi::IMidiInPort> midiInPort = { this };
+    muse::ContextInject<muse::IInteractive> interactive = { this };
 
 public:
     explicit AudioMidiPreferencesModel(QObject* parent = nullptr);

--- a/src/preferences/qml/MuseScore/Preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/preferences/qml/MuseScore/Preferences/commonaudioapiconfigurationmodel.cpp
@@ -75,9 +75,11 @@ QString CommonAudioApiConfigurationModel::currentDeviceId() const
 
 QVariantList CommonAudioApiConfigurationModel::deviceList() const
 {
-    QVariantList result;
-
     AudioDeviceList devices = audioDriverController()->availableOutputDevices();
+
+    QVariantList result;
+    result.reserve(devices.size());
+
     for (const AudioDevice& device : devices) {
         QVariantMap obj;
         obj["value"] = QString::fromStdString(device.id);
@@ -106,8 +108,10 @@ unsigned int CommonAudioApiConfigurationModel::bufferSize() const
 
 QList<unsigned int> CommonAudioApiConfigurationModel::bufferSizeList() const
 {
-    QList<unsigned int> result;
     std::vector<samples_t> bufferSizes = audioDriverController()->availableOutputDeviceBufferSizes();
+
+    QList<unsigned int> result;
+    result.reserve(bufferSizes.size());
 
     for (samples_t bufferSize : bufferSizes) {
         result << static_cast<unsigned int>(bufferSize);
@@ -128,8 +132,10 @@ unsigned int CommonAudioApiConfigurationModel::sampleRate() const
 
 QList<unsigned int> CommonAudioApiConfigurationModel::sampleRateList() const
 {
-    QList<unsigned int> result;
     std::vector<sample_rate_t> sampleRates = audioDriverController()->availableOutputDeviceSampleRates();
+
+    QList<unsigned int> result;
+    result.reserve(sampleRates.size());
 
     for (sample_rate_t sampleRate : sampleRates) {
         result << static_cast<unsigned int>(sampleRate);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31663
Resolves: https://github.com/musescore/MuseScore/issues/31664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive warning shown when switching to an audio driver with no output devices; selection reverts to the previous driver when confirmed.
  * Improved UI label: "Audio API" renamed to "Audio driver".

* **Bug Fixes**
  * More reliable default audio-device selection during driver initialization.
  * Clarified warning and log messages for driver/device state.
  * Minor performance improvements when enumerating MIDI devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->