### PR TITLE
Add note coloring scheme options to Style dialog

### DIFF
--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -492,6 +492,12 @@ PropertyValue Accidental::getProperty(Pid propertyId) const
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default accidental properties.
+ * When @p propertyId is @c Pid::COLOR and @c Sid::colorApplyToAccidental is set, returns the parent
+ * note's themed rendering color via @c Note::color() so accidentals follow the active coloring scheme.
+ * Otherwise falls back to @c EngravingItem::propertyDefault().
+ */
 PropertyValue Accidental::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -500,9 +506,32 @@ PropertyValue Accidental::propertyDefault(Pid propertyId) const
     case Pid::ACCIDENTAL_BRACKET: return int(AccidentalBracket::NONE);
     case Pid::ACCIDENTAL_ROLE:    return AccidentalRole::AUTO;
     case Pid::ACCIDENTAL_STACKING_ORDER_OFFSET: return 0;
+    case Pid::COLOR:
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return PropertyValue::fromValue(note()->color());
+        }
+        return EngravingItem::propertyDefault(propertyId);
     default:
         return EngravingItem::propertyDefault(propertyId);
     }
+}
+
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+/*!
+ * Draw color for this accidental when it still uses the score default: follows the parent
+ * note color when accidentals inherit coloring.
+ */
+Color Accidental::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return note()->color();
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -483,6 +483,10 @@ PropertyValue Accidental::getProperty(Pid propertyId) const
     case Pid::ACCIDENTAL_BRACKET: return int(bracket());
     case Pid::ACCIDENTAL_ROLE:    return role();
     case Pid::ACCIDENTAL_STACKING_ORDER_OFFSET: return stackingOrderOffset();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the parent note) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -492,6 +496,14 @@ PropertyValue Accidental::getProperty(Pid propertyId) const
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default accidental properties.
+ * When @p propertyId is @c Pid::COLOR and @c Sid::colorApplyToAccidental is set, returns the
+ * sentinel @c configuration()->defaultColor() so that resetting restores the "inherit from note"
+ * state instead of snapshotting the currently-themed color. @c Accidental::color() resolves the
+ * sentinel to the parent note's themed color at draw time.
+ * Otherwise falls back to @c EngravingItem::propertyDefault().
+ */
 PropertyValue Accidental::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -500,9 +512,32 @@ PropertyValue Accidental::propertyDefault(Pid propertyId) const
     case Pid::ACCIDENTAL_BRACKET: return int(AccidentalBracket::NONE);
     case Pid::ACCIDENTAL_ROLE:    return AccidentalRole::AUTO;
     case Pid::ACCIDENTAL_STACKING_ORDER_OFFSET: return 0;
+    case Pid::COLOR:
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return PropertyValue::fromValue(configuration()->defaultColor());
+        }
+        return EngravingItem::propertyDefault(propertyId);
     default:
         return EngravingItem::propertyDefault(propertyId);
     }
+}
+
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+/*!
+ * Draw color for this accidental when it still uses the score default: follows the parent
+ * note color when accidentals inherit coloring.
+ */
+Color Accidental::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return note()->color();
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -31,6 +31,8 @@
 
 #include "../editing/editnote.h"
 
+#include "iengravingconfiguration.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu;
@@ -490,6 +492,10 @@ PropertyValue Accidental::getProperty(Pid propertyId) const
     case Pid::ACCIDENTAL_BRACKET: return int(bracket());
     case Pid::ACCIDENTAL_ROLE:    return role();
     case Pid::ACCIDENTAL_STACKING_ORDER_OFFSET: return stackingOrderOffset();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the parent note) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -499,6 +505,14 @@ PropertyValue Accidental::getProperty(Pid propertyId) const
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default accidental properties.
+ * When @p propertyId is @c Pid::COLOR and @c Sid::colorApplyToAccidental is set, returns the
+ * sentinel @c configuration()->defaultColor() so that resetting restores the "inherit from note"
+ * state instead of snapshotting the currently-themed color. @c Accidental::color() resolves the
+ * sentinel to the parent note's themed color at draw time.
+ * Otherwise falls back to @c EngravingItem::propertyDefault().
+ */
 PropertyValue Accidental::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -507,9 +521,32 @@ PropertyValue Accidental::propertyDefault(Pid propertyId) const
     case Pid::ACCIDENTAL_BRACKET: return int(AccidentalBracket::NONE);
     case Pid::ACCIDENTAL_ROLE:    return AccidentalRole::AUTO;
     case Pid::ACCIDENTAL_STACKING_ORDER_OFFSET: return 0;
+    case Pid::COLOR:
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return PropertyValue::fromValue(configuration()->defaultColor());
+        }
+        return EngravingItem::propertyDefault(propertyId);
     default:
         return EngravingItem::propertyDefault(propertyId);
     }
+}
+
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+/*!
+ * Draw color for this accidental when it still uses the score default: follows the parent
+ * note color when accidentals inherit coloring.
+ */
+Color Accidental::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note() && note()->style().styleV(Sid::colorApplyToAccidental).toBool()) {
+            return note()->color();
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -249,6 +249,9 @@ public:
     void setRole(AccidentalRole r) { m_role = r; }
     AccidentalRole role() const { return m_role; }
 
+    //! Draw color; when inheriting, uses parent @c Note::color() (rendered head color).
+    Color color() const override;
+
     AccidentalBracket bracket() const { return m_bracket; }
     void setBracket(AccidentalBracket val) { m_bracket = val; }
     bool parentNoteHasParentheses() const;
@@ -266,6 +269,7 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: parent @c Note::color() when accidentals inherit themed color.
     PropertyValue propertyDefault(Pid propertyId) const override;
 
     static AccidentalVal subtype2value(AccidentalType);               // return effective pitch offset

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -250,6 +250,9 @@ public:
     void setRole(AccidentalRole r) { m_role = r; }
     AccidentalRole role() const { return m_role; }
 
+    //! Draw color; when inheriting, uses parent @c Note::color() (rendered head color).
+    Color color() const override;
+
     AccidentalBracket bracket() const { return m_bracket; }
     void setBracket(AccidentalBracket val) { m_bracket = val; }
     bool parentNoteHasParentheses() const;
@@ -267,6 +270,7 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when accidentals inherit themed color.
     PropertyValue propertyDefault(Pid propertyId) const override;
 
     static AccidentalVal subtype2value(AccidentalType);               // return effective pitch offset

--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -92,6 +92,7 @@ void Articulation::setTextType(ArticulationTextType textType)
     m_textType = textType;
 }
 
+/*! Selects or deselects this articulation, propagating to the text sub-element. */
 void Articulation::setSelected(bool f)
 {
     if (m_text) {
@@ -101,6 +102,7 @@ void Articulation::setSelected(bool f)
     EngravingItem::setSelected(f);
 }
 
+/*! Shows or hides this articulation, propagating visibility to the text sub-element. */
 void Articulation::setVisible(bool f)
 {
     if (m_text) {
@@ -239,6 +241,7 @@ Page* Articulation::page() const
     return toPage(s ? s->explicitParent() : 0);
 }
 
+/*! True if this articulation should not be rendered on the current TAB staff. */
 bool Articulation::isHiddenOnTabStaff() const
 {
     if (m_showOnTabStyles.first == Sid::NOSTYLE || m_showOnTabStyles.second == Sid::NOSTYLE) {
@@ -286,6 +289,7 @@ std::vector<LineF> Articulation::dragAnchorLines() const
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given articulation property. */
 PropertyValue Articulation::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -303,6 +307,7 @@ PropertyValue Articulation::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the articulation property identified by @p propertyId and triggers a relayout. */
 bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -332,6 +337,11 @@ bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default articulation properties.
+ * For @c Pid::COLOR on a chord-attached articulation, when @c Sid::colorApplyToArticulation is set,
+ * returns the top note's color.
+ */
 PropertyValue Articulation::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -344,10 +354,38 @@ PropertyValue Articulation::propertyDefault(Pid propertyId) const
     case Pid::PLAY:
         return true;
 
+    case Pid::COLOR: {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                return PropertyValue::fromValue(chord->upNote()->color());
+            }
+        }
+    }
+    // fall through
     default:
         break;
     }
     return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if articulations inherit note colors, returns
+ * the top note's color.
+ */
+Color Articulation::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                return chord->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -91,6 +91,7 @@ void Articulation::setTextType(ArticulationTextType textType)
     m_textType = textType;
 }
 
