### PR TITLE
Expose FretDiagram Harmony object and setDot/setMarker/setBarre/clear methods to the API

### DIFF
--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1567,17 +1567,36 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyApi)
     FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
     domFd->setHarmony(u"Fdim7");
 
-    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+    // Construct the wrapper through the public dispatcher so that
+    // the FretDiagram and Harmony branches added in elements.cpp are
+    // exercised.
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
 
-    // [WHEN/THEN] The harmonyPlainText property reflects the chord
+    // [WHEN/THEN] The chord symbol is reachable via plainText.
+    // displayText depends on layout state and is empty before layout runs;
+    // we just exercise the call to confirm the wrapper forwards correctly.
     EXPECT_EQ(apiFd->harmonyPlainText(), QString("Fdim7"));
+    apiFd->harmonyDisplayText();
 
-    // [WHEN/THEN] The nested Harmony wrapper is reachable and exposes plainText
+    // [WHEN/THEN] The nested Harmony wrapper is reachable via the typed
+    // FretDiagram::harmony() accessor (the path real plugins would use).
     apiv1::Harmony* apiHarmony = apiFd->harmony();
     ASSERT_NE(apiHarmony, nullptr);
     EXPECT_EQ(apiHarmony->plainText(), QString("Fdim7"));
+    apiHarmony->displayText();
+    EXPECT_FALSE(apiHarmony->harmonyName().isEmpty());
+
+    // Also exercise the wrap() dispatcher branch for Harmony.
+    apiv1::Harmony* apiHarmonyViaDispatcher
+        = qobject_cast<apiv1::Harmony*>(apiv1::wrap(domFd->harmony(), apiv1::Ownership::SCORE));
+    ASSERT_NE(apiHarmonyViaDispatcher, nullptr);
+    EXPECT_EQ(apiHarmonyViaDispatcher->plainText(), QString("Fdim7"));
 
     delete apiFd;
+    delete apiHarmony;
+    delete apiHarmonyViaDispatcher;
     delete domFd;
     delete domScore;
 }
@@ -1597,7 +1616,9 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
     FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
 
-    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
 
     EXPECT_EQ(domFd->dot(0).front().fret, 0);
 
@@ -1618,6 +1639,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
     EXPECT_EQ(domFd->dot(0).front().fret, 0);
 
     delete apiFd;
+    delete domFd;
     delete domScore;
 }
 
@@ -1632,7 +1654,9 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
     FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
 
-    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
 
     // [WHEN] We mute a string via the API inside a startCmd/endCmd transaction
     domScore->startCmd(TranslatableString::untranslatable("set marker test"));
@@ -1649,6 +1673,43 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
     EXPECT_EQ(domFd->marker(0).mtype, FretMarkerType::NONE);
 
     delete apiFd;
+    delete domFd;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   fretDiagramSetBarreApi
+//   Test the Plugin API write method FretDiagram::setBarre.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramSetBarreApi)
+{
+    // [GIVEN] A score and an empty FretDiagram, wrapped via the API
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
+
+    EXPECT_FALSE(domFd->barre(2).exists());
+
+    // [WHEN] We add a barre at fret 2 via the API inside a startCmd/endCmd transaction
+    domScore->startCmd(TranslatableString::untranslatable("set barre test"));
+    apiFd->setBarre(0, 2);
+    domScore->endCmd();
+
+    // [THEN] The barre is recorded
+    EXPECT_TRUE(domFd->barre(2).exists());
+
+    // [WHEN] We undo
+    domScore->undoRedo(true, nullptr);
+
+    // [THEN] The barre is gone
+    EXPECT_FALSE(domFd->barre(2).exists());
+
+    delete apiFd;
+    delete domFd;
     delete domScore;
 }
 
@@ -1668,7 +1729,9 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramClearApi)
 
     ASSERT_FALSE(domFd->isClear());
 
-    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
 
     // [WHEN] We clear the diagram via the API inside a startCmd/endCmd transaction
     domScore->startCmd(TranslatableString::untranslatable("clear diagram test"));
@@ -1688,5 +1751,6 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramClearApi)
     EXPECT_EQ(domFd->marker(1).mtype, FretMarkerType::CROSS);
 
     delete apiFd;
+    delete domFd;
     delete domScore;
 }

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1768,3 +1768,59 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramClearApi)
     delete domFd;
     delete domScore;
 }
+
+//---------------------------------------------------------
+//   fretDiagramGettersApi
+//   Test the read-only getters: scalar properties (strings,
+//   frets, fretOffset) and collection methods (dots, markers,
+//   barres) that allow plugins to read back diagram state.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramGettersApi)
+{
+    // [GIVEN] A FretDiagram populated with known content
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+
+    // Set a dot on string 0 fret 3, a marker on string 1, and a barre at fret 2
+    domFd->setDot(0, 3);
+    domFd->setMarker(1, FretMarkerType::CROSS);
+    domFd->setBarre(2, 5, 2);     // startString=2, endString=5, fret=2
+    domFd->setFretOffset(3);
+
+    apiv1::FretDiagram* apiFd
+        = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
+    ASSERT_NE(apiFd, nullptr);
+
+    // [THEN] Scalar properties match the DOM state
+    EXPECT_EQ(apiFd->strings(), domFd->strings());
+    EXPECT_EQ(apiFd->frets(), domFd->frets());
+    EXPECT_EQ(apiFd->fretOffset(), 3);
+
+    // [THEN] dots() returns the dot we placed
+    QVariantList dotList = apiFd->dots();
+    ASSERT_EQ(dotList.size(), 1);
+    QVariantMap dot0 = dotList[0].toMap();
+    EXPECT_EQ(dot0["string"].toInt(), 0);
+    EXPECT_EQ(dot0["fret"].toInt(), 3);
+    EXPECT_EQ(dot0["dotType"].toInt(), int(FretDotType::NORMAL));
+
+    // [THEN] markers() returns the marker we placed
+    QVariantList markerList = apiFd->markers();
+    ASSERT_EQ(markerList.size(), 1);
+    QVariantMap marker0 = markerList[0].toMap();
+    EXPECT_EQ(marker0["string"].toInt(), 1);
+    EXPECT_EQ(marker0["markerType"].toInt(), int(FretMarkerType::CROSS));
+
+    // [THEN] barres() returns the barre we placed
+    QVariantList barreList = apiFd->barres();
+    ASSERT_EQ(barreList.size(), 1);
+    QVariantMap barre0 = barreList[0].toMap();
+    EXPECT_EQ(barre0["fret"].toInt(), 2);
+    EXPECT_EQ(barre0["startString"].toInt(), 2);
+    EXPECT_EQ(barre0["endString"].toInt(), 5);
+
+    delete apiFd;
+    delete domFd;
+    delete domScore;
+}

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1639,15 +1639,10 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
     // [THEN] The dot is gone, confirming the change went through the undo stack
     EXPECT_EQ(domFd->dot(0).front().fret, 0);
 
