### PR TITLE
Allow more item types and list selections to be nudged

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -560,11 +560,11 @@ void NotationBraille::setKeys(const QString& sequence)
             if (brailleInput()->addedOctave() != -1) {
                 if (brailleInput()->addedOctave() < brailleInput()->octave()) {
                     for (int i = brailleInput()->addedOctave(); i < brailleInput()->octave(); i++) {
-                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE);
+                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE, selection()->elements());
                     }
                 } else if (brailleInput()->addedOctave() > brailleInput()->octave()) {
                     for (int i = brailleInput()->octave(); i < brailleInput()->addedOctave(); i++) {
-                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE);
+                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE, selection()->elements());
                     }
                 }
                 brailleInput()->setOctave(brailleInput()->addedOctave(), true);
@@ -623,11 +623,11 @@ void NotationBraille::setKeys(const QString& sequence)
             if (brailleInput()->addedOctave() != -1) {
                 if (brailleInput()->addedOctave() < brailleInput()->octave()) {
                     for (int i = brailleInput()->addedOctave(); i < brailleInput()->octave(); i++) {
-                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE);
+                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE, selection()->elements());
                     }
                 } else if (brailleInput()->addedOctave() > brailleInput()->octave()) {
                     for (int i = brailleInput()->octave(); i < brailleInput()->addedOctave(); i++) {
-                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE);
+                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE, selection()->elements());
                     }
                 }
                 brailleInput()->setOctave(brailleInput()->addedOctave());

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -239,6 +239,7 @@ void HairpinSegment::dragGrip(EditData& ed)
         }
         hairpin()->setHairpinHeight(Spatium(newHeight));
         triggerLayout();
+        return;
     }
     TextLineBaseSegment::dragGrip(ed);
 }

--- a/src/engraving/dom/image.cpp
+++ b/src/engraving/dom/image.cpp
@@ -346,7 +346,8 @@ std::vector<PointF> Image::gripsPositions(const EditData&) const
     RectF r(pageBoundingRect());
     return {
         PointF(r.x() + r.width(), r.y() + r.height() * .5),
-        PointF(r.x() + r.width() * .5, r.y() + r.height())
+        PointF(r.x() + r.width() * .5, r.y() + r.height()),
+        PointF(r.x() + r.width() * .5, r.y()),
     };
 }
 

--- a/src/engraving/dom/image.h
+++ b/src/engraving/dom/image.h
@@ -96,9 +96,9 @@ public:
     const std::shared_ptr<muse::draw::Pixmap>& rasterImage() const { return m_rasterDoc; }
 
     bool needStartEditingAfterSelecting() const override { return true; }
-    int gripsCount() const override { return 2; }
-    Grip initialEditModeGrip() const override { return Grip(1); }
-    Grip defaultGrip() const override { return Grip(1); }
+    int gripsCount() const override { return 3; }
+    Grip initialEditModeGrip() const override { return Grip(2); }
+    Grip defaultGrip() const override { return Grip(2); }
     std::vector<PointF> gripsPositions(const EditData&) const override;
 
     SizeF pixel2size(const SizeF& s) const;

--- a/src/engraving/dom/image.h
+++ b/src/engraving/dom/image.h
@@ -97,8 +97,8 @@ public:
 
     bool needStartEditingAfterSelecting() const override { return true; }
     int gripsCount() const override { return 3; }
-    Grip initialEditModeGrip() const override { return Grip(2); }
-    Grip defaultGrip() const override { return Grip(2); }
+    Grip initialEditModeGrip() const override { return Grip::MIDDLE; }
+    Grip defaultGrip() const override { return Grip::MIDDLE; }
     std::vector<PointF> gripsPositions(const EditData&) const override;
 
     SizeF pixel2size(const SizeF& s) const;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -132,7 +132,7 @@ public:
     virtual bool moveSelectionAvailable(MoveSelectionType type) const = 0;
     virtual void moveSelection(MoveDirection d, MoveSelectionType type) = 0;
 
