### PR TITLE
added require api support for autobot

### DIFF
--- a/src/framework/autobot/autobotmodule.cpp
+++ b/src/framework/autobot/autobotmodule.cpp
@@ -65,8 +65,8 @@ void AutobotModule::resolveImports()
 
     auto api = globalIoc()->resolve<IApiRegister>(mname);
     if (api) {
-        api->regApiCreator(mname, "api.autobot", new ApiCreator<api::AutobotApi>());
-        api->regApiCreator(mname, "api.context", new ApiCreator<ContextApi>());
+        api->regApiCreator(mname, "MuseInternal.Autobot", new ApiCreator<api::AutobotApi>());
+        api->regApiCreator(mname, "MuseInternal.AutobotContext", new ApiCreator<ContextApi>());
     }
 }
 

--- a/src/framework/autobot/internal/api/scriptapi.h
+++ b/src/framework/autobot/internal/api/scriptapi.h
@@ -52,10 +52,10 @@ public:
     ~ScriptApi();
 
     QJSValue log() const { return api("MuseApi.Log"); }
-    QJSValue autobot() const { return api("api.autobot"); }
+    QJSValue autobot() const { return api("MuseInternal.Autobot"); }
     QJSValue dispatcher() const { return api("MuseInternal.Dispatcher"); }
     QJSValue navigation() const { return api("MuseInternal.Navigation"); }
-    QJSValue context() const { return api("api.context"); }
+    QJSValue context() const { return api("MuseInternal.AutobotContext"); }
     QJSValue shortcuts() const { return api("MuseInternal.Shortcuts"); }
     QJSValue interactive() const { return api("MuseApi.Interactive"); }
     QJSValue keyboard() const { return api("MuseInternal.Keyboard"); }

--- a/src/framework/autobot/internal/jsmoduleloader.cpp
+++ b/src/framework/autobot/internal/jsmoduleloader.cpp
@@ -59,13 +59,21 @@ QJSValue JsModuleLoader::require(QString module)
         return QJSValue();
     }
 
-    bool ok = false;
-    QString filePath = resolvePath(module, &ok);
-    if (!ok) {
-        return QJSValue();
+    // require built-in module
+    //! NOTE Internal modules are available for the Autobot
+    if (module.startsWith("MuseApi.") || module.startsWith("MuseInternal.")) {
+        return engine()->requireModule(module);
     }
+    // require js file
+    else {
+        bool ok = false;
+        QString filePath = resolvePath(module, &ok);
+        if (!ok) {
+            return QJSValue();
+        }
 
-    return engine()->require(filePath);
+        return engine()->requireFile(filePath);
+    }
 }
 
 QJSValue JsModuleLoader::exports() const

--- a/src/framework/autobot/internal/scriptengine.cpp
+++ b/src/framework/autobot/internal/scriptengine.cpp
@@ -36,6 +36,7 @@ ScriptEngine::ScriptEngine(const modularity::ContextPtr& iocContext)
     : m_iocContext(iocContext)
 {
     m_engine = new QJSEngine();
+    m_apiengine = new JsApiEngine(m_engine, m_iocContext);
     m_api = new ScriptApi(this, m_engine);
 
     m_engine->globalObject().setProperty("api", newQObject(m_api));
@@ -50,7 +51,8 @@ ScriptEngine::ScriptEngine(const modularity::ContextPtr& iocContext)
 }
 
 ScriptEngine::ScriptEngine(ScriptEngine* engine)
-    : m_iocContext(engine->m_iocContext), m_engine(engine->m_engine), m_api(engine->m_api), m_moduleLoader(engine->m_moduleLoader),
+    : m_iocContext(engine->m_iocContext), m_engine(engine->m_engine), m_apiengine(engine->m_apiengine), m_api(engine->m_api),
+    m_moduleLoader(engine->m_moduleLoader),
     m_isRequireMode(true)
 {
     m_moduleLoader->pushEngine(this);
@@ -63,6 +65,7 @@ ScriptEngine::~ScriptEngine()
     if (!m_isRequireMode) {
         delete m_moduleLoader;
         delete m_api;
+        delete m_apiengine;
         delete m_engine;
     }
 }
@@ -77,7 +80,20 @@ io::path_t ScriptEngine::scriptPath() const
     return m_scriptPath;
 }
 
