### PR TITLE
[4.7] Video export. Step 7. Stabilization 

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -120,13 +120,17 @@ struct SoundTrackFormat {
     OutputSpec outputSpec;
     AudioSampleFormat sampleFormat = AudioSampleFormat::Undefined;
     int bitRate = 0;
+    msecs_t leadingSilenceDuration = 0;
+    msecs_t trailingSilenceDuration = 0;
 
     bool operator==(const SoundTrackFormat& other) const
     {
         return type == other.type
                && outputSpec == other.outputSpec
                && sampleFormat == other.sampleFormat
-               && bitRate == other.bitRate;
+               && bitRate == other.bitRate
+               && leadingSilenceDuration == other.leadingSilenceDuration
+               && trailingSilenceDuration == other.trailingSilenceDuration;
     }
 
     bool isValid() const

--- a/src/framework/audio/common/rpc/rpcpacker.h
+++ b/src/framework/audio/common/rpc/rpcpacker.h
@@ -278,12 +278,14 @@ inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::AudioSampleFo
 
 inline void pack_custom(muse::msgpack::Packer& p, const muse::audio::SoundTrackFormat& value)
 {
-    p.process(value.type, value.outputSpec, value.sampleFormat, value.bitRate);
+    p.process(value.type, value.outputSpec, value.sampleFormat, value.bitRate,
+              value.leadingSilenceDuration, value.trailingSilenceDuration);
 }
 
 inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::SoundTrackFormat& value)
 {
-    p.process(value.type, value.outputSpec, value.sampleFormat, value.bitRate);
+    p.process(value.type, value.outputSpec, value.sampleFormat, value.bitRate,
+              value.leadingSilenceDuration, value.trailingSilenceDuration);
 }
 
 inline void pack_custom(muse::msgpack::Packer& p, const muse::audio::SaveSoundTrackStage& value)

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -118,10 +118,15 @@ Ret SoundTrackWriter::write()
     DEFER {
         m_encoderPtr->flush();
 
-        audioEngine()->setMode(RenderMode::IdleMode);
+        //! NOTE Changes to the source and audio engine state
+        //! must be performed via execOperation - so that synchronization with the audio driver process works
+        IAudioEngine::Operation func = [this]() {
+            audioEngine()->setMode(RenderMode::IdleMode);
 
-        m_source->setOutputSpec(audioEngine()->outputSpec());
-        m_source->setIsActive(false);
+            m_source->setOutputSpec(audioEngine()->outputSpec());
+            m_source->setIsActive(false);
+        };
+        audioEngine()->execOperation(OperationType::LongOperation, func);
 
         m_isAborted = false;
     };

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -70,8 +70,16 @@ SoundTrackWriter::SoundTrackWriter(const io::path_t& destination, const SoundTra
     }
 
     const OutputSpec& outputSpec = format.outputSpec;
-    const uint64_t totalUs = static_cast<uint64_t>(std::max<int64_t>(0, totalDuration));
-    m_totalSamplesPerChannel = static_cast<samples_t>((totalUs * static_cast<uint64_t>(outputSpec.sampleRate)) / 1000000ULL);
+
+    auto durationToSamples = [&](msecs_t duration) {
+        const uint64_t _duration = static_cast<uint64_t>(std::max<int64_t>(0, duration));
+        return static_cast<samples_t>((_duration * static_cast<uint64_t>(outputSpec.sampleRate)) / 1000000ULL);
+    };
+
+    m_dataSamples = durationToSamples(totalDuration);
+    m_leadingSilenceSamples = durationToSamples(format.leadingSilenceDuration);
+    samples_t trailingSilenceSamples = durationToSamples(format.trailingSilenceDuration);
+    m_totalSamples = m_leadingSilenceSamples + m_dataSamples + trailingSilenceSamples;
 
     const samples_t intermediateSamplesNumber = outputSpec.samplesPerChannel * outputSpec.audioChannelCount;
     m_intermBuffer.resize(intermediateSamplesNumber);
@@ -82,7 +90,7 @@ SoundTrackWriter::SoundTrackWriter(const io::path_t& destination, const SoundTra
         return;
     }
 
-    if (!m_encoderPtr->init(destination, format, m_totalSamplesPerChannel)) {
+    if (!m_encoderPtr->init(destination, format, m_totalSamples)) {
         m_encoderPtr.reset();
     }
 }