+/*! Selects or deselects this articulation, propagating to the text sub-element. */
 void Articulation::setSelected(bool f)
 {
     if (m_text) {
@@ -100,6 +101,7 @@ void Articulation::setSelected(bool f)
     EngravingItem::setSelected(f);
 }
 
+/*! Shows or hides this articulation, propagating visibility to the text sub-element. */
 void Articulation::setVisible(bool f)
 {
     if (m_text) {
@@ -238,6 +240,7 @@ Page* Articulation::page() const
     return toPage(s ? s->explicitParent() : 0);
 }
 
+/*! True if this articulation should not be rendered on the current TAB staff. */
 bool Articulation::isHiddenOnTabStaff() const
 {
     if (m_showOnTabStyles.first == Sid::NOSTYLE || m_showOnTabStyles.second == Sid::NOSTYLE) {
@@ -285,6 +288,7 @@ std::vector<LineF> Articulation::dragAnchorLines() const
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given articulation property. */
 PropertyValue Articulation::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -293,6 +297,10 @@ PropertyValue Articulation::getProperty(Pid propertyId) const
     case Pid::ARTICULATION_ANCHOR: return int(anchor());
     case Pid::ORNAMENT_STYLE:      return ornamentStyle();
     case Pid::PLAY:                return playArticulation();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the side note) so writers and
+        // undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -302,6 +310,7 @@ PropertyValue Articulation::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the articulation property identified by @p propertyId and triggers a relayout. */
 bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -331,6 +340,13 @@ bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default articulation properties.
+ * For @c Pid::COLOR on a chord-attached articulation, when @c Sid::colorApplyToArticulation is set,
+ * returns the sentinel @c configuration()->defaultColor() so that resetting restores the "inherit
+ * from note" state. @c Articulation::color() resolves the sentinel to the color of the chord note
+ * on the articulation's side (@c upNote() when above, @c downNote() when below).
+ */
 PropertyValue Articulation::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -343,10 +359,42 @@ PropertyValue Articulation::propertyDefault(Pid propertyId) const
     case Pid::PLAY:
         return true;
 
+    case Pid::COLOR: {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            Note* sideNote = up() ? chord->upNote() : chord->downNote();
+            if (sideNote->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                // Return sentinel so resetting keeps "inherit from note"; @c Articulation::color()
+                // resolves the sentinel to @c sideNote->color() at draw time.
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    // fall through
     default:
         break;
     }
     return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if articulations inherit note colors, returns the color
+ * of the chord note on the articulation's side (top note when above, bottom note when below).
+ */
+Color Articulation::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            Note* sideNote = up() ? chord->upNote() : chord->downNote();
+            if (sideNote->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                return sideNote->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -37,6 +37,8 @@
 #include "system.h"
 #include "note.h"
 
+#include "iengravingconfiguration.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu;
@@ -91,6 +93,7 @@ void Articulation::setTextType(ArticulationTextType textType)
     m_textType = textType;
 }
 
+/*! Selects or deselects this articulation, propagating to the text sub-element. */
 void Articulation::setSelected(bool f)
 {
     if (m_text) {
@@ -100,6 +103,7 @@ void Articulation::setSelected(bool f)
     EngravingItem::setSelected(f);
 }
 
+/*! Shows or hides this articulation, propagating visibility to the text sub-element. */
 void Articulation::setVisible(bool f)
 {
     if (m_text) {
@@ -238,6 +242,7 @@ Page* Articulation::page() const
     return s ? s->page() : nullptr;
 }
 
+/*! True if this articulation should not be rendered on the current TAB staff. */
 bool Articulation::isHiddenOnTabStaff() const
 {
     if (m_showOnTabStyles.first == Sid::NOSTYLE || m_showOnTabStyles.second == Sid::NOSTYLE) {
@@ -285,6 +290,7 @@ std::vector<LineF> Articulation::dragAnchorLines() const
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given articulation property. */
 PropertyValue Articulation::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -293,6 +299,10 @@ PropertyValue Articulation::getProperty(Pid propertyId) const
     case Pid::ARTICULATION_ANCHOR: return int(anchor());
     case Pid::ORNAMENT_STYLE:      return ornamentStyle();
     case Pid::PLAY:                return playArticulation();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the side note) so writers and
+        // undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -302,6 +312,7 @@ PropertyValue Articulation::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the articulation property identified by @p propertyId and triggers a relayout. */
 bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -331,6 +342,13 @@ bool Articulation::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default articulation properties.
+ * For @c Pid::COLOR on a chord-attached articulation, when @c Sid::colorApplyToArticulation is set,
+ * returns the sentinel @c configuration()->defaultColor() so that resetting restores the "inherit
+ * from note" state. @c Articulation::color() resolves the sentinel to the color of the chord note
+ * on the articulation's side (@c upNote() when above, @c downNote() when below).
+ */
 PropertyValue Articulation::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -343,10 +361,42 @@ PropertyValue Articulation::propertyDefault(Pid propertyId) const
     case Pid::PLAY:
         return true;
 
+    case Pid::COLOR: {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            Note* sideNote = up() ? chord->upNote() : chord->downNote();
+            if (sideNote->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                // Return sentinel so resetting keeps "inherit from note"; @c Articulation::color()
+                // resolves the sentinel to @c sideNote->color() at draw time.
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    // fall through
     default:
         break;
     }
     return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if articulations inherit note colors, returns the color
+ * of the chord note on the articulation's side (top note when above, bottom note when below).
+ */
+Color Articulation::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = chordRest();
+        if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            Note* sideNote = up() ? chord->upNote() : chord->downNote();
+            if (sideNote->style().styleV(Sid::colorApplyToArticulation).toBool()) {
+                return sideNote->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/articulation.h
+++ b/src/engraving/dom/articulation.h
@@ -140,7 +140,10 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when articulations inherit themed color.
     PropertyValue propertyDefault(Pid) const override;
+    //! Draw color: @c Chord::upNote()/downNote() color (side-dependent) when inheriting themed note color.
+    Color color() const override;
     void resetProperty(Pid id) override;
     Sid getPropertyStyle(Pid id) const override;
 

--- a/src/engraving/dom/articulation.h
+++ b/src/engraving/dom/articulation.h
@@ -140,7 +140,10 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: @c chordRootColorDefault() when articulations inherit themed color.
     PropertyValue propertyDefault(Pid) const override;
+    //! Draw color: @c chordRootNoteColor() when inheriting themed note color.
+    Color color() const override;
     void resetProperty(Pid id) override;
     Sid getPropertyStyle(Pid id) const override;
 

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -32,6 +32,7 @@
 
 #include "actionicon.h"
 #include "chord.h"
+#include "note.h"
 #include "groups.h"
 #include "measure.h"
 #include "score.h"
@@ -48,6 +49,21 @@ using namespace muse;
 using namespace mu::engraving;
 
 namespace mu::engraving {
+/*!
+ * First chord in beam order, skipping leading rests so beam color can follow the first pitched content.
+ * @param elements Chord/rest sequence stored on the beam.
+ * @return First @c Chord in @p elements, or @c nullptr if none.
+ */
+static ChordRest* firstChordRestInBeam(const std::vector<ChordRest*>& elements)
+{
+    for (ChordRest* cr : elements) {
+        if (cr && cr->isChord()) {
+            return cr;
+        }
+    }
+    return nullptr;
+}
+
 static const ElementStyle beamStyle {
     { Sid::beamNoSlope,                        Pid::BEAM_NO_SLOPE },
 };
@@ -222,6 +238,7 @@ void Beam::move(const PointF& offset)
     }
 }
 
+/*! Determines whether sub-beams at @p level are broken between @p prevCr and @p cr. */
 void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken16, bool& isBroken32) const
 {
     BeamMode beamMode = cr->beamMode();
@@ -415,6 +432,7 @@ void Beam::setDirection(DirectionV d)
     }
 }
 
+/*! Converts the beam into a feathered (accelerando/ritardando) beam. */
 void Beam::setAsFeathered(const bool slower)
 {
     if (slower) {
@@ -545,6 +563,7 @@ void Beam::setBeamPos(const PairF& bp)
     }
 }
 
+/*! Sets @p b as the no-slope flag and updates the beam position to be level. */
 void Beam::setNoSlope(bool b)
 {
     m_noSlope = b;
@@ -559,6 +578,7 @@ void Beam::setNoSlope(bool b)
     }
 }
 
+/*! Recalculates slope from the current start and end anchor positions. */
 void Beam::computeAndSetSlope()
 {
     double xDiff = m_endAnchor.x() - m_startAnchor.x();
@@ -576,6 +596,7 @@ void Beam::computeAndSetSlope()
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given beam property. */
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -601,6 +622,7 @@ PropertyValue Beam::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the beam property identified by @p propertyId and triggers a relayout. */
 bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -644,14 +666,47 @@ bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default beam properties.
+ * For @c Pid::COLOR, uses the first chord in @c m_elements (skipping leading rests); when
+ * @c Sid::colorApplyToBeam is enabled, returns the top note's color.
+ */
 PropertyValue Beam::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::GROW_LEFT:      return 1.0;
     case Pid::GROW_RIGHT:     return 1.0;
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
+    case Pid::COLOR: {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return PropertyValue::fromValue(chord->upNote()->color());
+            }
+        }
+    }
+    // fall through
     default:                  return BeamBase::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: if beams inherit note colors, returns
+ * the top note's color for the first chord after skipping leading rests.
+ */
+Color Beam::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return chord->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------
@@ -758,6 +813,7 @@ RectF Beam::drag(EditData& ed)
 //---------------------------------------------------------
 //   isMovable
 //---------------------------------------------------------
+/*! Beams are always considered user-movable (grip editing). */
 bool Beam::isMovable() const
 {
     return true;
@@ -766,6 +822,7 @@ bool Beam::isMovable() const
 //---------------------------------------------------------
 //   initBeamEditData
 //---------------------------------------------------------
+/*! Initialises edit-mode data for the beam, saving the fragment state for undo. */
 void Beam::initBeamEditData(EditData& ed)
 {
     std::shared_ptr<BeamEditData> bed = std::make_shared<BeamEditData>();
@@ -786,6 +843,7 @@ void Beam::startDrag(EditData& editData)
 //---------------------------------------------------------
 //   containsChord
 //---------------------------------------------------------
+/*! Returns true when every element in the beam group is a rest (no chords). */
 bool Beam::hasAllRests()
 {
     for (ChordRest* cr : m_elements) {
@@ -796,6 +854,7 @@ bool Beam::hasAllRests()
     return true;
 }
 
+/*! Deletes all rendered beam segments and detaches beamlet references from child chord-rests. */
 void Beam::clearBeamSegments()
 {
     for (ChordRest* chordRest : m_elements) {

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -32,6 +32,7 @@
 
 #include "actionicon.h"
 #include "chord.h"
+#include "note.h"
 #include "groups.h"
 #include "measure.h"
 #include "score.h"
@@ -48,6 +49,21 @@ using namespace muse;
 using namespace mu::engraving;
 
 namespace mu::engraving {
+/*!
+ * First chord in beam order, skipping leading rests so beam color can follow the first pitched content.
+ * @param elements Chord/rest sequence stored on the beam.
+ * @return First @c Chord in @p elements, or @c nullptr if none.
+ */
+static ChordRest* firstChordRestInBeam(const std::vector<ChordRest*>& elements)
+{
+    for (ChordRest* cr : elements) {
+        if (cr && cr->isChord()) {
+            return cr;
+        }
+    }
+    return nullptr;
+}
+
 static const ElementStyle beamStyle {
     { Sid::beamNoSlope,                        Pid::BEAM_NO_SLOPE },
 };
@@ -223,6 +239,7 @@ void Beam::move(const PointF& offset)
     }
 }
 
+/*! Determines whether sub-beams at @p level are broken between @p prevCr and @p cr. */
 void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken16, bool& isBroken32) const
 {
     BeamMode beamMode = cr->beamMode();
@@ -416,6 +433,7 @@ void Beam::setDirection(DirectionV d)
     }
 }
 
+/*! Converts the beam into a feathered (accelerando/ritardando) beam. */
 void Beam::setAsFeathered(const bool slower)
 {
     if (slower) {
@@ -546,6 +564,7 @@ void Beam::setBeamPos(const PairF& bp)
     }
 }
 
+/*! Sets @p b as the no-slope flag and updates the beam position to be level. */
 void Beam::setNoSlope(bool b)
 {
     m_noSlope = b;
@@ -560,6 +579,7 @@ void Beam::setNoSlope(bool b)
     }
 }
 
+/*! Recalculates slope from the current start and end anchor positions. */
 void Beam::computeAndSetSlope()
 {
     double xDiff = m_endAnchor.x() - m_startAnchor.x();
@@ -577,6 +597,7 @@ void Beam::computeAndSetSlope()
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given beam property. */
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -584,6 +605,10 @@ PropertyValue Beam::getProperty(Pid propertyId) const
     case Pid::GROW_RIGHT:     return growRight();
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
     case Pid::BEAM_NO_SLOPE:  return noSlope();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the beam's chords) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         for (ChordRest* chordRest : elements()) {
@@ -602,6 +627,7 @@ PropertyValue Beam::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the beam property identified by @p propertyId and triggers a relayout. */
 bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -645,14 +671,49 @@ bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default beam properties.
+ * For @c Pid::COLOR, uses the first chord in @c m_elements (skipping leading rests); when
+ * @c Sid::colorApplyToBeam is enabled, returns the sentinel @c configuration()->defaultColor()
+ * so that resetting restores the "inherit from note" state; @c Beam::color() resolves the
+ * sentinel to the top note's color at draw time.
+ */
 PropertyValue Beam::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::GROW_LEFT:      return 1.0;
     case Pid::GROW_RIGHT:     return 1.0;
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
+    case Pid::COLOR: {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    // fall through
     default:                  return BeamBase::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: if beams inherit note colors, returns
+ * the top note's color for the first chord after skipping leading rests.
+ */
+Color Beam::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return chord->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------
@@ -759,6 +820,7 @@ RectF Beam::drag(EditData& ed)
 //---------------------------------------------------------
 //   isMovable
 //---------------------------------------------------------
+/*! Beams are always considered user-movable (grip editing). */
 bool Beam::isMovable() const
 {
     return true;
@@ -767,6 +829,7 @@ bool Beam::isMovable() const
 //---------------------------------------------------------
 //   initBeamEditData
 //---------------------------------------------------------
+/*! Initialises edit-mode data for the beam, saving the fragment state for undo. */
 void Beam::initBeamEditData(EditData& ed)
 {
     std::shared_ptr<BeamEditData> bed = std::make_shared<BeamEditData>();
@@ -787,6 +850,7 @@ void Beam::startDrag(EditData& editData)
 //---------------------------------------------------------
 //   containsChord
 //---------------------------------------------------------
+/*! Returns true when every element in the beam group is a rest (no chords). */
 bool Beam::hasAllRests()
 {
     for (ChordRest* cr : m_elements) {
@@ -797,6 +861,7 @@ bool Beam::hasAllRests()
     return true;
 }
 
+/*! Deletes all rendered beam segments and detaches beamlet references from child chord-rests. */
 void Beam::clearBeamSegments()
 {
     for (ChordRest* chordRest : m_elements) {

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -32,6 +32,7 @@
 
 #include "actionicon.h"
 #include "chord.h"
+#include "note.h"
 #include "groups.h"
 #include "measure.h"
 #include "score.h"
@@ -41,6 +42,8 @@
 #include "tremolotwochord.h"
 #include "tuplet.h"
 
+#include "iengravingconfiguration.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu;
@@ -48,6 +51,21 @@ using namespace muse;
 using namespace mu::engraving;
 
 namespace mu::engraving {
+/*!
+ * First chord in beam order, skipping leading rests so beam color can follow the first pitched content.
+ * @param elements Chord/rest sequence stored on the beam.
+ * @return First @c Chord in @p elements, or @c nullptr if none.
+ */
+static ChordRest* firstChordRestInBeam(const std::vector<ChordRest*>& elements)
+{
+    for (ChordRest* cr : elements) {
+        if (cr && cr->isChord()) {
+            return cr;
+        }
+    }
+    return nullptr;
+}
+
 static const ElementStyle beamStyle {
     { Sid::beamNoSlope,                        Pid::BEAM_NO_SLOPE },
 };
@@ -246,6 +264,7 @@ void Beam::move(const PointF& offset)
     }
 }
 
+/*! Determines whether sub-beams at @p level are broken between @p prevCr and @p cr. */
 void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken16, bool& isBroken32) const
 {
     BeamMode beamMode = cr->beamMode();
@@ -439,6 +458,7 @@ void Beam::setDirection(DirectionV d)
     }
 }
 
+/*! Converts the beam into a feathered (accelerando/ritardando) beam. */
 void Beam::setAsFeathered(const bool slower)
 {
     if (slower) {
@@ -569,6 +589,7 @@ void Beam::setBeamPos(const PairF& bp)
     }
 }
 
+/*! Sets @p b as the no-slope flag and updates the beam position to be level. */
 void Beam::setNoSlope(bool b)
 {
     m_noSlope = b;
@@ -583,6 +604,7 @@ void Beam::setNoSlope(bool b)
     }
 }
 
+/*! Recalculates slope from the current start and end anchor positions. */
 void Beam::computeAndSetSlope()
 {
     double xDiff = m_endAnchor.x() - m_startAnchor.x();
@@ -600,6 +622,7 @@ void Beam::computeAndSetSlope()
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given beam property. */
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -607,6 +630,10 @@ PropertyValue Beam::getProperty(Pid propertyId) const
     case Pid::GROW_RIGHT:     return growRight();
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
     case Pid::BEAM_NO_SLOPE:  return noSlope();
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the beam's chords) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         for (ChordRest* chordRest : elements()) {
@@ -625,6 +652,7 @@ PropertyValue Beam::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the beam property identified by @p propertyId and triggers a relayout. */
 bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -668,14 +696,49 @@ bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default beam properties.
+ * For @c Pid::COLOR, uses the first chord in @c m_elements (skipping leading rests); when
+ * @c Sid::colorApplyToBeam is enabled, returns the sentinel @c configuration()->defaultColor()
+ * so that resetting restores the "inherit from note" state; @c Beam::color() resolves the
+ * sentinel to the top note's color at draw time.
+ */
 PropertyValue Beam::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::GROW_LEFT:      return 1.0;
     case Pid::GROW_RIGHT:     return 1.0;
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
+    case Pid::COLOR: {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    // fall through
     default:                  return BeamBase::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: if beams inherit note colors, returns
+ * the top note's color for the first chord after skipping leading rests.
+ */
+Color Beam::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        ChordRest* cr = firstChordRestInBeam(m_elements);
+        if (cr) {
+            Chord* chord = toChord(cr);
+            if (chord->upNote()->style().styleV(Sid::colorApplyToBeam).toBool()) {
+                return chord->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }
 
 //---------------------------------------------------------
@@ -782,6 +845,7 @@ RectF Beam::drag(EditData& ed)
 //---------------------------------------------------------
 //   isMovable
 //---------------------------------------------------------
+/*! Beams are always considered user-movable (grip editing). */
 bool Beam::isMovable() const
 {
     return true;
@@ -790,6 +854,7 @@ bool Beam::isMovable() const
 //---------------------------------------------------------
 //   initBeamEditData
 //---------------------------------------------------------
+/*! Initialises edit-mode data for the beam, saving the fragment state for undo. */
 void Beam::initBeamEditData(EditData& ed)
 {
     std::shared_ptr<BeamEditData> bed = std::make_shared<BeamEditData>();
@@ -810,6 +875,7 @@ void Beam::startDrag(EditData& editData)
 //---------------------------------------------------------
 //   containsChord
 //---------------------------------------------------------
+/*! Returns true when every element in the beam group is a rest (no chords). */
 bool Beam::hasAllRests()
 {
     for (ChordRest* cr : m_elements) {
@@ -820,6 +886,7 @@ bool Beam::hasAllRests()
     return true;
 }
 
+/*! Deletes all rendered beam segments and detaches beamlet references from child chord-rests. */
 void Beam::clearBeamSegments()
 {
     for (ChordRest* chordRest : m_elements) {

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -116,7 +116,10 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: @c chordRootColorDefault() when beams inherit themed color.
     PropertyValue propertyDefault(Pid id) const override;
+    //! Draw color: @c chordRootNoteColor() when inheriting (skips leading rests).
+    Color color() const override;
 
     void setIsGrace(bool val) { m_isGrace = val; }
     bool isGrace() const { return m_isGrace; }

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -116,7 +116,10 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when beams inherit themed color.
     PropertyValue propertyDefault(Pid id) const override;
+    //! Draw color: top note of the first chord (skipping leading rests) when inheriting themed color.
+    Color color() const override;
 
     void setIsGrace(bool val) { m_isGrace = val; }
     bool isGrace() const { return m_isGrace; }

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -121,7 +121,10 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when beams inherit themed color.
     PropertyValue propertyDefault(Pid id) const override;
+    //! Draw color: top note of the first chord (skipping leading rests) when inheriting themed color.
+    Color color() const override;
 
     void setIsGrace(bool val) { m_isGrace = val; }
     bool isGrace() const { return m_isGrace; }

--- a/src/engraving/dom/hook.cpp
+++ b/src/engraving/dom/hook.cpp
@@ -25,6 +25,7 @@
 #include "style/style.h"
 
 #include "chord.h"
+#include "note.h"
 
 #include "log.h"
 
@@ -98,4 +99,53 @@ SymId Hook::symIdForHookIndex(int index, bool straight)
     }
 
     return SymId::noSym;
+}
+
+/*!
+ * Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting from the chord's top
+ * note), so writers and undo compare against the persisted value rather than the dynamically
+ * resolved theme color.
+ */
+PropertyValue Hook::getProperty(Pid id) const
+{
+    if (id == Pid::COLOR) {
+        return PropertyValue::fromValue(m_color);
+    }
+    return Symbol::getProperty(id);
+}
+
+/*!
+ * Default hook (flag) properties.
+ * For @c Pid::COLOR, returns the sentinel @c configuration()->defaultColor() when
+ * @c Sid::colorApplyToFlag is on so that resetting restores the "inherit from note" state;
+ * @c Hook::color() resolves the sentinel to the top note's color at draw time.
+ */
+PropertyValue Hook::propertyDefault(Pid id) const
+{
+    switch (id) {
+    case Pid::COLOR:
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToFlag).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    // fall through
+    default:
+        return Symbol::propertyDefault(id);
+    }
+}
+
+/*!
+ * Draw color when using the score default: follows the top note's color if flags inherit note color.
+ */
+Color Hook::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToFlag).toBool()) {
+                return chord()->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }

--- a/src/engraving/dom/hook.cpp
+++ b/src/engraving/dom/hook.cpp
@@ -25,6 +25,9 @@
 #include "style/style.h"
 
 #include "chord.h"
+#include "note.h"
+
+#include "iengravingconfiguration.h" // IWYU pragma: keep
 
 #include "log.h"
 
@@ -98,4 +101,53 @@ SymId Hook::symIdForHookIndex(int index, bool straight)
     }
 
     return SymId::noSym;
+}
+
+/*!
+ * Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting from the chord's top
+ * note), so writers and undo compare against the persisted value rather than the dynamically
+ * resolved theme color.
+ */
+PropertyValue Hook::getProperty(Pid id) const
+{
+    if (id == Pid::COLOR) {
+        return PropertyValue::fromValue(m_color);
+    }
+    return Symbol::getProperty(id);
+}
+
+/*!
+ * Default hook (flag) properties.
+ * For @c Pid::COLOR, returns the sentinel @c configuration()->defaultColor() when
+ * @c Sid::colorApplyToFlag is on so that resetting restores the "inherit from note" state;
+ * @c Hook::color() resolves the sentinel to the top note's color at draw time.
+ */
+PropertyValue Hook::propertyDefault(Pid id) const
+{
+    switch (id) {
+    case Pid::COLOR:
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToFlag).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    // fall through
+    default:
+        return Symbol::propertyDefault(id);
+    }
+}
+
+/*!
+ * Draw color when using the score default: follows the top note's color if flags inherit note color.
+ */
+Color Hook::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToFlag).toBool()) {
+                return chord()->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }

--- a/src/engraving/dom/hook.h
+++ b/src/engraving/dom/hook.h
@@ -48,6 +48,10 @@ public:
     Chord* chord() const { return toChord(explicitParent()); }
     PointF smuflAnchor() const;
 
+    PropertyValue getProperty(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
+    Color color() const override;
+
     //! @p index: the number of flags (positive: upwards, negative: downwards)
     //! @p straight: whether to use straight flags
     static SymId symIdForHookIndex(int index, bool straight);

--- a/src/engraving/dom/hook.h
+++ b/src/engraving/dom/hook.h
@@ -48,6 +48,10 @@ public:
     Chord* chord() const { return toChord(ownershipParent()); }
     PointF smuflAnchor() const;
 
+    PropertyValue getProperty(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
+    Color color() const override;
+
     //! @p index: the number of flags (positive: upwards, negative: downwards)
     //! @p straight: whether to use straight flags
     static SymId symIdForHookIndex(int index, bool straight);

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -23,6 +23,8 @@
 /**
  \file
  Implementation of classes Note and ShadowNote.
+
+ @c Note::color() defaults use @c notecoloringscheme.h.
 */
 
 #include "note.h"
@@ -1527,6 +1529,7 @@ void Note::setVisible(bool v)
     }
 }
 
+/*! Validates and finalises note state after being read from a file (pitch clamping, TPC repair, tab fret color). */
 void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
 {
     // ensure sane values:
@@ -2990,6 +2993,7 @@ void Note::setNval(const NoteVal& nval, Fraction tick)
 //   localSpatiumChanged
 //---------------------------------------------------------
 
+/*! Propagates a spatium change to child dots, attached elements, and incoming spanners. */
 void Note::localSpatiumChanged(double oldValue, double newValue)
 {
     EngravingItem::localSpatiumChanged(oldValue, newValue);
@@ -3010,6 +3014,11 @@ void Note::localSpatiumChanged(double oldValue, double newValue)
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given note property.
+ * @c Pid::COLOR returns the raw stored color (@c m_color), not the themed rendering color
+ * from @c Note::color(), so that @c undoChangeProperty() compares against the actual
+ * persisted value rather than the auto-computed theme swatch.
+ */
 PropertyValue Note::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -3059,6 +3068,8 @@ PropertyValue Note::getProperty(Pid propertyId) const
         return m_hasParens ? ParenthesesMode::BOTH : ParenthesesMode::NONE;
     case Pid::HIDE_GENERATED_PARENTHESES:
         return m_hideGeneratedParens;
+    case Pid::COLOR:
+        return PropertyValue::fromValue(m_color);
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         if (chord()) {
@@ -3074,6 +3085,7 @@ PropertyValue Note::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the note property identified by @p propertyId, triggers layout, and marks playback dirty where relevant. */
 bool Note::setProperty(Pid propertyId, const PropertyValue& v)
 {
     Measure* m = chord() ? chord()->measure() : nullptr;
@@ -3194,10 +3206,74 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * MIDI pitch used for note coloring: respects style @c Sid::colorNotesByConcertPitch
+ * (written vs concert basis) and Ottava linkage offset, consistent with @c Note::epitch() conventions.
+ *
+ * @param n Note whose style and pitch are read.
+ * @return Pitch number in the coloring basis.
+ */
+static int noteColoringEpitch(const Note* n)
+{
+    bool byConcertPitch = n->style().styleV(Sid::colorNotesByConcertPitch).toBool();
+    return n->pitch() - (byConcertPitch ? 0 : n->transposition()) + n->linkedOttavaPitchOffset();
+}
+
+/*!
+ * Swatch index (0-11) into @c Sid::noteColor0 ... @c Sid::noteColor11 for the current @c Sid::noteColorTheme.
+ * Matches the logic of @c Note::color() and @c Note::propertyDefault(Pid::COLOR) for non-one-color themes.
+ *
+ * @param note Note providing pitch, TPC, staff key, measure, and style.
+ * @return Index added to @c Sid::noteColor0 to obtain the style color id.
+ */
+static int noteColoringSwatchIndex(const Note* note)
+{
+    NoteColoringScheme scheme = static_cast<NoteColoringScheme>(note->style().styleV(Sid::noteColorTheme).toInt());
+    bool byConcertPitch = note->style().styleV(Sid::colorNotesByConcertPitch).toBool();
+    int colorTpc = byConcertPitch ? note->tpc1() : note->tpc2();
+    int colorEpitch = note->pitch() - (byConcertPitch ? 0 : note->transposition()) + note->linkedOttavaPitchOffset();
+
+    switch (scheme) {
+    case NoteColoringScheme::OneColor:
+        return 0;
+    case NoteColoringScheme::AbsolutePitchSimple:
+        return tpc2step(colorTpc);
+    case NoteColoringScheme::AbsolutePitchChromatic: {
+        int idx = colorEpitch % 12;
+        return idx < 0 ? idx + 12 : idx;
+    }
+    case NoteColoringScheme::MoveableDoSimple:
+    case NoteColoringScheme::MoveableDoChromatic: {
+        Key key = Key::C;
+        if (note->staff()) {
+            key = byConcertPitch ? note->staff()->concertKey(note->tick()) : note->staff()->key(note->tick());
+        }
+        if (scheme == NoteColoringScheme::MoveableDoSimple) {
+            int idx = tpc2degree(colorTpc, key);
+            return idx < 0 ? idx + 7 : idx;
+        }
+        int pC = colorEpitch % 12;
+        if (pC < 0) {
+            pC += 12;
+        }
+        int tonicPitchClass = tonicPitchClassFromKey(static_cast<int>(key));
+        return (pC - tonicPitchClass + 12) % 12;
+    }
+    default:
+        return 0;
+    }
+}
+
 //---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 
+/*!
+ * Default property values for notes.
+ * @c Pid::COLOR uses tab fret text color on TAB staves with text-style frets; for
+ * @c NoteColoringScheme::OneColor uses @c Sid::defaultNoteColor; otherwise the themed swatch from
+ * @c noteColoringSwatchIndex() and @c Sid::noteColor0 … @c Sid::noteColor11.
+ */
 PropertyValue Note::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
@@ -3250,7 +3326,13 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
         if (st && st->isTabStaff() && st->fretUseTextStyle()) {
             return style().styleV(Sid::tabFretNumberColor);
         }
-        return EngravingItem::propertyDefault(propertyId);
+        NoteColoringScheme theme = static_cast<NoteColoringScheme>(style().styleV(Sid::noteColorTheme).toInt());
+        if (theme != NoteColoringScheme::OneColor) {
+            int colorIdx = noteColoringSwatchIndex(this);
+            Sid colorSid = static_cast<Sid>(static_cast<int>(Sid::noteColor0) + colorIdx);
+            return style().styleV(colorSid);
+        }
+        return style().styleV(Sid::defaultNoteColor);
     }
     case Pid::HIDE_GENERATED_PARENTHESES:
         return false;
@@ -3260,6 +3342,35 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
     return EngravingItem::propertyDefault(propertyId);
 }
 
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+/*!
+ * Note head color: @c Sid::defaultNoteColor for one-color themes, else the palette swatch from
+ * @c noteColoringSwatchIndex() when still using the score default color.
+ */
+Color Note::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        NoteColoringScheme scheme = static_cast<NoteColoringScheme>(style().styleV(Sid::noteColorTheme).toInt());
+
+        if (scheme == NoteColoringScheme::OneColor) {
+            return style().styleV(Sid::defaultNoteColor).value<Color>();
+        }
+
+        int colorIdx = noteColoringSwatchIndex(this);
+
+        Sid colorSid = static_cast<Sid>(static_cast<int>(Sid::noteColor0) + colorIdx);
+        return style().styleV(colorSid).value<Color>();
+    }
+    return m_color;
+}
+
+/*!
+ * When the score style changes, TAB staves with text-style frets take @c Sid::tabFretNumberColor for @c Pid::COLOR.
+ * Other cases defer to @c EngravingItem::styleChanged().
+ */
 void Note::styleChanged()
 {
     const StaffType* st = staffType();

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -23,9 +23,13 @@
 /**
  \file
  Implementation of classes Note and ShadowNote.
+
+ @c Note::color() defaults use @c notecoloringscheme.h.
 */
 
 #include "note.h"
+
+#include "../types/notecoloringscheme.h"
 
 #include <cassert>
 
@@ -1641,6 +1645,12 @@ bool Note::isExactUnison(Note* other)
     return other->pitch() == m_pitch && other->tpc() == tpc();
 }
 
+/*!
+ * Validates and finalises note state after being read from a file: pitch clamping, TPC repair, etc.
+ *
+ * @param ctxTick Tick used for staff/key lookups when repairing pitch/TPC.
+ * @param pasteMode When @c true, skips some consistency checks meant for file load only.
+ */
 void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
 {
     // ensure sane values:
@@ -1706,11 +1716,6 @@ void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
                 }
             }
         }
-    }
-
-    const StaffType* st = staffType();
-    if (st && st->isTabStaff() && st->fretUseTextStyle() && color() == configuration()->defaultColor()) {
-        setColor(propertyDefault(Pid::COLOR).value<Color>());
     }
 }
 
@@ -3068,6 +3073,7 @@ void Note::setNval(const NoteVal& nval, Fraction tick)
 //   localSpatiumChanged
 //---------------------------------------------------------
 
+/*! Propagates a spatium change to child dots, attached elements, and incoming spanners. */
 void Note::localSpatiumChanged(double oldValue, double newValue)
 {
     EngravingItem::localSpatiumChanged(oldValue, newValue);
@@ -3088,6 +3094,11 @@ void Note::localSpatiumChanged(double oldValue, double newValue)
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given note property.
+ * @c Pid::COLOR returns the raw stored color (@c m_color), not the themed rendering color
+ * from @c Note::color(), so that @c undoChangeProperty() compares against the actual
+ * persisted value rather than the auto-computed theme swatch.
+ */
 PropertyValue Note::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -3137,6 +3148,8 @@ PropertyValue Note::getProperty(Pid propertyId) const
         return m_hasParens ? ParenthesesMode::BOTH : ParenthesesMode::NONE;
     case Pid::HIDE_GENERATED_PARENTHESES:
         return m_hideGeneratedParens;
+    case Pid::COLOR:
+        return PropertyValue::fromValue(m_color);
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         if (chord()) {
@@ -3152,6 +3165,7 @@ PropertyValue Note::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the note property identified by @p propertyId, triggers layout, and marks playback dirty where relevant. */
 bool Note::setProperty(Pid propertyId, const PropertyValue& v)
 {
     Measure* m = chord() ? chord()->measure() : nullptr;
@@ -3267,6 +3281,63 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * Swatch index (0–11) into @c Sid::noteColor0 … @c Sid::noteColor11 for the current @c Sid::noteColorTheme.
+ * Uses the same pitch/TPC basis as @c Note::color() for multi-color themes (when @c m_color is the sentinel).
+ *
+ * @param note Note providing pitch, TPC, staff key, tick, and @c Sid::colorNotesByConcertPitch.
+ * @return Index added to @c Sid::noteColor0 to obtain the style color id (always 0 for @c OneColor).
+ *
+ * @details
+ * - @c AbsolutePitchSimple: diatonic step from TPC (@c tpc2step), seven effective swatches.
+ * - @c AbsolutePitchChromatic: MIDI chroma from effective pitch (concert vs written per style).
+ * - @c MoveableDoSimple: scale degree 0–6 from TPC and local key (@c tpc2degree).
+ * - @c MoveableDoChromatic: chroma relative to the key tonic (@c tonicPitchClassFromKey + offset).
+ */
+static int noteColoringSwatchIndex(const Note* note)
+{
+    NoteColoringScheme scheme = static_cast<NoteColoringScheme>(note->style().styleV(Sid::noteColorTheme).toInt());
+    bool byConcertPitch = note->style().styleV(Sid::colorNotesByConcertPitch).toBool();
+    int colorTpc = byConcertPitch ? note->tpc1() : note->tpc2();
+    int colorEpitch = note->pitch() - (byConcertPitch ? 0 : note->transposition()) + note->linkedOttavaPitchOffset();
+
+    switch (scheme) {
+    case NoteColoringScheme::OneColor:
+        return 0;
+    case NoteColoringScheme::AbsolutePitchSimple:
+        if (colorTpc == Tpc::TPC_INVALID) {
+            return 0;
+        }
+        return tpc2step(colorTpc);
+    case NoteColoringScheme::AbsolutePitchChromatic: {
+        int idx = colorEpitch % 12;
+        return idx < 0 ? idx + 12 : idx;
+    }
+    case NoteColoringScheme::MoveableDoSimple:
+    case NoteColoringScheme::MoveableDoChromatic: {
+        Key key = Key::C;
+        if (note->staff()) {
+            key = byConcertPitch ? note->staff()->concertKey(note->tick()) : note->staff()->key(note->tick());
+        }
+        if (scheme == NoteColoringScheme::MoveableDoSimple) {
+            if (colorTpc == Tpc::TPC_INVALID) {
+                return 0;
+            }
+            int idx = tpc2degree(colorTpc, key);
+            return idx < 0 ? idx + 7 : idx;
+        }
+        int pC = colorEpitch % 12;
+        if (pC < 0) {
+            pC += 12;
+        }
+        int tonicPitchClass = tonicPitchClassFromKey(static_cast<int>(key));
+        return (pC - tonicPitchClass + 12) % 12;
+    }
+    default:
+        return 0;
+    }
+}
+
 //---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
@@ -3318,13 +3389,8 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
             }
         }
         return EngravingItem::propertyDefault(propertyId);
-    case Pid::COLOR: {
-        const StaffType* st = staffType();
-        if (st && st->isTabStaff() && st->fretUseTextStyle()) {
-            return style().styleV(Sid::tabFretNumberColor);
-        }
-        return EngravingItem::propertyDefault(propertyId);
-    }
+    case Pid::COLOR:
+        return PropertyValue::fromValue(configuration()->defaultColor());
     case Pid::HIDE_GENERATED_PARENTHESES:
         return false;
     default:
@@ -3333,12 +3399,34 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
     return EngravingItem::propertyDefault(propertyId);
 }
 
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+Color Note::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        const StaffType* st = staffType();
+        if (st && st->isTabStaff() && st->fretUseTextStyle()) {
+            return style().styleV(Sid::tabFretNumberColor).value<Color>();
+        }
+
+        NoteColoringScheme scheme = static_cast<NoteColoringScheme>(style().styleV(Sid::noteColorTheme).toInt());
+
+        if (scheme == NoteColoringScheme::OneColor) {
+            return style().styleV(Sid::defaultNoteColor).value<Color>();
+        }
+
+        int colorIdx = noteColoringSwatchIndex(this);
+
+        Sid colorSid = static_cast<Sid>(static_cast<int>(Sid::noteColor0) + colorIdx);
+        return style().styleV(colorSid).value<Color>();
+    }
+    return m_color;
+}
+
 void Note::styleChanged()
 {
-    const StaffType* st = staffType();
-    if (st && st->isTabStaff() && st->fretUseTextStyle()) {
-        setProperty(Pid::COLOR, style().styleV(Sid::tabFretNumberColor));
-    }
     EngravingItem::styleChanged();
 }
 

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -23,9 +23,13 @@
 /**
  \file
  Implementation of classes Note and ShadowNote.
+
+ @c Note::color() defaults use @c notecoloringscheme.h.
 */
 
 #include "note.h"
+
+#include "../types/notecoloringscheme.h"
 
 #include <cassert>
 
@@ -1643,6 +1647,12 @@ bool Note::isExactUnison(Note* other)
     return other->pitch() == m_pitch && other->tpc() == tpc();
 }
 
+/*!
+ * Validates and finalises note state after being read from a file: pitch clamping, TPC repair, etc.
+ *
+ * @param ctxTick Tick used for staff/key lookups when repairing pitch/TPC.
+ * @param pasteMode When @c true, skips some consistency checks meant for file load only.
+ */
 void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
 {
     // ensure sane values:
@@ -1708,11 +1718,6 @@ void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
                 }
             }
         }
-    }
-
-    const StaffType* st = staffType();
-    if (st && st->isTabStaff() && st->fretUseTextStyle() && color() == configuration()->defaultColor()) {
-        setColor(propertyDefault(Pid::COLOR).value<Color>());
     }
 }
 
@@ -3069,6 +3074,7 @@ void Note::setNval(const NoteVal& nval, Fraction tick)
 //   localSpatiumChanged
 //---------------------------------------------------------
 
+/*! Propagates a spatium change to child dots, attached elements, and incoming spanners. */
 void Note::localSpatiumChanged(double oldValue, double newValue)
 {
     EngravingItem::localSpatiumChanged(oldValue, newValue);
@@ -3089,6 +3095,11 @@ void Note::localSpatiumChanged(double oldValue, double newValue)
 //   getProperty
 //---------------------------------------------------------
 
+/*! Returns the current value of the given note property.
+ * @c Pid::COLOR returns the raw stored color (@c m_color), not the themed rendering color
+ * from @c Note::color(), so that @c undoChangeProperty() compares against the actual
+ * persisted value rather than the auto-computed theme swatch.
+ */
 PropertyValue Note::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -3138,6 +3149,8 @@ PropertyValue Note::getProperty(Pid propertyId) const
         return m_hasParens ? ParenthesesMode::BOTH : ParenthesesMode::NONE;
     case Pid::HIDE_GENERATED_PARENTHESES:
         return m_hideGeneratedParens;
+    case Pid::COLOR:
+        return PropertyValue::fromValue(m_color);
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         if (chord()) {
@@ -3153,6 +3166,7 @@ PropertyValue Note::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
+/*! Applies @p v to the note property identified by @p propertyId, triggers layout, and marks playback dirty where relevant. */
 bool Note::setProperty(Pid propertyId, const PropertyValue& v)
 {
     Measure* m = chord() ? chord()->measure() : nullptr;
@@ -3268,6 +3282,63 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * Swatch index (0–11) into @c Sid::noteColor0 … @c Sid::noteColor11 for the current @c Sid::noteColorTheme.
+ * Uses the same pitch/TPC basis as @c Note::color() for multi-color themes (when @c m_color is the sentinel).
+ *
+ * @param note Note providing pitch, TPC, staff key, tick, and @c Sid::colorNotesByConcertPitch.
+ * @return Index added to @c Sid::noteColor0 to obtain the style color id (always 0 for @c OneColor).
+ *
+ * @details
+ * - @c AbsolutePitchSimple: diatonic step from TPC (@c tpc2step), seven effective swatches.
+ * - @c AbsolutePitchChromatic: MIDI chroma from effective pitch (concert vs written per style).
+ * - @c MoveableDoSimple: scale degree 0–6 from TPC and local key (@c tpc2degree).
+ * - @c MoveableDoChromatic: chroma relative to the key tonic (@c tonicPitchClassFromKey + offset).
+ */
+static int noteColoringSwatchIndex(const Note* note)
+{
+    NoteColoringScheme scheme = static_cast<NoteColoringScheme>(note->style().styleV(Sid::noteColorTheme).toInt());
+    bool byConcertPitch = note->style().styleV(Sid::colorNotesByConcertPitch).toBool();
+    int colorTpc = byConcertPitch ? note->tpc1() : note->tpc2();
+    int colorEpitch = note->pitch() - (byConcertPitch ? 0 : note->transposition()) + note->linkedOttavaPitchOffset();
+
+    switch (scheme) {
+    case NoteColoringScheme::OneColor:
+        return 0;
+    case NoteColoringScheme::AbsolutePitchSimple:
+        if (colorTpc == Tpc::TPC_INVALID) {
+            return 0;
+        }
+        return tpc2step(colorTpc);
+    case NoteColoringScheme::AbsolutePitchChromatic: {
+        int idx = colorEpitch % 12;
+        return idx < 0 ? idx + 12 : idx;
+    }
+    case NoteColoringScheme::MoveableDoSimple:
+    case NoteColoringScheme::MoveableDoChromatic: {
+        Key key = Key::C;
+        if (note->staff()) {
+            key = byConcertPitch ? note->staff()->concertKey(note->tick()) : note->staff()->key(note->tick());
+        }
+        if (scheme == NoteColoringScheme::MoveableDoSimple) {
+            if (colorTpc == Tpc::TPC_INVALID) {
+                return 0;
+            }
+            int idx = tpc2degree(colorTpc, key);
+            return idx < 0 ? idx + 7 : idx;
+        }
+        int pC = colorEpitch % 12;
+        if (pC < 0) {
+            pC += 12;
+        }
+        int tonicPitchClass = tonicPitchClassFromKey(static_cast<int>(key));
+        return (pC - tonicPitchClass + 12) % 12;
+    }
+    default:
+        return 0;
+    }
+}
+
 //---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
@@ -3319,13 +3390,8 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
             }
         }
         return EngravingItem::propertyDefault(propertyId);
-    case Pid::COLOR: {
-        const StaffType* st = staffType();
-        if (st && st->isTabStaff() && st->fretUseTextStyle()) {
-            return style().styleV(Sid::tabFretNumberColor);
-        }
-        return EngravingItem::propertyDefault(propertyId);
-    }
+    case Pid::COLOR:
+        return PropertyValue::fromValue(configuration()->defaultColor());
     case Pid::HIDE_GENERATED_PARENTHESES:
         return false;
     default:
@@ -3334,12 +3400,34 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
     return EngravingItem::propertyDefault(propertyId);
 }
 
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+Color Note::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        const StaffType* st = staffType();
+        if (st && st->isTabStaff() && st->fretUseTextStyle()) {
+            return style().styleV(Sid::tabFretNumberColor).value<Color>();
+        }
+
+        NoteColoringScheme scheme = static_cast<NoteColoringScheme>(style().styleV(Sid::noteColorTheme).toInt());
+
+        if (scheme == NoteColoringScheme::OneColor) {
+            return style().styleV(Sid::defaultNoteColor).value<Color>();
+        }
+
+        int colorIdx = noteColoringSwatchIndex(this);
+
+        Sid colorSid = static_cast<Sid>(static_cast<int>(Sid::noteColor0) + colorIdx);
+        return style().styleV(colorSid).value<Color>();
+    }
+    return m_color;
+}
+
 void Note::styleChanged()
 {
-    const StaffType* st = staffType();
-    if (st && st->isTabStaff() && st->fretUseTextStyle()) {
-        setProperty(Pid::COLOR, style().styleV(Sid::tabFretNumberColor));
-    }
     EngravingItem::styleChanged();
 }
 

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -33,6 +33,8 @@
 #include "tie.h"
 #include "tiejumppointlist.h"
 