-#ifndef NDEBUG
-    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
-    EXPECT_DEATH({ apiFd->setDot(99, 3);
-                 }, ".*string.*");
-    EXPECT_DEATH({ apiFd->setDot(0, -1);
-                 }, ".*fret.*");
-    EXPECT_DEATH({ apiFd->setDot(0, 3, false, 99);
-                 }, ".*dotType.*");
-#endif
+    // Negative-path checks: invalid inputs log a warning and return early.
+    apiFd->setDot(99, 3);
+    apiFd->setDot(0, -1);
+    apiFd->setDot(0, 3, false, 99);
 
     delete apiFd;
     delete domFd;
@@ -1683,13 +1678,9 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
     // [THEN] The marker is gone
     EXPECT_EQ(domFd->marker(0).mtype, FretMarkerType::NONE);
 
-#ifndef NDEBUG
-    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
-    EXPECT_DEATH({ apiFd->setMarker(99, int(FretMarkerType::CROSS));
-                 }, ".*string.*");
-    EXPECT_DEATH({ apiFd->setMarker(0, 99);
-                 }, ".*marker.*");
-#endif
+    // Negative-path checks: invalid inputs log a warning and return early.
+    apiFd->setMarker(99, int(FretMarkerType::CROSS));
+    apiFd->setMarker(0, 99);
 
     delete apiFd;
     delete domFd;
@@ -1727,13 +1718,9 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetBarreApi)
     // [THEN] The barre is gone
     EXPECT_FALSE(domFd->barre(2).exists());
 
-#ifndef NDEBUG
-    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
-    EXPECT_DEATH({ apiFd->setBarre(99, 2);
-                 }, ".*string.*");
-    EXPECT_DEATH({ apiFd->setBarre(0, 0);
-                 }, ".*fret.*");
-#endif
+    // Negative-path checks: invalid inputs log a warning and return early.
+    apiFd->setBarre(99, 2);
+    apiFd->setBarre(0, 0);
 
     delete apiFd;
     delete domFd;

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1580,15 +1580,16 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyApi)
     EXPECT_EQ(apiFd->harmonyPlainText(), QString("Fdim7"));
     apiFd->harmonyDisplayText();
 
-    // [WHEN/THEN] The nested Harmony wrapper is reachable via the typed
-    // FretDiagram::harmony() accessor (the path real plugins would use).
+    // [WHEN/THEN] (A) The plugin-facing accessor returns the nested Harmony
+    // wrapper (this is the path a real plugin would use).
     apiv1::Harmony* apiHarmony = apiFd->harmony();
     ASSERT_NE(apiHarmony, nullptr);
     EXPECT_EQ(apiHarmony->plainText(), QString("Fdim7"));
     apiHarmony->displayText();
     EXPECT_FALSE(apiHarmony->harmonyName().isEmpty());
 
-    // Also exercise the wrap() dispatcher branch for Harmony.
+    // [WHEN/THEN] (B) The wrap() dispatcher returns the same wrapper too
+    // (exercises the API_WRAP(Harmony) branch in elements.cpp).
     apiv1::Harmony* apiHarmonyViaDispatcher
         = qobject_cast<apiv1::Harmony*>(apiv1::wrap(domFd->harmony(), apiv1::Ownership::SCORE));
     ASSERT_NE(apiHarmonyViaDispatcher, nullptr);

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1638,6 +1638,16 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
     // [THEN] The dot is gone, confirming the change went through the undo stack
     EXPECT_EQ(domFd->dot(0).front().fret, 0);
 
+#ifndef NDEBUG
+    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
+    EXPECT_DEATH({ apiFd->setDot(99, 3);
+                 }, ".*string.*");
+    EXPECT_DEATH({ apiFd->setDot(0, -1);
+                 }, ".*fret.*");
+    EXPECT_DEATH({ apiFd->setDot(0, 3, false, 99);
+                 }, ".*dotType.*");
+#endif
+
     delete apiFd;
     delete domFd;
     delete domScore;
@@ -1671,6 +1681,14 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
 
     // [THEN] The marker is gone
     EXPECT_EQ(domFd->marker(0).mtype, FretMarkerType::NONE);
+
+#ifndef NDEBUG
+    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
+    EXPECT_DEATH({ apiFd->setMarker(99, int(FretMarkerType::CROSS));
+                 }, ".*string.*");
+    EXPECT_DEATH({ apiFd->setMarker(0, 99);
+                 }, ".*marker.*");
+#endif
 
     delete apiFd;
     delete domFd;
@@ -1707,6 +1725,14 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetBarreApi)
 
     // [THEN] The barre is gone
     EXPECT_FALSE(domFd->barre(2).exists());
+
+#ifndef NDEBUG
+    // Negative-path checks: invalid inputs trigger IF_ASSERT_FAILED.
+    EXPECT_DEATH({ apiFd->setBarre(99, 2);
+                 }, ".*string.*");
+    EXPECT_DEATH({ apiFd->setBarre(0, 0);
+                 }, ".*fret.*");
+#endif
 
     delete apiFd;
     delete domFd;

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -25,6 +25,8 @@
 #include "engraving/compat/scoreaccess.h"
 #include "engraving/dom/drumset.h"
 #include "engraving/dom/factory.h"
+#include "engraving/dom/fret.h"
+#include "engraving/dom/harmony.h"
 #include "engraving/dom/instrtemplate.h"
 #include "engraving/dom/instrument.h"
 #include "engraving/dom/scoreorder.h"