@@ -138,18 +146,38 @@ Progress SoundTrackWriter::progress()
 
 Ret SoundTrackWriter::writeStreaming()
 {
-    if (m_totalSamplesPerChannel == 0) {
+    if (m_totalSamples == 0) {
         LOGI() << "No audio to export";
         return make_ret(Err::NoAudioToExport);
     }
 
     samples_t framesWritten = 0;
 
-    sendStreamingProgress(0, m_totalSamplesPerChannel);
+    sendStreamingProgress(0, m_totalSamples);
 
-    while (framesWritten < m_totalSamplesPerChannel && !m_isAborted) {
+    // Phase 1: leading silence
+    const samples_t leadingEnd = m_leadingSilenceSamples;
+    while (framesWritten < leadingEnd && !m_isAborted) {
         const samples_t chunk = static_cast<samples_t>(
-            std::min<uint64_t>(m_renderStep, m_totalSamplesPerChannel - framesWritten));
+            std::min<uint64_t>(m_renderStep, leadingEnd - framesWritten));
+
+        std::fill(m_intermBuffer.begin(), m_intermBuffer.end(), 0.f);
+
+        const size_t encoded = m_encoderPtr->encode(chunk, m_intermBuffer.data());
+        if (encoded == 0) {
+            return make_ret(Err::ErrorEncode);
+        }
+
+        framesWritten += chunk;
+        sendStreamingProgress(framesWritten, m_totalSamples);
+        rpcChannel()->process();
+    }
+
+    // Phase 2: actual audio data
+    const samples_t audioEnd = m_leadingSilenceSamples + m_dataSamples;
+    while (framesWritten < audioEnd && !m_isAborted) {
+        const samples_t chunk = static_cast<samples_t>(
+            std::min<uint64_t>(m_renderStep, audioEnd - framesWritten));
 
         m_source->process(m_intermBuffer.data(), chunk);
 
@@ -159,10 +187,24 @@ Ret SoundTrackWriter::writeStreaming()
         }
 
         framesWritten += chunk;
-        sendStreamingProgress(framesWritten, m_totalSamplesPerChannel);
+        sendStreamingProgress(framesWritten, m_totalSamples);
+        rpcChannel()->process();
+    }
 
-        //! NOTE It is necessary for cancellation to work
-        //! and for information about the audio signal to be transmitted.
+    // Phase 3: trailing silence
+    while (framesWritten < m_totalSamples && !m_isAborted) {
+        const samples_t chunk = static_cast<samples_t>(
+            std::min<uint64_t>(m_renderStep, m_totalSamples - framesWritten));
+
+        std::fill(m_intermBuffer.begin(), m_intermBuffer.end(), 0.f);
+
+        const size_t encoded = m_encoderPtr->encode(chunk, m_intermBuffer.data());
+        if (encoded == 0) {
+            return make_ret(Err::ErrorEncode);
+        }
+
+        framesWritten += chunk;
+        sendStreamingProgress(framesWritten, m_totalSamples);
         rpcChannel()->process();
     }
 

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.h
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.h
@@ -60,8 +60,11 @@ private:
     engine::IAudioSourcePtr m_source = nullptr;
 
     std::vector<float> m_intermBuffer;
+
     samples_t m_renderStep = 0;
-    samples_t m_totalSamplesPerChannel = 0;
+    samples_t m_leadingSilenceSamples = 0;
+    samples_t m_dataSamples = 0;
+    samples_t m_totalSamples = 0;
 
     encode::AbstractAudioEncoderPtr m_encoderPtr = nullptr;
 

--- a/src/framework/audio/tests/rpcpacker_tests.cpp
+++ b/src/framework/audio/tests/rpcpacker_tests.cpp
@@ -259,12 +259,16 @@ TEST_F(Audio_RpcPackerTests, SoundTrackFormat)
     origin.outputSpec.audioChannelCount = 2;
     origin.bitRate = 196;
     origin.sampleFormat = AudioSampleFormat::Float32;
+    origin.leadingSilenceDuration = 3000000;
+    origin.trailingSilenceDuration = 5000000;
 
     KNOWN_FIELDS(origin,
                  origin.type,
                  origin.outputSpec,
                  origin.bitRate,
-                 origin.sampleFormat);
+                 origin.sampleFormat,
+                 origin.leadingSilenceDuration,
+                 origin.trailingSilenceDuration);
 
     ByteArray data = rpc::RpcPacker::pack(origin);
 

