### PR TITLE
Avoid redundant reloadCurrentPage calls during workspace change

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -714,22 +714,31 @@ void DockWindow::reloadCurrentPage()
         return;
     }
 
-    TRACEFUNC;
-
-    clearRegistry(m_ctx);
-
-    for (DockBase* dock : m_currentPage->allDocks()) {
-        dock->deinit();
+    if (m_reloadCurrentPageScheduled) {
+        return;
     }
 
-    QString currentPageUriBackup = currentPageUri();
+    m_reloadCurrentPageScheduled = true;
+    async::Async::call(this, [this]() {
+        m_reloadCurrentPageScheduled = false;
 
-    /// NOTE: for reset geometry
-    m_currentPage = nullptr;
+        TRACEFUNC;
 
-    if (doLoadPage(currentPageUriBackup)) {
-        notifyAboutDocksOpenStatus();
-    }
+        clearRegistry(m_ctx);
+
+        for (DockBase* dock : m_currentPage->allDocks()) {
+            dock->deinit();
+        }
+
+        QString currentPageUriBackup = currentPageUri();
+
+        /// NOTE: for reset geometry
+        m_currentPage = nullptr;
+
+        if (doLoadPage(currentPageUriBackup)) {
+            notifyAboutDocksOpenStatus();
+        }
+    });
 }
 
 void DockWindow::initDocks(DockPageView* page)

--- a/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -722,6 +722,10 @@ void DockWindow::reloadCurrentPage()
     async::Async::call(this, [this]() {
         m_reloadCurrentPageScheduled = false;
 
+        IF_ASSERT_FAILED(m_currentPage) {
+            return;
+        }
+
         TRACEFUNC;
 
         clearRegistry(m_ctx);

--- a/src/framework/dockwindow/qml/Muse/Dock/dockwindow.h
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockwindow.h
@@ -155,5 +155,6 @@ private:
 
     bool m_hasGeometryBeenRestored = false;
     bool m_reloadCurrentPageAllowed = false;
+    bool m_reloadCurrentPageScheduled = false;
 };
 }


### PR DESCRIPTION
Resolves: #https://github.com/audacity/audacity/issues/9773 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
When changing a workspace, UiArrangement::updateData fires multiple state change notifications in sequence. Two of them independently trigger a DockWindow page reload: windowGeometryChanged and pageStateValNt.notification.
This change defers the action, avoiding multiple page reloads.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
