### PR TITLE
Clean up warnings in MNX importer

### DIFF
--- a/src/importexport/mnx/CMakeLists.txt
+++ b/src/importexport/mnx/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
     FetchContent_Declare(
         mnxdom
         GIT_REPOSITORY https://github.com/rpatters1/mnxdom.git
-        GIT_TAG        1557afd19d47b7935ddda2b69131f5c62efab84c
+        GIT_TAG        e7c947bf768caccf315426dcae0dfac02caf738b
     )
     FetchContent_MakeAvailable(mnxdom)
     set(MNXDOM_LIB mnxdom)

--- a/src/importexport/mnx/internal/import/mnximporter.cpp
+++ b/src/importexport/mnx/internal/import/mnximporter.cpp
@@ -390,9 +390,7 @@ void MnxImporter::createStaff(Part* part, const mnx::Part& mnxPart, int staffNum
 
 void MnxImporter::importParts()
 {
-    size_t partNum = 0;
     for (mnx::Part mnxPart : mnxDocument().parts()) {
-        partNum++;
         Part* part = new Part(m_score);
         /// @todo a better way to find the instrument, perhaps by part name or else some future mnx enhancement
         const InstrumentTemplate* it = [&]() {


### PR DESCRIPTION
Clean up warnings in mnx importer and mnxdom.

- Apply change from `mnxdom` that fixed MSVC warning "'argument': conversion from 'size_t' to 'const int', possible loss of data (C4267)" (fixed by @Jojo-Schmitz)
- Remove unused variable in `MnxImporter::importParts`.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