-    virtual void moveLyrics(MoveDirection d) = 0;
+    virtual void moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& elements) = 0;
     virtual void expandSelection(ExpandSelectionMode mode) = 0;
     virtual void addToSelection(MoveDirection d, MoveSelectionType type) = 0;
     virtual void selectTopStaff() = 0;
@@ -140,9 +140,9 @@ public:
     virtual void moveSegmentSelection(MoveDirection d) = 0;
 
     // Move/nudge elements
-    virtual void movePitch(MoveDirection d, PitchMode mode) = 0;
-    virtual void nudge(MoveDirection d, bool quickly) = 0;
-    virtual void nudgeAnchors(MoveDirection d) = 0;
+    virtual void movePitch(MoveDirection d, PitchMode mode, const std::vector<EngravingItem*>& elements) = 0;
+    virtual void nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& elements) = 0;
+    virtual void nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& elements) = 0;
     virtual void moveChordRestToStaff(MoveDirection d) = 0;
     virtual void swapChordRest(MoveDirection d) = 0;
     virtual void toggleSnapToPrevious() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -142,7 +142,7 @@ public:
     // Move/nudge elements
     virtual void movePitch(MoveDirection d, PitchMode mode, const std::vector<EngravingItem*>& elements) = 0;
     virtual void nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& elements) = 0;
-    virtual void nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& elements) = 0;
+    virtual void nudgeAnchors(MoveDirection d) = 0;
     virtual void moveChordRestToStaff(MoveDirection d) = 0;
     virtual void swapChordRest(MoveDirection d) = 0;
     virtual void toggleSnapToPrevious() = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4249,7 +4249,7 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode, const std::
     startEdit(TranslatableString("undoableAction", "Change pitch"));
     for (EngravingItem* selected : selectedElements) {
         if (selected && selected->isRest()) {
-            if (noteInput()->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
+            if (selected->staff()->isTabStaff(selected->tick())) {
                 continue;
             }
             score()->cmdMoveRest(toRest(selected), toDirection(d));
@@ -4261,6 +4261,9 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode, const std::
 
 void NotationInteraction::moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& selectedElements)
 {
+    IF_ASSERT_FAILED(MoveDirection::Up == d || MoveDirection::Down == d) {
+        return;
+    }
     if (selectedElements.empty()) {
         return;
     }
@@ -4279,6 +4282,9 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
     if (selectedElements.empty()) {
         return;
     }
+    IF_ASSERT_FAILED(d != MoveDirection::Undefined) {
+        return;
+    }
     startEdit(TranslatableString("undoableAction", "Nudge element"));
     for (EngravingItem* el : selectedElements) {
         if (!el) {
@@ -4288,11 +4294,6 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
         step = step * el->spatium();
 
         switch (d) {
-        case MoveDirection::Undefined: {
-            IF_ASSERT_FAILED(d != MoveDirection::Undefined) {
-                return;
-            }
-        } break;
         case MoveDirection::Left:
             el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() - PointF(step, 0.0), mu::engraving::PropertyFlags::UNSTYLED);
             break;
@@ -4305,6 +4306,8 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
         case MoveDirection::Down:
             el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() + PointF(0.0, step), mu::engraving::PropertyFlags::UNSTYLED);
             break;
+        case MoveDirection::Undefined:
+            UNREACHABLE;
         }
     }
     apply();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4272,9 +4272,6 @@ void NotationInteraction::moveLyrics(MoveDirection d)
 void NotationInteraction::nudge(MoveDirection d, bool quickly)
 {
     EngravingItem* el = score()->selection().element();
-    IF_ASSERT_FAILED(el && (el->isTextBase() || el->isArticulationFamily())) {
-        return;
-    }
 
     startEdit(TranslatableString("undoableAction", "Nudge element"));
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4246,7 +4246,6 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode, const std::
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Change pitch"));
     for (EngravingItem* selected : selectedElements) {
         if (selected && selected->isRest()) {
             if (selected->staff()->isTabStaff(selected->tick())) {
@@ -4256,7 +4255,6 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode, const std::
         }
     }
     EditNote::upDown(score(), MoveDirection::Up == d, mode);
-    apply();
 }
 
 void NotationInteraction::moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& selectedElements)
@@ -4268,13 +4266,11 @@ void NotationInteraction::moveLyrics(MoveDirection d, const std::vector<Engravin
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Move lyrics"));
     for (EngravingItem* el : selectedElements) {
         if (el && el->isLyrics()) {
             score()->cmdMoveLyrics(toLyrics(el), toDirection(d));
         }
     }
-    apply();
 }
 
 void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& selectedElements)
@@ -4285,7 +4281,6 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
     IF_ASSERT_FAILED(d != MoveDirection::Undefined) {
         return;
     }
-    startEdit(TranslatableString("undoableAction", "Nudge element"));
     for (EngravingItem* el : selectedElements) {
         if (!el) {
             continue;
@@ -4310,7 +4305,6 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
             UNREACHABLE;
         }
     }
-    apply();
     notifyAboutDragChanged();
 }
 