--- a/src/framework/global/io/filestream.cpp
+++ b/src/framework/global/io/filestream.cpp
@@ -35,8 +35,14 @@ FileStream::FileStream(const path_t& filePath)
 
 FileStream::~FileStream()
 {
+    doClose();
+}
+
+void FileStream::doClose()
+{
     if (m_streamId != INVALID_STREAM_ID) {
         fileSystem()->closeStream(m_streamId);
+        m_streamId = INVALID_STREAM_ID;
     }
 }
 

--- a/src/framework/global/io/filestream.h
+++ b/src/framework/global/io/filestream.h
@@ -44,6 +44,7 @@ public:
 
 protected:
     bool doOpen(OpenMode m) override;
+    void doClose() override;
     size_t dataSize() const override;
     const uint8_t* rawData() const override;
     bool resizeData(size_t size) override;

--- a/src/framework/global/io/iodevice.cpp
+++ b/src/framework/global/io/iodevice.cpp
@@ -49,6 +49,7 @@ bool IODevice::open(IODevice::OpenMode mode)
 
 void IODevice::close()
 {
+    doClose();
     m_mode = Unknown;
 }
 

--- a/src/framework/global/io/iodevice.h
+++ b/src/framework/global/io/iodevice.h
@@ -75,6 +75,7 @@ public:
 protected:
 
     virtual bool doOpen(OpenMode m) = 0;
+    virtual void doClose() {}
     virtual size_t dataSize() const = 0;
     virtual const uint8_t* rawData() const = 0;
     virtual bool resizeData(size_t size) = 0;

--- a/src/framework/media/internal/ffmpeg/v4/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v4/videoencoder.cpp
@@ -617,6 +617,7 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath)
         if (outputFmtCtx) {
             if (outputFmtCtx->pb) {
                 m_ffmpegHandler->avio_close(outputFmtCtx->pb);
+                outputFmtCtx->pb = nullptr;
             }
             m_ffmpegHandler->avformat_free_context(outputFmtCtx);
         }

--- a/src/framework/media/internal/ffmpeg/v4/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v4/videoencoder.cpp
@@ -588,7 +588,7 @@ bool VideoEncoder::encodeVideo(const ByteArray& videoData, int maxFrames)
     return true;
 }
 
-bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
+bool VideoEncoder::addAudio(const io::path_t& audioPath)
 {
     if (m_outputPath.empty()) {
         LOGE() << "addAudio: encoder was not opened or path not set";
@@ -703,13 +703,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
         return false;
     }
 
-    int64_t audioOffsetPts = 0;
-    {
-        AVStream* audioOutStream = outputFmtCtx->streams[outAudioIdx];
-        audioOffsetPts = static_cast<int64_t>(audioOffsetSec * audioOutStream->time_base.den
-                                              / audioOutStream->time_base.num);
-    }
-
     AVPacket* pkt = m_ffmpegHandler->av_packet_alloc();
 
     while (m_ffmpegHandler->av_read_frame(videoFmtCtx, pkt) >= 0) {
@@ -728,8 +721,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
             pkt->stream_index = outAudioIdx;
             m_ffmpegHandler->av_packet_rescale_ts(pkt, audioFmtCtx->streams[audioInIdx]->time_base,
                                                   outputFmtCtx->streams[outAudioIdx]->time_base);
-            pkt->pts += audioOffsetPts;
-            pkt->dts += audioOffsetPts;
             pkt->pos = -1;
             m_ffmpegHandler->av_interleaved_write_frame(outputFmtCtx, pkt);
         }

--- a/src/framework/media/internal/ffmpeg/v4/videoencoder.h
+++ b/src/framework/media/internal/ffmpeg/v4/videoencoder.h
@@ -45,7 +45,7 @@ public:
 
     bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) override;
 
-    bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) override;
+    bool addAudio(const muse::io::path_t& audioPath) override;
 
 private:
     bool convertImage_sws(const QImage& img);

--- a/src/framework/media/internal/ffmpeg/v5/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v5/videoencoder.cpp
@@ -617,6 +617,7 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath)
         if (outputFmtCtx) {
             if (outputFmtCtx->pb) {
                 m_ffmpegHandler->avio_close(outputFmtCtx->pb);
+                outputFmtCtx->pb = nullptr;
             }
             m_ffmpegHandler->avformat_free_context(outputFmtCtx);
         }

