### PR TITLE
Don't remove outgoing ties when incrasing chord duration

### DIFF
--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -747,13 +747,7 @@ std::pair<Note*, Note*> Score::repitchReplaceNote(Chord* chord, const NoteVal& n
     // recreate tie forward if there is a note to tie to
     // one-sided ties will not be recreated
     if (firstTiedNote) {
-        Tie* tie = Factory::createTie(note);
-        tie->setStartNote(note);
-        tie->setEndNote(firstTiedNote);
-        tie->setTick(tie->startNote()->tick());
-        tie->setTick2(tie->endNote()->tick());
-        tie->setTrack(note->track());
-        undoAddElement(tie);
+        tieNotesTogether(note, firstTiedNote);
     }
     select(lastTiedNote);
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5938,6 +5938,20 @@ bool Score::autoLayoutEnabled() const
     return isOpen();
 }
 
+Tie* Score::tieNotesTogether(Note* n1, Note* n2)
+{
+    Tie* tie = Factory::createTie(this->dummy());
+    tie->setStartNote(n1);
+    tie->setEndNote(n2);
+    tie->setTick(tie->startNote()->tick());
+    tie->setTick2(tie->endNote()->tick());
+    tie->setTrack(n1->track());
+    n1->setTieFor(tie);
+    n2->setTieBack(tie);
+    undoAddElement(tie);
+    return tie;
+}
+
 //---------------------------------------------------------
 //   doLayout
 //    do a complete (re-) layout

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -866,6 +866,7 @@ public:
     Segment* lastSegment() const;
     Segment* lastSegmentMM() const;
 
+    Tie* tieNotesTogether(Note* n1, Note* n2);
     void connectTies(bool silent = false);
     void undoRemoveStaleTieJumpPoints(bool undo = true);
 

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -1769,6 +1769,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
     ChordRest* cr1 = cr;
     Chord* oc      = 0;
     Segment* s     = cr->segment();
+    Fraction endTickBefore = cr->isChord() ? toChord(cr)->endTickIncludingTied() : cr->endTick();
 
     bool first = true;
     for (const Fraction& f2 : flist) {
@@ -1856,6 +1857,22 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
         s = m1->first(SegmentType::ChordRest);
         cr1 = toChordRest(s->element(track));
     }
+
+    Fraction endTickAfter = cr->isChord() ? toChord(cr)->endTickIncludingTied() : cr->endTick();
+    while (endTickAfter < endTickBefore) {  // making a chord *longer* shouldn't _shorten_ its total duration
+        if (!oc){  // everything up to oc should already be tied together
+            oc = toChord(cr1);
+        }
+
+        for (Note* n: oc->notes()){
+            if (Note* nn = searchTieNote(n)){
+                tieNotesTogether(n, nn);
+            }
+        }
+        oc = oc->next();
+        endTickAfter = cr->isChord() ? toChord(cr)->endTickIncludingTied() : cr->endTick();
+    }
+
     connectTies();
 
     if (elementToSelect) {

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -1066,15 +1066,7 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
             for (unsigned int i = 0; i < oc->notes().size(); ++i) {
                 Note* on = oc->notes()[i];
                 Note* nn = nc->notes()[i];
-                Tie* tie = Factory::createTie(this->dummy());
-                tie->setStartNote(on);
-                tie->setEndNote(nn);
-                tie->setTick(tie->startNote()->tick());
-                tie->setTick2(tie->endNote()->tick());
-                tie->setTrack(cr->track());
-                on->setTieFor(tie);
-                nn->setTieBack(tie);
-                undoAddElement(tie);
+                tieNotesTogether(on, nn);
             }
         }
 
@@ -4214,13 +4206,7 @@ bool Score::cmdImplode()
                                 for (Note* tn : tied->notes()) {
                                     if (nn->pitch() == tn->pitch() && nn->tpc() == tn->tpc() && !tn->tieFor()) {
                                         // found note to tie
-                                        Tie* tie = Factory::createTie(this->dummy());
-                                        tie->setStartNote(tn);
-                                        tie->setEndNote(nn);
-                                        tie->setTick(tie->startNote()->tick());
-                                        tie->setTick2(tie->endNote()->tick());
-                                        tie->setTrack(tn->track());
-                                        undoAddElement(tie);
+                                        tieNotesTogether(tn, nn);
                                     }
                                 }
                             }

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -422,13 +422,7 @@ Chord* Score::addChord(const Fraction& tick, TDuration d, Chord* oc, bool genTie
         for (size_t i = 0; i < n; ++i) {
             Note* n1  = oc->notes()[i];
             Note* n2 = chord->notes()[i];
-            Tie* tie = Factory::createTie(this->dummy());
-            tie->setStartNote(n1);
-            tie->setEndNote(n2);
-            tie->setTick(tie->startNote()->tick());
-            tie->setTick2(tie->endNote()->tick());
-            tie->setTrack(n1->track());
-            undoAddElement(tie);
+            tieNotesTogether(n1, n2);
         }
     }
 
@@ -1700,15 +1694,7 @@ Note* Score::addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord, bool al
     if (prevChord) {
         Note* nn = prevChord->findNote(n->pitch());
         if (nn) {
-            Tie* tie = Factory::createTie(this->dummy());
-            tie->setStartNote(nn);
-            tie->setEndNote(n);
-            tie->setTick(tie->startNote()->tick());
-            tie->setTick2(tie->endNote()->tick());
-            tie->setTrack(n->track());
-            n->setTieBack(tie);
-            nn->setTieFor(tie);
-            undoAddElement(tie);
+            tieNotesTogether(nn, n);
         }
     }
     return n;
@@ -1908,14 +1894,7 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                             std::vector<Note*> nl2 = nchord2->notes();
                             if (!firstpart) {
                                 for (size_t j = 0; j < nl1.size(); ++j) {
-                                    Tie* tie = Factory::createTie(this->dummy());
-                                    tie->setStartNote(nl1[j]);
-                                    tie->setEndNote(nl2[j]);
-                                    tie->setTick(tie->startNote()->tick());
-                                    tie->setTick2(tie->endNote()->tick());
-                                    tie->setTrack(tr);
-                                    nl1[j]->setTieFor(tie);
-                                    nl2[j]->setTieBack(tie);
+                                    Tie* tie = tieNotesTogether(nl1[j], nl2[j]);
                                     ties.push_back(tie);
                                 }
                             }


### PR DESCRIPTION
Resolves: #31608

Ensures that the total length of a tied chord doesn't _decrease_ when _increasing_ the duration of a chord contained in the tie.

Additionally, adds a `tieNotesTogether` utility method, since the more-or-less same lines were repeated a few times in the codebase. I only replaced existing code with this utility method where I was reasonably sure that its 1:1 the same; the only potential difference in some places is that `note->setTieFor` and `note->setTieBack` are actually called, which I assume to be what should happen anyways.

_Note: I made the change while on 4.7 branch, and cherry-picked to master; there were no conflicts, so this should run fine; but I haven't managed to build master yet_

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal tie handling mechanism for note operations, enhancing consistency and reliability during chord restructuring and note manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->