@@ -4320,7 +4314,6 @@ void NotationInteraction::nudgeAnchors(MoveDirection d)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Nudge"));
     double vRaster = getVRaster();
     double hRaster = getHRaster();
 
@@ -4357,8 +4350,6 @@ void NotationInteraction::nudgeAnchors(MoveDirection d)
         m_editData.element->drag(m_editData);
         m_editData.element->endDrag(m_editData);
     }
-
-    apply();
 }
 
 bool NotationInteraction::isTextSelected() const

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4237,75 +4237,83 @@ inline mu::engraving::DirectionV toDirection(MoveDirection d)
     return d == MoveDirection::Up ? mu::engraving::DirectionV::UP : mu::engraving::DirectionV::DOWN;
 }
 
-void NotationInteraction::movePitch(MoveDirection d, PitchMode mode)
+void NotationInteraction::movePitch(MoveDirection d, PitchMode mode, const std::vector<EngravingItem*>& selectedElements)
 {
     IF_ASSERT_FAILED(MoveDirection::Up == d || MoveDirection::Down == d) {
         return;
     }
-    EngravingItem* selected = score()->selection().element();
-    if (selected && selected->isRest()) {
-        if (noteInput()->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
-            // The rest won't be visible - don't try to move it...
-            return;
-        }
-        startEdit(TranslatableString("undoableAction", "Change vertical position"));
-        score()->cmdMoveRest(toRest(selected), toDirection(d));
-    } else {
-        startEdit(TranslatableString("undoableAction", "Change pitch"));
-        EditNote::upDown(score(), MoveDirection::Up == d, mode);
-    }
-
-    apply();
-}
-
-void NotationInteraction::moveLyrics(MoveDirection d)
-{
-    EngravingItem* el = score()->selection().element();
-    IF_ASSERT_FAILED(el && el->isLyrics()) {
+    if (selectedElements.empty()) {
         return;
     }
-    startEdit(TranslatableString("undoableAction", "Move lyrics"));
-    score()->cmdMoveLyrics(toLyrics(el), toDirection(d));
+
+    startEdit(TranslatableString("undoableAction", "Change pitch"));
+    for (EngravingItem* selected : selectedElements) {
+        if (selected && selected->isRest()) {
+            if (noteInput()->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
+                continue;
+            }
+            score()->cmdMoveRest(toRest(selected), toDirection(d));
+        }
+    }
+    EditNote::upDown(score(), MoveDirection::Up == d, mode);
     apply();
 }
 
-void NotationInteraction::nudge(MoveDirection d, bool quickly)
+void NotationInteraction::moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& selectedElements)
 {
-    EngravingItem* el = score()->selection().element();
-
-    startEdit(TranslatableString("undoableAction", "Nudge element"));
-
-    qreal step = quickly ? mu::engraving::MScore::nudgeStep10 : mu::engraving::MScore::nudgeStep;
-    step = step * el->spatium();
-
-    switch (d) {
-    case MoveDirection::Undefined: {
-        IF_ASSERT_FAILED(d != MoveDirection::Undefined) {
-            return;
-        }
-    } break;
-    case MoveDirection::Left:
-        el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() - PointF(step, 0.0), mu::engraving::PropertyFlags::UNSTYLED);
-        break;
-    case MoveDirection::Right:
-        el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() + PointF(step, 0.0), mu::engraving::PropertyFlags::UNSTYLED);
-        break;
-    case MoveDirection::Up:
-        el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() - PointF(0.0, step), mu::engraving::PropertyFlags::UNSTYLED);
-        break;
-    case MoveDirection::Down:
-        el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() + PointF(0.0, step), mu::engraving::PropertyFlags::UNSTYLED);
-        break;
+    if (selectedElements.empty()) {
+        return;
     }
 