--- a/src/framework/media/internal/ffmpeg/v5/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v5/videoencoder.cpp
@@ -588,7 +588,7 @@ bool VideoEncoder::encodeVideo(const ByteArray& videoData, int maxFrames)
     return true;
 }
 
-bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
+bool VideoEncoder::addAudio(const io::path_t& audioPath)
 {
     if (m_outputPath.empty()) {
         LOGE() << "addAudio: encoder was not opened or path not set";
@@ -703,13 +703,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
         return false;
     }
 
-    int64_t audioOffsetPts = 0;
-    {
-        AVStream* audioOutStream = outputFmtCtx->streams[outAudioIdx];
-        audioOffsetPts = static_cast<int64_t>(audioOffsetSec * audioOutStream->time_base.den
-                                              / audioOutStream->time_base.num);
-    }
-
     AVPacket* pkt = m_ffmpegHandler->av_packet_alloc();
 
     while (m_ffmpegHandler->av_read_frame(videoFmtCtx, pkt) >= 0) {
@@ -728,8 +721,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
             pkt->stream_index = outAudioIdx;
             m_ffmpegHandler->av_packet_rescale_ts(pkt, audioFmtCtx->streams[audioInIdx]->time_base,
                                                   outputFmtCtx->streams[outAudioIdx]->time_base);
-            pkt->pts += audioOffsetPts;
-            pkt->dts += audioOffsetPts;
             pkt->pos = -1;
             m_ffmpegHandler->av_interleaved_write_frame(outputFmtCtx, pkt);
         }

--- a/src/framework/media/internal/ffmpeg/v5/videoencoder.h
+++ b/src/framework/media/internal/ffmpeg/v5/videoencoder.h
@@ -45,7 +45,7 @@ public:
 
     bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) override;
 
-    bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) override;
+    bool addAudio(const muse::io::path_t& audioPath) override;
 
 private:
     bool convertImage_sws(const QImage& img);

--- a/src/framework/media/internal/ffmpeg/v6/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v6/videoencoder.cpp
@@ -617,6 +617,7 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath)
         if (outputFmtCtx) {
             if (outputFmtCtx->pb) {
                 m_ffmpegHandler->avio_close(outputFmtCtx->pb);
+                outputFmtCtx->pb = nullptr;
             }
             m_ffmpegHandler->avformat_free_context(outputFmtCtx);
         }

--- a/src/framework/media/internal/ffmpeg/v6/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v6/videoencoder.cpp
@@ -588,7 +588,7 @@ bool VideoEncoder::encodeVideo(const ByteArray& videoData, int maxFrames)
     return true;
 }
 
-bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
+bool VideoEncoder::addAudio(const io::path_t& audioPath)
 {
     if (m_outputPath.empty()) {
         LOGE() << "addAudio: encoder was not opened or path not set";
@@ -703,13 +703,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
         return false;
     }
 
-    int64_t audioOffsetPts = 0;
-    {
-        AVStream* audioOutStream = outputFmtCtx->streams[outAudioIdx];
-        audioOffsetPts = static_cast<int64_t>(audioOffsetSec * audioOutStream->time_base.den
-                                              / audioOutStream->time_base.num);
-    }
-
     AVPacket* pkt = m_ffmpegHandler->av_packet_alloc();
 
     while (m_ffmpegHandler->av_read_frame(videoFmtCtx, pkt) >= 0) {
@@ -728,8 +721,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
             pkt->stream_index = outAudioIdx;
             m_ffmpegHandler->av_packet_rescale_ts(pkt, audioFmtCtx->streams[audioInIdx]->time_base,
                                                   outputFmtCtx->streams[outAudioIdx]->time_base);
-            pkt->pts += audioOffsetPts;
-            pkt->dts += audioOffsetPts;
             pkt->pos = -1;
             m_ffmpegHandler->av_interleaved_write_frame(outputFmtCtx, pkt);
         }

--- a/src/framework/media/internal/ffmpeg/v6/videoencoder.h
+++ b/src/framework/media/internal/ffmpeg/v6/videoencoder.h
@@ -45,7 +45,7 @@ public:
 
     bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) override;
 
-    bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) override;
+    bool addAudio(const muse::io::path_t& audioPath) override;
 
 private:
     bool convertImage_sws(const QImage& img);