+#include "../types/notecoloringscheme.h"
+
 namespace mu::engraving {
 class Factory;
 class Tie;
@@ -220,6 +222,8 @@ public:
     int tpc() const;
     int tpc1() const { return m_tpc[0]; }                  // non transposed tpc
     int tpc2() const { return m_tpc[1]; }                  // transposed tpc
+    //! Draw color from @c Sid::noteColor0…11 / @c defaultNoteColor, or explicit @c m_color override.
+    Color color() const override;
     String tpcUserName(bool explicitAccidental = false, bool full = false) const;
 
     void setTpc(int v);
@@ -369,7 +373,9 @@ public:
     void localSpatiumChanged(double oldValue, double newValue) override;
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: style swatch from @c noteColoringSwatchIndex() or TAB fret text color.
     PropertyValue propertyDefault(Pid) const override;
+    //! Reapplies TAB fret text color from style when the staff uses text-style frets.
     void styleChanged() override;
 
     bool mark() const { return m_mark; }

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -223,6 +223,8 @@ public:
     int tpc() const;
     int tpc1() const { return m_tpc[0]; }                  // non transposed tpc
     int tpc2() const { return m_tpc[1]; }                  // transposed tpc
+    //! Draw color from @c Sid::noteColor0…11 / @c defaultNoteColor, or explicit @c m_color override.
+    Color color() const override;
     String tpcUserName(bool explicitAccidental = false, bool full = false) const;
 
     void setTpc(int v);

--- a/src/engraving/dom/notedot.cpp
+++ b/src/engraving/dom/notedot.cpp
@@ -32,37 +32,78 @@
 using namespace mu;
 
 namespace mu::engraving {
-//---------------------------------------------------------
-//   NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Constructs a dot attached to @p parent note; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Note* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
+/*!
+ * Constructs a dot attached to @p parent rest; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Rest* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
-//---------------------------------------------------------
-//   elementBase
-//---------------------------------------------------------
-
+/*!
+ * @return The parent note or rest (same as @c parentItem()).
+ */
 EngravingItem* NoteDot::elementBase() const
 {
     return parentItem();
 }
 
-//---------------------------------------------------------
-//   mag
-//---------------------------------------------------------
-
+/*!
+ * @return Scale factor from the parent element times @c Sid::dotMag.
+ */
 double NoteDot::mag() const
 {
     return parentItem()->mag() * style().styleD(Sid::dotMag);
+}
+
+/*!
+ * Default note-dot properties.
+ * For @c Pid::COLOR, when @c Sid::colorApplyToDot is enabled, returns the parent
+ * note's themed rendering color via @c Note::color() so dots follow the active coloring scheme.
+ */
+PropertyValue NoteDot::propertyDefault(Pid propertyId) const
+{
+    if (propertyId == Pid::COLOR) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return PropertyValue::fromValue(note()->color());
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return rest()->getProperty(Pid::COLOR);
+            }
+        }
+    }
+    return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if dots inherit themed colors, returns the parent
+ * @c Note::color() or @c Rest::color().
+ */
+Color NoteDot::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return note()->color();
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return rest()->color();
+            }
+        }
+    }
+    return m_color;
 }
 }

--- a/src/engraving/dom/notedot.cpp
+++ b/src/engraving/dom/notedot.cpp
@@ -32,37 +32,93 @@
 using namespace mu;
 
 namespace mu::engraving {
-//---------------------------------------------------------
-//   NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Constructs a dot attached to @p parent note; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Note* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
+/*!
+ * Constructs a dot attached to @p parent rest; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Rest* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
-//---------------------------------------------------------
-//   elementBase
-//---------------------------------------------------------
-
+/*!
+ * @return The parent note or rest (same as @c parentItem()).
+ */
 EngravingItem* NoteDot::elementBase() const
 {
     return parentItem();
 }
 
-//---------------------------------------------------------
-//   mag
-//---------------------------------------------------------
-
+/*!
+ * @return Scale factor from the parent element times @c Sid::dotMag.
+ */
 double NoteDot::mag() const
 {
     return parentItem()->mag() * style().styleD(Sid::dotMag);
+}
+
+/*!
+ * Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting from the parent note
+ * or rest), so writers and undo compare against the persisted value rather than the dynamically
+ * resolved theme color.
+ */
+PropertyValue NoteDot::getProperty(Pid propertyId) const
+{
+    if (propertyId == Pid::COLOR) {
+        return PropertyValue::fromValue(m_color);
+    }
+    return EngravingItem::getProperty(propertyId);
+}
+
+/*!
+ * Default note-dot properties.
+ * For @c Pid::COLOR, when @c Sid::colorApplyToDot is enabled, returns the sentinel
+ * @c configuration()->defaultColor() so that resetting restores the "inherit from parent" state;
+ * @c NoteDot::color() resolves the sentinel to the parent @c Note::color() or @c Rest::color()
+ * at draw time.
+ */
+PropertyValue NoteDot::propertyDefault(Pid propertyId) const
+{
+    if (propertyId == Pid::COLOR) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if dots inherit themed colors, returns the parent
+ * @c Note::color() or @c Rest::color().
+ */
+Color NoteDot::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return note()->color();
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return rest()->color();
+            }
+        }
+    }
+    return m_color;
 }
 }

--- a/src/engraving/dom/notedot.cpp
+++ b/src/engraving/dom/notedot.cpp
@@ -27,42 +27,100 @@
 #include "note.h"
 #include "rest.h"
 
+#include "iengravingconfiguration.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu;
 
 namespace mu::engraving {
-//---------------------------------------------------------
-//   NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Constructs a dot attached to @p parent note; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Note* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
+/*!
+ * Constructs a dot attached to @p parent rest; the dot is not user-movable.
+ */
 NoteDot::NoteDot(Rest* parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
 
-//---------------------------------------------------------
-//   elementBase
-//---------------------------------------------------------
-
+/*!
+ * @return The parent note or rest (same as @c parentItem()).
+ */
 EngravingItem* NoteDot::elementBase() const
 {
     return ownershipParentItem(); // a dot can belong to a note or a rest
 }
 
-//---------------------------------------------------------
-//   mag
-//---------------------------------------------------------
-
+/*!
+ * @return Scale factor from the parent element times @c Sid::dotMag.
+ */
 double NoteDot::mag() const
 {
     return layoutParent()->mag() * style().styleD(Sid::dotMag);
+}
+
+/*!
+ * Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting from the parent note
+ * or rest), so writers and undo compare against the persisted value rather than the dynamically
+ * resolved theme color.
+ */
+PropertyValue NoteDot::getProperty(Pid propertyId) const
+{
+    if (propertyId == Pid::COLOR) {
+        return PropertyValue::fromValue(m_color);
+    }
+    return EngravingItem::getProperty(propertyId);
+}
+
+/*!
+ * Default note-dot properties.
+ * For @c Pid::COLOR, when @c Sid::colorApplyToDot is enabled, returns the sentinel
+ * @c configuration()->defaultColor() so that resetting restores the "inherit from parent" state;
+ * @c NoteDot::color() resolves the sentinel to the parent @c Note::color() or @c Rest::color()
+ * at draw time.
+ */
+PropertyValue NoteDot::propertyDefault(Pid propertyId) const
+{
+    if (propertyId == Pid::COLOR) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    }
+    return EngravingItem::propertyDefault(propertyId);
+}
+
+/*!
+ * Draw color when using the score default: if dots inherit themed colors, returns the parent
+ * @c Note::color() or @c Rest::color().
+ */
+Color NoteDot::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (note()) {
+            if (note()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return note()->color();
+            }
+        } else if (rest()) {
+            if (rest()->style().styleV(Sid::colorApplyToDot).toBool()) {
+                return rest()->color();
+            }
+        }
+    }
+    return m_color;
 }
 }

--- a/src/engraving/dom/notedot.h
+++ b/src/engraving/dom/notedot.h
@@ -30,10 +30,9 @@ class Factory;
 class Note;
 class Rest;
 
-//---------------------------------------------------------
-//   @@ NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Augmentation dot attached to a @c Note or @c Rest; shares placement and style with its parent.
+ */
 class NoteDot final : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, NoteDot)
@@ -41,16 +40,28 @@ class NoteDot final : public EngravingItem
 
 public:
 
+    //! @return Heap copy of this dot (palette / editing).
     NoteDot* clone() const override { return new NoteDot(*this); }
+    //! @return Product of the parent element’s scale and @c Sid::dotMag.
     double mag() const override;
 
+    //! @return Parent as @c Note, or @c nullptr if parent is a rest.
     Note* note() const { return explicitParent()->isNote() ? toNote(explicitParent()) : 0; }
+    //! @return Parent as @c Rest, or @c nullptr if parent is a note.
     Rest* rest() const { return explicitParent()->isRest() ? toRest(explicitParent()) : 0; }
+    //! @return The parent note or rest (see @c parentItem()).
     EngravingItem* elementBase() const override;
+
+    //! Default @c Pid::COLOR: parent @c Note::getProperty / @c Rest default when dots inherit themed color.
+    PropertyValue propertyDefault(Pid propertyId) const override;
+    //! Draw color: parent @c Note::color() or rest equivalent when inheriting.
+    Color color() const override;
 
 private:
     friend class Factory;
+    //! Constructed only via @c Factory; attaches to @p parent note.
     NoteDot(Note* parent);
+    //! Constructed only via @c Factory; attaches to @p parent rest.
     NoteDot(Rest* parent);
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/notedot.h
+++ b/src/engraving/dom/notedot.h
@@ -30,10 +30,9 @@ class Factory;
 class Note;
 class Rest;
 
-//---------------------------------------------------------
-//   @@ NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Augmentation dot attached to a @c Note or @c Rest; shares placement and style with its parent.
+ */
 class NoteDot final : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, NoteDot)
@@ -41,16 +40,31 @@ class NoteDot final : public EngravingItem
 
 public:
 
+    //! @return Heap copy of this dot (palette / editing).
     NoteDot* clone() const override { return new NoteDot(*this); }
+    //! @return Product of the parent element’s scale and @c Sid::dotMag.
     double mag() const override;
 
+    //! @return Parent as @c Note, or @c nullptr if parent is a rest.
     Note* note() const { return explicitParent()->isNote() ? toNote(explicitParent()) : 0; }
+    //! @return Parent as @c Rest, or @c nullptr if parent is a note.
     Rest* rest() const { return explicitParent()->isRest() ? toRest(explicitParent()) : 0; }
+    //! @return The parent note or rest (see @c parentItem()).
     EngravingItem* elementBase() const override;
+
+    //! Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting), so writers compare
+    //! against the persisted value rather than the dynamically resolved theme color.
+    PropertyValue getProperty(Pid propertyId) const override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when dots inherit themed color.
+    PropertyValue propertyDefault(Pid propertyId) const override;
+    //! Draw color: parent @c Note::color() or rest equivalent when inheriting.
+    Color color() const override;
 
 private:
     friend class Factory;
+    //! Constructed only via @c Factory; attaches to @p parent note.
     NoteDot(Note* parent);
+    //! Constructed only via @c Factory; attaches to @p parent rest.
     NoteDot(Rest* parent);
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/notedot.h
+++ b/src/engraving/dom/notedot.h
@@ -30,10 +30,9 @@ class Factory;
 class Note;
 class Rest;
 
-//---------------------------------------------------------
-//   @@ NoteDot
-//---------------------------------------------------------
-
+/*!
+ * Augmentation dot attached to a @c Note or @c Rest; shares placement and style with its parent.
+ */
 class NoteDot final : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, NoteDot)
@@ -41,16 +40,31 @@ class NoteDot final : public EngravingItem
 
 public:
 
+    //! @return Heap copy of this dot (palette / editing).
     NoteDot* clone() const override { return new NoteDot(*this); }
+    //! @return Product of the parent element’s scale and @c Sid::dotMag.
     double mag() const override;
 
+    //! @return Parent as @c Note, or @c nullptr if parent is a rest.
     Note* note() const { return ownershipParent()->isNote() ? toNote(ownershipParent()) : 0; }
+    //! @return Parent as @c Rest, or @c nullptr if parent is a note.
     Rest* rest() const { return ownershipParent()->isRest() ? toRest(ownershipParent()) : 0; }
+    //! @return The parent note or rest (see @c parentItem()).
     EngravingItem* elementBase() const override;
+
+    //! Returns the raw stored color for @c Pid::COLOR (sentinel when inheriting), so writers compare
+    //! against the persisted value rather than the dynamically resolved theme color.
+    PropertyValue getProperty(Pid propertyId) const override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when dots inherit themed color.
+    PropertyValue propertyDefault(Pid propertyId) const override;
+    //! Draw color: parent @c Note::color() or rest equivalent when inheriting.
+    Color color() const override;
 
 private:
     friend class Factory;
+    //! Constructed only via @c Factory; attaches to @p parent note.
     NoteDot(Note* parent);
+    //! Constructed only via @c Factory; attaches to @p parent rest.
     NoteDot(Rest* parent);
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -25,7 +25,10 @@
 
 #include "../editing/elementeditdata.h"
 
+#include "style/style.h"
+
 #include "chord.h"
+#include "note.h"
 #include "hook.h"
 #include "tremolosinglechord.h"
 
@@ -51,16 +54,19 @@ EngravingItem* Stem::elementBase() const
     return parentItem();
 }
 
+/*! Virtual staff index, accounting for cross-staff chord movement. */
 staff_idx_t Stem::vStaffIdx() const
 {
     return staffIdx() + chord()->staffMove();
 }
 
+/*! True if the parent chord's stem points upward. */
 bool Stem::up() const
 {
     return chord() ? chord()->up() : true;
 }
 
+/*! Sets the unstemmed (default) stem length, stored as an absolute value. */
 void Stem::setBaseLength(Spatium baseLength)
 {
     m_baseLength = Spatium(std::abs(baseLength.val()));
@@ -126,6 +132,7 @@ bool Stem::acceptDrop(EditData& data) const
     return false;
 }
 
+/*! Handles a drop event: attaches single-chord tremolos to the parent chord. */
 EngravingItem* Stem::drop(EditData& data)
 {
     EngravingItem* e = data.dropElement;
@@ -143,6 +150,7 @@ EngravingItem* Stem::drop(EditData& data)
     return 0;
 }
 
+/*! Returns the current value of the given stem property. */
 PropertyValue Stem::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -159,6 +167,7 @@ PropertyValue Stem::getProperty(Pid propertyId) const
     }
 }
 
+/*! Applies @p v to the stem property identified by @p propertyId and triggers a relayout. */
 bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -184,6 +193,10 @@ bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * Default stem properties.
+ * For @c Pid::COLOR, returns the top note's color when @c Sid::colorApplyToStem is on.
+ */
 PropertyValue Stem::propertyDefault(Pid id) const
 {
     switch (id) {
@@ -191,7 +204,29 @@ PropertyValue Stem::propertyDefault(Pid id) const
         return 0.0_sp;
     case Pid::STEM_DIRECTION:
         return PropertyValue::fromValue<DirectionV>(DirectionV::AUTO);
+    case Pid::COLOR:
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return PropertyValue::fromValue(chord()->upNote()->color());
+            }
+        }
+    // fall through
     default:
         return EngravingItem::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: follows the top note's color if stems inherit note color.
+ */
+Color Stem::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return chord()->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -25,7 +25,10 @@
 
 #include "../editing/elementeditdata.h"
 
+#include "style/style.h"
+
 #include "chord.h"
+#include "note.h"
 #include "hook.h"
 #include "tremolosinglechord.h"
 
@@ -51,16 +54,19 @@ EngravingItem* Stem::elementBase() const
     return parentItem();
 }
 
+/*! Virtual staff index, accounting for cross-staff chord movement. */
 staff_idx_t Stem::vStaffIdx() const
 {
-    return staffIdx() + chord()->staffMove();
+    return staffIdx() + (chord() ? chord()->staffMove() : 0);
 }
 
+/*! True if the parent chord's stem points upward. */
 bool Stem::up() const
 {
     return chord() ? chord()->up() : true;
 }
 
+/*! Sets the unstemmed (default) stem length, stored as an absolute value. */
 void Stem::setBaseLength(Spatium baseLength)
 {
     m_baseLength = Spatium(std::abs(baseLength.val()));
@@ -126,6 +132,7 @@ bool Stem::acceptDrop(EditData& data) const
     return false;
 }
 
+/*! Handles a drop event: attaches single-chord tremolos to the parent chord. */
 EngravingItem* Stem::drop(Transaction&, EditData& data)
 {
     EngravingItem* e = data.dropElement;
@@ -143,6 +150,7 @@ EngravingItem* Stem::drop(Transaction&, EditData& data)
     return 0;
 }
 
+/*! Returns the current value of the given stem property. */
 PropertyValue Stem::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -154,11 +162,16 @@ PropertyValue Stem::getProperty(Pid propertyId) const
         return PropertyValue::fromValue<DirectionV>(chord()->stemDirection());
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         return chord() ? chord()->isPropertyLinkedToMaster(Pid::STEM_DIRECTION) : true;
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the chord's top note) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
 }
 
+/*! Applies @p v to the stem property identified by @p propertyId and triggers a relayout. */
 bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -184,6 +197,12 @@ bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * Default stem properties.
+ * For @c Pid::COLOR, returns the sentinel @c configuration()->defaultColor() when
+ * @c Sid::colorApplyToStem is on so that resetting restores the "inherit from note" state;
+ * @c Stem::color() resolves the sentinel to the top note's color at draw time.
+ */
 PropertyValue Stem::propertyDefault(Pid id) const
 {
     switch (id) {
@@ -191,7 +210,29 @@ PropertyValue Stem::propertyDefault(Pid id) const
         return 0.0_sp;
     case Pid::STEM_DIRECTION:
         return PropertyValue::fromValue<DirectionV>(DirectionV::AUTO);
+    case Pid::COLOR:
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    // fall through
     default:
         return EngravingItem::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: follows the top note's color if stems inherit note color.
+ */
+Color Stem::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return chord()->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -25,9 +25,14 @@
 
 #include "../editing/elementeditdata.h"
 
+#include "style/style.h"
+
 #include "chord.h"
+#include "note.h"
 #include "hook.h"
 #include "tremolosinglechord.h"
+
+#include "iengravingconfiguration.h" // IWYU pragma: keep
 
 #include "log.h"
 
@@ -51,16 +56,19 @@ EngravingItem* Stem::elementBase() const
     return chord();
 }
 
+/*! Virtual staff index, accounting for cross-staff chord movement. */
 staff_idx_t Stem::vStaffIdx() const
 {
-    return staffIdx() + chord()->staffMove();
+    return staffIdx() + (chord() ? chord()->staffMove() : 0);
 }
 
+/*! True if the parent chord's stem points upward. */
 bool Stem::up() const
 {
     return chord() ? chord()->up() : true;
 }
 
+/*! Sets the unstemmed (default) stem length, stored as an absolute value. */
 void Stem::setBaseLength(Spatium baseLength)
 {
     m_baseLength = Spatium(std::abs(baseLength.val()));
@@ -126,6 +134,7 @@ bool Stem::acceptDrop(EditData& data) const
     return false;
 }
 
+/*! Handles a drop event: attaches single-chord tremolos to the parent chord. */
 EngravingItem* Stem::drop(Transaction&, EditData& data)
 {
     EngravingItem* e = data.dropElement;
@@ -143,6 +152,7 @@ EngravingItem* Stem::drop(Transaction&, EditData& data)
     return 0;
 }
 
+/*! Returns the current value of the given stem property. */
 PropertyValue Stem::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
@@ -154,11 +164,16 @@ PropertyValue Stem::getProperty(Pid propertyId) const
         return PropertyValue::fromValue<DirectionV>(chord()->stemDirection());
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         return chord() ? chord()->isPropertyLinkedToMaster(Pid::STEM_DIRECTION) : true;
+    case Pid::COLOR:
+        // Return the raw stored color (sentinel when inheriting from the chord's top note) so writers
+        // and undo compare against the persisted value, not the dynamically resolved theme color.
+        return PropertyValue::fromValue(m_color);
     default:
         return EngravingItem::getProperty(propertyId);
     }
 }
 
+/*! Applies @p v to the stem property identified by @p propertyId and triggers a relayout. */
 bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
@@ -184,6 +199,12 @@ bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+/*!
+ * Default stem properties.
+ * For @c Pid::COLOR, returns the sentinel @c configuration()->defaultColor() when
+ * @c Sid::colorApplyToStem is on so that resetting restores the "inherit from note" state;
+ * @c Stem::color() resolves the sentinel to the top note's color at draw time.
+ */
 PropertyValue Stem::propertyDefault(Pid id) const
 {
     switch (id) {
@@ -191,7 +212,29 @@ PropertyValue Stem::propertyDefault(Pid id) const
         return 0.0_sp;
     case Pid::STEM_DIRECTION:
         return PropertyValue::fromValue<DirectionV>(DirectionV::AUTO);
+    case Pid::COLOR:
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return PropertyValue::fromValue(configuration()->defaultColor());
+            }
+        }
+    // fall through
     default:
         return EngravingItem::propertyDefault(id);
     }
+}
+
+/*!
+ * Draw color when using the score default: follows the top note's color if stems inherit note color.
+ */
+Color Stem::color() const
+{
+    if (m_color == configuration()->defaultColor()) {
+        if (chord() && !chord()->notes().empty()) {
+            if (chord()->upNote()->style().styleV(Sid::colorApplyToStem).toBool()) {
+                return chord()->upNote()->color();
+            }
+        }
+    }
+    return m_color;
 }

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -52,7 +52,10 @@ public:
     void reset() override;
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: @c chordRootColorDefault() when stems inherit themed color.
     PropertyValue propertyDefault(Pid id) const override;
+    //! Draw color: @c chordRootNoteColor() when inheriting themed note color.
+    Color color() const override;
 
     staff_idx_t vStaffIdx() const override;
 

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -53,7 +53,10 @@ public:
     void reset() override;
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    //! Default @c Pid::COLOR: sentinel (so resets keep inheritance) when stems inherit themed color.
     PropertyValue propertyDefault(Pid id) const override;
+    //! Draw color: top note of the owning chord when inheriting themed note color.
+    Color color() const override;
 
     staff_idx_t vStaffIdx() const override;
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -29,6 +29,7 @@
 #include "dom/stafftype.h"
 #include "dom/tuplet.h"
 
+#include "types/notecoloringscheme.h"
 #include "types/types.h"
 
 using namespace mu::engraving;
@@ -36,7 +37,7 @@ using namespace mu::engraving;
 // Help keeping Sid names and XML tag texts in sync
 #define styleDef(sidAndXmlTag, property) { Sid::sidAndXmlTag, #sidAndXmlTag, property }
 