+    startEdit(TranslatableString("undoableAction", "Move lyrics"));
+    for (EngravingItem* el : selectedElements) {
+        if (el && el->isLyrics()) {
+            score()->cmdMoveLyrics(toLyrics(el), toDirection(d));
+        }
+    }
     apply();
+}
 
+void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& selectedElements)
+{
+    if (selectedElements.empty()) {
+        return;
+    }
+    startEdit(TranslatableString("undoableAction", "Nudge element"));
+    for (EngravingItem* el : selectedElements) {
+        if (!el) {
+            continue;
+        }
+        double step = quickly ? mu::engraving::MScore::nudgeStep10 : mu::engraving::MScore::nudgeStep;
+        step = step * el->spatium();
+
+        switch (d) {
+        case MoveDirection::Undefined: {
+            IF_ASSERT_FAILED(d != MoveDirection::Undefined) {
+                return;
+            }
+        } break;
+        case MoveDirection::Left:
+            el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() - PointF(step, 0.0), mu::engraving::PropertyFlags::UNSTYLED);
+            break;
+        case MoveDirection::Right:
+            el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() + PointF(step, 0.0), mu::engraving::PropertyFlags::UNSTYLED);
+            break;
+        case MoveDirection::Up:
+            el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() - PointF(0.0, step), mu::engraving::PropertyFlags::UNSTYLED);
+            break;
+        case MoveDirection::Down:
+            el->undoChangeProperty(mu::engraving::Pid::OFFSET, el->offset() + PointF(0.0, step), mu::engraving::PropertyFlags::UNSTYLED);
+            break;
+        }
+    }
+    apply();
     notifyAboutDragChanged();
 }
 
-void NotationInteraction::nudgeAnchors(MoveDirection d)
+void NotationInteraction::nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& selectedElements)
 {
-    IF_ASSERT_FAILED(m_editData.element) {
+    if (selectedElements.empty() || !m_editData.element) {
         return;
     }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4311,9 +4311,9 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly, const std::vector
     notifyAboutDragChanged();
 }
 
-void NotationInteraction::nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& selectedElements)
+void NotationInteraction::nudgeAnchors(MoveDirection d)
 {
-    if (selectedElements.empty() || !m_editData.element) {
+    IF_ASSERT_FAILED(m_editData.element) {
         return;
     }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -156,11 +156,11 @@ public:
     void selectEmptyTrailingMeasure() override;
 
     // Move
-    void movePitch(MoveDirection d, PitchMode mode) override;
-    void nudge(MoveDirection d, bool quickly) override;
-    void nudgeAnchors(MoveDirection) override;
+    void movePitch(MoveDirection d, PitchMode mode, const std::vector<EngravingItem*>& elements) override;
+    void nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& elements) override;
+    void nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& elements) override;
     void moveChordRestToStaff(MoveDirection d) override;
-    void moveLyrics(MoveDirection d) override;
+    void moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& elements) override;
     void swapChordRest(MoveDirection d) override;
     void toggleSnapToPrevious() override;
     void toggleSnapToNext() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -158,7 +158,7 @@ public:
     // Move
     void movePitch(MoveDirection d, PitchMode mode, const std::vector<EngravingItem*>& elements) override;
     void nudge(MoveDirection d, bool quickly, const std::vector<EngravingItem*>& elements) override;