--- a/src/framework/media/internal/ffmpeg/v7/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v7/videoencoder.cpp
@@ -617,6 +617,7 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath)
         if (outputFmtCtx) {
             if (outputFmtCtx->pb) {
                 m_ffmpegHandler->avio_close(outputFmtCtx->pb);
+                outputFmtCtx->pb = nullptr;
             }
             m_ffmpegHandler->avformat_free_context(outputFmtCtx);
         }

--- a/src/framework/media/internal/ffmpeg/v7/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v7/videoencoder.cpp
@@ -588,7 +588,7 @@ bool VideoEncoder::encodeVideo(const ByteArray& videoData, int maxFrames)
     return true;
 }
 
-bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
+bool VideoEncoder::addAudio(const io::path_t& audioPath)
 {
     if (m_outputPath.empty()) {
         LOGE() << "addAudio: encoder was not opened or path not set";
@@ -703,13 +703,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
         return false;
     }
 
-    int64_t audioOffsetPts = 0;
-    {
-        AVStream* audioOutStream = outputFmtCtx->streams[outAudioIdx];
-        audioOffsetPts = static_cast<int64_t>(audioOffsetSec * audioOutStream->time_base.den
-                                              / audioOutStream->time_base.num);
-    }
-
     AVPacket* pkt = m_ffmpegHandler->av_packet_alloc();
 
     while (m_ffmpegHandler->av_read_frame(videoFmtCtx, pkt) >= 0) {
@@ -728,8 +721,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
             pkt->stream_index = outAudioIdx;
             m_ffmpegHandler->av_packet_rescale_ts(pkt, audioFmtCtx->streams[audioInIdx]->time_base,
                                                   outputFmtCtx->streams[outAudioIdx]->time_base);
-            pkt->pts += audioOffsetPts;
-            pkt->dts += audioOffsetPts;
             pkt->pos = -1;
             m_ffmpegHandler->av_interleaved_write_frame(outputFmtCtx, pkt);
         }

--- a/src/framework/media/internal/ffmpeg/v7/videoencoder.h
+++ b/src/framework/media/internal/ffmpeg/v7/videoencoder.h
@@ -45,7 +45,7 @@ public:
 
     bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) override;
 
-    bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) override;
+    bool addAudio(const muse::io::path_t& audioPath) override;
 
 private:
     bool convertImage_sws(const QImage& img);

--- a/src/framework/media/internal/ffmpeg/v8/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v8/videoencoder.cpp
@@ -617,6 +617,7 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath)
         if (outputFmtCtx) {
             if (outputFmtCtx->pb) {
                 m_ffmpegHandler->avio_close(outputFmtCtx->pb);
+                outputFmtCtx->pb = nullptr;
             }
             m_ffmpegHandler->avformat_free_context(outputFmtCtx);
         }

--- a/src/framework/media/internal/ffmpeg/v8/videoencoder.cpp
+++ b/src/framework/media/internal/ffmpeg/v8/videoencoder.cpp
@@ -588,7 +588,7 @@ bool VideoEncoder::encodeVideo(const ByteArray& videoData, int maxFrames)
     return true;
 }
 
-bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
+bool VideoEncoder::addAudio(const io::path_t& audioPath)
 {
     if (m_outputPath.empty()) {
         LOGE() << "addAudio: encoder was not opened or path not set";
@@ -703,13 +703,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
         return false;
     }
 
-    int64_t audioOffsetPts = 0;
-    {
-        AVStream* audioOutStream = outputFmtCtx->streams[outAudioIdx];
-        audioOffsetPts = static_cast<int64_t>(audioOffsetSec * audioOutStream->time_base.den
-                                              / audioOutStream->time_base.num);
-    }
-
     AVPacket* pkt = m_ffmpegHandler->av_packet_alloc();
 
     while (m_ffmpegHandler->av_read_frame(videoFmtCtx, pkt) >= 0) {
@@ -728,8 +721,6 @@ bool VideoEncoder::addAudio(const io::path_t& audioPath, double audioOffsetSec)
             pkt->stream_index = outAudioIdx;
             m_ffmpegHandler->av_packet_rescale_ts(pkt, audioFmtCtx->streams[audioInIdx]->time_base,
                                                   outputFmtCtx->streams[outAudioIdx]->time_base);
-            pkt->pts += audioOffsetPts;
-            pkt->dts += audioOffsetPts;
             pkt->pos = -1;
             m_ffmpegHandler->av_interleaved_write_frame(outputFmtCtx, pkt);
         }

--- a/src/framework/media/internal/ffmpeg/v8/videoencoder.h
+++ b/src/framework/media/internal/ffmpeg/v8/videoencoder.h
@@ -45,7 +45,7 @@ public:
 
     bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) override;
 
