### PR TITLE
Fixes comment error

### DIFF
--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -2557,7 +2557,7 @@ class Spanner : public EngravingItem
     Q_OBJECT
     /// The tick this spanner starts at.
     API_PROPERTY(spannerTick,             SPANNER_TICK)
-    /// The tick this spanner end at.
+    /// The duration of this spanner.
     API_PROPERTY(spannerTicks,            SPANNER_TICKS)
     /// The track this spanner end at.
     API_PROPERTY_T(int, spannerTrack2,    SPANNER_TRACK2)


### PR DESCRIPTION
Resolves: #32991

This fixes a mistake in the API comments in elements.h — spannerTicks was listed as the 'end tick' of the spanner, but is in fact the _duration_ of the spanner

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
