### PR TITLE
[4.7] Video export. Updated the url

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Export/Mp4SettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/Mp4SettingsPage.qml
@@ -66,7 +66,7 @@ ExportSettingsPage {
                 navigation.row: root.navigationOrder
 
                 onClicked: {
-                    Qt.openUrlExternally("https://support.audacityteam.org/basics/installing-ffmpeg") // todo
+                    api.launcher.openUrl("https://handbook.musescore.org/video/installing-ffmpeg")
                 }
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FFmpeg download help link in the export settings to direct users to the correct MuseScore Handbook resource for FFmpeg installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->