-    bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) override;
+    bool addAudio(const muse::io::path_t& audioPath) override;
 
 private:
     bool convertImage_sws(const QImage& img);

--- a/src/framework/media/ivideoencoder.h
+++ b/src/framework/media/ivideoencoder.h
@@ -56,7 +56,7 @@ public:
 
     virtual bool encodeVideo(const muse::ByteArray& videoData, int maxFrames = -1) = 0;
 
-    virtual bool addAudio(const muse::io::path_t& audioPath, double audioOffsetSec) = 0;
+    virtual bool addAudio(const muse::io::path_t& audioPath) = 0;
 };
 using IVideoEncoderPtr = std::shared_ptr<IVideoEncoder>;
 }

--- a/src/framework/stubs/media/videoencoderstub.cpp
+++ b/src/framework/stubs/media/videoencoderstub.cpp
@@ -41,7 +41,7 @@ void VideoEncoderStub::finishEncode()
 {
 }
 
-bool VideoEncoderStub::addAudio(const muse::io::path_t&, double)
+bool VideoEncoderStub::addAudio(const muse::io::path_t&)
 {
     return false;
 }

--- a/src/framework/stubs/media/videoencoderstub.h
+++ b/src/framework/stubs/media/videoencoderstub.h
@@ -36,6 +36,6 @@ public:
     bool encodeImage(const QImage&) override;
     void finishEncode() override;
 
-    bool addAudio(const muse::io::path_t&, double) override;
+    bool addAudio(const muse::io::path_t&) override;
 };
 }

