### PR TITLE
[4.7] Small string fixes: Language, Cloud, Bit rate

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/internal/LanguagesSection.qml
+++ b/src/preferences/qml/MuseScore/Preferences/internal/LanguagesSection.qml
@@ -28,7 +28,7 @@ import Muse.UiComponents
 BaseSection {
     id: root
 
-    title: qsTrc("preferences", "Languages")
+    title: qsTrc("preferences", "Language")
 
     navigation.direction: NavigationPanel.Horizontal
 

--- a/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
+++ b/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
@@ -75,7 +75,7 @@ StyledDialogView {
             }
 
             SaveLocationOption {
-                title: qsTrc("project/save", "To the Cloud (free)")
+                title: qsTrc("project/save", "To the cloud (free)")
                 description: qsTrc("project/save", "Files are saved privately on your own personal account. \
 You can share drafts with others and publish your finished scores publicly too.")
                 buttonText: qsTrc("project/save", "Save to the cloud")

--- a/src/project/qml/MuseScore/Project/internal/Export/AudioSettings.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/AudioSettings.qml
@@ -69,7 +69,7 @@ Row {
     ExportOptionItem {
         id: bitrateLabel
         visible: root.showBitRateControl
-        text: qsTrc("project/export", "Bitrate:")
+        text: qsTrc("project/export", "Bit rate:")
 
         StyledDropdown {
             Layout.preferredWidth: 126


### PR DESCRIPTION
[4.7] Small string fixes: Language, Cloud, Bit rate
Port https://github.com/musescore/MuseScore/pull/32939

Changes:
- Languages -> Language (like in Audacity 4 - in this case we choose one single language from the list, like a theme in Appearance in Preferences)
- Cloud -> cloud ([changed in Audacity 4](https://github.com/audacity/audacity/pull/10654) - only in this one case is uppercase)
- Bitrate -> Bit rate ([changed in Audacity 4](https://github.com/audacity/audacity/pull/10654); on [Wikipedia](https://en.wikipedia.org/wiki/Bit_rate))

Greetings,
Grzegorz

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and corrected several user-facing labels for consistency: the Preferences section header now reads "Language", the cloud save option reads "To the cloud (free)", and the audio export label reads "Bit rate:".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->