### PR TITLE
Automation  - expanding on user interactions

### DIFF
--- a/src/engraving/automation/iautomation.h
+++ b/src/engraving/automation/iautomation.h
@@ -31,6 +31,8 @@ class IAutomation
 public:
     virtual ~IAutomation() = default;
 
+    virtual void clear() = 0;
+
     virtual const AutomationCurve& curve(const AutomationCurveKey& key) const = 0;
     virtual const AutomationPoint& activePoint(const AutomationCurveKey& key, int utick) const = 0;
 

--- a/src/engraving/automation/internal/automation.cpp
+++ b/src/engraving/automation/internal/automation.cpp
@@ -60,6 +60,11 @@ const AutomationPoint& Automation::activePoint(const AutomationCurveKey& key, in
     return it->second;
 }
 
+void Automation::clear()
+{
+    m_curveMap.clear();
+}
+
 bool Automation::isEmpty() const
 {
     return m_curveMap.empty();

--- a/src/engraving/automation/internal/automation.h
+++ b/src/engraving/automation/internal/automation.h
@@ -27,6 +27,8 @@ namespace mu::engraving {
 class Automation : public IAutomation
 {
 public:
+    void clear() override;
+
     const AutomationCurve& curve(const AutomationCurveKey& key) const override;
     const AutomationPoint& activePoint(const AutomationCurveKey& key, int utick) const override;
 

--- a/src/engraving/automation/internal/automationcontroller.cpp
+++ b/src/engraving/automation/internal/automationcontroller.cpp
@@ -240,6 +240,8 @@ void AutomationController::init(Score* score)
 {
     TRACEFUNC;
 
+    m_automation->clear();
+
     for (const RepeatSegment* repeatSegment : score->repeatList()) {
         const int tickOffset = repeatSegment->utick - repeatSegment->tick;
 

--- a/src/framework/automation/qml/Muse/Automation/AutomationOverlayLoader.qml
+++ b/src/framework/automation/qml/Muse/Automation/AutomationOverlayLoader.qml
@@ -32,10 +32,16 @@ Loader {
     property var viewMatrix: null
     property var linesData: null
 
+    signal pointChangeRequested(var lineIdx, var pointIdx, var x, var y)
+
     sourceComponent: AutomationOverlay {
         id: automationOverlay
 
         viewMatrix: root.viewMatrix
+
+        onPointChangeRequested: function(lineIdx, pointIdx, x, y) {
+            root.pointChangeRequested(lineIdx, pointIdx, x, y)
+        }
 
         Connections {
             target: root

--- a/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
+++ b/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
@@ -158,3 +158,11 @@ void AutomationOverlay::updatePolylinesGeometry(size_t firstIndex, size_t lastIn
         polyline->setHeight(lineHeight * m_viewMatrix.m22());
     }
 }
+
+void AutomationOverlay::updateAllPolylinesGeometry()
+{
+    IF_ASSERT_FAILED(!m_automationLinesData.empty()) {
+        return;
+    }
+    updatePolylinesGeometry(0, m_automationLinesData.size() - 1);
+}

--- a/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
+++ b/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
@@ -46,8 +46,8 @@ void AutomationOverlay::initAutomationLinesData(const QVariant& automationLinesD
 
     m_automationLinesData.reserve(automationDataList.size());
 
-    for (qsizetype i = 0; i < automationDataList.size(); ++i) {
-        const QVariantMap& lineDataMap = automationDataList.at(i).toMap();
+    for (qsizetype lineIdx = 0; lineIdx < automationDataList.size(); ++lineIdx) {
+        const QVariantMap& lineDataMap = automationDataList.at(lineIdx).toMap();
         IF_ASSERT_FAILED(!lineDataMap.isEmpty()) {
             continue;
         }
@@ -79,15 +79,16 @@ void AutomationOverlay::initAutomationLinesData(const QVariant& automationLinesD
         polyline->setDrawBackground(false);
 
         QObject::connect(polyline, &muse::uicomponents::PolylinePlot::pointMoved,
-                         [polyline](int index, qreal x, qreal y, bool completed) {
-            IF_ASSERT_FAILED(index > -1 && index < static_cast<int>(polyline->points().size())) {
+                         [this, lineIdx, polyline](int pointIdx, qreal x, qreal y, bool completed) {
+            IF_ASSERT_FAILED(pointIdx > -1 && pointIdx < static_cast<int>(polyline->points().size())) {
                 return;
             }
-            // TODO: When completed, change the model (create an undo action in the process)...
-            UNUSED(completed);
-
+            if (completed) {
+                emit pointChangeRequested(lineIdx, pointIdx, x, y);
+                return;
+            }
             QVector<QPointF> points = polyline->points();
-            points.replace(index, { x, y });
+            points.replace(pointIdx, { x, y });
             polyline->setPoints(points);
             polyline->update();                  // TODO: pass update rect?
         });

--- a/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
+++ b/src/framework/automation/qml/Muse/Automation/automationoverlay.cpp
@@ -83,14 +83,14 @@ void AutomationOverlay::initAutomationLinesData(const QVariant& automationLinesD
             IF_ASSERT_FAILED(pointIdx > -1 && pointIdx < static_cast<int>(polyline->points().size())) {
                 return;
             }
-            if (completed) {
-                emit pointChangeRequested(lineIdx, pointIdx, x, y);
-                return;
-            }
             QVector<QPointF> points = polyline->points();
             points.replace(pointIdx, { x, y });
             polyline->setPoints(points);
-            polyline->update();                  // TODO: pass update rect?
+            polyline->update(); // TODO: pass update rect?
+            if (completed) {
+                // Only request to update the model when completed...
+                emit pointChangeRequested(lineIdx, pointIdx, x, y);
+            }
         });
 
         AutomationLineData lineData = { lineDataMap, polyline };

--- a/src/framework/automation/qml/Muse/Automation/automationoverlay.h
+++ b/src/framework/automation/qml/Muse/Automation/automationoverlay.h
@@ -56,7 +56,7 @@ private:
     bool lineIndexIsValid(size_t index) const;
 
     void updatePolylinesGeometry(size_t firstIndex, size_t lastIndex);
-    void updateAllPolylinesGeometry() { updatePolylinesGeometry(0, m_automationLinesData.size() - 1); }
+    void updateAllPolylinesGeometry();
 
     QTransform m_viewMatrix;
     std::vector<AutomationLineData> m_automationLinesData;

--- a/src/framework/automation/qml/Muse/Automation/automationoverlay.h
+++ b/src/framework/automation/qml/Muse/Automation/automationoverlay.h
@@ -46,6 +46,7 @@ protected:
 
 signals:
     void viewMatrixChanged();
+    void pointChangeRequested(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y);
 
 private:
     struct AutomationLineData {

--- a/src/notation/inotationautomation.h
+++ b/src/notation/inotationautomation.h
@@ -36,6 +36,8 @@ public:
 
     virtual QVariant automationLinesData() const = 0;
     virtual muse::async::Notification automationLinesDataChanged() const = 0;
+
+    virtual void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y) = 0;
 };
 
 using INotationAutomationPtr = std::shared_ptr<INotationAutomation>;

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -43,17 +43,14 @@ void NotationAutomation::setAutomationModeEnabled(bool enabled)
         return;
     }
 
-    if (enabled) { // TODO: Placeholder - need to init this somewhere...
-        if (score() && score()->masterScore()) {
-            score()->masterScore()->initAutomation();
-        } else {
-            ASSERT_X("No score for automation...")
-        }
+    if (enabled) {
+        // TODO: Optimization - we don't need to init all the lines every time. Only the bits that
+        // changed since the last time automation was enabled...
+        initAutomationLinesData();
     }
 
     m_isAutomationModeEnabled = enabled;
     m_automationModeEnabledChanged.notify();
-    m_automationLinesDataChanged.notify(); // TODO: Delete once above placeholder has been removed...
 }
 
 muse::async::Notification NotationAutomation::automationModeEnabledChanged() const
@@ -63,20 +60,31 @@ muse::async::Notification NotationAutomation::automationModeEnabledChanged() con
 
 QVariant NotationAutomation::automationLinesData() const
 {
-    QVariantList automationLinesData;
+    return m_automationLinesData;
+}
 
-    IF_ASSERT_FAILED(automation()) {
-        return automationLinesData;
+void NotationAutomation::initAutomationLinesData()
+{
+    mu::engraving::MasterScore* masterScore = score() ? score()->masterScore() : nullptr;
+    IF_ASSERT_FAILED(masterScore) {
+        return;
     }
 
+    if (m_automationLinesData.isEmpty()) {
+        // TODO: Placeholder - init this elsewhere. Also note that automation data doesn't currently
+        // update through score interactions (such as deleting dynamics, etc)...
+        masterScore->initAutomation();
+    }
+
+    QVariantList automationLinesData;
     for (const System* system : score()->systems()) {
         const QVariantList linesData = linesDataForSystem(system);
         if (!linesData.empty()) {
             automationLinesData << linesData;
         }
     }
-
-    return automationLinesData;
+    m_automationLinesData = automationLinesData;
+    m_automationLinesDataChanged.notify();
 }
 
 QVariantList NotationAutomation::linesDataForSystem(const System* system) const
@@ -108,6 +116,7 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
         }
 
         QVariantMap lineData;
+        lineData["staffIdx"] = static_cast<int>(staffIdx);
         lineData["x"] = staffCanvasRect.x();
         lineData["y"] = staffCanvasRect.y();
         lineData["width"] = staffCanvasRect.width();
@@ -126,12 +135,18 @@ QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const 
                                                       int startTick, int endTick) const
 {
     QVariantList points;
-    const auto addPoint = [&points](double x, double y) {
+    const auto addPoint = [&points](double x, double y, int tick, PointType pointType) {
         QVariantMap pointData;
         pointData["x"] = x;
         pointData["y"] = y;
+        pointData["tick"] = tick;
+        pointData["pointType"] = static_cast<int>(pointType);
         points << pointData;
     };
+
+    IF_ASSERT_FAILED(automation()) {
+        return points;
+    }
 
     const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
     for (auto& point : automation()->curve(key)) {
@@ -151,14 +166,14 @@ QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const 
         // x positions scaled between 0 and 1 (where 0 is the staff start and 1 is the staff end)
         const double pointX = (seg->canvasX() - sysStaffCanvasRect.x()) / sysStaffCanvasRect.width();
 
+        // Point in/out values are always between 0 and 1 - higher value == lower Y...
         const mu::engraving::AutomationPoint& autoPoint = point.second;
-        if (!muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
-            // inValue is always between 0 and 1 - higher value == lower Y...
-            addPoint(pointX, 1 - autoPoint.inValue);
+        if (muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
+            addPoint(pointX, 1 - autoPoint.inValue, tick, PointType::BOTH);
+            continue;
         }
-
-        // outValue is always between 0 and 1 - higher value == lower Y...
-        addPoint(pointX, 1 - autoPoint.outValue);
+        addPoint(pointX, 1 - autoPoint.inValue, tick, PointType::IN);
+        addPoint(pointX, 1 - autoPoint.outValue, tick, PointType::OUT);
     }
 
     return points;
@@ -181,8 +196,50 @@ mu::engraving::IAutomation* NotationAutomation::automation() const
 
 void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y)
 {
-    // TODO: Placeholder
-    LOGD() << "AUTOMATION POINT CHANGE REQUEST RECEIVED:";
-    LOGD() << "lineIdx/pointIdx: " << lineIdx << ", " << pointIdx;
-    LOGD() << "requested x/y: " << x << ", " << y;
+    IF_ASSERT_FAILED(automation() && lineIdx < m_automationLinesData.size()) {
+        return;
+    }
+
+    const QVariantMap lineData = m_automationLinesData.at(lineIdx).toMap();
+    IF_ASSERT_FAILED(!lineData.isEmpty()) {
+        return;
+    }
+
+    bool ok;
+    const staff_idx_t staffIdx = static_cast<staff_idx_t>(lineData.value("staffIdx").toInt(&ok));
+    IF_ASSERT_FAILED(ok && staffIdx != muse::nidx) {
+        return;
+    }
+
+    const Staff* staff = score()->staff(staffIdx);
+    const QVariantList pointsList = lineData.value("points").toList();
+    IF_ASSERT_FAILED(staff && !pointsList.isEmpty() && pointIdx < pointsList.size()) {
+        return;
+    }
+
+    const QVariantMap point = pointsList.at(pointIdx).toMap();
+    IF_ASSERT_FAILED(!point.isEmpty()) {
+        return;
+    }
+
+    const int tick = point.value("tick").toInt(&ok);
+    const int pointTypeRaw = ok ? point.value("pointType").toInt(&ok) : 0;
+    IF_ASSERT_FAILED(ok) {
+        return;
+    }
+
+    const PointType pointType = static_cast<PointType>(pointTypeRaw);
+    const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
+
+    // Point in/out values are always between 0 and 1 - higher value == lower Y...
+    if (pointType == PointType::IN || pointType == PointType::BOTH) {
+        automation()->setPointInValue(key, tick, 1 - y);
+    }
+    if (pointType == PointType::OUT || pointType == PointType::BOTH) {
+        automation()->setPointOutValue(key, tick, 1 - y);
+    }
+
+    UNUSED(x);
+    // TODO: use x to calculate newTick...
+    // automation()->movePoint(key, tick, newTick) = 0;
 }

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -178,3 +178,11 @@ mu::engraving::IAutomation* NotationAutomation::automation() const
 {
     return score() ? score()->automation() : nullptr;
 }
+
+void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y)
+{
+    // TODO: Placeholder
+    LOGD() << "AUTOMATION POINT CHANGE REQUEST RECEIVED:";
+    LOGD() << "lineIdx/pointIdx: " << lineIdx << ", " << pointIdx;
+    LOGD() << "requested x/y: " << x << ", " << y;
+}

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -100,25 +100,41 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
         }
 
         QVariantList pointsOnLine;
+        const auto addPointToLine = [&pointsOnLine](double x, double y) {
+            QVariantMap pointData;
+            pointData["x"] = x;
+            pointData["y"] = y;
+            pointsOnLine << pointData;
+        };
+
+        const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
 
         const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
-        for (auto point : automation()->curve(key)) {
+        for (auto& point : automation()->curve(key)) {
             const int tick = point.first;
             if (tick < systemStartTick || tick > systemEndTick) {
                 continue;
             }
 
+            const Fraction frac = Fraction::fromTicks(tick);
+            const Segment* seg = score()->tick2segmentMM(frac);
+            IF_ASSERT_FAILED(seg) {
+                continue;
+            }
+
+            // TODO: The following won't work for dynamics at time ticks...
+
+            // x positions scaled between 0 and 1 (where 0 is the staff start and 1 is the staff end)
+            const double pointX = (seg->canvasX() - staffCanvasRect.x()) / staffCanvasRect.width();
+
             const mu::engraving::AutomationPoint& autoPoint = point.second;
+            if (!muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
+                // inValue is always between 0 and 1 - higher value == lower Y...
+                addPointToLine(pointX, 1 - autoPoint.inValue);
+            }
 
-            QVariantMap pointData;
-
-            // TODO: xFactor is a placeholder - it assumes time is linear in a staff - which is not the case. We should
-            // instead base this on segment/timetick positions...
-            const double xFactor = static_cast<double>(tick - systemStartTick) / (systemEndTick - systemStartTick);
-            pointData["x"] = xFactor;
-
-            pointData["y"] = autoPoint.inValue;
-            pointsOnLine << pointData;
+            // outValue is always between 0 and 1 - higher value == lower Y...
+            addPointToLine(pointX, 1 - autoPoint.outValue);
         }
 
         if (pointsOnLine.isEmpty()) {
@@ -126,13 +142,11 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
             continue;
         }
 
-        const muse::RectF staffRect = sysStaff->bbox().translated(system->canvasPos());
-
         QVariantMap lineData;
-        lineData["x"] = staffRect.x();
-        lineData["y"] = staffRect.y();
-        lineData["width"] = staffRect.width();
-        lineData["height"] = staffRect.height();
+        lineData["x"] = staffCanvasRect.x();
+        lineData["y"] = staffCanvasRect.y();
+        lineData["width"] = staffCanvasRect.width();
+        lineData["height"] = staffCanvasRect.height();
         lineData["points"] = pointsOnLine;
 
         lines << lineData;

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -94,50 +94,15 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
             staffIdx = system->nextVisibleStaff(staffIdx);
             continue;
         }
+
         if (!staff->isPrimaryStaff()) {
             staffIdx = system->nextVisibleStaff(staffIdx);
             continue;
         }
 
-        QVariantList pointsOnLine;
-        const auto addPointToLine = [&pointsOnLine](double x, double y) {
-            QVariantMap pointData;
-            pointData["x"] = x;
-            pointData["y"] = y;
-            pointsOnLine << pointData;
-        };
-
         const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
-
-        const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
-        for (auto& point : automation()->curve(key)) {
-            const int tick = point.first;
-            if (tick < systemStartTick || tick > systemEndTick) {
-                continue;
-            }
-
-            const Fraction frac = Fraction::fromTicks(tick);
-            const Segment* seg = score()->tick2segmentMM(frac);
-            IF_ASSERT_FAILED(seg) {
-                continue;
-            }
-
-            // TODO: The following won't work for dynamics at time ticks...
-
-            // x positions scaled between 0 and 1 (where 0 is the staff start and 1 is the staff end)
-            const double pointX = (seg->canvasX() - staffCanvasRect.x()) / staffCanvasRect.width();
-
-            const mu::engraving::AutomationPoint& autoPoint = point.second;
-            if (!muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
-                // inValue is always between 0 and 1 - higher value == lower Y...
-                addPointToLine(pointX, 1 - autoPoint.inValue);
-            }
-
-            // outValue is always between 0 and 1 - higher value == lower Y...
-            addPointToLine(pointX, 1 - autoPoint.outValue);
-        }
-
-        if (pointsOnLine.isEmpty()) {
+        const QVariantList staffLinesData = linesDataForSysStaff(staff, staffCanvasRect, systemStartTick, systemEndTick);
+        if (staffLinesData.isEmpty()) {
             staffIdx = system->nextVisibleStaff(staffIdx);
             continue;
         }
@@ -147,7 +112,7 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
         lineData["y"] = staffCanvasRect.y();
         lineData["width"] = staffCanvasRect.width();
         lineData["height"] = staffCanvasRect.height();
-        lineData["points"] = pointsOnLine;
+        lineData["points"] = staffLinesData;
 
         lines << lineData;
 
@@ -155,6 +120,48 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
     }
 
     return lines;
+}
+
+QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect,
+                                                      int startTick, int endTick) const
+{
+    QVariantList points;
+    const auto addPoint = [&points](double x, double y) {
+        QVariantMap pointData;
+        pointData["x"] = x;
+        pointData["y"] = y;
+        points << pointData;
+    };
+
+    const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
+    for (auto& point : automation()->curve(key)) {
+        const int tick = point.first;
+        if (tick < startTick || tick > endTick) {
+            continue;
+        }
+
+        const Fraction frac = Fraction::fromTicks(tick);
+        const Segment* seg = score()->tick2segmentMM(frac);
+        IF_ASSERT_FAILED(seg) {
+            continue;
+        }
+
+        // TODO: The following won't work for dynamics at time ticks...
+
+        // x positions scaled between 0 and 1 (where 0 is the staff start and 1 is the staff end)
+        const double pointX = (seg->canvasX() - sysStaffCanvasRect.x()) / sysStaffCanvasRect.width();
+
+        const mu::engraving::AutomationPoint& autoPoint = point.second;
+        if (!muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
+            // inValue is always between 0 and 1 - higher value == lower Y...
+            addPoint(pointX, 1 - autoPoint.inValue);
+        }
+
+        // outValue is always between 0 and 1 - higher value == lower Y...
+        addPoint(pointX, 1 - autoPoint.outValue);
+    }
+
+    return points;
 }
 
 muse::async::Notification NotationAutomation::automationLinesDataChanged() const

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -26,6 +26,26 @@
 
 using namespace mu::notation;
 
+// TODO: This will do for now, but it needs to be smarter because there will be gaps between ChordRest/TimeTick segment types (e.g.
+// barlines). This method effectively needs to return the closest segment of the desired type (and probably whether canvasX is before
+// or after the segment). If the canvasX is before the closest segment, then we'll go on to use the start tick of the segment. If it's
+// after, we'll use the end tick of the segment....
+static const Segment* segmentForCanvasX(const System* system, double canvasX)
+{
+    IF_ASSERT_FAILED(system) {
+        return nullptr;
+    }
+    const mu::engraving::SegmentType type = Segment::CHORD_REST_OR_TIME_TICK_TYPE;
+    const Segment* seg = system->firstMeasure() ? system->firstMeasure()->first(type) : nullptr;
+    while (seg && seg->system() == system) {
+        if (canvasX >= seg->canvasX() && canvasX <= seg->canvasX() + seg->width()) {
+            return seg;
+        }
+        seg = seg->next1(type);
+    }
+    return nullptr;
+}
+
 NotationAutomation::NotationAutomation(IGetScore* getScore,
                                        muse::async::Channel<muse::RectF> notationChanged)
     : m_getScore(getScore), m_notationChanged(notationChanged)
@@ -156,24 +176,29 @@ QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const 
         }
 
         const Fraction frac = Fraction::fromTicks(tick);
-        const Segment* seg = score()->tick2segmentMM(frac);
+        const Segment* seg = score()->tick2leftSegmentMM(frac);
         IF_ASSERT_FAILED(seg) {
             continue;
         }
 
-        // TODO: The following won't work for dynamics at time ticks...
+        // The point's tick may not exactly match that of a segment. For this reason we can only calculate the x position
+        // of our points based on a "tickRatio". This ratio is based on the "tick difference" between the point tick and
+        // the segment's tick, and the duration of the segment (in ticks)...
+        const int tickDiff = tick - seg->tick().ticks();
+        const double tickRatio = static_cast<double>(tickDiff) / seg->ticks().ticks();
+        const double pointXInSeg = tickRatio * seg->width(); // The point's x relative to the segment
 
-        // x positions scaled between 0 and 1 (where 0 is the staff start and 1 is the staff end)
-        const double pointX = (seg->canvasX() - sysStaffCanvasRect.x()) / sysStaffCanvasRect.width();
+        const double segXInStaff = seg->canvasX() - sysStaffCanvasRect.x(); // The segment's x relative to the staff
+        const double pointXInStaff = (segXInStaff + pointXInSeg) / sysStaffCanvasRect.width();
 
         // Point in/out values are always between 0 and 1 - higher value == lower Y...
         const mu::engraving::AutomationPoint& autoPoint = point.second;
         if (muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
-            addPoint(pointX, 1 - autoPoint.inValue, tick, PointType::BOTH);
+            addPoint(pointXInStaff, 1 - autoPoint.inValue, tick, PointType::BOTH);
             continue;
         }
-        addPoint(pointX, 1 - autoPoint.inValue, tick, PointType::IN);
-        addPoint(pointX, 1 - autoPoint.outValue, tick, PointType::OUT);
+        addPoint(pointXInStaff, 1 - autoPoint.inValue, tick, PointType::IN);
+        addPoint(pointXInStaff, 1 - autoPoint.outValue, tick, PointType::OUT);
     }
 
     return points;
@@ -222,7 +247,7 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
         return;
     }
 
-    const int tick = point.value("tick").toInt(&ok);
+    const int oldTick = point.value("tick").toInt(&ok); // "Old" because we might change it given a new x value...
     const int pointTypeRaw = ok ? point.value("pointType").toInt(&ok) : 0;
     IF_ASSERT_FAILED(ok) {
         return;
@@ -232,14 +257,62 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
     const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
 
     // Point in/out values are always between 0 and 1 - higher value == lower Y...
+    const double newValue = 1.0 - y;
+
     if (pointType == PointType::IN || pointType == PointType::BOTH) {
-        automation()->setPointInValue(key, tick, 1 - y);
+        automation()->setPointInValue(key, oldTick, newValue);
     }
     if (pointType == PointType::OUT || pointType == PointType::BOTH) {
-        automation()->setPointOutValue(key, tick, 1 - y);
+        automation()->setPointOutValue(key, oldTick, newValue);
     }
 
-    UNUSED(x);
-    // TODO: use x to calculate newTick...
-    // automation()->movePoint(key, tick, newTick) = 0;
+    //! NOTE: newSeg will always be in the same system as oldSeg...
+    const Segment* oldSeg = score()->tick2leftSegmentMM(Fraction::fromTicks(oldTick));
+    const System* system = oldSeg ? oldSeg->system() : nullptr;
+    const SysStaff* sysStaff = system ? system->staff(staffIdx) : nullptr;
+    IF_ASSERT_FAILED(sysStaff) {
+        return;
+    }
+
+    const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
+    const double staffStartCanvasX = staffCanvasRect.x();
+    const double staffEndCanvasX = staffStartCanvasX + staffCanvasRect.width();
+    const double pointCanvasX = staffStartCanvasX + x * (staffEndCanvasX - staffStartCanvasX);
+
+    // TODO: See segmentForCanvasX - it needs to be a bit smarter...
+    const Segment* newSeg = segmentForCanvasX(system, pointCanvasX);
+    IF_ASSERT_FAILED(newSeg) {
+        return;
+    }
+
+    const double segStartCanvasX = newSeg->canvasX();
+    const double setEndCanvasX = segStartCanvasX + newSeg->width();
+
+    const int segStartTick = newSeg->tick().ticks();
+    const int segEndTick = segStartTick + newSeg->ticks().ticks();
+
+    const double tickRatio = (pointCanvasX - segStartCanvasX) / (setEndCanvasX - segStartCanvasX);
+    const int newTick = segStartTick + static_cast<int>(tickRatio * (segEndTick - segStartTick));
+    if (newTick == oldTick) {
+        return;
+    }
+
+    //! NOTE: Moving a BOTH point is the simplest case - we can simply change the tick. Moving IN/OUT points is slightly
+    //! more complex. In this case we need to set the in/out values to be equal at oldTick (effectively converting the
+    //! original point to a BOTH point) and create a new point at newTick...
+
+    if (pointType == PointType::BOTH) {
+        automation()->movePoint(key, oldTick, newTick);
+        return;
+    }
+
+    const mu::engraving::AutomationPoint& oldPoint = automation()->activePoint(key, oldTick);
+    const mu::engraving::AutomationPoint newPoint = { newValue, newValue };
+    if (pointType == PointType::IN) {
+        automation()->setPointInValue(key, oldTick, oldPoint.outValue);
+    }
+    if (pointType == PointType::OUT) {
+        automation()->setPointOutValue(key, oldTick, oldPoint.inValue);
+    }
+    automation()->addPoint(key, newTick, newPoint);
 }

--- a/src/notation/internal/notationautomation.h
+++ b/src/notation/internal/notationautomation.h
@@ -50,6 +50,7 @@ public:
 
 private:
     QVariantList linesDataForSystem(const System* system) const;
+    QVariantList linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect, int startTick, int endTick) const;
 
     mu::engraving::Score* score() const;
     mu::engraving::IAutomation* automation() const;

--- a/src/notation/internal/notationautomation.h
+++ b/src/notation/internal/notationautomation.h
@@ -48,6 +48,8 @@ public:
     QVariant automationLinesData() const override;
     muse::async::Notification automationLinesDataChanged() const override; // TODO: probably a channel specifying indices
 
+    void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y) override;
+
 private:
     QVariantList linesDataForSystem(const System* system) const;
     QVariantList linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect, int startTick, int endTick) const;

--- a/src/notation/internal/notationautomation.h
+++ b/src/notation/internal/notationautomation.h
@@ -51,6 +51,15 @@ public:
     void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y) override;
 
 private:
+    enum class PointType : unsigned char {
+        UNKNOWN = 0,
+        IN,
+        OUT,
+        BOTH
+    };
+
+    void initAutomationLinesData();
+
     QVariantList linesDataForSystem(const System* system) const;
     QVariantList linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect, int startTick, int endTick) const;
 
@@ -63,6 +72,7 @@ private:
     bool m_isAutomationModeEnabled = false;
     muse::async::Notification m_automationModeEnabledChanged;
 
+    QVariantList m_automationLinesData;
     muse::async::Notification m_automationLinesDataChanged;
 };
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/NotationView.qml
@@ -227,7 +227,11 @@ FocusScope {
 
                         viewMatrix: notationView.matrix
                         linesData: notationView.automationLinesData
-                    }
+
+                        onPointChangeRequested: function(lineIdx, pointIdx, x, y) {
+                            notationView.requestChangeAutomationPoint(lineIdx, pointIdx, x, y)
+                        }
+                     }
 
                     NotationRegionsBeingProcessedView {
                         notationViewRect: Qt.rect(notationView.x, notationView.y, notationView.width, notationView.height)

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -1692,3 +1692,11 @@ void AbstractNotationPaintView::setPlaybackCursorItem(QQuickItem* cursor)
         });
     }
 }
+
+void AbstractNotationPaintView::requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y)
+{
+    IF_ASSERT_FAILED(notationAutomation()) {
+        return;
+    }
+    notationAutomation()->requestChangeAutomationPoint(lineIdx, pointIdx, x, y);
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.h
@@ -105,6 +105,8 @@ public:
 
     Q_INVOKABLE void setPlaybackCursorItem(QQuickItem* cursor);
 
+    Q_INVOKABLE void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y);
+
     qreal width() const override;
     qreal height() const override;
 


### PR DESCRIPTION
This PR:
- Addresses some code review feedback from [#32779](https://github.com/musescore/MuseScore/pull/32779)
- Properly makes use of both `in` and `out` automation point values
- Provides the basics for connecting user interactons with a `PolylinePlot` to our automation model

Much of the code added in this PR is concerned with converting x values coming from the polyline to tick values for the automation model (and vice versa). This is because, unlike automation in your typical DAW, there isn't a linear correlation between the canvas coordinates of an automation point and the "playback tick" of the automation change (because time isn't linear in a staff).

For example - in the following excerpt our automation change visually occurs roughly 2/3rds of the way through the given staff, but temporally only about 1/4 of the way through. This discrepancy needs to be taken into account when editing/generating points:
<img width="954" height="253" alt="Screenshot 2026-04-15 at 12 29 29" src="https://github.com/user-attachments/assets/0fbda998-6893-4072-9406-9683b74fd3da" />

---

In upcoming PRs we will:
- Improve on our `segmentForCanvasX` logic (see related code comment)
- Immediately feed automation model changes back to our polylines (this is necessary for a few things, including making automation editing an undoable action)
- Encapsulate/simplify some parts of `NotationAutomation::requestChangeAutomationPoint` (this method is pretty huge right now)