-    void nudgeAnchors(MoveDirection d, const std::vector<EngravingItem*>& elements) override;
+    void nudgeAnchors(MoveDirection d) override;
     void moveChordRestToStaff(MoveDirection d) override;
     void moveLyrics(MoveDirection d, const std::vector<EngravingItem*>& elements) override;
     void swapChordRest(MoveDirection d) override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -96,7 +96,7 @@ public:
     MOCK_METHOD(bool, moveSelectionAvailable, (MoveSelectionType), (const, override));
     MOCK_METHOD(void, moveSelection, (MoveDirection, MoveSelectionType), (override));
 
-    MOCK_METHOD(void, moveLyrics, (MoveDirection), (override));
+    MOCK_METHOD(void, moveLyrics, (MoveDirection, const std::vector<EngravingItem*>&), (override));
     MOCK_METHOD(void, expandSelection, (ExpandSelectionMode), (override));
     MOCK_METHOD(void, addToSelection, (MoveDirection, MoveSelectionType), (override));
     MOCK_METHOD(void, selectTopStaff, (), (override));
@@ -105,9 +105,9 @@ public:
 
     MOCK_METHOD(EngravingItem*, contextItem, (), (const, override));
 
-    MOCK_METHOD(void, movePitch, (MoveDirection, PitchMode), (override));
-    MOCK_METHOD(void, nudge, (MoveDirection, bool), (override));
-    MOCK_METHOD(void, nudgeAnchors, (MoveDirection), (override));
+    MOCK_METHOD(void, movePitch, (MoveDirection, PitchMode, const std::vector<EngravingItem*>&), (override));
+    MOCK_METHOD(void, nudge, (MoveDirection, bool, const std::vector<EngravingItem*>&), (override));
+    MOCK_METHOD(void, nudgeAnchors, (MoveDirection, const std::vector<EngravingItem*>&), (override));
     MOCK_METHOD(void, moveChordRestToStaff, (MoveDirection), (override));
     MOCK_METHOD(void, swapChordRest, (MoveDirection), (override));
     MOCK_METHOD(void, toggleSnapToPrevious, (), (override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -107,7 +107,7 @@ public:
 
     MOCK_METHOD(void, movePitch, (MoveDirection, PitchMode, const std::vector<EngravingItem*>&), (override));
     MOCK_METHOD(void, nudge, (MoveDirection, bool, const std::vector<EngravingItem*>&), (override));
-    MOCK_METHOD(void, nudgeAnchors, (MoveDirection, const std::vector<EngravingItem*>&), (override));
+    MOCK_METHOD(void, nudgeAnchors, (MoveDirection), (override));
     MOCK_METHOD(void, moveChordRestToStaff, (MoveDirection), (override));
     MOCK_METHOD(void, swapChordRest, (MoveDirection), (override));
     MOCK_METHOD(void, toggleSnapToPrevious, (), (override));

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1117,7 +1117,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         return;
     }
 
-    const EngravingItem* selectedElement = interaction->selection()->element();
+    const std::vector<EngravingItem*>& selectedElements = interaction->selection()->elements();
     INotationNoteInputPtr noteInput = interaction->noteInput();
     bool playChord = false;
 
@@ -1134,28 +1134,57 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         return isText || isArticulationFamily || isSymbol || isTupletText || isFermataOrBreath;
     };
 
