### PR TITLE
fix(musicxml): correct barre fret export for shifted chord diagrams

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -9108,7 +9108,7 @@ static void writeMusicXml(const FretDiagram* item, XmlWriter& xml)
         for (int j : bStarts) {
             xml.startElement("frame-note");
             xml.tag("string", mxmlString);
-            xml.tag("fret", j);
+            xml.tag("fret", j + item->fretOffset());
             xml.tag("barre", { { "type", "start" } });
             xml.endElement();
         }
@@ -9116,7 +9116,7 @@ static void writeMusicXml(const FretDiagram* item, XmlWriter& xml)
         for (int j : bEnds) {
             xml.startElement("frame-note");
             xml.tag("string", mxmlString);
-            xml.tag("fret", j);
+            xml.tag("fret", j + item->fretOffset());
             xml.tag("barre", { { "type", "stop" } });
             xml.endElement();
         }


### PR DESCRIPTION
Barre notes written via the 'unwritten barres' fallback path in writeMusicXml(FretDiagram) were emitting relative fret numbers instead of absolute ones, while every other code path (dots, first-fret tag) correctly applied fretOffset.

This caused any chord diagram with first-fret > 1 to render the barre at the wrong position in importing applications.

Fix: add item->fretOffset() to the fret value in both the bStarts and bEnds loops, consistent with how dot frets are already handled.

Example: a Csus4 barre at position 3 (fretOffset=2) was exporting fret=1 instead of the correct fret=3.

Fixes: barre chords in all shifted chord diagrams (first-fret > 1)

Resolves: #32958<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