@@ -1522,5 +1524,60 @@ TEST_F(Engraving_ApiScoreTests, setScoreOrderApi)
     // Clean up the added test order
     instrumentOrders.pop_back();
 
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   fretDiagramHarmonyAtDomLevel
+//   Confirm the DOM-level building block: a FretDiagram with
+//   setHarmony() exposes the chord text via harmonyPlainText().
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyAtDomLevel)
+{
+    // [GIVEN] A score and a FretDiagram with no harmony
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* fd = Factory::createFretDiagram(score->dummy()->segment());
+
+    EXPECT_EQ(fd->harmony(), nullptr);
+    EXPECT_EQ(fd->harmonyPlainText(), String());
+
+    // [WHEN] We attach a chord symbol to the diagram
+    fd->setHarmony(u"Cm7");
+
+    // [THEN] The diagram exposes the nested Harmony and its plain text
+    ASSERT_NE(fd->harmony(), nullptr);
+    EXPECT_EQ(fd->harmonyPlainText(), u"Cm7");
+
+    delete fd;
+    delete score;
+}
+
+//---------------------------------------------------------
+//   fretDiagramHarmonyApi
+//   Test the Plugin API wrappers for FretDiagram and Harmony.
+//   Plugins must be able to read the chord name from a fret
+//   diagram annotation and from the nested Harmony directly.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyApi)
+{
+    // [GIVEN] A score with a FretDiagram carrying a chord symbol
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    domFd->setHarmony(u"Fdim7");
+
+    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+
+    // [WHEN/THEN] The harmonyPlainText property reflects the chord
+    EXPECT_EQ(apiFd->harmonyPlainText(), QString("Fdim7"));
+
+    // [WHEN/THEN] The nested Harmony wrapper is reachable and exposes plainText
+    apiv1::Harmony* apiHarmony = apiFd->harmony();
+    ASSERT_NE(apiHarmony, nullptr);
+    EXPECT_EQ(apiHarmony->plainText(), QString("Fdim7"));
+
+    delete apiFd;
+    delete domFd;
     delete domScore;
 }

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1581,3 +1581,112 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyApi)
     delete domFd;
     delete domScore;
 }
