### PR TITLE
[4.7] Video export. Add Page video export style

### DIFF
--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -254,3 +254,14 @@ Fraction Page::endTick() const
 {
     return m_systems.empty() ? Fraction(-1, 1) : m_systems.back()->measures().back()->endTick();
 }
+
+Measure* Page::firstMeasure() const
+{
+    for (System* s : m_systems) {
+        if (Measure* m = s->firstMeasure()) {
+            return m;
+        }
+    }
+
+    return nullptr;
+}

--- a/src/engraving/dom/page.h
+++ b/src/engraving/dom/page.h
@@ -77,6 +77,7 @@ public:
     std::vector<EngravingItem*> elements() const;              ///< list of visible elements
     RectF tbbox() const;                             // tight bounding box, excluding white space
     Fraction endTick() const;
+    Measure* firstMeasure() const;
 
     Text* headerText(int index) const { return m_headerTexts.at(index); }
     Text* footerText(int index) const { return m_footerTexts.at(index); }

--- a/src/importexport/videoexport/internal/videoexportconfiguration.cpp
+++ b/src/importexport/videoexport/internal/videoexportconfiguration.cpp
@@ -23,7 +23,7 @@
 
 using namespace mu::iex::videoexport;
 
-static const ViewMode DEFAULT_VIEW_MODE = ViewMode::Auto;
+static const ViewMode DEFAULT_VIEW_MODE = ViewMode::PageFull;
 static const bool DEFAULT_SHOW_PIANO = false;
 static const PianoPosition DEFAULT_PIANO_POSITION = PianoPosition::Bottom;
 static const std::string DEFAULT_RESOLUTION = "1080p";

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -571,6 +571,11 @@ bool VideoWriter::generateScoreFrames(muse::media::IVideoEncoderPtr encoder, INo
             break;
         }
 
+        if (!page->firstMeasure()) {
+            // Skip pages with no notation
+            continue;
+        }
+
         INotationPainting::Options opt;
         opt.fromPage = static_cast<int>(page->pageNumber());
         opt.toPage = opt.fromPage;

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -222,6 +222,8 @@ VideoWriter::Config VideoWriter::makeConfig() const
     cfg.leadingSec = configuration()->leadingSec();
     cfg.trailingSec = configuration()->trailingSec();
 
+    cfg.viewMode = configuration()->viewMode();
+
     return cfg;
 }
 
