### PR TITLE
Fix Issue #26867: Proper Export Parts List Keyboard Navagation

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Export/ExportScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportScoresListView.qml
@@ -116,6 +116,7 @@ Rectangle {
                         return
                     }
 
+
                     listView.positionViewAtIndex(targetIndex, ListView.Contain)
 
                     Qt.callLater(function() {
@@ -128,13 +129,9 @@ Rectangle {
                     event.accepted = true
                 }
 
-                Connections {
-                    target: checkBox.navigation
-
-                    function onActiveChanged() {
-                        if (target.active) {
-                            listView.positionViewAtIndex(index, ListView.Contain)
-                        }
+                navigation.onActiveChanged: {
+                    if (navigation.active) {
+                        listView.positionViewAtIndex(index, ListView.Contain)
                     }
                 }
             }

--- a/src/project/qml/MuseScore/Project/internal/Export/ExportScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportScoresListView.qml
@@ -84,11 +84,58 @@ Rectangle {
                 navigation.name: "ExportScoreCheckBox " + text
                 navigation.panel: navPanel
                 navigation.row: delegateItem.index
+                navigation.column: 0
 
                 checked: delegateItem.isSelected
 
                 onClicked: {
                     root.scoresModel.setSelected(delegateItem.index, !checked)
+                }
+
+                navigation.onNavigationEvent: function(event) {
+                    let targetIndex = delegateItem.index
+
+                    switch (event.type) {
+                    case NavigationEvent.Up:
+                        if (delegateItem.index === 0) {
+                            event.accepted = true
+                            return
+                        }
+                        targetIndex = delegateItem.index - 1
+                        break
+
+                    case NavigationEvent.Down:
+                        if (delegateItem.index === listView.count - 1) {
+                            event.accepted = true
+                            return
+                        }
+                        targetIndex = delegateItem.index + 1
+                        break
+
+                    default:
+                        return
+                    }
+
+                    listView.positionViewAtIndex(targetIndex, ListView.Contain)
+
+                    Qt.callLater(function() {
+                        let item = listView.itemAtIndex(targetIndex)
+                        if (item) {
+                            item.requestActiveFocus()
+                        }
+                    })
+
+                    event.accepted = true
+                }
+
+                Connections {
+                    target: checkBox.navigation
+
+                    function onActiveChanged() {
+                        if (target.active) {
+                            listView.positionViewAtIndex(index, ListView.Contain)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implemented navigation handling for ExportScoresListView, allowing up and down navigation through the list and focus management without unexpected behavior of looping after 20 items without manual scrolling

Resolves: #26867 

Explicitly set navigation.column to 0 to ensure proper handling of the left and right arrow keys. The addition of Connections handles automatically scrolling the export menu while navigating with the arrow keys. This alone completely handles using arrow key navigation down the list of export options. Added navigation.onNavigationEvent to disallow navigating down from the final option and up from the first option. Otherwise such inputs would cause improper navigation behavior. This code also handles a bug where attempting to navigate back up the list would skip to the first option after 11 up inputs past the currently displayed top of the list.

No unit test was made in place of using extensive manual testing. This was due to time constraints and the small number of inputs possible in the export menu's part selection.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)