-//! Keep in sync with Sid in styledef.h
+//! Default for each @c Sid; keep in sync with @c styledef.h (includes @c noteColorTheme … @c colorNotesByConcertPitch for note coloring).
 const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValues { {
     styleDef(pageWidth,                                  210.0 / INCH),
     styleDef(pageHeight,                                 297.0 / INCH),   // A4
@@ -237,6 +238,26 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(timeSigAcrossY,                             0.0_sp),
 
     styleDef(useStraightNoteFlags,                       false),
+    styleDef(noteColorTheme,                             static_cast<int>(NoteColoringScheme::OneColor)),
+    styleDef(defaultNoteColor,                           PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor0,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor1,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor2,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor3,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor4,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor5,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor6,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor7,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor8,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor9,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor10,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor11,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(colorApplyToAccidental,                     true),
+    styleDef(colorApplyToStem,                           false),
+    styleDef(colorApplyToArticulation,                   false),
+    styleDef(colorApplyToDot,                            true),
+    styleDef(colorApplyToBeam,                           false),
+    styleDef(colorNotesByConcertPitch,                   false),
     styleDef(stemWidth,                                  0.10_sp),
     styleDef(shortenStem,                                true),
     styleDef(stemLength,                                 PropertyValue(3.5)),

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -29,6 +29,7 @@
 #include "dom/stafftype.h"
 #include "dom/tuplet.h"
 
+#include "types/notecoloringscheme.h"
 #include "types/types.h"
 
 using namespace mu::engraving;
@@ -36,7 +37,10 @@ using namespace mu::engraving;
 // Help keeping Sid names and XML tag texts in sync
 #define styleDef(sidAndXmlTag, property) { Sid::sidAndXmlTag, #sidAndXmlTag, property }
 
-//! Keep in sync with Sid in styledef.h
+/*!
+ * Factory default for every @c Sid row (XML name + typed value). Keep order and entries in sync with @c styledef.h.
+ * Note-color entries (@c noteColorTheme through @c colorNotesByConcertPitch) default the palette and apply-to flags.
+ */
 const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValues { {
     styleDef(pageWidth,                                  210.0 / INCH),
     styleDef(pageHeight,                                 297.0 / INCH),   // A4
@@ -2242,6 +2246,28 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(palmMuteBeginFilledArrowWidth,              0.85_sp),
     styleDef(palmMuteEndFilledArrowHeight,               1.0_sp),
     styleDef(palmMuteEndFilledArrowWidth,                0.85_sp),
+
+    styleDef(noteColorTheme,                             static_cast<int>(NoteColoringScheme::OneColor)),
+    styleDef(defaultNoteColor,                           PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor0,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor1,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor2,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor3,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor4,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor5,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor6,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor7,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor8,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor9,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor10,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor11,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(colorApplyToAccidental,                     true),
+    styleDef(colorApplyToStem,                           false),
+    styleDef(colorApplyToArticulation,                   false),
+    styleDef(colorApplyToDot,                            true),
+    styleDef(colorApplyToBeam,                           false),
+    styleDef(colorApplyToFlag,                           false),
+    styleDef(colorNotesByConcertPitch,                   false),
 } };
 
 #undef styleDef

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -29,6 +29,7 @@
 #include "dom/stafftype.h"
 #include "dom/tuplet.h"
 
+#include "types/notecoloringscheme.h"
 #include "types/types.h"
 
 using namespace mu::engraving;
@@ -36,7 +37,10 @@ using namespace mu::engraving;
 // Help keeping Sid names and XML tag texts in sync
 #define styleDef(sidAndXmlTag, property) { Sid::sidAndXmlTag, #sidAndXmlTag, property }
 
-//! Keep in sync with Sid in styledef.h
+/*!
+ * Factory default for every @c Sid row (XML name + typed value). Keep order and entries in sync with @c styledef.h.
+ * Note-color entries (@c noteColorTheme through @c colorNotesByConcertPitch) default the palette and apply-to flags.
+ */
 const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValues { {
     styleDef(pageWidth,                                  210.0 / INCH),
     styleDef(pageHeight,                                 297.0 / INCH),   // A4
@@ -2254,6 +2258,28 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(palmMuteBeginFilledArrowWidth,              0.85_sp),
     styleDef(palmMuteEndFilledArrowHeight,               1.0_sp),
     styleDef(palmMuteEndFilledArrowWidth,                0.85_sp),
+
+    styleDef(noteColorTheme,                             static_cast<int>(NoteColoringScheme::OneColor)),
+    styleDef(defaultNoteColor,                           PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor0,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor1,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor2,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor3,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor4,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor5,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor6,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor7,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor8,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor9,                                 PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor10,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(noteColor11,                                PropertyValue::fromValue(Color::BLACK)),
+    styleDef(colorApplyToAccidental,                     true),
+    styleDef(colorApplyToStem,                           false),
+    styleDef(colorApplyToArticulation,                   false),
+    styleDef(colorApplyToDot,                            true),
+    styleDef(colorApplyToBeam,                           false),
+    styleDef(colorApplyToFlag,                           false),
+    styleDef(colorNotesByConcertPitch,                   false),
 } };
 
 #undef styleDef

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -45,6 +45,8 @@ Q_NAMESPACE;
  * Enumerates the list of score style settings
  * @memberof Engraving
  * @enum
+ *
+ * Note-color keys from @c noteColorTheme through @c colorNotesByConcertPitch back @c notecoloringscheme.h and Edit Style.
  */
 enum class Sid : short {
     NOSTYLE = -1,
@@ -244,6 +246,26 @@ enum class Sid : short {
     timeSigAcrossY,
 
     useStraightNoteFlags,
+    noteColorTheme,                //!< @c NoteColoringScheme index (palette / harmony mode).
+    defaultNoteColor,              //!< Fallback note color when using a single-color scheme.
+    noteColor0,                    //!< Swatch 0 in the twelve-color note palette.
+    noteColor1,                    //!< Swatch 1 in the twelve-color note palette.
+    noteColor2,                    //!< Swatch 2 in the twelve-color note palette.
+    noteColor3,                    //!< Swatch 3 in the twelve-color note palette.
+    noteColor4,                    //!< Swatch 4 in the twelve-color note palette.
+    noteColor5,                    //!< Swatch 5 in the twelve-color note palette.
+    noteColor6,                    //!< Swatch 6 in the twelve-color note palette.
+    noteColor7,                    //!< Swatch 7 in the twelve-color note palette.
+    noteColor8,                    //!< Swatch 8 in the twelve-color note palette.
+    noteColor9,                    //!< Swatch 9 in the twelve-color note palette.
+    noteColor10,                   //!< Swatch 10 in the twelve-color note palette.
+    noteColor11,                   //!< Swatch 11 in the twelve-color note palette.
+    colorApplyToAccidental,        //!< When set, note coloring also tints accidentals.
+    colorApplyToStem,              //!< When set, note coloring also tints stems.
+    colorApplyToArticulation,      //!< When set, note coloring also tints articulations.
+    colorApplyToDot,               //!< When set, note coloring also tints augmentation dots.
+    colorApplyToBeam,              //!< When set, note coloring also tints beams.
+    colorNotesByConcertPitch,      //!< Use concert pitch for key/degree coloring when transposing instruments differ.
     stemWidth,
     shortenStem,
     stemLength,

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -46,6 +46,8 @@ Q_NAMESPACE;
  * Enumerates the list of score style settings
  * @memberof Engraving
  * @enum
+ *
+ * Note-color keys include @c noteColorTheme, @c colorNotesByConcertPitch, and related definitions in @c notecoloringscheme.h and Edit Style.
  */
 enum class Sid : short {
     NOSTYLE = -1,
@@ -2260,6 +2262,28 @@ enum class Sid : short {
     palmMuteBeginFilledArrowWidth,
     palmMuteEndFilledArrowHeight,
     palmMuteEndFilledArrowWidth,
+
+    noteColorTheme,                //!< @c NoteColoringScheme: one color, absolute pitch (diatonic/chromatic), or moveable-do (diatonic/chromatic).
+    defaultNoteColor,              //!< Fallback note color when using a single-color scheme.
+    noteColor0,                    //!< Swatch 0 in the twelve-color note palette.
+    noteColor1,                    //!< Swatch 1 in the twelve-color note palette.
+    noteColor2,                    //!< Swatch 2 in the twelve-color note palette.
+    noteColor3,                    //!< Swatch 3 in the twelve-color note palette.
+    noteColor4,                    //!< Swatch 4 in the twelve-color note palette.
+    noteColor5,                    //!< Swatch 5 in the twelve-color note palette.
+    noteColor6,                    //!< Swatch 6 in the twelve-color note palette.
+    noteColor7,                    //!< Swatch 7 in the twelve-color note palette.
+    noteColor8,                    //!< Swatch 8 in the twelve-color note palette.
+    noteColor9,                    //!< Swatch 9 in the twelve-color note palette.
+    noteColor10,                   //!< Swatch 10 in the twelve-color note palette.
+    noteColor11,                   //!< Swatch 11 in the twelve-color note palette.
+    colorApplyToAccidental,        //!< When set, note coloring also tints accidentals.
+    colorApplyToStem,              //!< When set, note coloring also tints stems.
+    colorApplyToArticulation,      //!< When set, note coloring also tints articulations.
+    colorApplyToDot,               //!< When set, note coloring also tints augmentation dots.
+    colorApplyToBeam,              //!< When set, note coloring also tints beams.
+    colorApplyToFlag,              //!< When set, note coloring also tints note flags.
+    colorNotesByConcertPitch,      //!< Use concert pitch for key/degree coloring when transposing instruments differ.
 
     STYLES
 };

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -46,6 +46,8 @@ Q_NAMESPACE;
  * Enumerates the list of score style settings
  * @memberof Engraving
  * @enum
+ *
+ * Note-color keys include @c noteColorTheme, @c colorNotesByConcertPitch, and related definitions in @c notecoloringscheme.h and Edit Style.
  */
 enum class Sid : short {
     NOSTYLE = -1,
@@ -2272,6 +2274,28 @@ enum class Sid : short {
     palmMuteBeginFilledArrowWidth,
     palmMuteEndFilledArrowHeight,
     palmMuteEndFilledArrowWidth,
+
+    noteColorTheme,                //!< @c NoteColoringScheme: one color, absolute pitch (diatonic/chromatic), or moveable-do (diatonic/chromatic).
+    defaultNoteColor,              //!< Fallback note color when using a single-color scheme.
+    noteColor0,                    //!< Swatch 0 in the twelve-color note palette.
+    noteColor1,                    //!< Swatch 1 in the twelve-color note palette.
+    noteColor2,                    //!< Swatch 2 in the twelve-color note palette.
+    noteColor3,                    //!< Swatch 3 in the twelve-color note palette.
+    noteColor4,                    //!< Swatch 4 in the twelve-color note palette.
+    noteColor5,                    //!< Swatch 5 in the twelve-color note palette.
+    noteColor6,                    //!< Swatch 6 in the twelve-color note palette.
+    noteColor7,                    //!< Swatch 7 in the twelve-color note palette.
+    noteColor8,                    //!< Swatch 8 in the twelve-color note palette.
+    noteColor9,                    //!< Swatch 9 in the twelve-color note palette.
+    noteColor10,                   //!< Swatch 10 in the twelve-color note palette.
+    noteColor11,                   //!< Swatch 11 in the twelve-color note palette.
+    colorApplyToAccidental,        //!< When set, note coloring also tints accidentals.
+    colorApplyToStem,              //!< When set, note coloring also tints stems.
+    colorApplyToArticulation,      //!< When set, note coloring also tints articulations.
+    colorApplyToDot,               //!< When set, note coloring also tints augmentation dots.
+    colorApplyToBeam,              //!< When set, note coloring also tints beams.
+    colorApplyToFlag,              //!< When set, note coloring also tints note flags.
+    colorNotesByConcertPitch,      //!< Use concert pitch for key/degree coloring when transposing instruments differ.
 
     STYLES
 };

--- a/src/engraving/types/notecoloringscheme.h
+++ b/src/engraving/types/notecoloringscheme.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ */
+
+/*!
+ * \file
+ * \brief Note coloring schemes and pitch-class helpers for engraving and Edit Style.
+ *
+ * Defines @c NoteColoringScheme and related pitch-class helpers used by @c Note coloring.
+ */
+#pragma once
+
+namespace mu::engraving {
+/*!
+ * Style-driven scheme for mapping notes to palette swatches (@c Sid::noteColor0 ... @c Sid::noteColor11).
+ */
+enum class NoteColoringScheme : int {
+    OneColor = 0, //!< Single user color for all notes.
+    AbsolutePitchSimple = 1,      //!< Step index from TPC (letter name / diatonic step).
+    AbsolutePitchChromatic = 2,   //!< MIDI chroma from effective pitch.
+    MoveableDoSimple = 3,         //!< Scale degree from TPC and local key.
+    MoveableDoChromatic = 4,      //!< Chromatic scale degree relative to key tonic.
+};
+
+/*! Semitone offsets of the major scale from the tonic (pitch classes). */
+inline constexpr int MAJOR_SCALE_INTERVALS[] = { 0, 2, 4, 5, 7, 9, 11 };
+
+/*!
+ * Pitch class (0-11) of the major tonic for a key signature given as circle-of-fifths index.
+ * @param keyFifths @c Key enum value (fifths from C).
+ * @return Tonic pitch class 0-11.
+ */
+inline int tonicPitchClassFromKey(int keyFifths)
+{
+    int pc = (keyFifths * 7) % 12;
+    return pc < 0 ? pc + 12 : pc;
+}
+
+/*!
+ * Diatonic degree index 0-6 for @p pitchClass in a major scale built on @p tonicPC, or -1 if not in scale.
+ * @param pitchClass Note chroma 0-11.
+ * @param tonicPC Major-key tonic chroma 0-11.
+ * @return Major scale degree index, or -1.
+ */
+inline int pitchToDegreeIndex(int pitchClass, int tonicPC)
+{
+    int semitones = (pitchClass - tonicPC + 12) % 12;
+    for (int i = 0; i < 7; ++i) {
+        if (MAJOR_SCALE_INTERVALS[i] == semitones) {
+            return i;
+        }
+    }
+    return -1;
+}
+}

--- a/src/engraving/types/notecoloringscheme.h
+++ b/src/engraving/types/notecoloringscheme.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ */
+
+/*!
+ * \file
+ * \brief Note coloring schemes and pitch-class helpers for engraving and Edit Style.
+ *
+ * Defines @c NoteColoringScheme, @c MAJOR_SCALE_INTERVALS, and helpers @c tonicPitchClassFromKey /
+ * @c pitchToDegreeIndex used when mapping notes to @c Sid::noteColor0 … @c Sid::noteColor11.
+ */
+#pragma once
+
+namespace mu::engraving {
+/*!
+ * Style-driven scheme for mapping notes to palette swatches (@c Sid::noteColor0 ... @c Sid::noteColor11).
+ */
+enum class NoteColoringScheme : int {
+    OneColor = 0, //!< Single user color for all notes.
+    AbsolutePitchSimple = 1,      //!< Step index from TPC (letter name / diatonic step).
+    AbsolutePitchChromatic = 2,   //!< MIDI chroma from effective pitch.
+    MoveableDoSimple = 3,         //!< Scale degree from TPC and local key.
+    MoveableDoChromatic = 4,      //!< Chromatic scale degree relative to key tonic.
+};
+
+/*! Semitone offsets of the major scale from the tonic (pitch classes). */
+inline constexpr int MAJOR_SCALE_INTERVALS[] = { 0, 2, 4, 5, 7, 9, 11 };
+
+/*!
+ * Pitch class (0-11) of the major tonic for a key signature given as circle-of-fifths index.
+ * @param keyFifths @c Key enum value (fifths from C).
+ * @return Tonic pitch class 0-11.
+ */
+inline int tonicPitchClassFromKey(int keyFifths)
+{
+    int pc = (keyFifths * 7) % 12;
+    return pc < 0 ? pc + 12 : pc;
+}
+
+/*!
+ * Diatonic degree index 0-6 for @p pitchClass in a major scale built on @p tonicPC, or -1 if not in scale.
+ * @param pitchClass Note chroma 0-11.
+ * @param tonicPC Major-key tonic chroma 0-11.
+ * @return Major scale degree index, or -1.
+ */
+inline int pitchToDegreeIndex(int pitchClass, int tonicPC)
+{
+    int semitones = (pitchClass - tonicPC + 12) % 12;
+    for (int i = 0; i < 7; ++i) {
+        if (MAJOR_SCALE_INTERVALS[i] == semitones) {
+            return i;
+        }
+    }
+    return -1;
+}
+} // namespace mu::engraving

--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -20,10 +20,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*!
+ * \file editstyle.cpp
+ * \brief Implementation of the score style dialog, including the dynamic note-color UI on the Notes page
+ *        (presets, schemes, apply-to flags, and reset).
+ *
+ * The Notes tab is mostly Qt widgets; after building the Color group, @c PageNotes is reparented into
+ * a @c QScrollArea so the tab scrolls when the stacked page height is limited (same pattern as other
+ * widget-heavy Style pages in @c editstyle.ui, e.g. Rests). QML-only pages such as Slurs & ties use
+ * @c StyledFlickable inside @c createQmlWidget() instead.
+ */
+
 #include "editstyle.h"
 
 #include <QAnyStringView>
 #include <QButtonGroup>
+#include <QFrame>
+#include <QGroupBox>
+#include <QListView>
+#include <QScrollArea>
 #include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickView>
@@ -41,7 +56,16 @@
 
 #include "engraving/dom/figuredbass.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/chord.h"
+#include "engraving/dom/stem.h"
+#include "engraving/dom/beam.h"
+#include "engraving/dom/articulation.h"
+#include "engraving/dom/accidental.h"
+#include "engraving/dom/notedot.h"
+#include "engraving/dom/staff.h"
 #include "engraving/dom/stafftype.h"
+#include "engraving/types/notecoloringscheme.h"
 #include "engraving/style/textstyle.h"
 #include "engraving/types/symnames.h"
 #include "engraving/types/types.h"
@@ -818,14 +842,522 @@ void EditStyle::classBegin()
     }
 
     // ====================================================
-    // Notes (QML)
+    // Notes (QML + widgets; see QScrollArea wrap below)
     // ====================================================
+    /*!
+     * \brief Notes page: flag-style control is QML inside @c groupBox_noteFlags; note metrics and
+     *        alignment come from @c editstyle.ui. The Color block is built in C++ in the next section.
+     *        All of these are later placed in one @c QScrollArea on @c PageNotes (widget-based scroll).
+     */
 
     auto noteFlagsTypeSelector = createQmlWidget(
         groupBox_noteFlags,
         QUrl(QString::fromUtf8("qrc:/qt/qml/MuseScore/NotationScene/styledialog/NoteFlagsTypeSelector.qml")));
     noteFlagsTypeSelector.widget->setMinimumSize(224, 70);
     groupBox_noteFlags->layout()->addWidget(noteFlagsTypeSelector.widget);
+
+    // ====================================================
+    // Note Colors (Dynamic C++)
+    // ====================================================
+    /*!
+     * \internal Builds the Notes-page Color @c QGroupBox: preset and scheme combos, twelve swatches, apply-to
+     * checkboxes, concert-pitch radios, and reset. Lambdas keep preset
+     * labels in sync with palette state. After this block, @c PageNotes is rebuilt: layout items from the UI
+     * are cleared (widgets are not destroyed), and flag, color, notes, and alignment groups are stacked inside
+     * a single @c QScrollArea child so the tab scrolls when @c pageStack minimum height is tight.
+     */
+    {
+        //! Built-in palette rows vs user-edited colors in the preset combo.
+        enum class NoteColorPreset : int {
+            Default = 0,
+            Boomwhackers = 1,
+            FigureNotes = 2,
+            Custom = 3
+        };
+
+        //! Number of visible swatches for @p scheme (7 diatonic modes, otherwise 12 chromatic).
+        auto swatchCountForScheme = [](NoteColoringScheme scheme) {
+            return (scheme == NoteColoringScheme::AbsolutePitchSimple || scheme == NoteColoringScheme::MoveableDoSimple) ? 7 : 12;
+        };
+
+        m_noteColorGroup = new QGroupBox(muse::qtrc("notation/editstyle", "Color"));
+        m_noteColorGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        QVBoxLayout* vbl = new QVBoxLayout(m_noteColorGroup);
+
+        m_noteColorPresetCombo = new QComboBox();
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Default"), static_cast<int>(NoteColorPreset::Default));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Boomwhackers"), static_cast<int>(NoteColorPreset::Boomwhackers));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"),
+                                        static_cast<int>(NoteColorPreset::FigureNotes));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Custom"), static_cast<int>(NoteColorPreset::Custom));
+
+        m_noteColorSchemeCombo = new QComboBox();
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "One color"), static_cast<int>(NoteColoringScheme::OneColor));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (simple)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchChromatic));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (simple)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoChromatic));
+
+        styleWidgets.append({ StyleId::noteColorTheme, false, m_noteColorSchemeCombo, nullptr });
+
+        QGridLayout* glTop = new QGridLayout();
+        m_noteColorPresetLabel = new QLabel(muse::qtrc("notation/editstyle", "Preset:"));
+        glTop->addWidget(m_noteColorPresetLabel, 0, 0);
+        m_noteColorPresetCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        glTop->addWidget(m_noteColorPresetCombo, 1, 0);
+
+        m_noteColorSchemeLabel = new QLabel(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+        glTop->addWidget(m_noteColorSchemeLabel, 0, 1);
+        m_noteColorSchemeCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        glTop->addWidget(m_noteColorSchemeCombo, 1, 1);
+
+        m_noteColorSwatchColorLabel = new QLabel(muse::qtrc("notation/editstyle", "Color:"));
+        glTop->addWidget(m_noteColorSwatchColorLabel, 0, 2);
+        Awl::ColorLabel* defaultColorLabel = new Awl::ColorLabel(m_noteColorGroup);
+        defaultColorLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        defaultColorLabel->setFixedHeight(32);
+        defaultColorLabel->setMinimumWidth(100);
+        styleWidgets.append({ StyleId::defaultNoteColor, false, defaultColorLabel, nullptr });
+        glTop->addWidget(defaultColorLabel, 1, 2);
+
+        vbl->addLayout(glTop);
+
+        m_noteColorSchemeDescription = new QLabel(m_noteColorGroup);
+        m_noteColorSchemeDescription->setWordWrap(true);
+        vbl->addWidget(m_noteColorSchemeDescription);
+
+        m_noteColorSwatchesContainer = new QWidget();
+        QHBoxLayout* hlSwatches = new QHBoxLayout(m_noteColorSwatchesContainer);
+        hlSwatches->setContentsMargins(0, 0, 0, 0);
+
+        QWidget* gridWidget = new QWidget();
+        QGridLayout* glColors = new QGridLayout(gridWidget);
+        glColors->setContentsMargins(0, 0, 0, 0);
+        glColors->setSpacing(8);
+        hlSwatches->addWidget(gridWidget);
+        vbl->addWidget(m_noteColorSwatchesContainer);
+
+        m_noteColorApplyToGroupBox = new QGroupBox(muse::qtrc("notation/editstyle", "Apply color to:"));
+        m_noteColorApplyToGroupBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        QGridLayout* glApplyTo = new QGridLayout(m_noteColorApplyToGroupBox);
+        m_noteColorCbAccidental = new QCheckBox(muse::qtrc("notation/editstyle", "Accidentals"));
+        m_noteColorCbStem = new QCheckBox(muse::qtrc("notation/editstyle", "Stems"));
+        m_noteColorCbArticulation = new QCheckBox(muse::qtrc("notation/editstyle", "Articulations"));
+        m_noteColorCbDot = new QCheckBox(muse::qtrc("notation/editstyle", "Dots"));
+        m_noteColorCbBeam = new QCheckBox(muse::qtrc("notation/editstyle", "Beams"));
+
+        styleWidgets.append({ StyleId::colorApplyToAccidental, false, m_noteColorCbAccidental, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToStem, false, m_noteColorCbStem, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToArticulation, false, m_noteColorCbArticulation, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToDot, false, m_noteColorCbDot, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToBeam, false, m_noteColorCbBeam, nullptr });
+
+        glApplyTo->addWidget(m_noteColorCbAccidental, 0, 0);
+        glApplyTo->addWidget(m_noteColorCbStem, 0, 1);
+        glApplyTo->addWidget(m_noteColorCbArticulation, 0, 2);
+        glApplyTo->addWidget(m_noteColorCbDot, 1, 0);
+        glApplyTo->addWidget(m_noteColorCbBeam, 1, 1);
+        glApplyTo->setColumnStretch(0, 1);
+        glApplyTo->setColumnStretch(1, 1);
+        glApplyTo->setColumnStretch(2, 1);
+        vbl->addWidget(m_noteColorApplyToGroupBox);
+
+        m_noteColorPitchGroupBox = new QGroupBox(muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"));
+        m_noteColorPitchGroupBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        m_noteColorRbWritten = new QRadioButton(muse::qtrc("notation/editstyle", "Written pitch"));
+        m_noteColorRbConcert = new QRadioButton(muse::qtrc("notation/editstyle", "Concert pitch"));
+        QButtonGroup* bgPitch = new QButtonGroup(m_noteColorGroup);
+        bgPitch->addButton(m_noteColorRbWritten, 0);
+        bgPitch->addButton(m_noteColorRbConcert, 1);
+
+        styleWidgets.append({ StyleId::colorNotesByConcertPitch, false, bgPitch, nullptr });
+
+        QVBoxLayout* vlPitch = new QVBoxLayout(m_noteColorPitchGroupBox);
+        vlPitch->addWidget(m_noteColorRbWritten);
+        vlPitch->addWidget(m_noteColorRbConcert);
+        vbl->addWidget(m_noteColorPitchGroupBox);
+
+        m_noteColorResetBtn = new QPushButton(muse::qtrc("notation/editstyle", "Reset all color settings"));
+        QHBoxLayout* hlReset = new QHBoxLayout();
+        hlReset->addStretch();
+        hlReset->addWidget(m_noteColorResetBtn);
+        vbl->addLayout(hlReset);
+
+        const StyleId colorSids[] = {
+            StyleId::noteColor0, StyleId::noteColor1,  StyleId::noteColor2,
+            StyleId::noteColor3, StyleId::noteColor4,  StyleId::noteColor5,
+            StyleId::noteColor6, StyleId::noteColor7,  StyleId::noteColor8,
+            StyleId::noteColor9, StyleId::noteColor10, StyleId::noteColor11 };
+
+        static const QColor boomwhackerColors[] = {
+            QColor(226, 38, 44),  QColor(241, 102, 38), QColor(246, 145, 33),
+            QColor(254, 203, 10), QColor(251, 237, 34), QColor(168, 202, 60),
+            QColor(57, 171, 71),  QColor(13, 138, 120), QColor(31, 152, 210),
+            QColor(43, 64, 144),  QColor(106, 38, 141), QColor(190, 40, 140) };
+        static const QColor figurenotesColors[] = {
+            QColor(226, 38, 44),   QColor(183, 103, 67),  QColor(140, 68, 41),
+            QColor(146, 192, 226), QColor(166, 172, 175), QColor(31, 152, 210),
+            QColor(181, 137, 199), QColor(230, 231, 232), QColor(0, 0, 0),
+            QColor(251, 237, 34),  QColor(168, 202, 60),  QColor(57, 171, 71) };
+
+        Awl::ColorLabel* colorLabels[12];
+        QLabel* colorTextLabels[12];
+        for (int i = 0; i < 12; ++i) {
+            colorLabels[i] = new Awl::ColorLabel(gridWidget);
+            colorLabels[i]->setFixedHeight(32);
+            colorLabels[i]->setMinimumWidth(32);
+            colorLabels[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+            colorTextLabels[i] = new QLabel("", gridWidget);
+            colorTextLabels[i]->setAlignment(Qt::AlignCenter);
+
+            QVBoxLayout* vSwatch = new QVBoxLayout();
+            vSwatch->addWidget(colorLabels[i]);
+            vSwatch->addWidget(colorTextLabels[i]);
+            vSwatch->setContentsMargins(0, 0, 0, 0);
+
+            glColors->addLayout(vSwatch, 0, i);
+            glColors->setColumnStretch(i, 1);
+            styleWidgets.append({ colorSids[i], false, colorLabels[i], nullptr });
+        }
+
+        //! Sets the preset combo to Default / Boomwhackers / Figurenotes / Custom from current colors.
+        auto updatePresetFromState = [=]() {
+            // Match EditStyle::getValue(StyleId::noteColorTheme): INT comboboxes use item user data, not row index.
+            NoteColoringScheme coloringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+            int inferredPreset = static_cast<int>(NoteColorPreset::Custom);
+
+            bool allBlack = true;
+            if (coloringScheme == NoteColoringScheme::OneColor) {
+                if (defaultColorLabel->color() != QColor(Qt::black)) {
+                    allBlack = false;
+                }
+            } else {
+                int numSwatches = swatchCountForScheme(coloringScheme);
+                for (int i = 0; i < numSwatches; ++i) {
+                    if (colorLabels[i]->color() != QColor(Qt::black)) {
+                        allBlack = false;
+                        break;
+                    }
+                }
+            }
+
+            if (allBlack) {
+                inferredPreset = static_cast<int>(NoteColorPreset::Default);
+            } else {
+                bool isBoom = true;
+                bool isFig = true;
+                int numSwatches = swatchCountForScheme(coloringScheme);
+                for (int i = 0; i < numSwatches; ++i) {
+                    if (colorLabels[i]->color() != boomwhackerColors[i]) {
+                        isBoom = false;
+                    }
+                    if (colorLabels[i]->color() != figurenotesColors[i]) {
+                        isFig = false;
+                    }
+                }
+                if (isBoom) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::Boomwhackers);
+                } else if (isFig) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::FigureNotes);
+                }
+            }
+
+            if (m_noteColorPresetCombo->currentIndex() != inferredPreset) {
+                m_noteColorPresetCombo->blockSignals(true);
+                m_noteColorPresetCombo->setCurrentIndex(inferredPreset);
+                m_noteColorPresetCombo->blockSignals(false);
+            }
+
+            int customIdx = m_noteColorPresetCombo->findData(static_cast<int>(NoteColorPreset::Custom));
+            if (customIdx >= 0) {
+                QListView* view = qobject_cast<QListView*>(m_noteColorPresetCombo->view());
+                if (view) {
+                    view->setRowHidden(customIdx, inferredPreset != static_cast<int>(NoteColorPreset::Custom));
+                }
+            }
+        };
+
+        connect(defaultColorLabel, &Awl::ColorLabel::colorChanged, this, [=]() {
+            updatePresetFromState();
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+        });
+
+        for (int i = 0; i < 12; ++i) {
+            connect(colorLabels[i], &Awl::ColorLabel::colorChanged, this, [=]() {
+                updatePresetFromState();
+                valueChanged(static_cast<int>(colorSids[i]));
+            });
+        }
+
+        //! Shows or hides swatches, sets captions for @p schemeMode, and updates the explanatory label text.
+        auto updateSwatchesUI = [=](NoteColoringScheme schemeMode) {
+            const QString absoluteSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, pitch name"),
+            };
+            const QString absoluteChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "C#/Db", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D#/Eb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F#/Gb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G#/Ab", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A#/Bb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, chromatic"),
+            };
+            const QString moveableSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do"),
+            };
+            const QString moveableChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Di/Ra", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ri/Me", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fi/Se", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Si/Le", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Li/Te", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do chromatic"),
+            };
+
+            if (schemeMode == NoteColoringScheme::OneColor) {
+                m_noteColorSwatchesContainer->setVisible(false);
+                m_noteColorSwatchColorLabel->setVisible(true);
+                defaultColorLabel->setVisible(true);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(false);
+            } else {
+                m_noteColorSwatchesContainer->setVisible(true);
+                m_noteColorSwatchColorLabel->setVisible(false);
+                defaultColorLabel->setVisible(false);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(true);
+
+                int numSwatches = swatchCountForScheme(schemeMode);
+                const QString* names = (schemeMode == NoteColoringScheme::AbsolutePitchSimple) ? absoluteSimpleNames
+                                       : (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) ? absoluteChromaticNames
+                                       : (schemeMode == NoteColoringScheme::MoveableDoSimple) ? moveableSimpleNames
+                                       : moveableChromaticNames;
+
+                for (int i = 0; i < 12; ++i) {
+                    if (i < numSwatches) {
+                        colorLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setText(names[i]);
+                    } else {
+                        colorLabels[i]->setVisible(false);
+                        colorTextLabels[i]->setVisible(false);
+                    }
+                }
+
+                if (schemeMode == NoteColoringScheme::AbsolutePitchSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Each natural note gets a color. Applying accidentals does not change the color. Enharmonics will be different colors."));
+                } else if (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color each chromatic pitch based on note name. Enharmonics will be the same color."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Each scale degree gets a color. Applying accidentals does not change the color. Enharmonics will be different colors."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes based on scale degree, including chromatic pitches. Enharmonics will be the same color."));
+                }
+            }
+        };
+
+        /*!
+         * Coloring scheme combo: updates swatch labels and preset inference only.
+         * @c StyleId::noteColorTheme is written by the generic @c styleWidgets signal mapper
+         * (see @c styleWidgets.append for @c m_noteColorSchemeCombo); do not call
+         * @c valueChanged(noteColorTheme) here or the style would be updated twice per change.
+         */
+        connect(m_noteColorSchemeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int idx) {
+            NoteColoringScheme scheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->itemData(idx).toInt());
+            updateSwatchesUI(scheme);
+            updatePresetFromState();
+        });
+
+        /*!
+         * Preset combo: applies packaged swatches and aligns the scheme combo with the preset
+         * (Default @c -> OneColor, Boomwhackers/FigureNotes @c -> AbsolutePitchChromatic)
+         * so automatic coloring matches the loaded colors.
+         * Always calls @c valueChanged(noteColorTheme) at the end (scheme combo updates use
+         * @c blockSignals so the styleWidgets mapper does not double-write).
+         */
+        connect(m_noteColorPresetCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int idx) {
+            NoteColorPreset preset = static_cast<NoteColorPreset>(idx);
+            if (preset == NoteColorPreset::Default) {
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(QColor(Qt::black));
+                    colorLabels[i]->blockSignals(false);
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+                defaultColorLabel->blockSignals(true);
+                defaultColorLabel->setColor(QColor(Qt::black));
+                defaultColorLabel->blockSignals(false);
+                valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+                int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+                if (oneIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != oneIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(NoteColoringScheme::OneColor);
+                }
+
+                m_noteColorRbWritten->setChecked(true);
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+            } else if (preset == NoteColorPreset::Boomwhackers || preset == NoteColorPreset::FigureNotes) {
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(preset == NoteColorPreset::Boomwhackers ? boomwhackerColors[i] : figurenotesColors[i]);
+                    colorLabels[i]->blockSignals(false);
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+                int chromIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::AbsolutePitchChromatic));
+                if (chromIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != chromIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(chromIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(NoteColoringScheme::AbsolutePitchChromatic);
+                }
+                if (preset == NoteColorPreset::Boomwhackers) {
+                    m_noteColorRbConcert->setChecked(true);
+                } else {
+                    m_noteColorRbWritten->setChecked(true);
+                }
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+        });
+
+        connect(m_noteColorResetBtn, &QPushButton::clicked, this, [=]() {
+            for (int i = 0; i < 12; ++i) {
+                colorLabels[i]->blockSignals(true);
+                colorLabels[i]->setColor(QColor(Qt::black));
+                colorLabels[i]->blockSignals(false);
+                valueChanged(static_cast<int>(colorSids[i]));
+            }
+            defaultColorLabel->blockSignals(true);
+            defaultColorLabel->setColor(QColor(Qt::black));
+            defaultColorLabel->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+            int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+            if (oneIdx >= 0) {
+                m_noteColorSchemeCombo->blockSignals(true);
+                m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                m_noteColorSchemeCombo->blockSignals(false);
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+            updateSwatchesUI(NoteColoringScheme::OneColor);
+
+            m_noteColorCbAccidental->blockSignals(true);
+            m_noteColorCbAccidental->setChecked(true);
+            m_noteColorCbAccidental->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorApplyToAccidental));
+            m_noteColorCbStem->blockSignals(true);
+            m_noteColorCbStem->setChecked(false);
+            m_noteColorCbStem->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorApplyToStem));
+            m_noteColorCbArticulation->blockSignals(true);
+            m_noteColorCbArticulation->setChecked(false);
+            m_noteColorCbArticulation->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorApplyToArticulation));
+            m_noteColorCbDot->blockSignals(true);
+            m_noteColorCbDot->setChecked(true);
+            m_noteColorCbDot->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorApplyToDot));
+            m_noteColorCbBeam->blockSignals(true);
+            m_noteColorCbBeam->setChecked(false);
+            m_noteColorCbBeam->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorApplyToBeam));
+
+            m_noteColorRbWritten->blockSignals(true);
+            m_noteColorRbWritten->setChecked(true);
+            m_noteColorRbWritten->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+
+            m_noteColorPresetCombo->blockSignals(true);
+            m_noteColorPresetCombo->setCurrentIndex(static_cast<int>(NoteColorPreset::Default));
+            m_noteColorPresetCombo->blockSignals(false);
+
+            updatePresetFromState();
+        });
+
+        m_syncNoteColorUi = [=]() {
+            updatePresetFromState();
+            updateSwatchesUI(static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt()));
+        };
+
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+
+        /*!
+         * Reparent all Notes-page sections under one scroll area. @c PageNotes starts with a vertical layout
+         * from @c editstyle.ui (flag box, notes box, alignment box, stretch spacer). We remove every layout
+         * item so the spacer is gone, then add @c groupBox_noteFlags, @c m_noteColorGroup, @c groupBox_notes,
+         * and @c groupBox_alignment to @c notesPageScrollContents in that order. If @c PageNotes is not a
+         * @c QVBoxLayout, fall back to inserting only @c m_noteColorGroup at index 1 (legacy layout).
+         */
+        QVBoxLayout* pageNotesLayout = qobject_cast<QVBoxLayout*>(PageNotes->layout());
+        IF_ASSERT_FAILED(pageNotesLayout) {
+            if (QBoxLayout* l = qobject_cast<QBoxLayout*>(PageNotes->layout())) {
+                l->insertWidget(1, m_noteColorGroup);
+            }
+        } else {
+            while (QLayoutItem* item = pageNotesLayout->takeAt(0)) {
+                delete item;
+            }
+
+            QScrollArea* notesPageScroll = new QScrollArea(PageNotes);
+            notesPageScroll->setWidgetResizable(true);
+            notesPageScroll->setFrameShape(QFrame::NoFrame);
+            notesPageScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+            QWidget* notesPageScrollContents = new QWidget;
+            notesPageScrollContents->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+            QVBoxLayout* notesPageScrollLayout = new QVBoxLayout(notesPageScrollContents);
+            notesPageScrollLayout->setContentsMargins(0, 0, 0, 0);
+
+            notesPageScrollLayout->addWidget(groupBox_noteFlags);
+            notesPageScrollLayout->addWidget(m_noteColorGroup);
+            notesPageScrollLayout->addWidget(groupBox_notes);
+            notesPageScrollLayout->addWidget(groupBox_alignment);
+
+            notesPageScroll->setWidget(notesPageScrollContents);
+            pageNotesLayout->addWidget(notesPageScroll);
+        }
+    }
 
     // ====================================================
     // Rests (QML)