+
+//---------------------------------------------------------
+//   fretDiagramSetDotApi
+//   Test the Plugin API write method FretDiagram::setDot.
+//   Verifies the change is recorded on the undo stack and can
+//   be undone, as required by reviewers of PR #32848.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
+{
+    // [GIVEN] A score and an empty FretDiagram, wrapped via the API.
+    // FretDiagram::dot(s) returns a placeholder Dot(fret=0) when no dot is set,
+    // so we check fret values rather than vector emptiness.
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+
+    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+
+    EXPECT_EQ(domFd->dot(0).front().fret, 0);
+
+    // [WHEN] We place a dot through the API inside a startCmd/endCmd transaction
+    domScore->startCmd(TranslatableString::untranslatable("set dot test"));
+    apiFd->setDot(0, 3);
+    domScore->endCmd();
+
+    // [THEN] The dot is recorded on the diagram
+    std::vector<FretItem::Dot> dots = domFd->dot(0);
+    ASSERT_EQ(dots.size(), 1u);
+    EXPECT_EQ(dots[0].fret, 3);
+
+    // [WHEN] We undo
+    domScore->undoRedo(true, nullptr);
+
+    // [THEN] The dot is gone, confirming the change went through the undo stack
+    EXPECT_EQ(domFd->dot(0).front().fret, 0);
+
+    delete apiFd;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   fretDiagramSetMarkerApi
+//   Test the Plugin API write method FretDiagram::setMarker.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
+{
+    // [GIVEN] A score and an empty FretDiagram, wrapped via the API
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+
+    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+
+    // [WHEN] We mute a string via the API inside a startCmd/endCmd transaction
+    domScore->startCmd(TranslatableString::untranslatable("set marker test"));
+    apiFd->setMarker(0, int(FretMarkerType::CROSS));
+    domScore->endCmd();
+
+    // [THEN] The marker is recorded
+    EXPECT_EQ(domFd->marker(0).mtype, FretMarkerType::CROSS);
+
+    // [WHEN] We undo
+    domScore->undoRedo(true, nullptr);
+
+    // [THEN] The marker is gone
+    EXPECT_EQ(domFd->marker(0).mtype, FretMarkerType::NONE);
+
+    delete apiFd;
+    delete domScore;
+}
+
+//---------------------------------------------------------
+//   fretDiagramClearApi
+//   Test the Plugin API write method FretDiagram::clear and
+//   that the previous content is restored on undo.
+//---------------------------------------------------------
+
+TEST_F(Engraving_ApiScoreTests, fretDiagramClearApi)
+{
+    // [GIVEN] A score and a FretDiagram populated with a dot and a marker
+    MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    domFd->setDot(0, 3);
+    domFd->setMarker(1, FretMarkerType::CROSS);
+
+    ASSERT_FALSE(domFd->isClear());
+
+    apiv1::FretDiagram* apiFd = new apiv1::FretDiagram(domFd, apiv1::Ownership::SCORE);
+
+    // [WHEN] We clear the diagram via the API inside a startCmd/endCmd transaction
+    domScore->startCmd(TranslatableString::untranslatable("clear diagram test"));
+    apiFd->clear();
+    domScore->endCmd();
+
+    // [THEN] The diagram is empty
+    EXPECT_TRUE(domFd->isClear());
+
+    // [WHEN] We undo
+    domScore->undoRedo(true, nullptr);
+
+    // [THEN] The previous dot and marker are restored
+    EXPECT_FALSE(domFd->isClear());
+    ASSERT_EQ(domFd->dot(0).size(), 1u);
+    EXPECT_EQ(domFd->dot(0)[0].fret, 3);
+    EXPECT_EQ(domFd->marker(1).mtype, FretMarkerType::CROSS);
+
+    delete apiFd;
+    delete domScore;
+}

--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -573,6 +573,13 @@ enum class FretDotType {
 };
 Q_ENUM_NS(FretDotType);
 
+// Pin the API/DOM enum equivalence so a future reorder of either enum
+// fails compilation instead of silently corrupting plugin writes.
+static_assert(int(FretDotType::NORMAL) == int(mu::engraving::FretDotType::NORMAL));
+static_assert(int(FretDotType::CROSS) == int(mu::engraving::FretDotType::CROSS));
+static_assert(int(FretDotType::SQUARE) == int(mu::engraving::FretDotType::SQUARE));
+static_assert(int(FretDotType::TRIANGLE) == int(mu::engraving::FretDotType::TRIANGLE));
+
 /** APIDOC
  * Type of string marker in a fretboard diagram (open / muted / none).
  * @memberof Engraving
@@ -585,6 +592,10 @@ enum class FretMarkerType {
     CROSS  = int(mu::engraving::FretMarkerType::CROSS),
 };
 Q_ENUM_NS(FretMarkerType);
+
+static_assert(int(FretMarkerType::NONE) == int(mu::engraving::FretMarkerType::NONE));
+static_assert(int(FretMarkerType::CIRCLE) == int(mu::engraving::FretMarkerType::CIRCLE));
+static_assert(int(FretMarkerType::CROSS) == int(mu::engraving::FretMarkerType::CROSS));
 
 /** APIDOC
  * Auto-hide flag

--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -26,6 +26,7 @@
 
 #include "engraving/dom/accidental.h"
 #include "engraving/dom/chord.h"
+#include "engraving/dom/fret.h"
 #include "engraving/dom/guitarbend.h"
 #include "engraving/dom/hairpin.h"
 #include "engraving/dom/harmony.h"
@@ -557,6 +558,33 @@ enum class Orientation {
     HORIZONTAL = int(mu::engraving::Orientation::HORIZONTAL),
 };
 Q_ENUM_NS(Orientation);
+
+/** APIDOC
+ * Type of dot in a fretboard diagram.
+ * @memberof Engraving
+ * @enum
+ * @since 4.7
+ */
+enum class FretDotType {
+    NORMAL   = int(mu::engraving::FretDotType::NORMAL),
+    CROSS    = int(mu::engraving::FretDotType::CROSS),
+    SQUARE   = int(mu::engraving::FretDotType::SQUARE),
+    TRIANGLE = int(mu::engraving::FretDotType::TRIANGLE),
+};
+Q_ENUM_NS(FretDotType);
+
+/** APIDOC
+ * Type of string marker in a fretboard diagram (open / muted / none).
+ * @memberof Engraving
+ * @enum
+ * @since 4.7
+ */
+enum class FretMarkerType {
+    NONE   = int(mu::engraving::FretMarkerType::NONE),
+    CIRCLE = int(mu::engraving::FretMarkerType::CIRCLE),
+    CROSS  = int(mu::engraving::FretMarkerType::CROSS),
+};
+Q_ENUM_NS(FretMarkerType);
 
 /** APIDOC
  * Auto-hide flag

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -663,6 +663,47 @@ Ornament* Spanner::ornament() const
 }
 
 //---------------------------------------------------------
+//   FretDiagram::setDot
+//   FretDiagram::setMarker
+//   FretDiagram::setBarre
+//   FretDiagram::clear
+///   These thin wrappers forward to the undo-aware DOM methods so that
+///   modifications are recorded on the undo stack and propagated to all
+///   linked clones of the diagram (the DOM walks linkList() internally).
+//---------------------------------------------------------
+
+void FretDiagram::setDot(int string, int fret, bool add, int dotType)
+{
+    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+        return;
+    }
+    fretDiagram()->undoSetFretDot(string, fret, add,
+                                  static_cast<mu::engraving::FretDotType>(dotType));
+}
+
+void FretDiagram::setMarker(int string, int marker)
+{
+    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+        return;
+    }
+    fretDiagram()->undoSetFretMarker(string,
+                                     static_cast<mu::engraving::FretMarkerType>(marker));
+}
+
+void FretDiagram::setBarre(int string, int fret, bool add)
+{
+    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+        return;
+    }
+    fretDiagram()->undoSetFretBarre(string, fret, add);
+}
+
+void FretDiagram::clear()
+{
+    fretDiagram()->undoFretClear();
+}
+
+//---------------------------------------------------------
 //   wrap
 ///   \cond PLUGIN_API \private \endcond
 ///   Wraps mu::engraving::EngravingItem choosing the correct wrapper type

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -667,9 +667,11 @@ Ornament* Spanner::ornament() const
 //   FretDiagram::setMarker
 //   FretDiagram::setBarre
 //   FretDiagram::clear
-///   These thin wrappers forward to the undo-aware DOM methods so that
-///   modifications are recorded on the undo stack and propagated to all
-///   linked clones of the diagram (the DOM walks linkList() internally).
+///   When the element is owned by the score, use the undo-aware DOM methods
+///   so that modifications are recorded on the undo stack and propagated to
+///   all linked clones. When the element is plugin-owned (not yet added to
+///   a score), use the direct setters to avoid accessing an invalid undo
+///   stack (see ScoreElement::set() in scoreelement.cpp for the same pattern).
 //---------------------------------------------------------
 
 void FretDiagram::setDot(int string, int fret, bool add, int dotType)
@@ -684,8 +686,13 @@ void FretDiagram::setDot(int string, int fret, bool add, int dotType)
                      && dotType <= int(mu::engraving::FretDotType::TRIANGLE)) {
         return;
     }
-    fretDiagram()->undoSetFretDot(string, fret, add,
-                                  static_cast<mu::engraving::FretDotType>(dotType));
+    if (ownership() == Ownership::SCORE) {
+        fretDiagram()->undoSetFretDot(string, fret, add,
+                                      static_cast<mu::engraving::FretDotType>(dotType));
+    } else {
+        fretDiagram()->setDot(string, fret, add,
+                              static_cast<mu::engraving::FretDotType>(dotType));
+    }
 }
 
 void FretDiagram::setMarker(int string, int marker)
@@ -697,8 +704,13 @@ void FretDiagram::setMarker(int string, int marker)
                      && marker <= int(mu::engraving::FretMarkerType::CROSS)) {
         return;
     }
-    fretDiagram()->undoSetFretMarker(string,
-                                     static_cast<mu::engraving::FretMarkerType>(marker));
+    if (ownership() == Ownership::SCORE) {
+        fretDiagram()->undoSetFretMarker(string,
+                                         static_cast<mu::engraving::FretMarkerType>(marker));
+    } else {
+        fretDiagram()->setMarker(string,
+                                 static_cast<mu::engraving::FretMarkerType>(marker));
+    }
 }
 
 void FretDiagram::setBarre(int string, int fret, bool add)
@@ -709,12 +721,20 @@ void FretDiagram::setBarre(int string, int fret, bool add)
     IF_ASSERT_FAILED(fret > 0) {
         return;
     }
-    fretDiagram()->undoSetFretBarre(string, fret, add);
+    if (ownership() == Ownership::SCORE) {
+        fretDiagram()->undoSetFretBarre(string, fret, add);
+    } else {
+        fretDiagram()->setBarre(string, fret, add);
+    }
 }
 
 void FretDiagram::clear()
 {
-    fretDiagram()->undoFretClear();
+    if (ownership() == Ownership::SCORE) {
+        fretDiagram()->undoFretClear();
+    } else {
+        fretDiagram()->clear();
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -676,14 +676,17 @@ Ornament* Spanner::ornament() const
 
 void FretDiagram::setDot(int string, int fret, bool add, int dotType)
 {
-    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+    if (string < 0 || string >= fretDiagram()->strings()) {
+        LOGW("PluginAPI::FretDiagram::setDot: string %d is out of range (0..%d)", string, fretDiagram()->strings() - 1);
         return;
     }
-    IF_ASSERT_FAILED(fret >= 0) {
+    if (fret < 0) {
+        LOGW("PluginAPI::FretDiagram::setDot: fret %d is negative", fret);
         return;
     }
-    IF_ASSERT_FAILED(dotType >= int(mu::engraving::FretDotType::NORMAL)
-                     && dotType <= int(mu::engraving::FretDotType::TRIANGLE)) {
+    if (dotType < int(mu::engraving::FretDotType::NORMAL)
+        || dotType > int(mu::engraving::FretDotType::TRIANGLE)) {
+        LOGW("PluginAPI::FretDiagram::setDot: dotType %d is out of range", dotType);
         return;
     }
     if (ownership() == Ownership::SCORE) {
@@ -697,11 +700,13 @@ void FretDiagram::setDot(int string, int fret, bool add, int dotType)
 
 void FretDiagram::setMarker(int string, int marker)
 {
-    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+    if (string < 0 || string >= fretDiagram()->strings()) {
+        LOGW("PluginAPI::FretDiagram::setMarker: string %d is out of range (0..%d)", string, fretDiagram()->strings() - 1);
         return;
     }
-    IF_ASSERT_FAILED(marker >= int(mu::engraving::FretMarkerType::NONE)
-                     && marker <= int(mu::engraving::FretMarkerType::CROSS)) {
+    if (marker < int(mu::engraving::FretMarkerType::NONE)
+        || marker > int(mu::engraving::FretMarkerType::CROSS)) {
+        LOGW("PluginAPI::FretDiagram::setMarker: marker %d is out of range", marker);
         return;
     }
     if (ownership() == Ownership::SCORE) {
@@ -715,10 +720,12 @@ void FretDiagram::setMarker(int string, int marker)
 
 void FretDiagram::setBarre(int string, int fret, bool add)
 {
-    IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+    if (string < 0 || string >= fretDiagram()->strings()) {
+        LOGW("PluginAPI::FretDiagram::setBarre: string %d is out of range (0..%d)", string, fretDiagram()->strings() - 1);
         return;
     }
-    IF_ASSERT_FAILED(fret > 0) {
+    if (fret <= 0) {
+        LOGW("PluginAPI::FretDiagram::setBarre: fret %d must be > 0", fret);
         return;
     }
     if (ownership() == Ownership::SCORE) {

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -687,6 +687,8 @@ EngravingItem* mu::engraving::apiv1::wrap(mu::engraving::EngravingItem* e, Owner
     API_WRAP(DurationElement)
     API_WRAP(Beam)
     API_WRAP(Lyrics)
+    API_WRAP(Harmony)
+    API_WRAP(FretDiagram)
     API_WRAP(Segment)
     API_WRAP(Measure)
     API_WRAP(MeasureBase)

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -677,6 +677,13 @@ void FretDiagram::setDot(int string, int fret, bool add, int dotType)
     IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
         return;
     }
+    IF_ASSERT_FAILED(fret >= 0) {
+        return;
+    }
+    IF_ASSERT_FAILED(dotType >= int(mu::engraving::FretDotType::NORMAL)
+                     && dotType <= int(mu::engraving::FretDotType::TRIANGLE)) {
+        return;
+    }
     fretDiagram()->undoSetFretDot(string, fret, add,
                                   static_cast<mu::engraving::FretDotType>(dotType));
 }
@@ -686,6 +693,10 @@ void FretDiagram::setMarker(int string, int marker)
     IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
         return;
     }
+    IF_ASSERT_FAILED(marker >= int(mu::engraving::FretMarkerType::NONE)
+                     && marker <= int(mu::engraving::FretMarkerType::CROSS)) {
+        return;
+    }
     fretDiagram()->undoSetFretMarker(string,
                                      static_cast<mu::engraving::FretMarkerType>(marker));
 }
@@ -693,6 +704,9 @@ void FretDiagram::setMarker(int string, int marker)
 void FretDiagram::setBarre(int string, int fret, bool add)
 {
     IF_ASSERT_FAILED(string >= 0 && string < fretDiagram()->strings()) {
+        return;
+    }
+    IF_ASSERT_FAILED(fret > 0) {
         return;
     }
     fretDiagram()->undoSetFretBarre(string, fret, add);

--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -744,6 +744,55 @@ void FretDiagram::clear()
     }
 }
 
+QVariantList FretDiagram::dots() const
+{
+    QVariantList result;
+    for (const auto& [string, dotVec] : fretDiagram()->dots()) {
+        for (const mu::engraving::FretItem::Dot& d : dotVec) {
+            if (!d.exists()) {
+                continue;
+            }
+            QVariantMap entry;
+            entry["string"] = string;
+            entry["fret"] = d.fret;
+            entry["dotType"] = int(d.dtype);
+            result.append(entry);
+        }
+    }
+    return result;
+}
+
+QVariantList FretDiagram::markers() const
+{
+    QVariantList result;
+    for (const auto& [string, m] : fretDiagram()->markers()) {
+        if (!m.exists()) {
+            continue;
+        }
+        QVariantMap entry;
+        entry["string"] = string;
+        entry["markerType"] = int(m.mtype);
+        result.append(entry);
+    }
+    return result;
+}
+
+QVariantList FretDiagram::barres() const
+{
+    QVariantList result;
+    for (const auto& [fret, b] : fretDiagram()->barres()) {
+        if (!b.exists()) {
+            continue;
+        }
+        QVariantMap entry;
+        entry["fret"] = fret;
+        entry["startString"] = b.startString;
+        entry["endString"] = b.endString;
+        result.append(entry);
+    }
+    return result;
+}
+
 //---------------------------------------------------------
 //   wrap
 ///   \cond PLUGIN_API \private \endcond

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -31,6 +31,8 @@
 #include "engraving/dom/beam.h"
 #include "engraving/dom/bracketItem.h"
 #include "engraving/dom/chord.h"
+#include "engraving/dom/fret.h"
+#include "engraving/dom/harmony.h"
 #include "engraving/dom/hook.h"
 #include "engraving/dom/lyrics.h"
 #include "engraving/dom/measure.h"
@@ -63,6 +65,8 @@ Q_MOC_INCLUDE("engraving/api/v1/part.h")
 
 namespace mu::engraving::apiv1 {
 class Fraction;
+class FretDiagram;
+class Harmony;
 class IntervalWrapper;
 class EngravingItem;
 class Lyrics;
@@ -82,10 +86,10 @@ class Beam;
 extern EngravingItem* wrap(mu::engraving::EngravingItem* se, Ownership own = Ownership::SCORE);
 
 #define API_PROPERTY(name, pid) \
-    Q_PROPERTY(QVariant name READ get_##name WRITE set_##name RESET reset_##name) \
-    QVariant get_##name() const { return get(mu::engraving::Pid::pid); }  \
-    void set_##name(QVariant val) { set(mu::engraving::Pid::pid, val); }  \
-    void reset_##name() { reset(mu::engraving::Pid::pid); }
+        Q_PROPERTY(QVariant name READ get_##name WRITE set_##name RESET reset_##name) \
+        QVariant get_##name() const { return get(mu::engraving::Pid::pid); }  \
+        void set_##name(QVariant val) { set(mu::engraving::Pid::pid, val); }  \
+        void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 /**
  * API_PROPERTY flavor which allows to define the property type.
@@ -94,40 +98,40 @@ extern EngravingItem* wrap(mu::engraving::EngravingItem* se, Ownership own = Own
  * value to be exposed to QML in case of invalid property.
  */
 #define API_PROPERTY_T(type, name, pid) \
-    Q_PROPERTY(type name READ get_##name WRITE set_##name RESET reset_##name) \
-    type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
-    void set_##name(type val) { set(mu::engraving::Pid::pid, QVariant::fromValue(val)); }  \
-    void reset_##name() { reset(mu::engraving::Pid::pid); }
+        Q_PROPERTY(type name READ get_##name WRITE set_##name RESET reset_##name) \
+        type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
+        void set_##name(type val) { set(mu::engraving::Pid::pid, QVariant::fromValue(val)); }  \
+        void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_ENUM(Enum, name, pid) \
-    Q_PROPERTY(QJSValue name READ get_##name WRITE set_##name RESET reset_##name) \
-    QJSValue get_##name() const { \
-        int val = get(mu::engraving::Pid::pid).toInt(); \
-        if (apiversion() == 1) { \
-            return QJSValue(val); \
-        } else { \
-            static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
-            return QJSValue(QString(meta.valueToKey(val))); \
-        } \
-    }  \
-    void set_##name(QJSValue val) { \
-        if (apiversion() == 1) { \
-            set(mu::engraving::Pid::pid, QVariant(val.toInt())); \
-        } else { \
-            static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
-            std::string key = val.toString().toStdString(); \
-            set(mu::engraving::Pid::pid, meta.keyToValue(key.c_str())); \
-        } \
-    }  \
-    void reset_##name() { reset(mu::engraving::Pid::pid); }
+        Q_PROPERTY(QJSValue name READ get_##name WRITE set_##name RESET reset_##name) \
+        QJSValue get_##name() const { \
+            int val = get(mu::engraving::Pid::pid).toInt(); \
+            if (apiversion() == 1) { \
+                return QJSValue(val); \
+            } else { \
+                static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
+                return QJSValue(QString(meta.valueToKey(val))); \
+            } \
+        }  \
+        void set_##name(QJSValue val) { \
+            if (apiversion() == 1) { \
+                set(mu::engraving::Pid::pid, QVariant(val.toInt())); \
+            } else { \
+                static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
+                std::string key = val.toString().toStdString(); \
+                set(mu::engraving::Pid::pid, meta.keyToValue(key.c_str())); \
+            } \
+        }  \
+        void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_READ_ONLY(name, pid) \
-    Q_PROPERTY(QVariant name READ get_##name) \
-    QVariant get_##name() const { return get(mu::engraving::Pid::pid); }
+        Q_PROPERTY(QVariant name READ get_##name) \
+        QVariant get_##name() const { return get(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_READ_ONLY_T(type, name, pid) \
-    Q_PROPERTY(type name READ get_##name) \
-    type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
+        Q_PROPERTY(type name READ get_##name) \
+        type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
 
 //---------------------------------------------------------
 //   EngravingItem
@@ -2663,6 +2667,82 @@ public:
     bool isMelisma() const { return lyrics()->isMelisma(); }
     /** APIDOC @property {EngravingItem} - the lyrics line for this lyric, if it exists */
     apiv1::EngravingItem* separator() const { return wrap(lyrics()->separator()); }
+};
+
+//---------------------------------------------------------
+//   Harmony
+//---------------------------------------------------------
+
+/** APIDOC
+ * Class representing a chord symbol (Harmony).
+ * @class Harmony
+ * @memberof Engraving
+ * @hideconstructor
+ * @since 4.7
+*/
+class Harmony : public EngravingItem
+{
+    Q_OBJECT
+    /// Plain text representation of the chord symbol (no formatting).
+    Q_PROPERTY(QString plainText READ plainText)
+    /// Display text of the chord symbol (with formatting).
+    Q_PROPERTY(QString displayText READ displayText)
+    /// Internal harmony name used for chord matching against the diagram database.
+    Q_PROPERTY(QString harmonyName READ harmonyName)
+
+public:
+    /// \cond MS_INTERNAL
+    Harmony(mu::engraving::Harmony* h = nullptr, Ownership own = Ownership::PLUGIN)
+        : EngravingItem(h, own) {}
+
+    mu::engraving::Harmony* harmony() { return toHarmony(e); }
+    const mu::engraving::Harmony* harmony() const { return toHarmony(e); }
+
+    QString plainText() const { return harmony()->plainText(); }
+    QString displayText() const { return harmony()->displayText().toQString(); }
+    QString harmonyName() const { return harmony()->harmonyName().toQString(); }
+    /// \endcond
+};
+
+//---------------------------------------------------------
+//   FretDiagram
+//---------------------------------------------------------
+
+/** APIDOC
+ * Class representing a fretboard diagram. The chord symbol that this diagram is
+ * associated with (when present) is nested inside it and can be reached via the
+ * `harmony` property.
+ * @class FretDiagram
+ * @memberof Engraving
+ * @hideconstructor
+ * @since 4.7
+*/
+class FretDiagram : public EngravingItem
+{
+    Q_OBJECT
+    /// The chord symbol nested inside this fretboard diagram, or null if none.
+    Q_PROPERTY(apiv1::Harmony * harmony READ harmony)
+    /// Plain text of the nested chord symbol, or an empty string if none.
+    Q_PROPERTY(QString harmonyPlainText READ harmonyPlainText)
+    /// Display text of the nested chord symbol, or an empty string if none.
+    Q_PROPERTY(QString harmonyDisplayText READ harmonyDisplayText)
+
+public:
+    /// \cond MS_INTERNAL
+    FretDiagram(mu::engraving::FretDiagram* fd = nullptr, Ownership own = Ownership::PLUGIN)
+        : EngravingItem(fd, own) {}
+
+    mu::engraving::FretDiagram* fretDiagram() { return toFretDiagram(e); }
+    const mu::engraving::FretDiagram* fretDiagram() const { return toFretDiagram(e); }
+
+    apiv1::Harmony* harmony() const
+    {
+        return wrap<apiv1::Harmony>(fretDiagram()->harmony(), Ownership::SCORE);
+    }
+
+    QString harmonyPlainText() const { return fretDiagram()->harmonyPlainText().toQString(); }
+    QString harmonyDisplayText() const { return fretDiagram()->harmonyDisplayText().toQString(); }
+    /// \endcond
 };
 
 #undef API_PROPERTY

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -2743,6 +2743,48 @@ public:
     QString harmonyPlainText() const { return fretDiagram()->harmonyPlainText().toQString(); }
     QString harmonyDisplayText() const { return fretDiagram()->harmonyDisplayText().toQString(); }
     /// \endcond
+
+    /** APIDOC
+     * Place or remove a dot at the given fret on the given string. The change is
+     * undoable and propagates to all linked clones of the diagram.
+     * @method
+     * @param {Number} string  0-based string index (0 is the lowest pitched string).
+     * @param {Number} fret    fret number (1-based, relative to fretOffset).
+     *                         Pass 0 to clear the dots on that string.
+     * @param {Boolean} add    If true, append to existing dots instead of replacing.
+     * @param {Number} dotType One of PluginAPI::PluginAPI::FretDotType values.
+     * @since 4.7
+     */
+    Q_INVOKABLE void setDot(int string, int fret, bool add = false, int dotType = 0);
+
+    /** APIDOC
+     * Set the marker for a string (open circle / muted X / none). Undoable and
+     * propagates to all linked clones.
+     * @method
+     * @param {Number} string 0-based string index.
+     * @param {Number} marker One of PluginAPI::PluginAPI::FretMarkerType values.
+     * @since 4.7
+     */
+    Q_INVOKABLE void setMarker(int string, int marker);
+
+    /** APIDOC
+     * Add a barre at the given fret extending up to the given string. Undoable and
+     * propagates to all linked clones.
+     * @method
+     * @param {Number} string 0-based last string covered by the barre.
+     * @param {Number} fret   fret number (1-based, relative to fretOffset).
+     * @param {Boolean} add   If true, append to existing barres at that fret.
+     * @since 4.7
+     */
+    Q_INVOKABLE void setBarre(int string, int fret, bool add = false);
+
+    /** APIDOC
+     * Clear all dots, markers, and barres from this diagram. Undoable and
+     * propagates to all linked clones.
+     * @method
+     * @since 4.7
+     */
+    Q_INVOKABLE void clear();
 };
 
 #undef API_PROPERTY

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -86,10 +86,10 @@ class Beam;
 extern EngravingItem* wrap(mu::engraving::EngravingItem* se, Ownership own = Ownership::SCORE);
 
 #define API_PROPERTY(name, pid) \
-        Q_PROPERTY(QVariant name READ get_##name WRITE set_##name RESET reset_##name) \
-        QVariant get_##name() const { return get(mu::engraving::Pid::pid); }  \
-        void set_##name(QVariant val) { set(mu::engraving::Pid::pid, val); }  \
-        void reset_##name() { reset(mu::engraving::Pid::pid); }
+    Q_PROPERTY(QVariant name READ get_##name WRITE set_##name RESET reset_##name) \
+    QVariant get_##name() const { return get(mu::engraving::Pid::pid); }  \
+    void set_##name(QVariant val) { set(mu::engraving::Pid::pid, val); }  \
+    void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 /**
  * API_PROPERTY flavor which allows to define the property type.
@@ -98,40 +98,40 @@ extern EngravingItem* wrap(mu::engraving::EngravingItem* se, Ownership own = Own
  * value to be exposed to QML in case of invalid property.
  */
 #define API_PROPERTY_T(type, name, pid) \
-        Q_PROPERTY(type name READ get_##name WRITE set_##name RESET reset_##name) \
-        type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
-        void set_##name(type val) { set(mu::engraving::Pid::pid, QVariant::fromValue(val)); }  \
-        void reset_##name() { reset(mu::engraving::Pid::pid); }
+    Q_PROPERTY(type name READ get_##name WRITE set_##name RESET reset_##name) \
+    type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
+    void set_##name(type val) { set(mu::engraving::Pid::pid, QVariant::fromValue(val)); }  \
+    void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_ENUM(Enum, name, pid) \
-        Q_PROPERTY(QJSValue name READ get_##name WRITE set_##name RESET reset_##name) \
-        QJSValue get_##name() const { \
-            int val = get(mu::engraving::Pid::pid).toInt(); \
-            if (apiversion() == 1) { \
-                return QJSValue(val); \
-            } else { \
-                static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
-                return QJSValue(QString(meta.valueToKey(val))); \
-            } \
-        }  \
-        void set_##name(QJSValue val) { \
-            if (apiversion() == 1) { \
-                set(mu::engraving::Pid::pid, QVariant(val.toInt())); \
-            } else { \
-                static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
-                std::string key = val.toString().toStdString(); \
-                set(mu::engraving::Pid::pid, meta.keyToValue(key.c_str())); \
-            } \
-        }  \
-        void reset_##name() { reset(mu::engraving::Pid::pid); }
+    Q_PROPERTY(QJSValue name READ get_##name WRITE set_##name RESET reset_##name) \
+    QJSValue get_##name() const { \
+        int val = get(mu::engraving::Pid::pid).toInt(); \
+        if (apiversion() == 1) { \
+            return QJSValue(val); \
+        } else { \
+            static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
+            return QJSValue(QString(meta.valueToKey(val))); \
+        } \
+    }  \
+    void set_##name(QJSValue val) { \
+        if (apiversion() == 1) { \
+            set(mu::engraving::Pid::pid, QVariant(val.toInt())); \
+        } else { \
+            static const QMetaEnum meta = QMetaEnum::fromType<Enum>(); \
+            std::string key = val.toString().toStdString(); \
+            set(mu::engraving::Pid::pid, meta.keyToValue(key.c_str())); \
+        } \
+    }  \
+    void reset_##name() { reset(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_READ_ONLY(name, pid) \
-        Q_PROPERTY(QVariant name READ get_##name) \
-        QVariant get_##name() const { return get(mu::engraving::Pid::pid); }
+    Q_PROPERTY(QVariant name READ get_##name) \
+    QVariant get_##name() const { return get(mu::engraving::Pid::pid); }
 
 #define API_PROPERTY_READ_ONLY_T(type, name, pid) \
-        Q_PROPERTY(type name READ get_##name) \
-        type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
+    Q_PROPERTY(type name READ get_##name) \
+    type get_##name() const { return get(mu::engraving::Pid::pid).value<type>(); }  \
 
 //---------------------------------------------------------
 //   EngravingItem
@@ -2755,7 +2755,7 @@ public:
      * @param {Number} dotType One of PluginAPI::PluginAPI::FretDotType values.
      * @since 4.7
      */
-    Q_INVOKABLE void setDot(int string, int fret, bool add = false, int dotType = 0);
+    Q_INVOKABLE void setDot(int string, int fret, bool add = false, int dotType = int(mu::engraving::FretDotType::NORMAL));
 
     /** APIDOC
      * Set the marker for a string (open circle / muted X / none). Undoable and

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -2726,6 +2726,12 @@ class FretDiagram : public EngravingItem
     Q_PROPERTY(QString harmonyPlainText READ harmonyPlainText)
     /// Display text of the nested chord symbol, or an empty string if none.
     Q_PROPERTY(QString harmonyDisplayText READ harmonyDisplayText)
+    /// Number of strings in this diagram.
+    Q_PROPERTY(int strings READ strings)
+    /// Number of frets displayed in this diagram.
+    Q_PROPERTY(int frets READ frets)
+    /// Starting fret number (0 means no offset, nut is shown).
+    Q_PROPERTY(int fretOffset READ fretOffset)
 
 public:
     /// \cond MS_INTERNAL
@@ -2742,7 +2748,41 @@ public:
 
     QString harmonyPlainText() const { return fretDiagram()->harmonyPlainText().toQString(); }
     QString harmonyDisplayText() const { return fretDiagram()->harmonyDisplayText().toQString(); }
+
+    int strings() const { return fretDiagram()->strings(); }
+    int frets() const { return fretDiagram()->frets(); }
+    int fretOffset() const { return fretDiagram()->fretOffset(); }
     /// \endcond
+
+    /** APIDOC
+     * Return all dots currently placed on this diagram as a list of objects,
+     * each with `string` (0-based), `fret` (1-based), and `dotType`
+     * (one of PluginAPI::PluginAPI::FretDotType values).
+     * @method
+     * @returns {Array.<{string: Number, fret: Number, dotType: Number}>}
+     * @since 4.7
+     */
+    Q_INVOKABLE QVariantList dots() const;
+
+    /** APIDOC
+     * Return all string markers on this diagram as a list of objects,
+     * each with `string` (0-based) and `markerType`
+     * (one of PluginAPI::PluginAPI::FretMarkerType values).
+     * Only strings with an active marker (open or muted) are included.
+     * @method
+     * @returns {Array.<{string: Number, markerType: Number}>}
+     * @since 4.7
+     */
+    Q_INVOKABLE QVariantList markers() const;
+
+    /** APIDOC
+     * Return all barres on this diagram as a list of objects,
+     * each with `fret` (1-based), `startString` and `endString` (0-based).
+     * @method
+     * @returns {Array.<{fret: Number, startString: Number, endString: Number}>}
+     * @since 4.7
+     */
+    Q_INVOKABLE QVariantList barres() const;
 
     /** APIDOC
      * Place or remove a dot at the given fret on the given string. The change is

--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -185,6 +185,8 @@ void PluginAPI::registerQmlTypes()
     qmlRegisterAnonymousType<Excerpt>("MuseScore", 3);
     qmlRegisterAnonymousType<Selection>("MuseScore", 3);
     qmlRegisterAnonymousType<Tie>("MuseScore", 3);
+    qmlRegisterAnonymousType<Harmony>("MuseScore", 3);
+    qmlRegisterAnonymousType<FretDiagram>("MuseScore", 3);
     qmlRegisterAnonymousType<Drumset>("MuseScore", 3);
     qmlRegisterAnonymousType<MeasureBase>("MuseScore", 3);
     qmlRegisterAnonymousType<System>("MuseScore", 3);


### PR DESCRIPTION
Resolves: #32993 and #32798  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

- Expose FretDiagram nested Harmony to Plugin API  so plugins can read the chord symbol associated with a fretboard diagram.
- Expose FretDiagram setDot/setMarker/setBarre/clear to Plugin API so plugins can populate fretboard diagrams and pass typed values.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