--- a/src/importexport/audioexport/internal/abstractaudiowriter.cpp
+++ b/src/importexport/audioexport/internal/abstractaudiowriter.cpp
@@ -114,7 +114,17 @@ Ret AbstractAudioWriter::doWriteAndWait(INotationPtr notation,
     playbackController()->setNotation(notation);
     playbackController()->setIsExportingAudio(true);
 
-    doWrite(path, format);
+    SoundTrackFormat actualFormat = format;
+
+    double leadingSilenceSec = muse::value(options, OptionKey::LEADING_SILENCE_SEC, Val(0.0)).toDouble();
+    actualFormat.leadingSilenceDuration = std::isfinite(leadingSilenceSec)
+                                          ? static_cast<msecs_t>(leadingSilenceSec * 1000000.0) : 0;
+
+    double trailingSilenceSec = muse::value(options, OptionKey::TRAILING_SILENCE_SEC, Val(0.0)).toDouble();
+    actualFormat.trailingSilenceDuration = std::isfinite(trailingSilenceSec)
+                                           ? static_cast<msecs_t>(trailingSilenceSec * 1000000.0) : 0;
+
+    doWrite(path, actualFormat);
 
     bool waitForCompletion = muse::value(options, OptionKey::WAIT_FOR_COMPLETION, Val(true)).toBool();
     if (waitForCompletion) {

--- a/src/importexport/videoexport/internal/videoexportconfiguration.cpp
+++ b/src/importexport/videoexport/internal/videoexportconfiguration.cpp
@@ -31,7 +31,7 @@ static const int DEFAULT_FPS = 24;
 static const double DEFAULT_LEADING_SEC = 3.0;
 static const double DEFAULT_TRAILING_SECONDS = 3.0;
 
-static const std::vector<std::string> AVAILABLE_RESOLUTIONS = { "2160p", "1440p", "1080p", "720p", "480p", "360p" };
+static const std::vector<std::string> AVAILABLE_RESOLUTIONS = { "2160p", "1440p", "1080p" };
 
 ViewMode VideoExportConfiguration::viewMode() const
 {

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -129,7 +129,7 @@ muse::Ret VideoWriter::write(INotationPtr notation, muse::io::IODevice& device, 
     startVideoExport(encoder, notation, cfg);
 
     if (withAudio) {
-        startAudioExport(notation, tempAudioPath);
+        startAudioExport(notation, tempAudioPath, cfg);
     } else {
         m_audioCompleted = true;
         m_audioRet = muse::make_ok();
@@ -151,7 +151,7 @@ muse::Ret VideoWriter::write(INotationPtr notation, muse::io::IODevice& device, 
 
     if (withAudio) {
         if (result && m_audioRet) {
-            if (!encoder->addAudio(tempAudioPath, cfg.leadingSec)) {
+            if (!encoder->addAudio(tempAudioPath)) {
                 result = make_ret(muse::Ret::Code::UnknownError);
             }
         } else if (!result) {
@@ -229,7 +229,7 @@ void VideoWriter::startVideoExport(muse::media::IVideoEncoderPtr encoder, INotat
     });
 }
 
-void VideoWriter::startAudioExport(INotationPtr notation, const muse::io::path_t& audioPath)
+void VideoWriter::startAudioExport(INotationPtr notation, const muse::io::path_t& audioPath, const Config& cfg)
 {
     m_audioWriter = writers()->writer("aac");
     if (!m_audioWriter) {
@@ -246,6 +246,8 @@ void VideoWriter::startAudioExport(INotationPtr notation, const muse::io::path_t
 
     Options audioOpts;
     audioOpts[OptionKey::WAIT_FOR_COMPLETION] = muse::Val(false);
+    audioOpts[OptionKey::LEADING_SILENCE_SEC] = muse::Val(static_cast<double>(cfg.leadingSec));
+    audioOpts[OptionKey::TRAILING_SILENCE_SEC] = muse::Val(static_cast<double>(cfg.trailingSec));
 
     muse::io::Buffer audioDevice;
     audioDevice.setMeta("file_path", audioPath.toStdString());

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -149,6 +149,9 @@ muse::Ret VideoWriter::write(INotationPtr notation, muse::io::IODevice& device, 
 
     encoder->finishEncode();
 
+    // Release the device's file handle before add audio replaces the file
+    device.close();
+
     if (withAudio) {
         if (result && m_audioRet) {
             if (!encoder->addAudio(tempAudioPath)) {

--- a/src/importexport/videoexport/internal/videowriter.h
+++ b/src/importexport/videoexport/internal/videowriter.h
@@ -82,7 +82,7 @@ private:
     Config makeConfig() const;
 
     void startVideoExport(muse::media::IVideoEncoderPtr encoder, notation::INotationPtr notation, const Config& cfg);
-    void startAudioExport(notation::INotationPtr notation, const muse::io::path_t& audioPath);
+    void startAudioExport(notation::INotationPtr notation, const muse::io::path_t& audioPath, const Config& cfg);
 
     void doGenerate(muse::media::IVideoEncoderPtr encoder, notation::INotationPtr notation, const Config& config);
 

--- a/src/preferences/qml/MuseScore/Preferences/internal/FFmpegSection.qml
+++ b/src/preferences/qml/MuseScore/Preferences/internal/FFmpegSection.qml
@@ -88,7 +88,7 @@ BaseSection {
                 navigation.column: 100
 
                 onClicked: {
-                    api.launcher.openUrl("https://support.audacityteam.org/basics/installing-ffmpeg") // todo
+                    api.launcher.openUrl("https://handbook.musescore.org/video/installing-ffmpeg")
                 }
             }
         }

--- a/src/project/inotationwriter.h
+++ b/src/project/inotationwriter.h
@@ -51,7 +51,10 @@ public:
         BEATS_COLORS,
         WAIT_FOR_COMPLETION,
 
-        WITH_AUDIO, // todo: delete after stabilization of the video export + audio
+        WITH_AUDIO,
+
+        LEADING_SILENCE_SEC,
+        TRAILING_SILENCE_SEC,
     };
 
     using Options = std::map<OptionKey, muse::Val>;


### PR DESCRIPTION
Previously, leading and trailing silence in exported video was implemented by shifting audio packet timestamps (PTS offset) in the FFmpeg muxer, leaving actual gaps in the audio stream with no data. On Linux, audio decoders are sensitive to such gaps and produce crackling artifacts.

This change moves silence generation to the PCM level: SoundTrackWriter now streams silence frames (zeroed buffer) before and after the actual score audio, producing a continuous audio stream with no gaps.

Resolves: #32933
Resolves: #32955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable leading/trailing silence durations for exports and options to control them.

* **Refactor**
  * Export now encodes leading, data, and trailing audio segments; muxing flow simplified.

* **Chores**
  * Video encoder API no longer accepts an explicit audio-offset parameter (callers must omit offset).

* **Tests**
  * Serialization tests updated to include the new silence-duration fields.

* **Documentation**
  * FFmpeg download link in Preferences updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->