@@ -1360,11 +1892,56 @@ void EditStyle::changeEvent(QEvent* event)
 ///   NOTE: keep in sync with constructor.
 //---------------------------------------------------------
 
+/*!
+ * Updates all translatable labels and combo texts in the Notes page color section.
+ * Called from @c retranslate() on UI language change; also reapplies swatch descriptions via @c m_syncNoteColorUi.
+ */
+void EditStyle::retranslateNoteColorSection()
+{
+    if (!m_noteColorGroup) {
+        return;
+    }
+
+    m_noteColorGroup->setTitle(muse::qtrc("notation/editstyle", "Color"));
+    m_noteColorPresetLabel->setText(muse::qtrc("notation/editstyle", "Preset:"));
+    m_noteColorSchemeLabel->setText(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+    m_noteColorSwatchColorLabel->setText(muse::qtrc("notation/editstyle", "Color:"));
+
+    m_noteColorPresetCombo->setItemText(0, muse::qtrc("notation/editstyle", "Default"));
+    m_noteColorPresetCombo->setItemText(1, muse::qtrc("notation/editstyle", "Boomwhackers"));
+    m_noteColorPresetCombo->setItemText(2, muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"));
+    m_noteColorPresetCombo->setItemText(3, muse::qtrc("notation/editstyle", "Custom"));
+
+    m_noteColorSchemeCombo->setItemText(0, muse::qtrc("notation/editstyle", "One color"));
+    m_noteColorSchemeCombo->setItemText(1, muse::qtrc("notation/editstyle", "Absolute pitch (simple)"));
+    m_noteColorSchemeCombo->setItemText(2, muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"));
+    m_noteColorSchemeCombo->setItemText(3, muse::qtrc("notation/editstyle", "Moveable do (simple)"));
+    m_noteColorSchemeCombo->setItemText(4, muse::qtrc("notation/editstyle", "Moveable do (chromatic)"));
+
+    m_noteColorApplyToGroupBox->setTitle(muse::qtrc("notation/editstyle", "Apply color to:"));
+    m_noteColorCbAccidental->setText(muse::qtrc("notation/editstyle", "Accidentals"));
+    m_noteColorCbStem->setText(muse::qtrc("notation/editstyle", "Stems"));
+    m_noteColorCbArticulation->setText(muse::qtrc("notation/editstyle", "Articulations"));
+    m_noteColorCbDot->setText(muse::qtrc("notation/editstyle", "Dots"));
+    m_noteColorCbBeam->setText(muse::qtrc("notation/editstyle", "Beams"));
+
+    m_noteColorPitchGroupBox->setTitle(muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"));
+    m_noteColorRbWritten->setText(muse::qtrc("notation/editstyle", "Written pitch"));
+    m_noteColorRbConcert->setText(muse::qtrc("notation/editstyle", "Concert pitch"));
+    m_noteColorResetBtn->setText(muse::qtrc("notation/editstyle", "Reset all color settings"));
+
+    if (m_syncNoteColorUi) {
+        m_syncNoteColorUi();
+    }
+}
+
 void EditStyle::retranslate()
 {
     retranslateUi(this);
 
     buttonApplyToAllParts->setText(muse::qtrc("notation/editstyle", "Apply to all parts"));
+
+    retranslateNoteColorSection();
 
     for (const LineStyleSelect* lineStyleSelect : m_lineStyleSelects) {
         int idx = 0;
@@ -1496,6 +2073,11 @@ void EditStyle::setHeaderFooterMacroInfoText()
 //   adjustPagesStackSize
 //---------------------------------------------------------
 
+/*!
+ * Sets @c pageStack minimum size to the current page's @c sizeHint() so the dialog does not leave excess
+ * blank space when switching tabs. For tall pages (e.g. Notes with the Color section), a short minimum
+ * height makes the inner @c QScrollArea on @c PageNotes provide vertical scrolling instead of growing the dialog.
+ */
 void EditStyle::adjustPagesStackSize(int currentPageIndex)
 {
     QSize preferredSize = pageStack->widget(currentPageIndex)->sizeHint();
@@ -1745,6 +2327,9 @@ void EditStyle::on_pageRowSelectionChanged()
 //   unhandledType
 //---------------------------------------------------------
 
+/*!
+ * Fails an assertion in debug builds when @p sw.widget cannot be read for its style type.
+ */
 void EditStyle::unhandledType(const StyleWidget sw)
 {
     P_TYPE type = MStyle::valueType(sw.idx);
@@ -1752,6 +2337,10 @@ void EditStyle::unhandledType(const StyleWidget sw)
                                sw.widget->metaObject()->className()));
 }
 
+/*!
+ * @return True if the style's boolean is edited with a two-button @c QButtonGroup
+ *         (value read/written via @c QButtonGroup::checkedId), not a single @c QCheckBox.
+ */
 bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
 {
     switch (id) {
@@ -1764,6 +2353,7 @@ bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
     case StyleId::angleHangingSlursAwayFromStaff:
     case StyleId::dividerLeftAlignToSystemBarline:
     case StyleId::dividerRightAlignToSystemBarline:
+    case StyleId::colorNotesByConcertPitch:
         return true;
     default:
         return false;
@@ -1775,6 +2365,9 @@ bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
 //    return current gui value
 //---------------------------------------------------------
 
+/*!
+ * Returns the value currently shown in the UI for @p idx, using the widget type from @c MStyle::valueType().
+ */
 PropertyValue EditStyle::getValue(StyleId idx)
 {
     const StyleWidget& sw = styleWidget(idx);
@@ -1879,6 +2472,13 @@ PropertyValue EditStyle::getValue(StyleId idx)
         QButtonGroup* bg = qobject_cast<QButtonGroup*>(sw.widget);
         return TiePlacement(bg->checkedId());
     } break;
+    case P_TYPE::COLOR: {
+        if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+            return Color::fromQColor(cl->color());
+        }
+        unhandledType(sw);
+        return PropertyValue();
+    } break;
     default: {
         ASSERT_X(QString::asprintf("EditStyle::getValue: unhandled type <%d>", static_cast<int>(type)));
     } break;
@@ -1891,6 +2491,9 @@ PropertyValue EditStyle::getValue(StyleId idx)
 //   setValues
 //---------------------------------------------------------
 
+/*!
+ * Fills every @c styleWidgets control from @c styleValue() / defaults, then unblocks signals and refreshes note-color UI.
+ */
 void EditStyle::setValues()
 {
     for (const StyleWidget& sw : styleWidgets) {
@@ -2007,6 +2610,13 @@ void EditStyle::setValues()
                 as->setOffset(val.value<muse::PointF>());
             }
         } break;
+        case P_TYPE::COLOR: {
+            if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+                cl->setColor(val.value<Color>().toQColor());
+            } else {
+                unhandledType(sw);
+            }
+        } break;
         default: {
             unhandledType(sw);
         } break;
@@ -2093,6 +2703,14 @@ void EditStyle::setValues()
     bool vertical = styleValue(StyleId::groupBracketTextOrientation).value<mu::engraving::Orientation>()
                     == mu::engraving::Orientation::VERTICAL;
     groupBracketHangIntoMargin->setEnabled(vertical && !textBracketRight);
+
+    if (m_syncNoteColorUi) {
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -20,10 +20,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*!
+ * \file editstyle.cpp
+ * \brief Implementation of the score style dialog, including the dynamic note-color UI on the Notes page
+ *        (presets, schemes, apply-to flags, and reset).
+ *
+ * The Notes tab is mostly Qt widgets; after building the Color group, @c PageNotes is reparented into
+ * a @c QScrollArea so the tab scrolls when the stacked page height is limited (same pattern as other
+ * widget-heavy Style pages in @c editstyle.ui, e.g. Rests). QML-only pages such as Slurs & ties use
+ * @c StyledFlickable inside @c createQmlWidget() instead.
+ */
+
 #include "editstyle.h"
 
 #include <QAnyStringView>
 #include <QButtonGroup>
+#include <QFrame>
+#include <QGroupBox>
+#include <QListView>
+#include <QScrollArea>
 #include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickView>
@@ -41,7 +56,16 @@
 
 #include "engraving/dom/figuredbass.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/chord.h"
+#include "engraving/dom/stem.h"
+#include "engraving/dom/beam.h"
+#include "engraving/dom/articulation.h"
+#include "engraving/dom/accidental.h"
+#include "engraving/dom/notedot.h"
+#include "engraving/dom/staff.h"
 #include "engraving/dom/stafftype.h"
+#include "engraving/types/notecoloringscheme.h"
 #include "engraving/style/textstyle.h"
 #include "engraving/types/symnames.h"
 #include "engraving/types/types.h"
@@ -63,6 +87,21 @@ using namespace mu;
 using namespace mu::notation;
 using namespace mu::engraving;
 using namespace muse::ui;
+
+namespace {
+//! Seven diatonic steps (C…B, Do…Ti) to the parallel chromatic swatch row (pitch class, epitch%12 order).
+const int DIATONIC_7_TO_CHROMA_12[7] = { 0, 2, 4, 5, 7, 9, 11 };
+
+bool isSevenSwatchScheme(NoteColoringScheme s)
+{
+    return s == NoteColoringScheme::AbsolutePitchSimple || s == NoteColoringScheme::MoveableDoSimple;
+}
+
+bool isTwelveSwatchScheme(NoteColoringScheme s)
+{
+    return s == NoteColoringScheme::AbsolutePitchChromatic || s == NoteColoringScheme::MoveableDoChromatic;
+}
+} // namespace
 
 static const QStringList ALL_PAGE_CODES {
     "score",
@@ -826,14 +865,681 @@ void EditStyle::classBegin()
     }
 
     // ====================================================
-    // Notes (QML)
+    // Notes (QML + widgets; see QScrollArea wrap below)
     // ====================================================
+    /*!
+     * \brief Notes page: flag-style control is QML inside @c groupBox_noteFlags; note metrics and
+     *        alignment come from @c editstyle.ui. The Color block is built in C++ in the next section.
+     *        All of these are later placed in one @c QScrollArea on @c PageNotes (widget-based scroll).
+     */
 
     auto noteFlagsTypeSelector = createQmlWidget(
         groupBox_noteFlags,
         QUrl(QString::fromUtf8("qrc:/qt/qml/MuseScore/NotationScene/styledialog/NoteFlagsTypeSelector.qml")));
     noteFlagsTypeSelector.widget->setMinimumSize(224, 70);
     groupBox_noteFlags->layout()->addWidget(noteFlagsTypeSelector.widget);
+
+    // ====================================================
+    // Note Colors (Dynamic C++)
+    // ====================================================
+    /*!
+     * \internal Builds the Notes-page Color @c QGroupBox: preset and scheme combos, twelve swatches, apply-to
+     * checkboxes, concert-pitch radios, and reset. Content is capped at 616px (three 200px columns,
+     * 8px gutters). Lambdas keep preset
+     * labels in sync with palette state. After this block, @c PageNotes is rebuilt: layout items from the UI
+     * are cleared (widgets are not destroyed), and flag, color, notes, and alignment groups are stacked inside
+     * a single @c QScrollArea child so the tab scrolls when @c pageStack minimum height is tight.
+     */
+    {
+        /*!
+         * Preset row in @c m_noteColorPresetCombo: packaged palettes vs user-edited @c Custom.
+         */
+        enum class NoteColorPreset : int {
+            Default = 0,        //!< All-black swatches, @c OneColor scheme, written pitch.
+            Boomwhackers = 1,   //!< Built-in Boomwhackers chromatic colors + concert pitch.
+            FigureNotes = 2,    //!< Built-in Figurenotes (stage 3) colors + written pitch.
+            Custom = 3          //!< Non-packaged colors; list row may be hidden until inferred.
+        };
+
+        //! Number of visible swatches for @p scheme (7 diatonic modes, otherwise 12 chromatic).
+        auto swatchCountForScheme = [](NoteColoringScheme scheme) {
+            return (scheme == NoteColoringScheme::AbsolutePitchSimple || scheme == NoteColoringScheme::MoveableDoSimple) ? 7 : 12;
+        };
+
+        m_noteColorGroup = new QGroupBox(muse::qtrc("notation/editstyle", "Color"));
+        m_noteColorGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        QVBoxLayout* outerVbl = new QVBoxLayout(m_noteColorGroup);
+        QWidget* noteColorContent = new QWidget(m_noteColorGroup);
+        // Preset / Coloring scheme / Color: 200px + 8px + 200px + 8px + 200px = 616px interior
+        static constexpr int noteColorColumnW = 200;
+        static constexpr int noteColorGutterW = 8;
+        static constexpr int noteColorContentMaxW = 3 * noteColorColumnW + 2 * noteColorGutterW;
+        noteColorContent->setFixedWidth(noteColorContentMaxW);
+        noteColorContent->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vbl = new QVBoxLayout(noteColorContent);
+        vbl->setContentsMargins(0, 0, 0, 0);
+
+        m_noteColorPresetCombo = new QComboBox();
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Default"), static_cast<int>(NoteColorPreset::Default));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Boomwhackers"), static_cast<int>(NoteColorPreset::Boomwhackers));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"),
+                                        static_cast<int>(NoteColorPreset::FigureNotes));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Custom"), static_cast<int>(NoteColorPreset::Custom));
+
+        m_noteColorSchemeCombo = new QComboBox();
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "One color"), static_cast<int>(NoteColoringScheme::OneColor));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (simple)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchChromatic));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (simple)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoChromatic));
+
+        m_noteColorPresetCombo->setFixedWidth(noteColorColumnW);
+        m_noteColorPresetCombo->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        m_noteColorSchemeCombo->setFixedWidth(noteColorColumnW);
+        m_noteColorSchemeCombo->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+        styleWidgets.append({ StyleId::noteColorTheme, false, m_noteColorSchemeCombo, nullptr });
+
+        QWidget* presetTopCol = new QWidget(noteColorContent);
+        presetTopCol->setFixedWidth(noteColorColumnW);
+        presetTopCol->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlPresetTop = new QVBoxLayout(presetTopCol);
+        vlPresetTop->setContentsMargins(0, 0, 0, 0);
+        vlPresetTop->setSpacing(4);
+        m_noteColorPresetLabel = new QLabel(muse::qtrc("notation/editstyle", "Preset:"));
+        m_noteColorPresetLabel->setWordWrap(true);
+        vlPresetTop->addWidget(m_noteColorPresetLabel);
+        vlPresetTop->addWidget(m_noteColorPresetCombo);
+
+        QWidget* schemeTopCol = new QWidget(noteColorContent);
+        schemeTopCol->setFixedWidth(noteColorColumnW);
+        schemeTopCol->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlSchemeTop = new QVBoxLayout(schemeTopCol);
+        vlSchemeTop->setContentsMargins(0, 0, 0, 0);
+        vlSchemeTop->setSpacing(4);
+        m_noteColorSchemeLabel = new QLabel(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+        m_noteColorSchemeLabel->setWordWrap(true);
+        vlSchemeTop->addWidget(m_noteColorSchemeLabel);
+        vlSchemeTop->addWidget(m_noteColorSchemeCombo);
+
+        // Third column always occupies 200px; for non-One color schemes the label and swatch are hidden (Preset/Scheme stay fixed width).
+        QWidget* noteColorColorColumn = new QWidget(noteColorContent);
+        noteColorColorColumn->setFixedWidth(noteColorColumnW);
+        noteColorColorColumn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlColorTop = new QVBoxLayout(noteColorColorColumn);
+        vlColorTop->setContentsMargins(0, 0, 0, 0);
+        vlColorTop->setSpacing(4);
+        m_noteColorSwatchColorLabel = new QLabel(muse::qtrc("notation/editstyle", "Color:"));
+        vlColorTop->addWidget(m_noteColorSwatchColorLabel);
+        Awl::ColorLabel* defaultColorLabel = new Awl::ColorLabel(noteColorColorColumn);
+        defaultColorLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        defaultColorLabel->setFixedSize(noteColorColumnW, 30);
+        styleWidgets.append({ StyleId::defaultNoteColor, false, defaultColorLabel, nullptr });
+        vlColorTop->addWidget(defaultColorLabel);
+
+        QWidget* noteColorTopRow = new QWidget(noteColorContent);
+        QHBoxLayout* hlTop = new QHBoxLayout(noteColorTopRow);
+        hlTop->setContentsMargins(0, 0, 0, 0);
+        hlTop->setSpacing(0);
+        hlTop->addWidget(presetTopCol);
+        hlTop->addSpacing(noteColorGutterW);
+        hlTop->addWidget(schemeTopCol);
+        hlTop->addSpacing(noteColorGutterW);
+        hlTop->addWidget(noteColorColorColumn);
+
+        vbl->addWidget(noteColorTopRow, 0, Qt::AlignLeft);
+
+        m_noteColorSchemeDescription = new QLabel(noteColorContent);
+        m_noteColorSchemeDescription->setWordWrap(true);
+        m_noteColorSchemeDescription->setFixedWidth(noteColorContentMaxW);
+        vbl->addWidget(m_noteColorSchemeDescription);
+
+        m_noteColorSwatchesContainer = new QWidget(noteColorContent);
+        m_noteColorSwatchesContainer->setFixedWidth(noteColorContentMaxW);
+        m_noteColorSwatchesContainer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QHBoxLayout* hlSwatches = new QHBoxLayout(m_noteColorSwatchesContainer);
+        hlSwatches->setContentsMargins(0, 0, 0, 0);
+
+        QWidget* gridWidget = new QWidget(m_noteColorSwatchesContainer);
+        QGridLayout* glColors = new QGridLayout(gridWidget);
+        glColors->setContentsMargins(0, 0, 0, 0);
+        glColors->setSpacing(8);
+        hlSwatches->addWidget(gridWidget);
+        vbl->addWidget(m_noteColorSwatchesContainer);
+
+        m_noteColorApplyToGroupBox = new QGroupBox(muse::qtrc("notation/editstyle", "Apply color to:"), noteColorContent);
+        m_noteColorApplyToGroupBox->setFixedWidth(noteColorContentMaxW);
+        m_noteColorApplyToGroupBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QGridLayout* glApplyTo = new QGridLayout(m_noteColorApplyToGroupBox);
+        glApplyTo->setHorizontalSpacing(noteColorGutterW);
+        glApplyTo->setColumnMinimumWidth(0, noteColorColumnW);
+        glApplyTo->setColumnMinimumWidth(1, noteColorColumnW);
+        glApplyTo->setColumnMinimumWidth(2, noteColorColumnW);
+        m_noteColorCbAccidental = new QCheckBox(muse::qtrc("notation/editstyle", "Accidentals"));
+        m_noteColorCbStem = new QCheckBox(muse::qtrc("notation/editstyle", "Stems"));
+        m_noteColorCbArticulation = new QCheckBox(muse::qtrc("notation/editstyle", "Articulations"));
+        m_noteColorCbDot = new QCheckBox(muse::qtrc("notation/editstyle", "Augmentation dots"));
+        m_noteColorCbBeam = new QCheckBox(muse::qtrc("notation/editstyle", "Beams"));
+        m_noteColorCbFlag = new QCheckBox(muse::qtrc("notation/editstyle", "Flags"));
+
+        styleWidgets.append({ StyleId::colorApplyToAccidental, false, m_noteColorCbAccidental, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToStem, false, m_noteColorCbStem, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToArticulation, false, m_noteColorCbArticulation, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToDot, false, m_noteColorCbDot, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToBeam, false, m_noteColorCbBeam, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToFlag, false, m_noteColorCbFlag, nullptr });
+
+        glApplyTo->addWidget(m_noteColorCbAccidental, 0, 0);
+        glApplyTo->addWidget(m_noteColorCbArticulation, 0, 1);
+        glApplyTo->addWidget(m_noteColorCbFlag, 0, 2);
+        glApplyTo->addWidget(m_noteColorCbDot, 1, 0);
+        glApplyTo->addWidget(m_noteColorCbBeam, 1, 1);
+        glApplyTo->addWidget(m_noteColorCbStem, 1, 2);
+        glApplyTo->setColumnStretch(0, 0);
+        glApplyTo->setColumnStretch(1, 0);
+        glApplyTo->setColumnStretch(2, 0);
+        vbl->addWidget(m_noteColorApplyToGroupBox);
+
+        m_noteColorPitchGroupBox = new QGroupBox(
+            muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"), noteColorContent);
+        m_noteColorPitchGroupBox->setFixedWidth(noteColorContentMaxW);
+        m_noteColorPitchGroupBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        m_noteColorRbWritten = new QRadioButton(muse::qtrc("notation/editstyle", "Written pitch"));
+        m_noteColorRbConcert = new QRadioButton(muse::qtrc("notation/editstyle", "Concert pitch"));
+        QButtonGroup* bgPitch = new QButtonGroup(noteColorContent);
+        bgPitch->addButton(m_noteColorRbWritten, 0);
+        bgPitch->addButton(m_noteColorRbConcert, 1);
+
+        styleWidgets.append({ StyleId::colorNotesByConcertPitch, false, bgPitch, nullptr });
+
+        QVBoxLayout* vlPitch = new QVBoxLayout(m_noteColorPitchGroupBox);
+        vlPitch->addWidget(m_noteColorRbWritten);
+        vlPitch->addWidget(m_noteColorRbConcert);
+        vbl->addWidget(m_noteColorPitchGroupBox);
+
+        m_noteColorResetBtn = new QPushButton(muse::qtrc("notation/editstyle", "Reset all color settings"), noteColorContent);
+        QHBoxLayout* hlReset = new QHBoxLayout();
+        hlReset->addStretch();
+        hlReset->addWidget(m_noteColorResetBtn);
+        vbl->addLayout(hlReset);
+
+        outerVbl->addWidget(noteColorContent, 0, Qt::AlignLeft);
+
+        const StyleId colorSids[] = {
+            StyleId::noteColor0, StyleId::noteColor1,  StyleId::noteColor2,
+            StyleId::noteColor3, StyleId::noteColor4,  StyleId::noteColor5,
+            StyleId::noteColor6, StyleId::noteColor7,  StyleId::noteColor8,
+            StyleId::noteColor9, StyleId::noteColor10, StyleId::noteColor11 };
+
+        // Boomwhackers: chromatic palette (12 entries, C..B), used with AbsolutePitchChromatic + written pitch.
+        // Hex codes match the Figma design (Community-projects, node 4607-4084).
+        static const QColor boomwhackerColors[] = {
+            QColor(0xE2, 0x1C, 0x48), QColor(0xF2, 0x66, 0x22), QColor(0xF9, 0x9D, 0x1C),
+            QColor(0xFF, 0xCC, 0x33), QColor(0xFF, 0xF3, 0x2B), QColor(0xBC, 0xD8, 0x5F),
+            QColor(0x62, 0xBC, 0x47), QColor(0x00, 0x9C, 0x95), QColor(0x00, 0x71, 0xBB),
+            QColor(0x5E, 0x50, 0xA1), QColor(0x8D, 0x5B, 0xA6), QColor(0xCF, 0x3E, 0x96) };
+        // Figurenotes (stage 3): simple palette (7 entries, C..B), used with AbsolutePitchSimple + written pitch.
+        // C = red, D = brown, E = gray, F = blue, G = black, A = yellow, B = green; hex codes from Figma.
+        static const QColor figurenotesColors[] = {
+            QColor(0xFF, 0x00, 0x00), QColor(0x94, 0x61, 0x33), QColor(0xC6, 0xC4, 0xC1),
+            QColor(0x00, 0x90, 0xD8), QColor(0x1A, 0x19, 0x19), QColor(0xF7, 0xE2, 0x00),
+            QColor(0x35, 0xA2, 0x21) };
+
+        Awl::ColorLabel* colorLabels[12];
+        QLabel* colorTextLabels[12];
+        for (int i = 0; i < 12; ++i) {
+            colorLabels[i] = new Awl::ColorLabel(gridWidget);
+            colorLabels[i]->setFixedSize(44, 30);
+            colorLabels[i]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            colorTextLabels[i] = new QLabel("", gridWidget);
+            colorTextLabels[i]->setAlignment(Qt::AlignCenter);
+
+            QVBoxLayout* vSwatch = new QVBoxLayout();
+            vSwatch->addWidget(colorLabels[i], 0, Qt::AlignHCenter);
+            vSwatch->addWidget(colorTextLabels[i]);
+            vSwatch->setContentsMargins(0, 0, 0, 0);
+
+            glColors->addLayout(vSwatch, 0, i);
+            glColors->setColumnMinimumWidth(i, 44);
+            styleWidgets.append({ colorSids[i], false, colorLabels[i], nullptr });
+        }
+        // Left-pack the fixed-width swatches so their size doesn't change between 7- and 12-swatch schemes.
+        glColors->setColumnStretch(12, 1);
+
+        //! Sets the preset combo to Default / Boomwhackers / Figurenotes / Custom from current colors.
+        auto updatePresetFromState = [=, this]() {
+            // Match EditStyle::getValue(StyleId::noteColorTheme): INT comboboxes use item user data, not row index.
+            NoteColoringScheme coloringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+            int inferredPreset = static_cast<int>(NoteColorPreset::Custom);
+
+            if (coloringScheme == NoteColoringScheme::OneColor) {
+                // OneColor exposes only @c defaultColorLabel; the 12 hidden swatches are irrelevant here.
+                // A non-black default is never a packaged preset, so classify as Custom without comparing swatches.
+                if (defaultColorLabel->color() == QColor(Qt::black)) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::Default);
+                }
+            } else {
+                bool allBlack = true;
+                int numSwatches = swatchCountForScheme(coloringScheme);
+                for (int i = 0; i < numSwatches; ++i) {
+                    if (colorLabels[i]->color() != QColor(Qt::black)) {
+                        allBlack = false;
+                        break;
+                    }
+                }
+
+                if (allBlack) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::Default);
+                } else {
+                    // Boomwhackers is only valid when the scheme is AbsolutePitchChromatic (12-color match against the chromatic palette).
+                    // Figurenotes (stage 3) is only valid when the scheme is AbsolutePitchSimple (7-color match against the diatonic palette).
+                    if (coloringScheme == NoteColoringScheme::AbsolutePitchChromatic) {
+                        bool isBoom = true;
+                        for (int i = 0; i < 12; ++i) {
+                            if (colorLabels[i]->color() != boomwhackerColors[i]) {
+                                isBoom = false;
+                                break;
+                            }
+                        }
+                        if (isBoom) {
+                            inferredPreset = static_cast<int>(NoteColorPreset::Boomwhackers);
+                        }
+                    } else if (coloringScheme == NoteColoringScheme::AbsolutePitchSimple) {
+                        bool isFig = true;
+                        for (int i = 0; i < 7; ++i) {
+                            if (colorLabels[i]->color() != figurenotesColors[i]) {
+                                isFig = false;
+                                break;
+                            }
+                        }
+                        if (isFig) {
+                            inferredPreset = static_cast<int>(NoteColorPreset::FigureNotes);
+                        }
+                    }
+                }
+            }
+
+            if (m_noteColorPresetCombo->currentIndex() != inferredPreset) {
+                m_noteColorPresetCombo->blockSignals(true);
+                m_noteColorPresetCombo->setCurrentIndex(inferredPreset);
+                m_noteColorPresetCombo->blockSignals(false);
+            }
+
+            int customIdx = m_noteColorPresetCombo->findData(static_cast<int>(NoteColorPreset::Custom));
+            if (customIdx >= 0) {
+                QListView* view = qobject_cast<QListView*>(m_noteColorPresetCombo->view());
+                if (view) {
+                    view->setRowHidden(customIdx, inferredPreset != static_cast<int>(NoteColorPreset::Custom));
+                }
+            }
+        };
+
+        connect(defaultColorLabel, &Awl::ColorLabel::colorChanged, this, [=, this]() {
+            updatePresetFromState();
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+        });
+
+        for (int i = 0; i < 12; ++i) {
+            connect(colorLabels[i], &Awl::ColorLabel::colorChanged, this, [=, this]() {
+                updatePresetFromState();
+                valueChanged(static_cast<int>(colorSids[i]));
+            });
+        }
+
+        //! Shows or hides swatches, sets captions for @p schemeMode, and updates the explanatory label text.
+        auto updateSwatchesUI = [=, this](NoteColoringScheme schemeMode) {
+            const QString absoluteSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, pitch name"),
+            };
+            const QString absoluteChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "C#/Db", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D#/Eb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F#/Gb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G#/Ab", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A#/Bb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, chromatic"),
+            };
+            const QString moveableSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do"),
+            };
+            const QString moveableChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Di/Ra", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ri/Me", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fi/Se", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Si/Le", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Li/Te", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do chromatic"),
+            };
+
+            // Pitch (written vs concert) only affects schemes that read pitch directly. Moveable do uses
+            // scale-degree relative to local key, so transposition makes no difference there. Hide for both.
+            const bool pitchGroupApplies = schemeMode == NoteColoringScheme::AbsolutePitchSimple
+                                           || schemeMode == NoteColoringScheme::AbsolutePitchChromatic;
+
+            if (schemeMode == NoteColoringScheme::OneColor) {
+                m_noteColorSwatchesContainer->setVisible(false);
+                m_noteColorSwatchColorLabel->setVisible(true);
+                defaultColorLabel->setVisible(true);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(false);
+                m_noteColorPitchGroupBox->setVisible(false);
+            } else {
+                m_noteColorSwatchesContainer->setVisible(true);
+                m_noteColorSwatchColorLabel->setVisible(false);
+                defaultColorLabel->setVisible(false);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(true);
+                m_noteColorPitchGroupBox->setVisible(pitchGroupApplies);
+
+                int numSwatches = swatchCountForScheme(schemeMode);
+                const QString* names = (schemeMode == NoteColoringScheme::AbsolutePitchSimple) ? absoluteSimpleNames
+                                       : (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) ? absoluteChromaticNames
+                                       : (schemeMode == NoteColoringScheme::MoveableDoSimple) ? moveableSimpleNames
+                                       : moveableChromaticNames;
+
+                for (int i = 0; i < 12; ++i) {
+                    if (i < numSwatches) {
+                        colorLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setText(names[i]);
+                    } else {
+                        colorLabels[i]->setVisible(false);
+                        colorTextLabels[i]->setVisible(false);
+                    }
+                }
+
+                if (schemeMode == NoteColoringScheme::AbsolutePitchSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by their letter name. Accidentals do not affect the color."));
+                } else if (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by their chromatic pitch. Enharmonic equivalents get the same color."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by scale degree with respect to key signatures. Accidentals do not affect the color."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by scale degree with respect to key signatures. Enharmonic equivalents get the same color."));
+                }
+            }
+        };
+
+        /*!
+         * Coloring scheme combo: updates swatch labels and preset inference only.
+         * @c StyleId::noteColorTheme is written by the generic @c styleWidgets signal mapper
+         * (see @c styleWidgets.append for @c m_noteColorSchemeCombo); do not call
+         * @c valueChanged(noteColorTheme) here or the style would be updated twice per change.
+         */
+        connect(m_noteColorSchemeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int idx) {
+            const NoteColoringScheme newScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->itemData(idx).toInt());
+            const NoteColoringScheme oldScheme = m_lastNoteColoringScheme;
+            // Chromatic-only positions (C#/Db, D#/Eb, F#/Gb, G#/Ab, A#/Bb): all 12 minus the 7 diatonic ones.
+            static constexpr int CHROMATIC_ONLY_INDICES[5] = { 1, 3, 6, 8, 10 };
+            if (oldScheme != newScheme) {
+                if (isSevenSwatchScheme(oldScheme) && isTwelveSwatchScheme(newScheme)) {
+                    // Simple → chromatic: keep the 7 diatonic colors at their pitch slots; restore the
+                    // five chromatic-only slots from the previous chromatic state if available, otherwise black.
+                    QColor d7[7];
+                    for (int i = 0; i < 7; ++i) {
+                        d7[i] = colorLabels[i]->color();
+                    }
+                    for (int j = 0; j < 12; ++j) {
+                        colorLabels[j]->blockSignals(true);
+                        colorLabels[j]->setColor(QColor(Qt::black));
+                        colorLabels[j]->blockSignals(false);
+                    }
+                    for (int i = 0; i < 7; ++i) {
+                        const int t = DIATONIC_7_TO_CHROMA_12[i];
+                        colorLabels[t]->blockSignals(true);
+                        colorLabels[t]->setColor(d7[i]);
+                        colorLabels[t]->blockSignals(false);
+                    }
+                    if (m_hasSavedChromaticOnlyColors) {
+                        for (int k = 0; k < 5; ++k) {
+                            const int t = CHROMATIC_ONLY_INDICES[k];
+                            colorLabels[t]->blockSignals(true);
+                            colorLabels[t]->setColor(m_savedChromaticOnlyColors[k]);
+                            colorLabels[t]->blockSignals(false);
+                        }
+                    }
+                    for (int j = 0; j < 12; ++j) {
+                        valueChanged(static_cast<int>(colorSids[j]));
+                    }
+                } else if (isTwelveSwatchScheme(oldScheme) && isSevenSwatchScheme(newScheme)) {
+                    // Chromatic → simple: cache the chromatic-only colors so a later simple→chromatic restores them.
+                    QColor c12[12];
+                    for (int j = 0; j < 12; ++j) {
+                        c12[j] = colorLabels[j]->color();
+                    }
+                    for (int k = 0; k < 5; ++k) {
+                        m_savedChromaticOnlyColors[k] = c12[CHROMATIC_ONLY_INDICES[k]];
+                    }
+                    m_hasSavedChromaticOnlyColors = true;
+                    for (int i = 0; i < 7; ++i) {
+                        const QColor c = c12[DIATONIC_7_TO_CHROMA_12[i]];
+                        colorLabels[i]->blockSignals(true);
+                        colorLabels[i]->setColor(c);
+                        colorLabels[i]->blockSignals(false);
+                        valueChanged(static_cast<int>(colorSids[i]));
+                    }
+                }
+            }
+            updateSwatchesUI(newScheme);
+            updatePresetFromState();
+            m_lastNoteColoringScheme = newScheme;
+        });
+
+        /*!
+         * Preset combo: applies packaged swatches and aligns the scheme combo with the preset
+         * (Default @c -> OneColor, Boomwhackers/FigureNotes @c -> MoveableDoChromatic)
+         * so automatic coloring matches the loaded colors.
+         * Always calls @c valueChanged(noteColorTheme) at the end (scheme combo updates use
+         * @c blockSignals so the styleWidgets mapper does not double-write).
+         */
+        connect(m_noteColorPresetCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int idx) {
+            NoteColorPreset preset = static_cast<NoteColorPreset>(idx);
+            if (preset == NoteColorPreset::Default) {
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(QColor(Qt::black));
+                    colorLabels[i]->blockSignals(false);
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+                defaultColorLabel->blockSignals(true);
+                defaultColorLabel->setColor(QColor(Qt::black));
+                defaultColorLabel->blockSignals(false);
+                valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+                int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+                if (oneIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != oneIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(NoteColoringScheme::OneColor);
+                }
+
+                m_noteColorRbWritten->setChecked(true);
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+                updatePresetFromState();
+                m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+                m_hasSavedChromaticOnlyColors = false;
+            } else if (preset == NoteColorPreset::Boomwhackers || preset == NoteColorPreset::FigureNotes) {
+                // Boomwhackers → AbsolutePitchChromatic (12 swatches); Figurenotes → AbsolutePitchSimple (7 swatches).
+                // Both presets follow the convention that printed note name = color, so use written pitch.
+                const NoteColoringScheme presetScheme = (preset == NoteColorPreset::Boomwhackers)
+                                                        ? NoteColoringScheme::AbsolutePitchChromatic
+                                                        : NoteColoringScheme::AbsolutePitchSimple;
+                const int presetSwatchCount = (preset == NoteColorPreset::Boomwhackers) ? 12 : 7;
+
+                // Reset the full 12-slot palette first so unused slots in the simple preset don't keep stale colors.
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(QColor(Qt::black));
+                    colorLabels[i]->blockSignals(false);
+                }
+                for (int i = 0; i < presetSwatchCount; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(preset == NoteColorPreset::Boomwhackers ? boomwhackerColors[i] : figurenotesColors[i]);
+                    colorLabels[i]->blockSignals(false);
+                }
+                for (int i = 0; i < 12; ++i) {
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+
+                int presetSchemeIdx = m_noteColorSchemeCombo->findData(static_cast<int>(presetScheme));
+                if (presetSchemeIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != presetSchemeIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(presetSchemeIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(presetScheme);
+                }
+                m_noteColorRbWritten->setChecked(true);
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+                updatePresetFromState();
+                m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+        });
+
+        /*!
+         * "Reset all color settings": black swatches, @c OneColor theme, factory-default apply-to flags,
+         * written pitch, and @c Default preset; mirrors @c NoteColorPreset::Default handling.
+         */
+        connect(m_noteColorResetBtn, &QPushButton::clicked, this, [=, this]() {
+            for (int i = 0; i < 12; ++i) {
+                colorLabels[i]->blockSignals(true);
+                colorLabels[i]->setColor(QColor(Qt::black));
+                colorLabels[i]->blockSignals(false);
+                valueChanged(static_cast<int>(colorSids[i]));
+            }
+            defaultColorLabel->blockSignals(true);
+            defaultColorLabel->setColor(QColor(Qt::black));
+            defaultColorLabel->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+            int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+            if (oneIdx >= 0) {
+                m_noteColorSchemeCombo->blockSignals(true);
+                m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                m_noteColorSchemeCombo->blockSignals(false);
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+            updateSwatchesUI(NoteColoringScheme::OneColor);
+            m_lastNoteColoringScheme = NoteColoringScheme::OneColor;
+            m_hasSavedChromaticOnlyColors = false;
+
+            const std::pair<QCheckBox*, StyleId> applyToCheckboxes[] = {
+                { m_noteColorCbAccidental,   StyleId::colorApplyToAccidental },
+                { m_noteColorCbStem,         StyleId::colorApplyToStem },
+                { m_noteColorCbArticulation, StyleId::colorApplyToArticulation },
+                { m_noteColorCbDot,          StyleId::colorApplyToDot },
+                { m_noteColorCbBeam,         StyleId::colorApplyToBeam },
+                { m_noteColorCbFlag,         StyleId::colorApplyToFlag },
+            };
+            for (const auto& [cb, sid] : applyToCheckboxes) {
+                cb->blockSignals(true);
+                cb->setChecked(defaultStyleValue(sid).toBool());
+                cb->blockSignals(false);
+                valueChanged(static_cast<int>(sid));
+            }
+
+            m_noteColorRbWritten->blockSignals(true);
+            m_noteColorRbWritten->setChecked(true);
+            m_noteColorRbWritten->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+
+            m_noteColorPresetCombo->blockSignals(true);
+            m_noteColorPresetCombo->setCurrentIndex(static_cast<int>(NoteColorPreset::Default));
+            m_noteColorPresetCombo->blockSignals(false);
+
+            updatePresetFromState();
+        });
+
+        /*!
+         * Re-runs @c updatePresetFromState and @c updateSwatchesUI after @c setValues() or
+         * @c retranslateNoteColorSection() so labels and preset row match the loaded style.
+         */
+        m_syncNoteColorUi = [=, this]() {
+            updatePresetFromState();
+            updateSwatchesUI(static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt()));
+            m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+        };
+
+        /*! Defer first sync until the event loop so note-color widgets are fully constructed. */
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+
+        /*!
+         * Reparent all Notes-page sections under one scroll area. @c PageNotes starts with a vertical layout
+         * from @c editstyle.ui (flag box, notes box, alignment box, stretch spacer). We remove every layout
+         * item so the spacer is gone, then add @c groupBox_noteFlags, @c m_noteColorGroup, @c groupBox_notes,
+         * and @c groupBox_alignment to @c notesPageScrollContents in that order. If @c PageNotes is not a
+         * @c QVBoxLayout, fall back to inserting only @c m_noteColorGroup at index 1 (legacy layout).
+         */
+        QVBoxLayout* pageNotesLayout = qobject_cast<QVBoxLayout*>(PageNotes->layout());
+        IF_ASSERT_FAILED(pageNotesLayout) {
+            if (QBoxLayout* l = qobject_cast<QBoxLayout*>(PageNotes->layout())) {
+                l->insertWidget(1, m_noteColorGroup);
+            }
+        } else {
+            while (QLayoutItem* item = pageNotesLayout->takeAt(0)) {
+                delete item;
+            }
+
+            QScrollArea* notesPageScroll = new QScrollArea(PageNotes);
+            notesPageScroll->setWidgetResizable(true);
+            notesPageScroll->setFrameShape(QFrame::NoFrame);
+            notesPageScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+            QWidget* notesPageScrollContents = new QWidget;
+            notesPageScrollContents->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+            QVBoxLayout* notesPageScrollLayout = new QVBoxLayout(notesPageScrollContents);
+            notesPageScrollLayout->setContentsMargins(0, 0, 0, 0);
+
+            notesPageScrollLayout->addWidget(groupBox_noteFlags);
+            notesPageScrollLayout->addWidget(m_noteColorGroup);
+            notesPageScrollLayout->addWidget(groupBox_notes);
+            notesPageScrollLayout->addWidget(groupBox_alignment);
+            // Absorb spare vertical space so the group boxes don't stretch when the dialog is tall.
+            notesPageScrollLayout->addStretch(1);
+
+            notesPageScroll->setWidget(notesPageScrollContents);
+            pageNotesLayout->addWidget(notesPageScroll);
+        }
+    }
 
     // ====================================================
     // Rests (QML)