+    // Categorize selected elements
+    std::vector<EngravingItem*> lyrics;
+    std::vector<EngravingItem*> nudgeable;
+    std::vector<EngravingItem*> gripEditable;
+    std::vector<EngravingItem*> notes;
+
+    for (EngravingItem* el : selectedElements) {
+        if (el->isLyrics()) {
+            lyrics.push_back(el);
+        }
+        if (shouldNudge(el)) {
+            nudgeable.push_back(el);
+        }
+        if (el->hasGrips() && interaction->isGripEditStarted()) {
+            gripEditable.push_back(el);
+        }
+        if (el->isNote() || el->isRest()) {
+            notes.push_back(el);
+        }
+    }
+
     switch (direction) {
     case MoveDirection::Up:
     case MoveDirection::Down:
-        if (!quickly && selectedElement && selectedElement->isLyrics()) {
-            interaction->moveLyrics(direction);
-        } else if (shouldNudge(selectedElement)) {
-            interaction->nudge(direction, quickly);
-        } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
-            interaction->nudgeAnchors(direction);
-        } else if (noteInput->isNoteInputMode() && noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)) {
+        if (noteInput->isNoteInputMode() && noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)) {
             moveInputNotes(direction == MoveDirection::Up, quickly ? PitchMode::OCTAVE : PitchMode::DIATONIC);
             return;
         } else if (noteInput->isNoteInputMode() && noteInput->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
             if (quickly) {
-                interaction->movePitch(direction, PitchMode::OCTAVE);
+                interaction->movePitch(direction, PitchMode::OCTAVE, notes);
             }
             interaction->moveSelection(direction, MoveSelectionType::String);
             return;
-        } else if (interaction->selection()->isNone() && !state.beyondScore()) {
+        }
+
+        if (!lyrics.empty() && !quickly) {
+            interaction->moveLyrics(direction, lyrics);
+        }
+        if (!nudgeable.empty()) {
+            interaction->nudge(direction, quickly, nudgeable);
+        }
+        if (!gripEditable.empty()) {
+            interaction->nudgeAnchors(direction, gripEditable);
+        }
+        if (!notes.empty()) {
+            interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC, notes);
+            playChord = true;
+        }
+        if (lyrics.empty() && nudgeable.empty() && gripEditable.empty() && notes.empty() && interaction->selection()->isNone()
+            && !state.beyondScore()) {
             interaction->selectFirstElement(false);
-        } else {
-            interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC);
         }
         break;
     case MoveDirection::Right:
@@ -1198,11 +1227,13 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             return;
         }
 
-        if (shouldNudge(selectedElement)) {
-            interaction->nudge(direction, quickly);
-        } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
-            interaction->nudgeAnchors(direction);
-        } else {
+        if (!nudgeable.empty()) {
+            interaction->nudge(direction, quickly, nudgeable);
+        }
+        if (!gripEditable.empty()) {
+            interaction->nudgeAnchors(direction, gripEditable);
+        }
+        if (nudgeable.empty() && gripEditable.empty()) {
             if (interaction->selection()->isNone() && !state.beyondScore()) {
                 interaction->selectFirstElement(false);
             }
@@ -1246,7 +1277,7 @@ void NotationActionController::movePitchDiatonic(MoveDirection direction, bool)
         return;
     }
 
-    interaction->movePitch(direction, PitchMode::DIATONIC);
+    interaction->movePitch(direction, PitchMode::DIATONIC, interaction->selection()->elements());
     seekAndPlaySelectedElement(true);
 }
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1134,17 +1134,16 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         return isText || isArticulationFamily || isSymbol || isTupletText || isFermataOrBreath;
     };
 
-    // Categorize selected elements
     std::vector<EngravingItem*> lyrics;
     std::vector<EngravingItem*> nudgeable;