@@ -298,11 +300,14 @@ std::optional<VideoWriter::ScoreRestoreData> VideoWriter::prepareScore(INotation
     score->setLayoutMode(engraving::LayoutMode::PAGE);
 
     score->setShowFrames(false);
-    score->setShowInstrumentNames(false);
     score->setShowInvisible(false);
     score->setShowPageborders(false);
     score->setShowUnprintable(false);
-    score->setShowVBox(false);
+
+    if (config.viewMode == ViewMode::Flexible) {
+        score->setShowInstrumentNames(false);
+        score->setShowVBox(false);
+    }
 
     score->doLayout();
 
@@ -314,6 +319,16 @@ std::optional<VideoWriter::ScoreRestoreData> VideoWriter::prepareScore(INotation
     }
 
     const Page* page = pages.front();
+
+    if (config.viewMode == ViewMode::PageFull) {
+        double scaleX = config.width / page->width();
+        double scaleY = config.height / page->height();
+        double scale = std::min(scaleX, scaleY);
+        config.canvasDpi = scale * engraving::DPI;
+        config.moveToCenter = muse::PointF(0.5 * (config.width / scale - page->width()), 0.5 * (config.height / scale - page->height()));
+        return result;
+    }
+
     if (score->staves().size() > 3) {
         //! NOTE: Calculate the dpi to display all page elements
         muse::RectF ttbox = page->tbbox();
@@ -343,7 +358,6 @@ std::optional<VideoWriter::ScoreRestoreData> VideoWriter::prepareScore(INotation
     score->style().set(engraving::Sid::staffUpperBorder, engraving::Spatium(7));
 
     score->setLayoutAll();
-    score->doLayout();
     score->update();
 
     return result;
@@ -562,7 +576,10 @@ bool VideoWriter::generateScoreFrames(muse::media::IVideoEncoderPtr encoder, INo
         opt.toPage = opt.fromPage;
         opt.deviceDpi = config.canvasDpi;
 
-        painter.fillRect(frameRect, Color::WHITE);
+        painter.fillRect(frameRect, Color::BLACK);
+
+        painter.save();
+        painter.translate(config.moveToCenter);
 
         painting->paintPrint(&painter, opt);
 
@@ -573,6 +590,8 @@ bool VideoWriter::generateScoreFrames(muse::media::IVideoEncoderPtr encoder, INo
         muse::RectF cursorAbsRect = cursorRect.translated(-pagePos);
 
         painter.fillRect(cursorAbsRect, CURSOR_COLOR);
+
+        painter.restore();
 
         encoder->encodeImage(frame);
     }

--- a/src/importexport/videoexport/internal/videowriter.h
+++ b/src/importexport/videoexport/internal/videowriter.h
@@ -67,7 +67,6 @@ public:
     void abort() override;
 
 private:
-
     struct Config
     {
         int width = 1920;
@@ -77,6 +76,8 @@ private:
         float leadingSec = 3.;
         float trailingSec = 3.;
         double canvasDpi = 300.0;
+        ViewMode viewMode = ViewMode::PageFull;
+        muse::PointF moveToCenter;
     };
 
     Config makeConfig() const;

--- a/src/importexport/videoexport/videoexporttypes.h
+++ b/src/importexport/videoexport/videoexporttypes.h
@@ -24,11 +24,8 @@
 
 namespace mu::iex::videoexport {
 enum ViewMode {
-    Auto,
-    PagedFloat,
-    PagedOriginal,
-    PagedFloatHeight,
-    Pano
+    PageFull,
+    Flexible,
 };
 
 enum PianoPosition {

--- a/src/project/qml/MuseScore/Project/ExportDialog.qml
+++ b/src/project/qml/MuseScore/Project/ExportDialog.qml
@@ -34,7 +34,7 @@ StyledDialogView {
     title: qsTrc("project/export", "Export")
 
     contentWidth: 756
-    contentHeight: 372
+    contentHeight: 420
     margins: 24
 
     ExportDialogModel {

--- a/src/project/qml/MuseScore/Project/internal/Export/Mp4SettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/Mp4SettingsPage.qml
@@ -113,9 +113,10 @@ ExportSettingsPage {
 
             ExportOptionItem {
                 id: videoResolutionLabel
-                text: qsTrc("project/export", "Video resolution:")
+                text: qsTrc("project/export", "Video resolution")
 
                 StyledDropdown {
+                    id: videoResolutionDropdown
                     Layout.preferredWidth: 126
 
                     navigation.name: "VideoResolutionDropdown"
@@ -132,6 +133,30 @@ ExportSettingsPage {
                     onActivated: function(index, value) {
                         root.model.videoResolution = value
                     }
+                }
+            }
+
+            RadioButtonGroup {
+                orientation: ListView.Vertical
+                spacing: 8
+                width: parent.width
+
+                model: root.model ? root.model.availableViewModes().map(function(obj) {
+                    return { text: obj.text, value: obj.value }
+                }) : []
+
+                delegate: RoundedRadioButton {
+                    required property var modelData
+                    required property int index
+
+                    text: modelData.text
+                    checked: root.model.viewMode === modelData.value
+                    onToggled: root.model.viewMode = modelData.value
+
+                    navigation.name: modelData.text
+                    navigation.panel: root.navigationPanel
+                    navigation.row: videoResolutionDropdown.navigation.row + 1 + index
+                    navigation.accessible.name: modelData.text
                 }
             }
 

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -615,6 +615,40 @@ void ExportDialogModel::setVideoResolution(const QString& resolution)
     emit videoResolutionChanged(resolution);
 }
 
+QVariantList ExportDialogModel::availableViewModes() const
+{
+    std::map<ViewMode, QString> viewModes {
+        { ViewMode::PageFull, muse::qtrc("project/export", "Use page layout") },
+        { ViewMode::Flexible, muse::qtrc("project/export", "Reflow to fit video resolution") },
+    };
+
+    QVariantList result;
+
+    for (const auto& [value, text] : viewModes) {
+        QVariantMap obj;
+        obj["value"] = value;
+        obj["text"] = text;
+        result << obj;
+    }
+
+    return result;
+}
+
+void ExportDialogModel::setViewMode(ViewMode v)
+{
+    if (v == videoExportConfiguration()->viewMode()) {
+        return;
+    }
+
+    videoExportConfiguration()->setViewMode(v);
+    emit viewModeChanged(v);
+}
+
+ExportDialogModel::ViewMode ExportDialogModel::viewMode() const
+{
+    return videoExportConfiguration()->viewMode();
+}
+
 bool ExportDialogModel::isFFmpegAvailable() const
 {
 #ifdef MUE_BUILD_IMPEXP_VIDEOEXPORT_MODULE

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
@@ -80,6 +80,10 @@ class ExportDialogModel : public QAbstractListModel, public QQmlParserStatus, pu
 
     Q_PROPERTY(QString videoResolution READ videoResolution WRITE setVideoResolution NOTIFY videoResolutionChanged)
 
+    using ViewMode = mu::iex::videoexport::ViewMode;
+    Q_ENUM(ViewMode);
+    Q_PROPERTY(ViewMode viewMode READ viewMode WRITE setViewMode NOTIFY viewModeChanged FINAL)
+
     Q_PROPERTY(int sampleRate READ sampleRate WRITE setSampleRate NOTIFY sampleRateChanged)
     Q_PROPERTY(int bitRate READ bitRate WRITE setBitRate NOTIFY bitRateChanged)
     Q_PROPERTY(QVariantList availableSampleFormats READ availableSampleFormats NOTIFY availableSampleFormatsChanged)
@@ -176,6 +180,10 @@ public:
     QString videoResolution() const;
     void setVideoResolution(const QString& resolution);
 
+    Q_INVOKABLE QVariantList availableViewModes() const;
+    ViewMode viewMode() const;
+    void setViewMode(ViewMode v);
+
     Q_INVOKABLE QList<int> availableSampleRates() const;
     int sampleRate() const;
     void setSampleRate(int sampleRate);
@@ -251,6 +259,7 @@ signals:
     void svgIllustratorCompatChanged(bool compat);
 
     void videoResolutionChanged(const QString& resolution);
+    void viewModeChanged(ViewMode v);
 
     void availableSampleRatesChanged();
     void sampleRateChanged(int sampleRate);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video export view mode selection with "Page Full" and "Flexible" options and exposed controls so selection persists.

* **UI/UX**
  * Increased export dialog height to fit new controls.
  * Removed trailing colon from the "Video resolution" label.

* **Behavior**
  * Default now favors full-page presentation; full-page mode centers and fits content to the frame and skips empty pages. Flexible mode preserves prior rendering choices (e.g., instrument names/layout).

* **Visual**
  * Video export background changed to black.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->