@@ -1377,11 +2083,57 @@ void EditStyle::changeEvent(QEvent* event)
 ///   NOTE: keep in sync with constructor.
 //---------------------------------------------------------
 
+/*!
+ * Updates all translatable labels and combo texts in the Notes page color section.
+ * Called from @c retranslate() on UI language change; also reapplies swatch descriptions via @c m_syncNoteColorUi.
+ */
+void EditStyle::retranslateNoteColorSection()
+{
+    if (!m_noteColorGroup) {
+        return;
+    }
+
+    m_noteColorGroup->setTitle(muse::qtrc("notation/editstyle", "Color"));
+    m_noteColorPresetLabel->setText(muse::qtrc("notation/editstyle", "Preset:"));
+    m_noteColorSchemeLabel->setText(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+    m_noteColorSwatchColorLabel->setText(muse::qtrc("notation/editstyle", "Color:"));
+
+    m_noteColorPresetCombo->setItemText(0, muse::qtrc("notation/editstyle", "Default"));
+    m_noteColorPresetCombo->setItemText(1, muse::qtrc("notation/editstyle", "Boomwhackers"));
+    m_noteColorPresetCombo->setItemText(2, muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"));
+    m_noteColorPresetCombo->setItemText(3, muse::qtrc("notation/editstyle", "Custom"));
+
+    m_noteColorSchemeCombo->setItemText(0, muse::qtrc("notation/editstyle", "One color"));
+    m_noteColorSchemeCombo->setItemText(1, muse::qtrc("notation/editstyle", "Absolute pitch (simple)"));
+    m_noteColorSchemeCombo->setItemText(2, muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"));
+    m_noteColorSchemeCombo->setItemText(3, muse::qtrc("notation/editstyle", "Moveable do (simple)"));
+    m_noteColorSchemeCombo->setItemText(4, muse::qtrc("notation/editstyle", "Moveable do (chromatic)"));
+
+    m_noteColorApplyToGroupBox->setTitle(muse::qtrc("notation/editstyle", "Apply color to:"));
+    m_noteColorCbAccidental->setText(muse::qtrc("notation/editstyle", "Accidentals"));
+    m_noteColorCbStem->setText(muse::qtrc("notation/editstyle", "Stems"));
+    m_noteColorCbArticulation->setText(muse::qtrc("notation/editstyle", "Articulations"));
+    m_noteColorCbDot->setText(muse::qtrc("notation/editstyle", "Augmentation dots"));
+    m_noteColorCbBeam->setText(muse::qtrc("notation/editstyle", "Beams"));
+    m_noteColorCbFlag->setText(muse::qtrc("notation/editstyle", "Flags"));
+
+    m_noteColorPitchGroupBox->setTitle(muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"));
+    m_noteColorRbWritten->setText(muse::qtrc("notation/editstyle", "Written pitch"));
+    m_noteColorRbConcert->setText(muse::qtrc("notation/editstyle", "Concert pitch"));
+    m_noteColorResetBtn->setText(muse::qtrc("notation/editstyle", "Reset all color settings"));
+
+    if (m_syncNoteColorUi) {
+        m_syncNoteColorUi();
+    }
+}
+
 void EditStyle::retranslate()
 {
     retranslateUi(this);
 
     buttonApplyToAllParts->setText(muse::qtrc("notation/editstyle", "Apply to all parts"));
+
+    retranslateNoteColorSection();
 
     for (const LineStyleSelect* lineStyleSelect : m_lineStyleSelects) {
         int idx = 0;
@@ -1513,6 +2265,11 @@ void EditStyle::setHeaderFooterMacroInfoText()
 //   adjustPagesStackSize
 //---------------------------------------------------------
 
+/*!
+ * Sets @c pageStack minimum size to the current page's @c sizeHint() so the dialog does not leave excess
+ * blank space when switching tabs. For tall pages (e.g. Notes with the Color section), a short minimum
+ * height makes the inner @c QScrollArea on @c PageNotes provide vertical scrolling instead of growing the dialog.
+ */
 void EditStyle::adjustPagesStackSize(int currentPageIndex)
 {
     QSize preferredSize = pageStack->widget(currentPageIndex)->sizeHint();
@@ -1762,6 +2519,9 @@ void EditStyle::on_pageRowSelectionChanged()
 //   unhandledType
 //---------------------------------------------------------
 
+/*!
+ * Fails an assertion in debug builds when @p sw.widget cannot be read for its style type.
+ */
 void EditStyle::unhandledType(const StyleWidget sw)
 {
     P_TYPE type = MStyle::valueType(sw.idx);
@@ -1769,6 +2529,10 @@ void EditStyle::unhandledType(const StyleWidget sw)
                                sw.widget->metaObject()->className()));
 }
 
+/*!
+ * @return True if the style's boolean is edited with a two-button @c QButtonGroup
+ *         (value read/written via @c QButtonGroup::checkedId), not a single @c QCheckBox.
+ */
 bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
 {
     switch (id) {
@@ -1781,6 +2545,7 @@ bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
     case StyleId::angleHangingSlursAwayFromStaff:
     case StyleId::dividerLeftAlignToSystemBarline:
     case StyleId::dividerRightAlignToSystemBarline:
+    case StyleId::colorNotesByConcertPitch:
         return true;
     default:
         return false;
@@ -1896,6 +2661,13 @@ PropertyValue EditStyle::getValue(StyleId idx)
         QButtonGroup* bg = qobject_cast<QButtonGroup*>(sw.widget);
         return TiePlacement(bg->checkedId());
     } break;
+    case P_TYPE::COLOR: {
+        if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+            return Color::fromQColor(cl->color());
+        }
+        unhandledType(sw);
+        return PropertyValue();
+    } break;
     default: {
         ASSERT_X(QString::asprintf("EditStyle::getValue: unhandled type <%d>", static_cast<int>(type)));
     } break;
@@ -1908,6 +2680,9 @@ PropertyValue EditStyle::getValue(StyleId idx)
 //   setValues
 //---------------------------------------------------------
 
+/*!
+ * Fills every @c styleWidgets control from @c styleValue() / defaults, then unblocks signals and refreshes note-color UI.
+ */
 void EditStyle::setValues()
 {
     for (const StyleWidget& sw : styleWidgets) {
@@ -2024,6 +2799,13 @@ void EditStyle::setValues()
                 as->setOffset(val.value<muse::PointF>());
             }
         } break;
+        case P_TYPE::COLOR: {
+            if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+                cl->setColor(val.value<Color>().toQColor());
+            } else {
+                unhandledType(sw);
+            }
+        } break;
         default: {
             unhandledType(sw);
         } break;
@@ -2110,6 +2892,14 @@ void EditStyle::setValues()
     bool vertical = styleValue(StyleId::groupBracketTextOrientation).value<mu::engraving::Orientation>()
                     == mu::engraving::Orientation::VERTICAL;
     groupBracketHangIntoMargin->setEnabled(vertical && !textBracketRight);
+
+    if (m_syncNoteColorUi) {
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -20,10 +20,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*!
+ * \file editstyle.cpp
+ * \brief Implementation of the score style dialog, including the dynamic note-color UI on the Notes page
+ *        (presets, schemes, apply-to flags, and reset).
+ *
+ * The Notes tab is mostly Qt widgets; after building the Color group, @c PageNotes is reparented into
+ * a @c QScrollArea so the tab scrolls when the stacked page height is limited (same pattern as other
+ * widget-heavy Style pages in @c editstyle.ui, e.g. Rests). QML-only pages such as Slurs & ties use
+ * @c StyledFlickable inside @c createQmlWidget() instead.
+ */
+
 #include "editstyle.h"
 
 #include <QAnyStringView>
 #include <QButtonGroup>
+#include <QFrame>
+#include <QGroupBox>
+#include <QListView>
+#include <QScrollArea>
 #include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickView>
@@ -41,7 +56,16 @@
 
 #include "engraving/dom/figuredbass.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/chord.h"
+#include "engraving/dom/stem.h"
+#include "engraving/dom/beam.h"
+#include "engraving/dom/articulation.h"
+#include "engraving/dom/accidental.h"
+#include "engraving/dom/notedot.h"
+#include "engraving/dom/staff.h"
 #include "engraving/dom/stafftype.h"
+#include "engraving/types/notecoloringscheme.h"
 #include "engraving/style/textstyle.h"
 #include "engraving/types/symnames.h"
 #include "engraving/types/types.h"
@@ -63,6 +87,21 @@ using namespace mu;
 using namespace mu::notation;
 using namespace mu::engraving;
 using namespace muse::ui;
+
+namespace {
+//! Seven diatonic steps (C…B, Do…Ti) to the parallel chromatic swatch row (pitch class, epitch%12 order).
+const int DIATONIC_7_TO_CHROMA_12[7] = { 0, 2, 4, 5, 7, 9, 11 };
+
+bool isSevenSwatchScheme(NoteColoringScheme s)
+{
+    return s == NoteColoringScheme::AbsolutePitchSimple || s == NoteColoringScheme::MoveableDoSimple;
+}
+
+bool isTwelveSwatchScheme(NoteColoringScheme s)
+{
+    return s == NoteColoringScheme::AbsolutePitchChromatic || s == NoteColoringScheme::MoveableDoChromatic;
+}
+} // namespace
 
 static const QStringList ALL_PAGE_CODES {
     "score",
@@ -829,14 +868,681 @@ void EditStyle::classBegin()
     }
 
     // ====================================================
-    // Notes (QML)
+    // Notes (QML + widgets; see QScrollArea wrap below)
     // ====================================================
+    /*!
+     * \brief Notes page: flag-style control is QML inside @c groupBox_noteFlags; note metrics and
+     *        alignment come from @c editstyle.ui. The Color block is built in C++ in the next section.
+     *        All of these are later placed in one @c QScrollArea on @c PageNotes (widget-based scroll).
+     */
 
     auto noteFlagsTypeSelector = createQmlWidget(
         groupBox_noteFlags,
         QUrl(QString::fromUtf8("qrc:/qt/qml/MuseScore/NotationScene/styledialog/NoteFlagsTypeSelector.qml")));
     noteFlagsTypeSelector.widget->setMinimumSize(224, 70);
     groupBox_noteFlags->layout()->addWidget(noteFlagsTypeSelector.widget);
+
+    // ====================================================
+    // Note Colors (Dynamic C++)
+    // ====================================================
+    /*!
+     * \internal Builds the Notes-page Color @c QGroupBox: preset and scheme combos, twelve swatches, apply-to
+     * checkboxes, concert-pitch radios, and reset. Content is capped at 616px (three 200px columns,
+     * 8px gutters). Lambdas keep preset
+     * labels in sync with palette state. After this block, @c PageNotes is rebuilt: layout items from the UI
+     * are cleared (widgets are not destroyed), and flag, color, notes, and alignment groups are stacked inside
+     * a single @c QScrollArea child so the tab scrolls when @c pageStack minimum height is tight.
+     */
+    {
+        /*!
+         * Preset row in @c m_noteColorPresetCombo: packaged palettes vs user-edited @c Custom.
+         */
+        enum class NoteColorPreset : int {
+            Default = 0,        //!< All-black swatches, @c OneColor scheme, written pitch.
+            Boomwhackers = 1,   //!< Built-in Boomwhackers chromatic colors + concert pitch.
+            FigureNotes = 2,    //!< Built-in Figurenotes (stage 3) colors + written pitch.
+            Custom = 3          //!< Non-packaged colors; list row may be hidden until inferred.
+        };
+
+        //! Number of visible swatches for @p scheme (7 diatonic modes, otherwise 12 chromatic).
+        auto swatchCountForScheme = [](NoteColoringScheme scheme) {
+            return (scheme == NoteColoringScheme::AbsolutePitchSimple || scheme == NoteColoringScheme::MoveableDoSimple) ? 7 : 12;
+        };
+
+        m_noteColorGroup = new QGroupBox(muse::qtrc("notation/editstyle", "Color"));
+        m_noteColorGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        QVBoxLayout* outerVbl = new QVBoxLayout(m_noteColorGroup);
+        QWidget* noteColorContent = new QWidget(m_noteColorGroup);
+        // Preset / Coloring scheme / Color: 200px + 8px + 200px + 8px + 200px = 616px interior
+        static constexpr int noteColorColumnW = 200;
+        static constexpr int noteColorGutterW = 8;
+        static constexpr int noteColorContentMaxW = 3 * noteColorColumnW + 2 * noteColorGutterW;
+        noteColorContent->setFixedWidth(noteColorContentMaxW);
+        noteColorContent->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vbl = new QVBoxLayout(noteColorContent);
+        vbl->setContentsMargins(0, 0, 0, 0);
+
+        m_noteColorPresetCombo = new QComboBox();
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Default"), static_cast<int>(NoteColorPreset::Default));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Boomwhackers"), static_cast<int>(NoteColorPreset::Boomwhackers));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"),
+                                        static_cast<int>(NoteColorPreset::FigureNotes));
+        m_noteColorPresetCombo->addItem(muse::qtrc("notation/editstyle", "Custom"), static_cast<int>(NoteColorPreset::Custom));
+
+        m_noteColorSchemeCombo = new QComboBox();
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "One color"), static_cast<int>(NoteColoringScheme::OneColor));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (simple)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::AbsolutePitchChromatic));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (simple)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoSimple));
+        m_noteColorSchemeCombo->addItem(muse::qtrc("notation/editstyle", "Moveable do (chromatic)"),
+                                        static_cast<int>(NoteColoringScheme::MoveableDoChromatic));
+
+        m_noteColorPresetCombo->setFixedWidth(noteColorColumnW);
+        m_noteColorPresetCombo->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        m_noteColorSchemeCombo->setFixedWidth(noteColorColumnW);
+        m_noteColorSchemeCombo->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+        styleWidgets.append({ StyleId::noteColorTheme, false, m_noteColorSchemeCombo, nullptr });
+
+        QWidget* presetTopCol = new QWidget(noteColorContent);
+        presetTopCol->setFixedWidth(noteColorColumnW);
+        presetTopCol->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlPresetTop = new QVBoxLayout(presetTopCol);
+        vlPresetTop->setContentsMargins(0, 0, 0, 0);
+        vlPresetTop->setSpacing(4);
+        m_noteColorPresetLabel = new QLabel(muse::qtrc("notation/editstyle", "Preset:"));
+        m_noteColorPresetLabel->setWordWrap(true);
+        vlPresetTop->addWidget(m_noteColorPresetLabel);
+        vlPresetTop->addWidget(m_noteColorPresetCombo);
+
+        QWidget* schemeTopCol = new QWidget(noteColorContent);
+        schemeTopCol->setFixedWidth(noteColorColumnW);
+        schemeTopCol->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlSchemeTop = new QVBoxLayout(schemeTopCol);
+        vlSchemeTop->setContentsMargins(0, 0, 0, 0);
+        vlSchemeTop->setSpacing(4);
+        m_noteColorSchemeLabel = new QLabel(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+        m_noteColorSchemeLabel->setWordWrap(true);
+        vlSchemeTop->addWidget(m_noteColorSchemeLabel);
+        vlSchemeTop->addWidget(m_noteColorSchemeCombo);
+
+        // Third column always occupies 200px; for non-One color schemes the label and swatch are hidden (Preset/Scheme stay fixed width).
+        QWidget* noteColorColorColumn = new QWidget(noteColorContent);
+        noteColorColorColumn->setFixedWidth(noteColorColumnW);
+        noteColorColorColumn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QVBoxLayout* vlColorTop = new QVBoxLayout(noteColorColorColumn);
+        vlColorTop->setContentsMargins(0, 0, 0, 0);
+        vlColorTop->setSpacing(4);
+        m_noteColorSwatchColorLabel = new QLabel(muse::qtrc("notation/editstyle", "Color:"));
+        vlColorTop->addWidget(m_noteColorSwatchColorLabel);
+        Awl::ColorLabel* defaultColorLabel = new Awl::ColorLabel(noteColorColorColumn);
+        defaultColorLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        defaultColorLabel->setFixedSize(noteColorColumnW, 30);
+        styleWidgets.append({ StyleId::defaultNoteColor, false, defaultColorLabel, nullptr });
+        vlColorTop->addWidget(defaultColorLabel);
+
+        QWidget* noteColorTopRow = new QWidget(noteColorContent);
+        QHBoxLayout* hlTop = new QHBoxLayout(noteColorTopRow);
+        hlTop->setContentsMargins(0, 0, 0, 0);
+        hlTop->setSpacing(0);
+        hlTop->addWidget(presetTopCol);
+        hlTop->addSpacing(noteColorGutterW);
+        hlTop->addWidget(schemeTopCol);
+        hlTop->addSpacing(noteColorGutterW);
+        hlTop->addWidget(noteColorColorColumn);
+
+        vbl->addWidget(noteColorTopRow, 0, Qt::AlignLeft);
+
+        m_noteColorSchemeDescription = new QLabel(noteColorContent);
+        m_noteColorSchemeDescription->setWordWrap(true);
+        m_noteColorSchemeDescription->setFixedWidth(noteColorContentMaxW);
+        vbl->addWidget(m_noteColorSchemeDescription);
+
+        m_noteColorSwatchesContainer = new QWidget(noteColorContent);
+        m_noteColorSwatchesContainer->setFixedWidth(noteColorContentMaxW);
+        m_noteColorSwatchesContainer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QHBoxLayout* hlSwatches = new QHBoxLayout(m_noteColorSwatchesContainer);
+        hlSwatches->setContentsMargins(0, 0, 0, 0);
+
+        QWidget* gridWidget = new QWidget(m_noteColorSwatchesContainer);
+        QGridLayout* glColors = new QGridLayout(gridWidget);
+        glColors->setContentsMargins(0, 0, 0, 0);
+        glColors->setSpacing(8);
+        hlSwatches->addWidget(gridWidget);
+        vbl->addWidget(m_noteColorSwatchesContainer);
+
+        m_noteColorApplyToGroupBox = new QGroupBox(muse::qtrc("notation/editstyle", "Apply color to:"), noteColorContent);
+        m_noteColorApplyToGroupBox->setFixedWidth(noteColorContentMaxW);
+        m_noteColorApplyToGroupBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        QGridLayout* glApplyTo = new QGridLayout(m_noteColorApplyToGroupBox);
+        glApplyTo->setHorizontalSpacing(noteColorGutterW);
+        glApplyTo->setColumnMinimumWidth(0, noteColorColumnW);
+        glApplyTo->setColumnMinimumWidth(1, noteColorColumnW);
+        glApplyTo->setColumnMinimumWidth(2, noteColorColumnW);
+        m_noteColorCbAccidental = new QCheckBox(muse::qtrc("notation/editstyle", "Accidentals"));
+        m_noteColorCbStem = new QCheckBox(muse::qtrc("notation/editstyle", "Stems"));
+        m_noteColorCbArticulation = new QCheckBox(muse::qtrc("notation/editstyle", "Articulations"));
+        m_noteColorCbDot = new QCheckBox(muse::qtrc("notation/editstyle", "Augmentation dots"));
+        m_noteColorCbBeam = new QCheckBox(muse::qtrc("notation/editstyle", "Beams"));
+        m_noteColorCbFlag = new QCheckBox(muse::qtrc("notation/editstyle", "Flags"));
+
+        styleWidgets.append({ StyleId::colorApplyToAccidental, false, m_noteColorCbAccidental, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToStem, false, m_noteColorCbStem, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToArticulation, false, m_noteColorCbArticulation, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToDot, false, m_noteColorCbDot, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToBeam, false, m_noteColorCbBeam, nullptr });
+        styleWidgets.append({ StyleId::colorApplyToFlag, false, m_noteColorCbFlag, nullptr });
+
+        glApplyTo->addWidget(m_noteColorCbAccidental, 0, 0);
+        glApplyTo->addWidget(m_noteColorCbArticulation, 0, 1);
+        glApplyTo->addWidget(m_noteColorCbFlag, 0, 2);
+        glApplyTo->addWidget(m_noteColorCbDot, 1, 0);
+        glApplyTo->addWidget(m_noteColorCbBeam, 1, 1);
+        glApplyTo->addWidget(m_noteColorCbStem, 1, 2);
+        glApplyTo->setColumnStretch(0, 0);
+        glApplyTo->setColumnStretch(1, 0);
+        glApplyTo->setColumnStretch(2, 0);
+        vbl->addWidget(m_noteColorApplyToGroupBox);
+
+        m_noteColorPitchGroupBox = new QGroupBox(
+            muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"), noteColorContent);
+        m_noteColorPitchGroupBox->setFixedWidth(noteColorContentMaxW);
+        m_noteColorPitchGroupBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+        m_noteColorRbWritten = new QRadioButton(muse::qtrc("notation/editstyle", "Written pitch"));
+        m_noteColorRbConcert = new QRadioButton(muse::qtrc("notation/editstyle", "Concert pitch"));
+        QButtonGroup* bgPitch = new QButtonGroup(noteColorContent);
+        bgPitch->addButton(m_noteColorRbWritten, 0);
+        bgPitch->addButton(m_noteColorRbConcert, 1);
+
+        styleWidgets.append({ StyleId::colorNotesByConcertPitch, false, bgPitch, nullptr });
+
+        QVBoxLayout* vlPitch = new QVBoxLayout(m_noteColorPitchGroupBox);
+        vlPitch->addWidget(m_noteColorRbWritten);
+        vlPitch->addWidget(m_noteColorRbConcert);
+        vbl->addWidget(m_noteColorPitchGroupBox);
+
+        m_noteColorResetBtn = new QPushButton(muse::qtrc("notation/editstyle", "Reset all color settings"), noteColorContent);
+        QHBoxLayout* hlReset = new QHBoxLayout();
+        hlReset->addStretch();
+        hlReset->addWidget(m_noteColorResetBtn);
+        vbl->addLayout(hlReset);
+
+        outerVbl->addWidget(noteColorContent, 0, Qt::AlignLeft);
+
+        const StyleId colorSids[] = {
+            StyleId::noteColor0, StyleId::noteColor1,  StyleId::noteColor2,
+            StyleId::noteColor3, StyleId::noteColor4,  StyleId::noteColor5,
+            StyleId::noteColor6, StyleId::noteColor7,  StyleId::noteColor8,
+            StyleId::noteColor9, StyleId::noteColor10, StyleId::noteColor11 };
+
+        // Boomwhackers: chromatic palette (12 entries, C..B), used with AbsolutePitchChromatic + written pitch.
+        // Hex codes match the Figma design (Community-projects, node 4607-4084).
+        static const QColor boomwhackerColors[] = {
+            QColor(0xE2, 0x1C, 0x48), QColor(0xF2, 0x66, 0x22), QColor(0xF9, 0x9D, 0x1C),
+            QColor(0xFF, 0xCC, 0x33), QColor(0xFF, 0xF3, 0x2B), QColor(0xBC, 0xD8, 0x5F),
+            QColor(0x62, 0xBC, 0x47), QColor(0x00, 0x9C, 0x95), QColor(0x00, 0x71, 0xBB),
+            QColor(0x5E, 0x50, 0xA1), QColor(0x8D, 0x5B, 0xA6), QColor(0xCF, 0x3E, 0x96) };
+        // Figurenotes (stage 3): simple palette (7 entries, C..B), used with AbsolutePitchSimple + written pitch.
+        // C = red, D = brown, E = gray, F = blue, G = black, A = yellow, B = green; hex codes from Figma.
+        static const QColor figurenotesColors[] = {
+            QColor(0xFF, 0x00, 0x00), QColor(0x94, 0x61, 0x33), QColor(0xC6, 0xC4, 0xC1),
+            QColor(0x00, 0x90, 0xD8), QColor(0x1A, 0x19, 0x19), QColor(0xF7, 0xE2, 0x00),
+            QColor(0x35, 0xA2, 0x21) };
+
+        Awl::ColorLabel* colorLabels[12];
+        QLabel* colorTextLabels[12];
+        for (int i = 0; i < 12; ++i) {
+            colorLabels[i] = new Awl::ColorLabel(gridWidget);
+            colorLabels[i]->setFixedSize(44, 30);
+            colorLabels[i]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            colorTextLabels[i] = new QLabel("", gridWidget);
+            colorTextLabels[i]->setAlignment(Qt::AlignCenter);
+
+            QVBoxLayout* vSwatch = new QVBoxLayout();
+            vSwatch->addWidget(colorLabels[i], 0, Qt::AlignHCenter);
+            vSwatch->addWidget(colorTextLabels[i]);
+            vSwatch->setContentsMargins(0, 0, 0, 0);
+
+            glColors->addLayout(vSwatch, 0, i);
+            glColors->setColumnMinimumWidth(i, 44);
+            styleWidgets.append({ colorSids[i], false, colorLabels[i], nullptr });
+        }
+        // Left-pack the fixed-width swatches so their size doesn't change between 7- and 12-swatch schemes.
+        glColors->setColumnStretch(12, 1);
+
+        //! Sets the preset combo to Default / Boomwhackers / Figurenotes / Custom from current colors.
+        auto updatePresetFromState = [=, this]() {
+            // Match EditStyle::getValue(StyleId::noteColorTheme): INT comboboxes use item user data, not row index.
+            NoteColoringScheme coloringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+            int inferredPreset = static_cast<int>(NoteColorPreset::Custom);
+
+            if (coloringScheme == NoteColoringScheme::OneColor) {
+                // OneColor exposes only @c defaultColorLabel; the 12 hidden swatches are irrelevant here.
+                // A non-black default is never a packaged preset, so classify as Custom without comparing swatches.
+                if (defaultColorLabel->color() == QColor(Qt::black)) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::Default);
+                }
+            } else {
+                bool allBlack = true;
+                int numSwatches = swatchCountForScheme(coloringScheme);
+                for (int i = 0; i < numSwatches; ++i) {
+                    if (colorLabels[i]->color() != QColor(Qt::black)) {
+                        allBlack = false;
+                        break;
+                    }
+                }
+
+                if (allBlack) {
+                    inferredPreset = static_cast<int>(NoteColorPreset::Default);
+                } else {
+                    // Boomwhackers is only valid when the scheme is AbsolutePitchChromatic (12-color match against the chromatic palette).
+                    // Figurenotes (stage 3) is only valid when the scheme is AbsolutePitchSimple (7-color match against the diatonic palette).
+                    if (coloringScheme == NoteColoringScheme::AbsolutePitchChromatic) {
+                        bool isBoom = true;
+                        for (int i = 0; i < 12; ++i) {
+                            if (colorLabels[i]->color() != boomwhackerColors[i]) {
+                                isBoom = false;
+                                break;
+                            }
+                        }
+                        if (isBoom) {
+                            inferredPreset = static_cast<int>(NoteColorPreset::Boomwhackers);
+                        }
+                    } else if (coloringScheme == NoteColoringScheme::AbsolutePitchSimple) {
+                        bool isFig = true;
+                        for (int i = 0; i < 7; ++i) {
+                            if (colorLabels[i]->color() != figurenotesColors[i]) {
+                                isFig = false;
+                                break;
+                            }
+                        }
+                        if (isFig) {
+                            inferredPreset = static_cast<int>(NoteColorPreset::FigureNotes);
+                        }
+                    }
+                }
+            }
+
+            if (m_noteColorPresetCombo->currentIndex() != inferredPreset) {
+                m_noteColorPresetCombo->blockSignals(true);
+                m_noteColorPresetCombo->setCurrentIndex(inferredPreset);
+                m_noteColorPresetCombo->blockSignals(false);
+            }
+
+            int customIdx = m_noteColorPresetCombo->findData(static_cast<int>(NoteColorPreset::Custom));
+            if (customIdx >= 0) {
+                QListView* view = qobject_cast<QListView*>(m_noteColorPresetCombo->view());
+                if (view) {
+                    view->setRowHidden(customIdx, inferredPreset != static_cast<int>(NoteColorPreset::Custom));
+                }
+            }
+        };
+
+        connect(defaultColorLabel, &Awl::ColorLabel::colorChanged, this, [=, this]() {
+            updatePresetFromState();
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+        });
+
+        for (int i = 0; i < 12; ++i) {
+            connect(colorLabels[i], &Awl::ColorLabel::colorChanged, this, [=, this]() {
+                updatePresetFromState();
+                valueChanged(static_cast<int>(colorSids[i]));
+            });
+        }
+
+        //! Shows or hides swatches, sets captions for @p schemeMode, and updates the explanatory label text.
+        auto updateSwatchesUI = [=, this](NoteColoringScheme schemeMode) {
+            const QString absoluteSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, pitch name"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, pitch name"),
+            };
+            const QString absoluteChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "C", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "C#/Db", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "D#/Eb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "E", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "F#/Gb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "G#/Ab", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "A#/Bb", "note color swatch, chromatic"),
+                muse::qtrc("notation/editstyle", "B", "note color swatch, chromatic"),
+            };
+            const QString moveableSimpleNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do"),
+            };
+            const QString moveableChromaticNames[] = {
+                muse::qtrc("notation/editstyle", "Do", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Di/Ra", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Re", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ri/Me", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Mi", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fa", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Fi/Se", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Sol", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Si/Le", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "La", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Li/Te", "note color swatch, movable do chromatic"),
+                muse::qtrc("notation/editstyle", "Ti", "note color swatch, movable do chromatic"),
+            };
+
+            // Pitch (written vs concert) only affects schemes that read pitch directly. Moveable do uses
+            // scale-degree relative to local key, so transposition makes no difference there. Hide for both.
+            const bool pitchGroupApplies = schemeMode == NoteColoringScheme::AbsolutePitchSimple
+                                           || schemeMode == NoteColoringScheme::AbsolutePitchChromatic;
+
+            if (schemeMode == NoteColoringScheme::OneColor) {
+                m_noteColorSwatchesContainer->setVisible(false);
+                m_noteColorSwatchColorLabel->setVisible(true);
+                defaultColorLabel->setVisible(true);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(false);
+                m_noteColorPitchGroupBox->setVisible(false);
+            } else {
+                m_noteColorSwatchesContainer->setVisible(true);
+                m_noteColorSwatchColorLabel->setVisible(false);
+                defaultColorLabel->setVisible(false);
+                m_noteColorResetBtn->setVisible(true);
+                m_noteColorSchemeDescription->setVisible(true);
+                m_noteColorPitchGroupBox->setVisible(pitchGroupApplies);
+
+                int numSwatches = swatchCountForScheme(schemeMode);
+                const QString* names = (schemeMode == NoteColoringScheme::AbsolutePitchSimple) ? absoluteSimpleNames
+                                       : (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) ? absoluteChromaticNames
+                                       : (schemeMode == NoteColoringScheme::MoveableDoSimple) ? moveableSimpleNames
+                                       : moveableChromaticNames;
+
+                for (int i = 0; i < 12; ++i) {
+                    if (i < numSwatches) {
+                        colorLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setVisible(true);
+                        colorTextLabels[i]->setText(names[i]);
+                    } else {
+                        colorLabels[i]->setVisible(false);
+                        colorTextLabels[i]->setVisible(false);
+                    }
+                }
+
+                if (schemeMode == NoteColoringScheme::AbsolutePitchSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by their letter name. Accidentals do not affect the color."));
+                } else if (schemeMode == NoteColoringScheme::AbsolutePitchChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by their chromatic pitch. Enharmonic equivalents get the same color."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoSimple) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by scale degree with respect to key signatures. Accidentals do not affect the color."));
+                } else if (schemeMode == NoteColoringScheme::MoveableDoChromatic) {
+                    m_noteColorSchemeDescription->setText(muse::qtrc("notation/editstyle",
+                                                                     "Color notes by scale degree with respect to key signatures. Enharmonic equivalents get the same color."));
+                }
+            }
+        };
+
+        /*!
+         * Coloring scheme combo: updates swatch labels and preset inference only.
+         * @c StyleId::noteColorTheme is written by the generic @c styleWidgets signal mapper
+         * (see @c styleWidgets.append for @c m_noteColorSchemeCombo); do not call
+         * @c valueChanged(noteColorTheme) here or the style would be updated twice per change.
+         */
+        connect(m_noteColorSchemeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int idx) {
+            const NoteColoringScheme newScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->itemData(idx).toInt());
+            const NoteColoringScheme oldScheme = m_lastNoteColoringScheme;
+            // Chromatic-only positions (C#/Db, D#/Eb, F#/Gb, G#/Ab, A#/Bb): all 12 minus the 7 diatonic ones.
+            static constexpr int CHROMATIC_ONLY_INDICES[5] = { 1, 3, 6, 8, 10 };
+            if (oldScheme != newScheme) {
+                if (isSevenSwatchScheme(oldScheme) && isTwelveSwatchScheme(newScheme)) {
+                    // Simple → chromatic: keep the 7 diatonic colors at their pitch slots; restore the
+                    // five chromatic-only slots from the previous chromatic state if available, otherwise black.
+                    QColor d7[7];
+                    for (int i = 0; i < 7; ++i) {
+                        d7[i] = colorLabels[i]->color();
+                    }
+                    for (int j = 0; j < 12; ++j) {
+                        colorLabels[j]->blockSignals(true);
+                        colorLabels[j]->setColor(QColor(Qt::black));
+                        colorLabels[j]->blockSignals(false);
+                    }
+                    for (int i = 0; i < 7; ++i) {
+                        const int t = DIATONIC_7_TO_CHROMA_12[i];
+                        colorLabels[t]->blockSignals(true);
+                        colorLabels[t]->setColor(d7[i]);
+                        colorLabels[t]->blockSignals(false);
+                    }
+                    if (m_hasSavedChromaticOnlyColors) {
+                        for (int k = 0; k < 5; ++k) {
+                            const int t = CHROMATIC_ONLY_INDICES[k];
+                            colorLabels[t]->blockSignals(true);
+                            colorLabels[t]->setColor(m_savedChromaticOnlyColors[k]);
+                            colorLabels[t]->blockSignals(false);
+                        }
+                    }
+                    for (int j = 0; j < 12; ++j) {
+                        valueChanged(static_cast<int>(colorSids[j]));
+                    }
+                } else if (isTwelveSwatchScheme(oldScheme) && isSevenSwatchScheme(newScheme)) {
+                    // Chromatic → simple: cache the chromatic-only colors so a later simple→chromatic restores them.
+                    QColor c12[12];
+                    for (int j = 0; j < 12; ++j) {
+                        c12[j] = colorLabels[j]->color();
+                    }
+                    for (int k = 0; k < 5; ++k) {
+                        m_savedChromaticOnlyColors[k] = c12[CHROMATIC_ONLY_INDICES[k]];
+                    }
+                    m_hasSavedChromaticOnlyColors = true;
+                    for (int i = 0; i < 7; ++i) {
+                        const QColor c = c12[DIATONIC_7_TO_CHROMA_12[i]];
+                        colorLabels[i]->blockSignals(true);
+                        colorLabels[i]->setColor(c);
+                        colorLabels[i]->blockSignals(false);
+                        valueChanged(static_cast<int>(colorSids[i]));
+                    }
+                }
+            }
+            updateSwatchesUI(newScheme);
+            updatePresetFromState();
+            m_lastNoteColoringScheme = newScheme;
+        });
+
+        /*!
+         * Preset combo: applies packaged swatches and aligns the scheme combo with the preset
+         * (Default @c -> OneColor, Boomwhackers/FigureNotes @c -> MoveableDoChromatic)
+         * so automatic coloring matches the loaded colors.
+         * Always calls @c valueChanged(noteColorTheme) at the end (scheme combo updates use
+         * @c blockSignals so the styleWidgets mapper does not double-write).
+         */
+        connect(m_noteColorPresetCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int idx) {
+            NoteColorPreset preset = static_cast<NoteColorPreset>(idx);
+            if (preset == NoteColorPreset::Default) {
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(QColor(Qt::black));
+                    colorLabels[i]->blockSignals(false);
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+                defaultColorLabel->blockSignals(true);
+                defaultColorLabel->setColor(QColor(Qt::black));
+                defaultColorLabel->blockSignals(false);
+                valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+                int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+                if (oneIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != oneIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(NoteColoringScheme::OneColor);
+                }
+
+                m_noteColorRbWritten->setChecked(true);
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+                updatePresetFromState();
+                m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+                m_hasSavedChromaticOnlyColors = false;
+            } else if (preset == NoteColorPreset::Boomwhackers || preset == NoteColorPreset::FigureNotes) {
+                // Boomwhackers → AbsolutePitchChromatic (12 swatches); Figurenotes → AbsolutePitchSimple (7 swatches).
+                // Both presets follow the convention that printed note name = color, so use written pitch.
+                const NoteColoringScheme presetScheme = (preset == NoteColorPreset::Boomwhackers)
+                                                        ? NoteColoringScheme::AbsolutePitchChromatic
+                                                        : NoteColoringScheme::AbsolutePitchSimple;
+                const int presetSwatchCount = (preset == NoteColorPreset::Boomwhackers) ? 12 : 7;
+
+                // Reset the full 12-slot palette first so unused slots in the simple preset don't keep stale colors.
+                for (int i = 0; i < 12; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(QColor(Qt::black));
+                    colorLabels[i]->blockSignals(false);
+                }
+                for (int i = 0; i < presetSwatchCount; ++i) {
+                    colorLabels[i]->blockSignals(true);
+                    colorLabels[i]->setColor(preset == NoteColorPreset::Boomwhackers ? boomwhackerColors[i] : figurenotesColors[i]);
+                    colorLabels[i]->blockSignals(false);
+                }
+                for (int i = 0; i < 12; ++i) {
+                    valueChanged(static_cast<int>(colorSids[i]));
+                }
+
+                int presetSchemeIdx = m_noteColorSchemeCombo->findData(static_cast<int>(presetScheme));
+                if (presetSchemeIdx >= 0 && m_noteColorSchemeCombo->currentIndex() != presetSchemeIdx) {
+                    m_noteColorSchemeCombo->blockSignals(true);
+                    m_noteColorSchemeCombo->setCurrentIndex(presetSchemeIdx);
+                    m_noteColorSchemeCombo->blockSignals(false);
+                    updateSwatchesUI(presetScheme);
+                }
+                m_noteColorRbWritten->setChecked(true);
+                valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+                updatePresetFromState();
+                m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+        });
+
+        /*!
+         * "Reset all color settings": black swatches, @c OneColor theme, factory-default apply-to flags,
+         * written pitch, and @c Default preset; mirrors @c NoteColorPreset::Default handling.
+         */
+        connect(m_noteColorResetBtn, &QPushButton::clicked, this, [=, this]() {
+            for (int i = 0; i < 12; ++i) {
+                colorLabels[i]->blockSignals(true);
+                colorLabels[i]->setColor(QColor(Qt::black));
+                colorLabels[i]->blockSignals(false);
+                valueChanged(static_cast<int>(colorSids[i]));
+            }
+            defaultColorLabel->blockSignals(true);
+            defaultColorLabel->setColor(QColor(Qt::black));
+            defaultColorLabel->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::defaultNoteColor));
+
+            int oneIdx = m_noteColorSchemeCombo->findData(static_cast<int>(NoteColoringScheme::OneColor));
+            if (oneIdx >= 0) {
+                m_noteColorSchemeCombo->blockSignals(true);
+                m_noteColorSchemeCombo->setCurrentIndex(oneIdx);
+                m_noteColorSchemeCombo->blockSignals(false);
+            }
+            valueChanged(static_cast<int>(StyleId::noteColorTheme));
+            updateSwatchesUI(NoteColoringScheme::OneColor);
+            m_lastNoteColoringScheme = NoteColoringScheme::OneColor;
+            m_hasSavedChromaticOnlyColors = false;
+
+            const std::pair<QCheckBox*, StyleId> applyToCheckboxes[] = {
+                { m_noteColorCbAccidental,   StyleId::colorApplyToAccidental },
+                { m_noteColorCbStem,         StyleId::colorApplyToStem },
+                { m_noteColorCbArticulation, StyleId::colorApplyToArticulation },
+                { m_noteColorCbDot,          StyleId::colorApplyToDot },
+                { m_noteColorCbBeam,         StyleId::colorApplyToBeam },
+                { m_noteColorCbFlag,         StyleId::colorApplyToFlag },
+            };
+            for (const auto& [cb, sid] : applyToCheckboxes) {
+                cb->blockSignals(true);
+                cb->setChecked(defaultStyleValue(sid).toBool());
+                cb->blockSignals(false);
+                valueChanged(static_cast<int>(sid));
+            }
+
+            m_noteColorRbWritten->blockSignals(true);
+            m_noteColorRbWritten->setChecked(true);
+            m_noteColorRbWritten->blockSignals(false);
+            valueChanged(static_cast<int>(StyleId::colorNotesByConcertPitch));
+
+            m_noteColorPresetCombo->blockSignals(true);
+            m_noteColorPresetCombo->setCurrentIndex(static_cast<int>(NoteColorPreset::Default));
+            m_noteColorPresetCombo->blockSignals(false);
+
+            updatePresetFromState();
+        });
+
+        /*!
+         * Re-runs @c updatePresetFromState and @c updateSwatchesUI after @c setValues() or
+         * @c retranslateNoteColorSection() so labels and preset row match the loaded style.
+         */
+        m_syncNoteColorUi = [=, this]() {
+            updatePresetFromState();
+            updateSwatchesUI(static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt()));
+            m_lastNoteColoringScheme = static_cast<NoteColoringScheme>(m_noteColorSchemeCombo->currentData().toInt());
+        };
+
+        /*! Defer first sync until the event loop so note-color widgets are fully constructed. */
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+
+        /*!
+         * Reparent all Notes-page sections under one scroll area. @c PageNotes starts with a vertical layout
+         * from @c editstyle.ui (flag box, notes box, alignment box, stretch spacer). We remove every layout
+         * item so the spacer is gone, then add @c groupBox_noteFlags, @c m_noteColorGroup, @c groupBox_notes,
+         * and @c groupBox_alignment to @c notesPageScrollContents in that order. If @c PageNotes is not a
+         * @c QVBoxLayout, fall back to inserting only @c m_noteColorGroup at index 1 (legacy layout).
+         */
+        QVBoxLayout* pageNotesLayout = qobject_cast<QVBoxLayout*>(PageNotes->layout());
+        IF_ASSERT_FAILED(pageNotesLayout) {
+            if (QBoxLayout* l = qobject_cast<QBoxLayout*>(PageNotes->layout())) {
+                l->insertWidget(1, m_noteColorGroup);
+            }
+        } else {
+            while (QLayoutItem* item = pageNotesLayout->takeAt(0)) {
+                delete item;
+            }
+
+            QScrollArea* notesPageScroll = new QScrollArea(PageNotes);
+            notesPageScroll->setWidgetResizable(true);
+            notesPageScroll->setFrameShape(QFrame::NoFrame);
+            notesPageScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+            notesPageScroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+            QWidget* notesPageScrollContents = new QWidget;
+            notesPageScrollContents->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+            QVBoxLayout* notesPageScrollLayout = new QVBoxLayout(notesPageScrollContents);
+            notesPageScrollLayout->setContentsMargins(0, 0, 0, 0);
+
+            notesPageScrollLayout->addWidget(groupBox_noteFlags);
+            notesPageScrollLayout->addWidget(m_noteColorGroup);
+            notesPageScrollLayout->addWidget(groupBox_notes);
+            notesPageScrollLayout->addWidget(groupBox_alignment);
+            // Absorb spare vertical space so the group boxes don't stretch when the dialog is tall.
+            notesPageScrollLayout->addStretch(1);
+
+            notesPageScroll->setWidget(notesPageScrollContents);
+            pageNotesLayout->addWidget(notesPageScroll);
+        }
+    }
 
     // ====================================================
     // Rests (QML)