-    std::vector<EngravingItem*> gripEditable;
+    bool gripEditable = false;  // TODO: Refactor grip editing to allow multiple selection and nudging (without rebasing anchors)
     std::vector<EngravingItem*> notes;
 
     for (EngravingItem* el : selectedElements) {
         if (el->isLyrics()) {
             lyrics.push_back(el);
         } else if (el->hasGrips() && interaction->isGripEditStarted()) {
-            gripEditable.push_back(el);
+            gripEditable = true;
         } else if (shouldNudge(el) || el->hasGrips()) {
             nudgeable.push_back(el);
         } else if (el->isNote() || el->isRest()) {
@@ -1172,14 +1171,14 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         if (!nudgeable.empty()) {
             interaction->nudge(direction, quickly, nudgeable);
         }
-        if (!gripEditable.empty()) {
-            interaction->nudgeAnchors(direction, gripEditable);
+        if (gripEditable) {
+            interaction->nudgeAnchors(direction);
         }
         if (!notes.empty()) {
             interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC, notes);
             playChord = true;
         }
-        if (lyrics.empty() && nudgeable.empty() && gripEditable.empty() && notes.empty() && interaction->selection()->isNone()
+        if (lyrics.empty() && nudgeable.empty() && !gripEditable && notes.empty() && interaction->selection()->isNone()
             && !state.beyondScore()) {
             interaction->selectFirstElement(false);
         }
@@ -1227,10 +1226,10 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         if (!nudgeable.empty()) {
             interaction->nudge(direction, quickly, nudgeable);
         }
-        if (!gripEditable.empty()) {
-            interaction->nudgeAnchors(direction, gripEditable);
+        if (gripEditable) {
+            interaction->nudgeAnchors(direction);
         }
-        if (nudgeable.empty() && gripEditable.empty()) {
+        if (nudgeable.empty() && !gripEditable) {
             if (interaction->selection()->isNone() && !state.beyondScore()) {
                 interaction->selectFirstElement(false);
             }

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1155,18 +1155,24 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
 
     switch (direction) {
     case MoveDirection::Up:
-    case MoveDirection::Down:
+    case MoveDirection::Down: {
         if (noteInput->isNoteInputMode() && noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)) {
             moveInputNotes(direction == MoveDirection::Up, quickly ? PitchMode::OCTAVE : PitchMode::DIATONIC);
             return;
         } else if (noteInput->isNoteInputMode() && noteInput->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
             if (quickly) {
+                currentNotationUndoStack()->prepareChanges(TranslatableString("undoableAction", "Change pitch"));
                 interaction->movePitch(direction, PitchMode::OCTAVE, notes);
+                currentNotationUndoStack()->commitChanges();
             }
             interaction->moveSelection(direction, MoveSelectionType::String);
             return;
         }
 
+        bool doUndoCommand = !lyrics.empty() || !nudgeable.empty() || gripEditable || !notes.empty();
+        if (doUndoCommand) {
+            currentNotationUndoStack()->prepareChanges(TranslatableString("undoableAction", "Move items"));
+        }
         if (!lyrics.empty()) {
             interaction->moveLyrics(direction, lyrics);
         }
@@ -1180,13 +1186,17 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC, notes);
             playChord = true;
         }
+        if (doUndoCommand) {
+            currentNotationUndoStack()->commitChanges();
+        }
         if (lyrics.empty() && nudgeable.empty() && !gripEditable && notes.empty() && interaction->selection()->isNone()
             && !state.beyondScore()) {
             interaction->selectFirstElement(false);
         }
         break;
+    }
     case MoveDirection::Right:
-    case MoveDirection::Left:
+    case MoveDirection::Left: {
         if (playbackController()->isPlaying()) {
             MeasureBeat beat = playbackController()->currentBeat();
             int targetBeatIdx = static_cast<int>(beat.beat);
@@ -1225,11 +1235,18 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             return;
         }
 
+        bool doUndoCommand = !nudgeable.empty() || gripEditable;
+        if (doUndoCommand) {
+            currentNotationUndoStack()->prepareChanges(TranslatableString("undoableAction", "Move items"));
+        }
         if (!nudgeable.empty()) {
             interaction->nudge(direction, quickly, nudgeable);
         }
         if (gripEditable) {
             interaction->nudgeAnchors(direction);
+        }
+        if (doUndoCommand) {
+            currentNotationUndoStack()->commitChanges();
         }
         if (nudgeable.empty() && !gripEditable) {
             if (interaction->selection()->isNone() && !state.beyondScore()) {
@@ -1239,6 +1256,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             playChord = true;
         }
         break;
+    }
     case MoveDirection::Undefined:
         break;
     }

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1121,12 +1121,25 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
     INotationNoteInputPtr noteInput = interaction->noteInput();
     bool playChord = false;
 
+    auto shouldNudge = [](const EngravingItem* selectedElement) -> bool {
+        if (!selectedElement) {
+            return false;
+        }
+        bool isText = selectedElement->isTextBase();
+        bool isArticulationFamily = selectedElement->isArticulationFamily();
+        bool isSymbol = selectedElement->isSymbol();
+        bool isTupletText = selectedElement->isTuplet() && !toTuplet(selectedElement)->hasBracket();
+        bool isFermataOrBreath = selectedElement->isFermata() || selectedElement->isBreath();
+
+        return isText || isArticulationFamily || isSymbol || isTupletText || isFermataOrBreath;
+    };
+
     switch (direction) {
     case MoveDirection::Up:
     case MoveDirection::Down:
         if (!quickly && selectedElement && selectedElement->isLyrics()) {
             interaction->moveLyrics(direction);
-        } else if (selectedElement && (selectedElement->isTextBase() || selectedElement->isArticulationFamily())) {
+        } else if (shouldNudge(selectedElement)) {
             interaction->nudge(direction, quickly);
         } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
             interaction->nudgeAnchors(direction);
@@ -1185,7 +1198,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             return;
         }
 
-        if (selectedElement && selectedElement->isTextBase()) {
+        if (shouldNudge(selectedElement)) {
             interaction->nudge(direction, quickly);
         } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
             interaction->nudgeAnchors(direction);

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1130,8 +1130,10 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         bool isSymbol = selectedElement->isSymbol();
         bool isTupletText = selectedElement->isTuplet() && !toTuplet(selectedElement)->hasBracket();
         bool isFermataOrBreath = selectedElement->isFermata() || selectedElement->isBreath();
+        bool hasGrips = selectedElement->hasGrips();
+        bool isLyrics = selectedElement->isLyrics();
 
-        return isText || isArticulationFamily || isSymbol || isTupletText || isFermataOrBreath;
+        return isText || isArticulationFamily || isSymbol || isTupletText || isFermataOrBreath || hasGrips || isLyrics;
     };
 
     std::vector<EngravingItem*> lyrics;
@@ -1140,11 +1142,11 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
     std::vector<EngravingItem*> notes;
 
     for (EngravingItem* el : selectedElements) {
-        if (el->isLyrics()) {
+        if (el->isLyrics() && !quickly && (direction == MoveDirection::Up || direction == MoveDirection::Down)) {
             lyrics.push_back(el);
         } else if (el->hasGrips() && interaction->isGripEditStarted()) {
             gripEditable = true;
-        } else if (shouldNudge(el) || el->hasGrips()) {
+        } else if (shouldNudge(el)) {
             nudgeable.push_back(el);
         } else if (el->isNote() || el->isRest()) {
             notes.push_back(el);
@@ -1165,7 +1167,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             return;
         }
 
-        if (!lyrics.empty() && !quickly) {
+        if (!lyrics.empty()) {
             interaction->moveLyrics(direction, lyrics);
         }
         if (!nudgeable.empty()) {

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1143,14 +1143,11 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
     for (EngravingItem* el : selectedElements) {
         if (el->isLyrics()) {
             lyrics.push_back(el);
-        }
-        if (shouldNudge(el)) {
-            nudgeable.push_back(el);
-        }
-        if (el->hasGrips() && interaction->isGripEditStarted()) {
+        } else if (el->hasGrips() && interaction->isGripEditStarted()) {
             gripEditable.push_back(el);
-        }
-        if (el->isNote() || el->isRest()) {
+        } else if (shouldNudge(el) || el->hasGrips()) {
+            nudgeable.push_back(el);
+        } else if (el->isNote() || el->isRest()) {
             notes.push_back(el);
         }
     }

--- a/src/notationscene/qml/MuseScore/NotationScene/editpercussionshortcutmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/editpercussionshortcutmodel.cpp
@@ -23,6 +23,8 @@
 #include "editpercussionshortcutmodel.h"
 #include "shortcuts/shortcutstypes.h"
 
+#include "translation.h"
+
 using namespace muse;
 using namespace mu::notation;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30678
Resolves: https://github.com/musescore/MuseScore/issues/34018

Items which can now be nudged with the arrow keys:
- Fermatas & breaths
- Images
- Symbols
- Tuplet numbers (when bracket is hidden)