-QJSValue ScriptEngine::require(const QString& filePath)
+QJSValue ScriptEngine::requireModule(const QString& module)
+{
+    LOGD() << module;
+    auto obj = apiRegister()->createApi(module.toStdString(), m_apiengine);
+    if (!obj.first) {
+        LOGE() << "failed create api for module: " << module;
+        return QJSValue();
+    }
+    bool isNeedDelete = obj.second;
+    QJSEngine::setObjectOwnership(obj.first, isNeedDelete ? QJSEngine::JavaScriptOwnership : QJSEngine::CppOwnership);
+    return m_engine->newQObject(obj.first);
+}
+
+QJSValue ScriptEngine::requireFile(const QString& filePath)
 {
     TRACEFUNC;
 

--- a/src/framework/autobot/internal/scriptengine.h
+++ b/src/framework/autobot/internal/scriptengine.h
@@ -31,6 +31,7 @@
 #include "modularity/ioc.h"
 #include "io/ifilesystem.h"
 #include "types/ret.h"
+#include "global/api/iapiregister.h"
 
 #include "api/iapiengine.h"
 #include "api/scriptapi.h"
@@ -40,6 +41,8 @@ class JsModuleLoader;
 class ScriptEngine : public muse::api::IApiEngine
 {
     GlobalInject<io::IFileSystem> fileSystem;
+    GlobalInject<muse::api::IApiRegister> apiRegister;
+
 public:
     ScriptEngine(const modularity::ContextPtr& iocContext);
     ~ScriptEngine();
@@ -63,7 +66,8 @@ public:
     void throwError(const QString& message);
 
     // js modules
-    QJSValue require(const QString& filePath);
+    QJSValue requireModule(const QString& module);
+    QJSValue requireFile(const QString& filePath);
     QJSValue exports() const;
     void setExports(const QJSValue& obj);
 
@@ -92,6 +96,7 @@ private:
 
     const modularity::ContextPtr m_iocContext;
     QJSEngine* m_engine = nullptr;
+    muse::api::JsApiEngine* m_apiengine = nullptr;
     ScriptApi* m_api = nullptr;
     JsModuleLoader* m_moduleLoader = nullptr;
     bool m_isRequireMode = false;

--- a/src/framework/extensions/internal/jsmoduleloader.cpp
+++ b/src/framework/extensions/internal/jsmoduleloader.cpp
@@ -59,7 +59,8 @@ QJSValue JsModuleLoader::require(QString module)
         return QJSValue();
     }
 
-    // require buildin module
+    // require built-in module
+    //! NOTE Only public modules are available
     if (module.startsWith("MuseApi.")) {
         return engine()->requireModule(module);
     }

--- a/src/framework/extensions/internal/scriptengine.cpp
+++ b/src/framework/extensions/internal/scriptengine.cpp
@@ -76,7 +76,8 @@ ScriptEngine::ScriptEngine(const modularity::ContextPtr& iocCtx, int apiversion)
 }
 
 ScriptEngine::ScriptEngine(ScriptEngine* engine)
-    : m_iocContext(engine->m_iocContext), m_engine(engine->m_engine), m_api(engine->m_api), m_moduleLoader(engine->m_moduleLoader),
+    : m_iocContext(engine->m_iocContext), m_engine(engine->m_engine), m_apiengine(engine->m_apiengine), m_api(engine->m_api),
+    m_moduleLoader(engine->m_moduleLoader),
     m_isRequireMode(true)
 {
     m_moduleLoader->pushEngine(this);
@@ -89,6 +90,7 @@ ScriptEngine::~ScriptEngine()
     if (!m_isRequireMode) {
         delete m_moduleLoader;
         delete m_api;
+        delete m_apiengine;
         delete m_engine;
     }
 }
@@ -107,6 +109,10 @@ QJSValue ScriptEngine::requireModule(const QString& module)
 {
     LOGD() << module;
     auto obj = apiRegister()->createApi(module.toStdString(), m_apiengine);
+    if (!obj.first) {
+        LOGE() << "failed create api for module: " << module;
+        return QJSValue();
+    }
     bool isNeedDelete = obj.second;
     QJSEngine::setObjectOwnership(obj.first, isNeedDelete ? QJSEngine::JavaScriptOwnership : QJSEngine::CppOwnership);
     return m_engine->newQObject(obj.first);


### PR DESCRIPTION
example 
```

const Autobot = require("MuseInternal.Autobot");
const Interactive = require("MuseApi.Interactive");
const Dispatcher = require("MuseInternal.Dispatcher");

var testCase = {
    name: "Test API",
    description: "Test API",
    steps: [
        {name: "Info", func: function() {
            Interactive.info("Test API", "Test API")
        }},
        {name: "Dispatch", func: function() {
            Dispatcher.dispatch("file-open")
        }}
    ]
};

function main()
{
    Autobot.setInterval(1000)
    Autobot.runTestCase(testCase)
}

```