@@ -1380,11 +2086,57 @@ void EditStyle::changeEvent(QEvent* event)
 ///   NOTE: keep in sync with constructor.
 //---------------------------------------------------------
 
+/*!
+ * Updates all translatable labels and combo texts in the Notes page color section.
+ * Called from @c retranslate() on UI language change; also reapplies swatch descriptions via @c m_syncNoteColorUi.
+ */
+void EditStyle::retranslateNoteColorSection()
+{
+    if (!m_noteColorGroup) {
+        return;
+    }
+
+    m_noteColorGroup->setTitle(muse::qtrc("notation/editstyle", "Color"));
+    m_noteColorPresetLabel->setText(muse::qtrc("notation/editstyle", "Preset:"));
+    m_noteColorSchemeLabel->setText(muse::qtrc("notation/editstyle", "Coloring scheme:"));
+    m_noteColorSwatchColorLabel->setText(muse::qtrc("notation/editstyle", "Color:"));
+
+    m_noteColorPresetCombo->setItemText(0, muse::qtrc("notation/editstyle", "Default"));
+    m_noteColorPresetCombo->setItemText(1, muse::qtrc("notation/editstyle", "Boomwhackers"));
+    m_noteColorPresetCombo->setItemText(2, muse::qtrc("notation/editstyle", "Figurenotes (stage 3)"));
+    m_noteColorPresetCombo->setItemText(3, muse::qtrc("notation/editstyle", "Custom"));
+
+    m_noteColorSchemeCombo->setItemText(0, muse::qtrc("notation/editstyle", "One color"));
+    m_noteColorSchemeCombo->setItemText(1, muse::qtrc("notation/editstyle", "Absolute pitch (simple)"));
+    m_noteColorSchemeCombo->setItemText(2, muse::qtrc("notation/editstyle", "Absolute pitch (chromatic)"));
+    m_noteColorSchemeCombo->setItemText(3, muse::qtrc("notation/editstyle", "Moveable do (simple)"));
+    m_noteColorSchemeCombo->setItemText(4, muse::qtrc("notation/editstyle", "Moveable do (chromatic)"));
+
+    m_noteColorApplyToGroupBox->setTitle(muse::qtrc("notation/editstyle", "Apply color to:"));
+    m_noteColorCbAccidental->setText(muse::qtrc("notation/editstyle", "Accidentals"));
+    m_noteColorCbStem->setText(muse::qtrc("notation/editstyle", "Stems"));
+    m_noteColorCbArticulation->setText(muse::qtrc("notation/editstyle", "Articulations"));
+    m_noteColorCbDot->setText(muse::qtrc("notation/editstyle", "Augmentation dots"));
+    m_noteColorCbBeam->setText(muse::qtrc("notation/editstyle", "Beams"));
+    m_noteColorCbFlag->setText(muse::qtrc("notation/editstyle", "Flags"));
+
+    m_noteColorPitchGroupBox->setTitle(muse::qtrc("notation/editstyle", "Color notes on transposing instruments based on:"));
+    m_noteColorRbWritten->setText(muse::qtrc("notation/editstyle", "Written pitch"));
+    m_noteColorRbConcert->setText(muse::qtrc("notation/editstyle", "Concert pitch"));
+    m_noteColorResetBtn->setText(muse::qtrc("notation/editstyle", "Reset all color settings"));
+
+    if (m_syncNoteColorUi) {
+        m_syncNoteColorUi();
+    }
+}
+
 void EditStyle::retranslate()
 {
     retranslateUi(this);
 
     buttonApplyToAllParts->setText(muse::qtrc("notation/editstyle", "Apply to all parts"));
+
+    retranslateNoteColorSection();
 
     for (const LineStyleSelect* lineStyleSelect : m_lineStyleSelects) {
         int idx = 0;
@@ -1516,6 +2268,11 @@ void EditStyle::setHeaderFooterMacroInfoText()
 //   adjustPagesStackSize
 //---------------------------------------------------------
 
+/*!
+ * Sets @c pageStack minimum size to the current page's @c sizeHint() so the dialog does not leave excess
+ * blank space when switching tabs. For tall pages (e.g. Notes with the Color section), a short minimum
+ * height makes the inner @c QScrollArea on @c PageNotes provide vertical scrolling instead of growing the dialog.
+ */
 void EditStyle::adjustPagesStackSize(int currentPageIndex)
 {
     QSize preferredSize = pageStack->widget(currentPageIndex)->sizeHint();
@@ -1765,6 +2522,9 @@ void EditStyle::on_pageRowSelectionChanged()
 //   unhandledType
 //---------------------------------------------------------
 
+/*!
+ * Fails an assertion in debug builds when @p sw.widget cannot be read for its style type.
+ */
 void EditStyle::unhandledType(const StyleWidget sw)
 {
     P_TYPE type = MStyle::valueType(sw.idx);
@@ -1772,6 +2532,10 @@ void EditStyle::unhandledType(const StyleWidget sw)
                                sw.widget->metaObject()->className()));
 }
 
+/*!
+ * @return True if the style's boolean is edited with a two-button @c QButtonGroup
+ *         (value read/written via @c QButtonGroup::checkedId), not a single @c QCheckBox.
+ */
 bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
 {
     switch (id) {
@@ -1784,6 +2548,7 @@ bool EditStyle::isBoolStyleRepresentedByButtonGroup(StyleId id)
     case StyleId::angleHangingSlursAwayFromStaff:
     case StyleId::dividerLeftAlignToSystemBarline:
     case StyleId::dividerRightAlignToSystemBarline:
+    case StyleId::colorNotesByConcertPitch:
         return true;
     default:
         return false;
@@ -1908,6 +2673,13 @@ PropertyValue EditStyle::getValue(StyleId idx)
         QButtonGroup* bg = qobject_cast<QButtonGroup*>(sw.widget);
         return TiePlacement(bg->checkedId());
     } break;
+    case P_TYPE::COLOR: {
+        if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+            return Color::fromQColor(cl->color());
+        }
+        unhandledType(sw);
+        return PropertyValue();
+    } break;
     default: {
         ASSERT_X(QString::asprintf("EditStyle::getValue: unhandled type <%d>", static_cast<int>(type)));
     } break;
@@ -1920,6 +2692,9 @@ PropertyValue EditStyle::getValue(StyleId idx)
 //   setValues
 //---------------------------------------------------------
 
+/*!
+ * Fills every @c styleWidgets control from @c styleValue() / defaults, then unblocks signals and refreshes note-color UI.
+ */
 void EditStyle::setValues()
 {
     for (const StyleWidget& sw : styleWidgets) {
@@ -2047,6 +2822,13 @@ void EditStyle::setValues()
                 as->setOffset(offset);
             }
         } break;
+        case P_TYPE::COLOR: {
+            if (Awl::ColorLabel* cl = qobject_cast<Awl::ColorLabel*>(sw.widget)) {
+                cl->setColor(val.value<Color>().toQColor());
+            } else {
+                unhandledType(sw);
+            }
+        } break;
         default: {
             unhandledType(sw);
         } break;
@@ -2135,6 +2917,14 @@ void EditStyle::setValues()
     bool vertical = styleValue(StyleId::groupBracketTextOrientation).value<mu::engraving::Orientation>()
                     == mu::engraving::Orientation::VERTICAL;
     groupBracketHangIntoMargin->setEnabled(vertical && !textBracketRight);
+
+    if (m_syncNoteColorUi) {
+        QMetaObject::invokeMethod(this, [this]() {
+            if (m_syncNoteColorUi) {
+                m_syncNoteColorUi();
+            }
+        }, Qt::QueuedConnection);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/notationscene/widgets/editstyle.h
+++ b/src/notationscene/widgets/editstyle.h
@@ -22,9 +22,19 @@
 
 #pragma once
 
+#include <functional>
+
 #include "ui/view/widgetdialog.h"
 
 #include "ui_editstyle.h"
+
+class QCheckBox;
+class QComboBox;
+class QGroupBox;
+class QLabel;
+class QPushButton;
+class QRadioButton;
+class QWidget;
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
@@ -40,6 +50,13 @@
 class QQuickView;
 
 namespace mu::notation {
+/*!
+ * Full score and part style dialog: binds @c Ui::EditStyleBase widgets to @c engraving::StyleId values.
+ *
+ * The Notes page adds a programmatic Color @c QGroupBox (presets, schemes, swatches, apply-to, concert pitch,
+ * reset) in @c classBegin(), then wraps the whole Notes tab (flags, color, notes,
+ * alignment) in a @c QScrollArea so widget content scrolls like other native Style pages.
+ */
 class EditStyle : public muse::ui::WidgetDialog, private Ui::EditStyleBase
 {
     Q_OBJECT
@@ -58,9 +75,12 @@ class EditStyle : public muse::ui::WidgetDialog, private Ui::EditStyleBase
 public:
     EditStyle(QWidget* = nullptr);
 
+    //! Wires style widgets, including the dynamic note-color UI on the Notes page.
     void classBegin() override;
 
+    //! Page list identifier for the style sidebar (persisted view state).
     QString currentPageCode() const;
+    //! Sub-page (e.g. text style) identifier within the current page.
     QString currentSubPageCode() const;
 
 public slots:
@@ -82,17 +102,25 @@ private:
     void changeEvent(QEvent*) override;
     void keyPressEvent(QKeyEvent* event) override;
 
+    //! Refreshes all translatable strings from the UI file and note-color section.
     void retranslate();
+    //! Retranslates labels and swatch captions in the note-color section after language change.
+    void retranslateNoteColorSection();
+    //! Sets help text for header/footer macro placeholders on the page style tab.
     void setHeaderFooterMacroInfoText();
+    //! Resizes the stacked widget so the selected style page fits without excess blank space.
     void adjustPagesStackSize(int currentPageIndex);
 
+    //! @c true when a style bool is edited via an exclusive @c QButtonGroup (not a plain checkbox).
     bool isBoolStyleRepresentedByButtonGroup(StyleId id);
 
+    //! Host widget plus optional @c QQuickView for embedded QML style controls.
     struct WidgetAndView {
-        QWidget* widget = nullptr;
-        QQuickView* view = nullptr;
+        QWidget* widget = nullptr;      //!< Container placed in the page layout.
+        QQuickView* view = nullptr;    //!< Quick scene for QML content, if used.
     };
 
+    //! Creates a @c QWidget embedding QML from @p source (e.g. rests/flags selectors).
     WidgetAndView createQmlWidget(QWidget* parent, const QUrl& source);
 
     /// EditStylePage
@@ -100,32 +128,74 @@ private:
     /// It's used to create static references to the pointers to pages.
     typedef QWidget* EditStyle::* EditStylePage;
 
+    //! One style control plus optional reset button; used by @c getValue() / @c setValues().
     struct StyleWidget {
-        StyleId idx = StyleId::NOSTYLE;
-        bool showPercent = false;
-        QObject* widget = nullptr;
-        QToolButton* reset = nullptr;
+        StyleId idx = StyleId::NOSTYLE;     //!< Style key written to the score.
+        bool showPercent = false;           //!< Spin boxes show 0–100 when true.
+        QObject* widget = nullptr;          //!< Bound control (combo, checkbox, color label, …).
+        QToolButton* reset = nullptr;       //!< Resets @p idx to default when present.
     };
 
+    //! All registered controls in declaration order (order matters for reset-all).
     QVector<StyleWidget> styleWidgets;
+    //! Looks up the @c StyleWidget row for @p id (asserts if missing).
     const StyleWidget& styleWidget(StyleId id) const;
 
     class LineStyleSelect;
+    //! Dash/gap spin boxes for line style customizations (ottava, pedal, …).
     std::vector<LineStyleSelect*> m_lineStyleSelects;
 
+    //! Shared above/below items for line and text placement combos.
     std::vector<QComboBox*> verticalPlacementComboBoxes;
 
+    //! Applies the current page of style changes to every part in the score.
     QPushButton* buttonApplyToAllParts = nullptr;
 
+    /**
+     * @name Note color (Edit Style)
+     * Widgets for the note-color preset, scheme, swatches, apply-to options, and concert pitch.
+     **/
+    ///@{
+    QGroupBox* m_noteColorGroup = nullptr;
+    QLabel* m_noteColorPresetLabel = nullptr;
+    QLabel* m_noteColorSchemeLabel = nullptr;
+    QComboBox* m_noteColorPresetCombo = nullptr;
+    QComboBox* m_noteColorSchemeCombo = nullptr;
+    QLabel* m_noteColorSwatchColorLabel = nullptr;
+    QWidget* m_noteColorSwatchesContainer = nullptr;
+    QLabel* m_noteColorSchemeDescription = nullptr;
+    QGroupBox* m_noteColorApplyToGroupBox = nullptr;
+    QCheckBox* m_noteColorCbAccidental = nullptr;
+    QCheckBox* m_noteColorCbStem = nullptr;
+    QCheckBox* m_noteColorCbArticulation = nullptr;
+    QCheckBox* m_noteColorCbDot = nullptr;
+    QCheckBox* m_noteColorCbBeam = nullptr;
+    QGroupBox* m_noteColorPitchGroupBox = nullptr;
+    QRadioButton* m_noteColorRbWritten = nullptr;
+    QRadioButton* m_noteColorRbConcert = nullptr;
+    QPushButton* m_noteColorResetBtn = nullptr;
+    //! Rebuilds note-color controls from current style (queued after @c setValues()).
+    std::function<void()> m_syncNoteColorUi;
+    ///@}
+
+    //! Asserts on debug builds when a @c StyleWidget has no matching @c getValue / @c setValues handler.
     void unhandledType(const StyleWidget);
+    //! Reads the current value from the widget registered for @p idx (spin box, combo, color label, etc.).
     PropertyValue getValue(StyleId idx);
+    //! Loads the notation style into all @c styleWidgets controls (blocked signals while applying).
     void setValues();
 
+    //! Live style value from the open notation (master or current part).
     const PropertyValue& styleValue(StyleId id) const;
+    //! Factory default for @p id (for reset buttons and comparisons).
     const PropertyValue& defaultStyleValue(StyleId id) const;
+    //! @c true when the score value for @p id equals the style default (@c defaultStyleValue(id) == @c styleValue(id)).
     bool hasDefaultStyleValue(StyleId id) const;
+    //! Whether dynamics/hairpin placement combos should expose score-specific defaults.
     bool dynamicsAndHairpinPosPropertiesHaveDefaultStyleValue() const;
+    //! Writes @p value into the notation style after converting from Qt types.
     void setStyleQVariantValue(StyleId id, const QVariant& value);
+    //! Writes @p value into the notation style (undoable).
     void setStyleValue(StyleId id, const PropertyValue& value);
 
 private slots:

--- a/src/notationscene/widgets/editstyle.h
+++ b/src/notationscene/widgets/editstyle.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <functional>
+
+#include <QColor>
+
 #include "ui/view/widgetdialog.h"
 
 #include "ui_editstyle.h"
@@ -37,10 +41,25 @@
 #include "engraving/style/textstyle.h"
 
 #include "inotationsceneconfiguration.h"
+#include "engraving/types/notecoloringscheme.h"
 
+class QCheckBox;
+class QComboBox;
+class QGroupBox;
+class QLabel;
+class QPushButton;
 class QQuickView;
+class QRadioButton;
+class QWidget;
 
 namespace mu::notation {
+/*!
+ * Full score and part style dialog: binds @c Ui::EditStyleBase widgets to @c engraving::StyleId values.
+ *
+ * The Notes page adds a programmatic Color @c QGroupBox (presets, schemes, swatches, apply-to, concert pitch,
+ * reset) in @c classBegin(), then wraps the whole Notes tab (flags, color, notes,
+ * alignment) in a @c QScrollArea so widget content scrolls like other native Style pages.
+ */
 class EditStyle : public muse::ui::WidgetDialog, private Ui::EditStyleBase
 {
     Q_OBJECT
@@ -59,6 +78,7 @@ class EditStyle : public muse::ui::WidgetDialog, private Ui::EditStyleBase
 public:
     EditStyle(QWidget* = nullptr);
 
+    //! Wires style widgets, including the dynamic note-color UI on the Notes page.
     void classBegin() override;
 
     QString currentPageCode() const;
@@ -84,14 +104,16 @@ private:
     void keyPressEvent(QKeyEvent* event) override;
 
     void retranslate();
+    //! Retranslates labels and swatch captions in the note-color section after language change.
+    void retranslateNoteColorSection();
     void setHeaderFooterMacroInfoText();
     void adjustPagesStackSize(int currentPageIndex);
 
     bool isBoolStyleRepresentedByButtonGroup(engraving::Sid id);
 
     struct WidgetAndView {
-        QWidget* widget = nullptr;
-        QQuickView* view = nullptr;
+        QWidget* widget = nullptr;      //!< Container placed in the page layout.
+        QQuickView* view = nullptr;    //!< Quick scene for QML content, if used.
     };
 
     WidgetAndView createQmlWidget(QWidget* parent, const QUrl& source);
@@ -102,10 +124,10 @@ private:
     typedef QWidget* EditStyle::* EditStylePage;
 
     struct StyleWidget {
-        engraving::Sid idx = engraving::Sid::NOSTYLE;
-        bool showPercent = false;
-        QObject* widget = nullptr;
-        QToolButton* reset = nullptr;
+        engraving::Sid idx = engraving::Sid::NOSTYLE;     //!< Style key written to the score.
+        bool showPercent = false;                         //!< Spin boxes show 0–100 when true.
+        QObject* widget = nullptr;                        //!< Bound control (combo, checkbox, color label, …).
+        QToolButton* reset = nullptr;                     //!< Resets @p idx to default when present.
     };
 
     QVector<StyleWidget> styleWidgets;
@@ -117,6 +139,40 @@ private:
     std::vector<QComboBox*> verticalPlacementComboBoxes;
 
     QPushButton* buttonApplyToAllParts = nullptr;
+
+    /**
+     * @name Note color (Edit Style)
+     * Widgets for the note-color preset, scheme, swatches, apply-to options, and concert pitch.
+     **/
+    ///@{
+    QGroupBox* m_noteColorGroup = nullptr;                 //!< Container group box for all note-color widgets.
+    QLabel* m_noteColorPresetLabel = nullptr;              //!< "Preset:" caption.
+    QLabel* m_noteColorSchemeLabel = nullptr;              //!< "Coloring scheme:" caption.
+    QComboBox* m_noteColorPresetCombo = nullptr;           //!< Default / Boomwhackers / Figurenotes / Custom.
+    QComboBox* m_noteColorSchemeCombo = nullptr;           //!< @c NoteColoringScheme selector.
+    QLabel* m_noteColorSwatchColorLabel = nullptr;         //!< Caption above the default color swatch.
+    QWidget* m_noteColorSwatchesContainer = nullptr;       //!< Holds the 12 per-pitch color labels.
+    QLabel* m_noteColorSchemeDescription = nullptr;        //!< Scheme-specific explanatory text.
+    QGroupBox* m_noteColorApplyToGroupBox = nullptr;       //!< "Apply color to:" check-box group.
+    QCheckBox* m_noteColorCbAccidental = nullptr;          //!< Bound to @c Sid::colorApplyToAccidental.
+    QCheckBox* m_noteColorCbStem = nullptr;                //!< Bound to @c Sid::colorApplyToStem.
+    QCheckBox* m_noteColorCbArticulation = nullptr;        //!< Bound to @c Sid::colorApplyToArticulation.
+    QCheckBox* m_noteColorCbDot = nullptr;                 //!< Bound to @c Sid::colorApplyToDot.
+    QCheckBox* m_noteColorCbBeam = nullptr;                //!< Bound to @c Sid::colorApplyToBeam.
+    QCheckBox* m_noteColorCbFlag = nullptr;                //!< Bound to @c Sid::colorApplyToFlag.
+    QGroupBox* m_noteColorPitchGroupBox = nullptr;         //!< Written vs concert pitch radio group.
+    QRadioButton* m_noteColorRbWritten = nullptr;          //!< Color by written (displayed) pitch.
+    QRadioButton* m_noteColorRbConcert = nullptr;          //!< Color by concert (sounding) pitch.
+    QPushButton* m_noteColorResetBtn = nullptr;            //!< Reverts every note-color style to defaults.
+    //! Rebuilds note-color controls from current style (queued after @c setValues()).
+    std::function<void()> m_syncNoteColorUi;
+    //! Last @c noteColorTheme when remapping 7- vs 12-swatch columns on scheme change; synced in @c m_syncNoteColorUi.
+    mu::engraving::NoteColoringScheme m_lastNoteColoringScheme = mu::engraving::NoteColoringScheme::OneColor;
+    //! Chromatic-only palette slots (1, 3, 6, 8, 10) cached on a chromatic→simple switch so a later
+    //! simple→chromatic switch can restore them rather than reset to black.
+    QColor m_savedChromaticOnlyColors[5];
+    bool m_hasSavedChromaticOnlyColors = false;
+    ///@}
 
     void unhandledType(const StyleWidget);
     engraving::PropertyValue getValue(engraving::Sid idx);


### PR DESCRIPTION
Resolves: #32778

Adds a **Color** section on the Notes page of **Format → Style** so users can choose note coloring schemes (including movable-do coloring), configure swatch colors, and control whether color applies to accidentals, stems, beams, articulations, and dots.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

<img width="1005" height="405" alt="Screenshot 2026-04-14 at 6 08 46 PM" src="https://github.com/user-attachments/assets/70dabdd4-900c-44ee-862e-905c44e474aa" />
<img width="935" height="234" alt="Screenshot 2026-04-14 at 6 08 53 PM" src="https://github.com/user-attachments/assets/ea718380-b301-4180-9002-f5730235d1e4" />

