### PR TITLE
Fix #23306 SVG generation bug for OttavaSegment

### DIFF
--- a/src/importexport/imagesexport/internal/svggenerator.cpp
+++ b/src/importexport/imagesexport/internal/svggenerator.cpp
@@ -128,6 +128,9 @@ static void translate_dashPattern(QVector<qreal> pattern, const qreal& width, QS
 
     // Note that SVG operates in absolute lengths, whereas Qt uses a length/width ratio.
     foreach (qreal entry, pattern) {
+        if (entry < 0) {
+            entry = -entry;
+        }
         *pattern_string += QString::fromLatin1("%1,").arg(entry * width);
     }
 


### PR DESCRIPTION
Resolves: #23306<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
The issue aims to solve a bug when exporting to SVG format.  According to SVG standard (1.1 and 2)  stroke-dasharray negative values are invalid. This PR change negative values to positive when a mscz file is exported to SVG

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
