### PR TITLE
[4.7.0] VST: process MMC messages

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -554,4 +554,27 @@ enum SaveSoundTrackStage {
 };
 
 using SaveSoundTrackProgress = async::Channel<int64_t /*current*/, int64_t /*total*/, SaveSoundTrackStage>;
+
+struct TransportEvent {
+    enum class Type : unsigned char {
+        Unknown = 0,
+        Play,
+        Pause,
+        Stop,
+        Seek,
+    };
+
+    struct SeekData {
+        secs_t position = 0.;
+    };
+
+    static TransportEvent play() { return { Type::Play, {} }; }
+    static TransportEvent pause() { return { Type::Pause, {} }; }
+    static TransportEvent stop() { return { Type::Stop, {} }; }
+    static TransportEvent seek(secs_t pos) { return { Type::Seek, SeekData { pos } }; }
+
+    Type type = Type::Unknown;
+    std::variant<std::monostate, SeekData> data;
+};
+using TransportEvents = std::vector<TransportEvent>;
 }

--- a/src/framework/audio/common/rpc/irpcchannel.h
+++ b/src/framework/audio/common/rpc/irpcchannel.h
@@ -117,6 +117,9 @@ enum class Method {
     LoadSoundFonts,
     AddSoundFont,
     AddSoundFontData,
+
+    // Transport
+    TransportEventReceived,
 };
 
 inline std::string to_string(Method m)
@@ -201,6 +204,9 @@ inline std::string to_string(Method m)
     case Method::LoadSoundFonts: return "LoadSoundFonts";
     case Method::AddSoundFont: return "AddSoundFont";
     case Method::AddSoundFontData: return "AddSoundFontData";
+
+    // Transport
+    case Method::TransportEventReceived: return "TransportEventReceived";
     }
 
     assert(false && "unknown enum value");

--- a/src/framework/audio/common/rpc/rpcpacker.h
+++ b/src/framework/audio/common/rpc/rpcpacker.h
@@ -81,6 +81,9 @@ void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::InputProcessingProgr
 void pack_custom(muse::msgpack::Packer& p, const muse::audio::InputProcessingProgress::StatusInfo& value);
 void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::InputProcessingProgress::StatusInfo& value);
 
+void pack_custom(muse::msgpack::Packer& p, const muse::audio::TransportEvent& value);
+void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::TransportEvent& value);
+
 // MPE
 // PlaybackEvent
 void pack_custom(muse::msgpack::Packer& p, const muse::mpe::ArrangementContext& value);
@@ -340,6 +343,29 @@ inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::InputProcessi
     uint8_t status = 0;
     p.process(status, value.errorCode, value.errorText, value.data);
     value.status = static_cast<muse::audio::InputProcessingProgress::Status>(status);
+}
+
+inline void pack_custom(muse::msgpack::Packer& p, const muse::audio::TransportEvent& value)
+{
+    p.process(static_cast<uint8_t>(value.type));
+
+    if (value.type == muse::audio::TransportEvent::Type::Seek) {
+        const auto& seek = std::get<muse::audio::TransportEvent::SeekData>(value.data);
+        p.process(seek.position);
+    }
+}
+
+inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::TransportEvent& value)
+{
+    uint8_t type = 0;
+    p.process(type);
+    value.type = static_cast<muse::audio::TransportEvent::Type>(type);
+
+    if (value.type == muse::audio::TransportEvent::Type::Seek) {
+        muse::audio::TransportEvent::SeekData seek;
+        p.process(seek.position);
+        value.data = seek;
+    }
 }
 
 // MPE

--- a/src/framework/audio/engine/CMakeLists.txt
+++ b/src/framework/audio/engine/CMakeLists.txt
@@ -46,6 +46,7 @@ else()
         isynthesizer.h
         isynthresolver.h
         isoundfontrepository.h
+        itransporteventsdispatcher.h
 
         # internal
         internal/audioengineconfiguration.cpp
@@ -87,6 +88,8 @@ else()
         # internal/noisesource.h
         internal/abstracteventsequencer.h
         internal/audiosignalnotifier.h
+        internal/transporteventsdispatcher.cpp
+        internal/transporteventsdispatcher.h
 
         # DSP
         internal/dsp/envelopefilterconfig.h

--- a/src/framework/audio/engine/internal/enginecontroller.cpp
+++ b/src/framework/audio/engine/internal/enginecontroller.cpp
@@ -42,6 +42,8 @@
 #include "synthesizers/synthresolver.h"
 #include "synthesizers/soundfontrepository.h"
 
+#include "transporteventsdispatcher.h"
+
 #include "log.h"
 
 using namespace muse;
@@ -94,6 +96,7 @@ void EngineController::registerExports()
     m_fxResolver = std::make_shared<FxResolver>();
     m_synthResolver = std::make_shared<SynthResolver>();
     m_soundFontRepository = std::make_shared<SoundFontRepository>();
+    m_transportEventsDispatcher = std::make_shared<TransportEventsDispatcher>(iocContext());
 
     globalIoc()->registerExport<IAudioEngineConfiguration>(moduleName(), m_configuration);
     globalIoc()->registerExport<IAudioEngine>(moduleName(), m_audioEngine);
@@ -101,6 +104,7 @@ void EngineController::registerExports()
     globalIoc()->registerExport<IFxResolver>(moduleName(), m_fxResolver);
     globalIoc()->registerExport<ISynthResolver>(moduleName(), m_synthResolver);
     globalIoc()->registerExport<ISoundFontRepository>(moduleName(), m_soundFontRepository);
+    globalIoc()->registerExport<ITransportEventsDispatcher>(moduleName(), m_transportEventsDispatcher);
 }
 
 void EngineController::unregisterExports()
@@ -112,6 +116,7 @@ void EngineController::unregisterExports()
     globalIoc()->unregister<IFxResolver>(moduleName());
     globalIoc()->unregister<ISynthResolver>(moduleName());
     globalIoc()->unregister<ISoundFontRepository>(moduleName());
+    globalIoc()->unregister<ITransportEventsDispatcher>(moduleName());
 }
 
 void EngineController::onStartRunning()
@@ -148,6 +153,8 @@ void EngineController::init(const OutputSpec& outputSpec, const AudioEngineConfi
     m_synthResolver->init(m_configuration->defaultAudioInputParams(), outputSpec);
 
     m_playback->init();
+
+    m_transportEventsDispatcher->init();
 }
 
 void EngineController::deinit()

--- a/src/framework/audio/engine/internal/enginecontroller.h
+++ b/src/framework/audio/engine/internal/enginecontroller.h
@@ -46,6 +46,7 @@ class AudioEngine;
 class WebAudioChannel;
 class EnginePlayback;
 class EngineRpcController;
+class TransportEventsDispatcher;
 
 class EngineController : public IEngineController, public muse::Contextable
 {
@@ -77,5 +78,6 @@ private:
     std::shared_ptr<synth::SynthResolver> m_synthResolver;
     std::shared_ptr<synth::SoundFontRepository> m_soundFontRepository;
     std::shared_ptr<WebAudioChannel> m_webAudioChannel;
+    std::shared_ptr<TransportEventsDispatcher> m_transportEventsDispatcher;
 };
 }

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -415,6 +415,7 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_masterParams.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
             m_masterOutputParamsChanged.send(m_masterParams);
+            updateShouldProcessMasterFxDuringSilence();
         }, async::Asyncable::Mode::SetReplace);
     }
 
@@ -443,13 +444,9 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
         }
     }
 
-    m_shouldProcessMasterFxDuringSilence = std::any_of(m_masterFxProcessors.cbegin(), m_masterFxProcessors.cend(),
-                                                       [](const IFxProcessorPtr& fx) {
-        return fx->shouldProcessDuringSilence();
-    });
-
     m_masterParams = resultParams;
     m_masterOutputParamsChanged.send(resultParams);
+    updateShouldProcessMasterFxDuringSilence();
 }
 
 void Mixer::clearMasterOutputParams()
@@ -610,6 +607,17 @@ void Mixer::completeOutput(float* buffer, samples_t samplesPerChannel)
     }
 
     m_isSilence = RealIsNull(globalPeak);
+}
+
+void Mixer::updateShouldProcessMasterFxDuringSilence()
+{
+    m_shouldProcessMasterFxDuringSilence = false;
+    for (const IFxProcessorPtr& fx : m_masterFxProcessors) {
+        if (fx->shouldProcessDuringSilence()) {
+            m_shouldProcessMasterFxDuringSilence = true;
+            return;
+        }
+    }
 }
 
 void Mixer::notifyAboutAudioSignalChanges()

--- a/src/framework/audio/engine/internal/mixer.h
+++ b/src/framework/audio/engine/internal/mixer.h
@@ -97,6 +97,8 @@ private:
 
     bool useMultithreading() const;
 
+    void updateShouldProcessMasterFxDuringSilence();
+
     void notifyAboutAudioSignalChanges();
     void notifyNoAudioSignal();
 

--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -97,6 +97,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_params.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
             m_paramsChanges.send(m_params);
+            updateShouldProcessDuringSilence();
         }, async::Asyncable::Mode::SetReplace);
     }
 
@@ -134,15 +135,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
         m_mutedChanged.notify();
     }
 
-    const bool shouldProcessDuringSilence = std::any_of(m_fxProcessors.cbegin(), m_fxProcessors.cend(),
-                                                        [](const IFxProcessorPtr& fx) {
-        return fx->shouldProcessDuringSilence();
-    });
-
-    if (shouldProcessDuringSilence != m_shouldProcessDuringSilence) {
-        m_shouldProcessDuringSilence = shouldProcessDuringSilence;
-        m_shouldProcessDuringSilenceChanged.send(shouldProcessDuringSilence);
-    }
+    updateShouldProcessDuringSilence();
 }
 
 async::Channel<AudioOutputParams> MixerChannel::outputParamsChanged() const
@@ -265,6 +258,22 @@ void MixerChannel::completeOutput(float* buffer, unsigned int samplesCount)
     }
 
     m_isSilent = RealIsNull(globalPeak);
+}
+
+void MixerChannel::updateShouldProcessDuringSilence()
+{
+    bool shouldProcessDuringSilence = false;
+    for (const IFxProcessorPtr& fx : m_fxProcessors) {
+        if (fx->shouldProcessDuringSilence()) {
+            shouldProcessDuringSilence = true;
+            break;
+        }
+    }
+
+    if (shouldProcessDuringSilence != m_shouldProcessDuringSilence) {
+        m_shouldProcessDuringSilence = shouldProcessDuringSilence;
+        m_shouldProcessDuringSilenceChanged.send(shouldProcessDuringSilence);
+    }
 }
 
 bool MixerChannel::isSilent() const

--- a/src/framework/audio/engine/internal/mixerchannel.h
+++ b/src/framework/audio/engine/internal/mixerchannel.h
@@ -73,6 +73,8 @@ public:
 private:
     void completeOutput(float* buffer, unsigned int samplesCount);
 
+    void updateShouldProcessDuringSilence();
+
     TrackId m_trackId = -1;
 
     OutputSpec m_outputSpec;

--- a/src/framework/audio/engine/internal/sequenceplayer.cpp
+++ b/src/framework/audio/engine/internal/sequenceplayer.cpp
@@ -85,6 +85,10 @@ void SequencePlayer::play(const secs_t delay)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
+    if (playbackStatus() == PlaybackStatus::Running) {
+        return;
+    }
+
     m_clock->setCountDown(secsToMicrosecs(delay));
     m_countDownIsSet = !delay.is_zero();
     audioEngine()->setMode(RenderMode::RealTimeMode);
@@ -106,6 +110,10 @@ void SequencePlayer::stop()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
+    if (playbackStatus() == PlaybackStatus::Stopped) {
+        return;
+    }
+
     audioEngine()->setMode(RenderMode::IdleMode);
     m_clock->stop();
     m_notYetReadyToPlayTrackIdSet.clear();
@@ -115,6 +123,10 @@ void SequencePlayer::pause()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
+    if (playbackStatus() == PlaybackStatus::Paused) {
+        return;
+    }
+
     audioEngine()->setMode(RenderMode::IdleMode);
     m_clock->pause();
     m_notYetReadyToPlayTrackIdSet.clear();
@@ -123,6 +135,10 @@ void SequencePlayer::pause()
 void SequencePlayer::resume(const secs_t delay)
 {
     ONLY_AUDIO_ENGINE_THREAD;
+
+    if (playbackStatus() == PlaybackStatus::Running) {
+        return;
+    }
 
     m_clock->setCountDown(secsToMicrosecs(delay));
     m_countDownIsSet = !delay.is_zero();

--- a/src/framework/audio/engine/internal/transporteventsdispatcher.cpp
+++ b/src/framework/audio/engine/internal/transporteventsdispatcher.cpp
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "transporteventsdispatcher.h"
+
+#include "audio/common/rpc/rpcpacker.h"
+#include "audio/common/audiosanitizer.h"
+
+using namespace muse::audio::engine;
+using namespace muse::audio::rpc;
+
+TransportEventsDispatcher::TransportEventsDispatcher(const modularity::ContextPtr& iocCtx)
+    : Contextable(iocCtx),
+    m_eventsReceived(async::makeOpt()
+                     .name("audio::engine::TransportEventsDispatcher::m_eventsReceived")
+                     .disableWaitPendingsOnSend())
+{
+}
+
+void TransportEventsDispatcher::init()
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+
+    m_eventsReceived.onReceive(this, [this](const TransportEvents& events) {
+        for (const TransportEvent& event : events) {
+            rpcChannel()->send(rpc::make_request(Method::TransportEventReceived, RpcPacker::pack(event)));
+        }
+    });
+}
+
+void TransportEventsDispatcher::dispatch(const TransportEvents& events)
+{
+    ONLY_AUDIO_PROC_THREAD;
+
+    //! Transfer events to the audio engine thread
+    m_eventsReceived.send(events);
+}

--- a/src/framework/audio/engine/internal/transporteventsdispatcher.h
+++ b/src/framework/audio/engine/internal/transporteventsdispatcher.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "audio/engine/itransporteventsdispatcher.h"
+#include "global/modularity/ioc.h"
+
+#include "audio/common/rpc/irpcchannel.h"
+
+namespace muse::audio::engine {
+class TransportEventsDispatcher : public ITransportEventsDispatcher, public Contextable, public async::Asyncable
+{
+    ContextInject<rpc::IRpcChannel> rpcChannel = { this };
+
+public:
+    TransportEventsDispatcher(const modularity::ContextPtr& iocCtx);
+
+    void init();
+
+    void dispatch(const TransportEvents& events) override;
+
+private:
+    async::Channel<TransportEvents> m_eventsReceived;
+};
+}

--- a/src/framework/audio/engine/itransporteventsdispatcher.h
+++ b/src/framework/audio/engine/itransporteventsdispatcher.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "global/modularity/imoduleinterface.h"
+
+#include "audio/common/audiotypes.h"
+
+namespace muse::audio::engine {
+class ITransportEventsDispatcher : MODULE_CONTEXT_INTERFACE
+{
+    INTERFACE_ID(ITransportEventsDispatcher)
+
+public:
+    virtual ~ITransportEventsDispatcher() = default;
+
+    virtual void dispatch(const TransportEvents& events) = 0;
+};
+}

--- a/src/framework/audio/main/CMakeLists.txt
+++ b/src/framework/audio/main/CMakeLists.txt
@@ -37,6 +37,8 @@ target_sources(muse_audio_main PRIVATE
     internal/audiouiactions.h
     internal/audioactionscontroller.cpp
     internal/audioactionscontroller.h
+    internal/transporteventscontroller.cpp
+    internal/transporteventscontroller.h
     internal/startaudiocontroller.cpp
     internal/startaudiocontroller.h
     internal/playback.cpp

--- a/src/framework/audio/main/audiomodule.cpp
+++ b/src/framework/audio/main/audiomodule.cpp
@@ -36,6 +36,7 @@
 
 #include "internal/audioconfiguration.h"
 #include "internal/audioactionscontroller.h"
+#include "internal/transporteventscontroller.h"
 #include "internal/audiouiactions.h"
 #include "internal/startaudiocontroller.h"
 #include "internal/playback.h"
@@ -63,6 +64,7 @@ void AudioModule::registerExports()
 {
     m_configuration = std::make_shared<AudioConfiguration>(iocContext());
     m_actionsController = std::make_shared<AudioActionsController>(iocContext());
+    m_transportEventsController = std::make_shared<TransportEventsController>(iocContext());
     m_mainPlayback = std::make_shared<Playback>(iocContext());
     m_audioDriverController = std::make_shared<AudioDriverController>(iocContext());
 
@@ -113,6 +115,8 @@ void AudioModule::onInit(const IApplication::RunMode& mode)
     }, Ticker::Mode::Repeat);
 #endif
 
+    m_transportEventsController->init(); //! NOTE: init AFTER RPC
+
     m_mainPlayback->init();
 
     m_startAudioController->init();
@@ -140,6 +144,7 @@ void AudioModule::onDeinit()
     }
 
     m_mainPlayback->deinit();
+    m_transportEventsController->deinit();
     m_rpcTicker.stop();
 
     m_startAudioController->stopAudioProcessing();

--- a/src/framework/audio/main/audiomodule.h
+++ b/src/framework/audio/main/audiomodule.h
@@ -35,6 +35,7 @@ class IRpcChannel;
 namespace muse::audio {
 class AudioConfiguration;
 class AudioActionsController;
+class TransportEventsController;
 class StartAudioController;
 class Playback;
 class ISoundFontController;
@@ -54,6 +55,7 @@ public:
 private:
     std::shared_ptr<AudioConfiguration> m_configuration;
     std::shared_ptr<AudioActionsController> m_actionsController;
+    std::shared_ptr<TransportEventsController> m_transportEventsController;
     std::shared_ptr<StartAudioController> m_startAudioController;
     std::shared_ptr<Playback> m_mainPlayback;
     std::shared_ptr<ISoundFontController> m_soundFontController;

--- a/src/framework/audio/main/internal/transporteventscontroller.cpp
+++ b/src/framework/audio/main/internal/transporteventscontroller.cpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "transporteventscontroller.h"
+
+#include "audio/common/audiosanitizer.h"
+
+using namespace muse::audio;
+using namespace muse::audio::rpc;
+using namespace muse::actions;
+
+void TransportEventsController::init()
+{
+    ONLY_AUDIO_MAIN_THREAD;
+
+    channel()->onMethod(Method::TransportEventReceived, [this](const Msg& msg) {
+        ONLY_AUDIO_MAIN_THREAD;
+
+        TransportEvent event;
+        IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, event)) {
+            return;
+        }
+
+        onEventReceived(event);
+    });
+}
+
+void TransportEventsController::deinit()
+{
+    ONLY_AUDIO_MAIN_THREAD;
+
+    channel()->onMethod(Method::TransportEventReceived, nullptr);
+}
+
+void TransportEventsController::onEventReceived(const TransportEvent& event)
+{
+    ONLY_AUDIO_MAIN_THREAD;
+
+    switch (event.type) {
+    case TransportEvent::Type::Play:
+        dispatcher()->dispatch("play");
+        break;
+    case TransportEvent::Type::Pause:
+        dispatcher()->dispatch("pause");
+        break;
+    case TransportEvent::Type::Stop:
+        dispatcher()->dispatch("stop");
+        break;
+    case TransportEvent::Type::Seek:
+        if (std::holds_alternative<TransportEvent::SeekData>(event.data)) {
+            const secs_t pos = std::get<TransportEvent::SeekData>(event.data).position;
+            dispatcher()->dispatch("rewind", ActionData::make_arg1<secs_t>(pos));
+        }
+        break;
+    case TransportEvent::Type::Unknown:
+        break;
+    }
+}

--- a/src/framework/audio/main/internal/transporteventscontroller.h
+++ b/src/framework/audio/main/internal/transporteventscontroller.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modularity/ioc.h"
+
+#include "audio/common/rpc/irpcchannel.h"
+#include "actions/iactionsdispatcher.h"
+
+namespace muse::audio {
+class TransportEventsController : public async::Asyncable, public Contextable
+{
+    ContextInject<rpc::IRpcChannel> channel = { this };
+    ContextInject<actions::IActionsDispatcher> dispatcher = { this };
+
+public:
+    TransportEventsController(const muse::modularity::ContextPtr& iocCtx)
+        : Contextable(iocCtx) {}
+
+    void init();
+    void deinit();
+
+private:
+    void onEventReceived(const TransportEvent& event);
+};
+}

--- a/src/framework/midiremote/CMakeLists.txt
+++ b/src/framework/midiremote/CMakeLists.txt
@@ -23,16 +23,23 @@ muse_create_module(muse_midiremote ALIAS muse::midiremote)
 target_sources(muse_midiremote PRIVATE
     midiremotemodule.cpp
     midiremotemodule.h
-    mmc.cpp
-    mmc.h
     midiremotetypes.h
     imidiremoteconfiguration.h
     imidiremote.h
+
+    mmctypes.h
+    immcdecoder.h
+    immcdecoderfactory.h
 
     internal/midiremoteconfiguration.cpp
     internal/midiremoteconfiguration.h
     internal/midiremote.cpp
     internal/midiremote.h
+
+    internal/mmcdecoder.cpp
+    internal/mmcdecoder.h
+    internal/mmcdecoderfactory.cpp
+    internal/mmcdecoderfactory.h
 )
 
 if (MUSE_MODULE_MIDIREMOTE_QML)

--- a/src/framework/midiremote/immcdecoder.h
+++ b/src/framework/midiremote/immcdecoder.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <memory>
+
+#include "mmctypes.h"
+
+namespace muse::midi {
+struct Event;
+}
+
+namespace muse::midiremote {
+class IMMCDecoder
+{
+public:
+    virtual ~IMMCDecoder() = default;
+
+    virtual std::optional<MMCMessage> decode(const midi::Event& event) = 0;
+    virtual std::optional<MMCMessage> decode(const uint8_t* data, size_t size) = 0;
+
+    virtual std::optional<double> locateToSeconds(const MMCMessage& msg) const = 0;
+};
+
+using IMMCDecoderPtr = std::shared_ptr<IMMCDecoder>;
+}

--- a/src/framework/midiremote/immcdecoderfactory.h
+++ b/src/framework/midiremote/immcdecoderfactory.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+
+#include "immcdecoder.h"
+
+namespace muse::midiremote {
+class IMMCDecoderFactory : MODULE_GLOBAL_INTERFACE
+{
+    INTERFACE_ID(IMMCDecoderFactory)
+
+public:
+    virtual ~IMMCDecoderFactory() = default;
+
+    virtual IMMCDecoderPtr makeDecoder() const = 0;
+};
+}

--- a/src/framework/midiremote/internal/midiremote.cpp
+++ b/src/framework/midiremote/internal/midiremote.cpp
@@ -56,6 +56,8 @@ void MidiRemote::init()
     });
 
     readMidiMappings();
+
+    m_mmcDecoder = mmcDecoderFactory()->makeDecoder();
 }
 
 const MidiMappingList& MidiRemote::midiMappings() const
@@ -117,8 +119,8 @@ Ret MidiRemote::process(const Event& ev)
         return Ret(Ret::Code::Undefined);
     }
 
-    if (ev.messageType() == Event::MessageType::SystemExclusiveData) {
-        const std::optional<MMCMessage> msg = m_mmcParser.process(ev);
+    if (ev.messageType() == Event::MessageType::SystemExclusiveData && m_mmcDecoder) {
+        const std::optional<MMCMessage> msg = m_mmcDecoder->decode(ev);
         if (msg.has_value()) {
             processMMC(msg.value());
         }
@@ -300,7 +302,7 @@ void MidiRemote::processMMC(const MMCMessage& msg)
         dispatcher()->dispatch("stop");
         break;
     case MMCCommand::Locate: {
-        const std::optional<double> pos = MMCParser::locateToSeconds(msg);
+        const std::optional<double> pos = m_mmcDecoder->locateToSeconds(msg);
         if (pos.has_value()) {
             dispatcher()->dispatch("rewind", actions::ActionData::make_arg1<secs_t>(pos.value()));
         }

--- a/src/framework/midiremote/internal/midiremote.h
+++ b/src/framework/midiremote/internal/midiremote.h
@@ -31,7 +31,7 @@
 #include "actions/iactionsdispatcher.h"
 #include "multiwindows/imultiwindowsprovider.h"
 
-#include "midiremote/mmc.h"
+#include "midiremote/immcdecoderfactory.h"
 
 namespace muse {
 class XmlStreamReader;
@@ -44,6 +44,7 @@ class MidiRemote : public IMidiRemote, public Contextable, public async::Asyncab
     GlobalInject<IMidiRemoteConfiguration> configuration;
     GlobalInject<io::IFileSystem> fileSystem;
     GlobalInject<mi::IMultiWindowsProvider> multiwindowsProvider;
+    GlobalInject<IMMCDecoderFactory> mmcDecoderFactory;
     ContextInject<muse::actions::IActionsDispatcher> dispatcher = { this };
 
 public:
@@ -84,6 +85,6 @@ private:
     MidiMappingList m_midiMappings;
     async::Notification m_midiMappingsChanged;
 
-    midiremote::MMCParser m_mmcParser;
+    IMMCDecoderPtr m_mmcDecoder;
 };
 }

--- a/src/framework/midiremote/internal/mmcdecoder.cpp
+++ b/src/framework/midiremote/internal/mmcdecoder.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "mmc.h"
+#include "mmcdecoder.h"
 
 #include "midi/midievent.h"
 #include "log.h"
@@ -94,7 +94,7 @@ static MMCMessage parseMMC(const std::vector<uint8_t>& sysex)
     return msg;
 }
 
-class MMCParser::SysExAssembler
+class MMCDecoder::SysExAssembler
 {
 public:
     bool process(const Event& event, std::vector<uint8_t>& result)
@@ -189,20 +189,21 @@ private:
     bool m_inProgress = false;
 };
 
-MMCParser::MMCParser()
-    : m_assembler(new SysExAssembler())
+MMCDecoder::~MMCDecoder()
 {
+    if (m_assembler) {
+        delete m_assembler;
+    }
 }
 
-MMCParser::~MMCParser()
-{
-    delete m_assembler;
-}
-
-std::optional<MMCMessage> MMCParser::process(const Event& event)
+std::optional<MMCMessage> MMCDecoder::decode(const Event& event)
 {
     if (event.messageType() != Event::MessageType::SystemExclusiveData) {
         return std::nullopt;
+    }
+
+    if (!m_assembler) {
+        m_assembler = new SysExAssembler();
     }
 
     std::vector<uint8_t> sysex;
@@ -217,10 +218,14 @@ std::optional<MMCMessage> MMCParser::process(const Event& event)
     return parseMMC(sysex);
 }
 
-std::optional<MMCMessage> MMCParser::process(const uint8_t* data, size_t size)
+std::optional<MMCMessage> MMCDecoder::decode(const uint8_t* data, size_t size)
 {
     if (!data || size == 0) {
         return std::nullopt;
+    }
+
+    if (!m_assembler) {
+        m_assembler = new SysExAssembler();
     }
 
     std::vector<uint8_t> sysex;
@@ -235,7 +240,7 @@ std::optional<MMCMessage> MMCParser::process(const uint8_t* data, size_t size)
     return parseMMC(sysex);
 }
 
-std::optional<double> MMCParser::locateToSeconds(const MMCMessage& msg)
+std::optional<double> MMCDecoder::locateToSeconds(const MMCMessage& msg) const
 {
     IF_ASSERT_FAILED(msg.command == MMCCommand::Locate) {
         return std::nullopt;

--- a/src/framework/midiremote/internal/mmcdecoder.h
+++ b/src/framework/midiremote/internal/mmcdecoder.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "midiremote/immcdecoder.h"
+
+namespace muse::midiremote {
+class MMCDecoder : public IMMCDecoder
+{
+public:
+    MMCDecoder() = default;
+    ~MMCDecoder();
+
+    MMCDecoder(const MMCDecoder&) = delete;
+    MMCDecoder& operator=(const MMCDecoder&) = delete;
+
+    std::optional<MMCMessage> decode(const midi::Event& event) override;
+    std::optional<MMCMessage> decode(const uint8_t* data, size_t size) override;
+
+    std::optional<double> locateToSeconds(const MMCMessage& msg) const override;
+
+private:
+    class SysExAssembler;
+    SysExAssembler* m_assembler = nullptr;
+};
+}

--- a/src/framework/midiremote/internal/mmcdecoderfactory.cpp
+++ b/src/framework/midiremote/internal/mmcdecoderfactory.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mmcdecoderfactory.h"
+
+#include "mmcdecoder.h"
+
+using namespace muse::midiremote;
+
+IMMCDecoderPtr MMCDecoderFactory::makeDecoder() const
+{
+    return std::make_shared<MMCDecoder>();
+}

--- a/src/framework/midiremote/internal/mmcdecoderfactory.h
+++ b/src/framework/midiremote/internal/mmcdecoderfactory.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "midiremote/immcdecoderfactory.h"
+
+namespace muse::midiremote {
+class MMCDecoderFactory : public IMMCDecoderFactory
+{
+public:
+    IMMCDecoderPtr makeDecoder() const override;
+};
+}

--- a/src/framework/midiremote/midiremotemodule.cpp
+++ b/src/framework/midiremote/midiremotemodule.cpp
@@ -24,6 +24,7 @@
 
 #include "midiremote/internal/midiremoteconfiguration.h"
 #include "midiremote/internal/midiremote.h"
+#include "midiremote/internal/mmcdecoderfactory.h"
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
 #include "diagnostics/idiagnosticspathsregister.h"
@@ -43,6 +44,8 @@ void MidiRemoteModule::registerExports()
 
     ioc()->registerExport<IMidiRemoteConfiguration>(moduleName(), m_configuration);
     ioc()->registerExport<IMidiRemote>(moduleName(), m_midiRemote);
+
+    globalIoc()->registerExport<IMMCDecoderFactory>(moduleName(), std::make_shared<MMCDecoderFactory>());
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
     auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());

--- a/src/framework/midiremote/mmc.cpp
+++ b/src/framework/midiremote/mmc.cpp
@@ -28,44 +28,6 @@
 using namespace muse::midi;
 using namespace muse::midiremote;
 
-inline std::optional<MMCMessage> fastParseMMC(const Event& event)
-{
-    if (event.midi20WordCount() < 2) {
-        return std::nullopt;
-    }
-
-    const uint32_t* words = event.midi20Words();
-    const uint32_t w0 = words[0];
-
-    // Extract UMP SysEx header fields
-    const uint8_t status = (w0 >> 20) & 0xF; // 0 = complete packet
-    const uint8_t count  = (w0 >> 16) & 0xF; // number of valid bytes (0-6)
-
-    // Fast path only handles complete, short messages
-    // Long messages, such as Locate, are ignored here
-    if (status != 0 || count != 4) {
-        return std::nullopt;
-    }
-
-    // SysEx packs first 2 bytes in word 0, next bytes in word 1
-    const uint8_t b0 = (w0 >> 8) & 0xFF;
-    const uint8_t b1 = (w0 >> 0) & 0xFF;
-    const uint32_t w1 = words[1];
-    const uint8_t b2 = (w1 >> 24) & 0xFF;
-    const uint8_t b3 = (w1 >> 16) & 0xFF;
-
-    // MMC structure: 7F <device> 06 <command>
-    if (!(b0 == 0x7F && b2 == 0x06)) {
-        return std::nullopt;
-    }
-
-    MMCMessage msg;
-    msg.deviceId = b1;
-    msg.command = static_cast<MMCCommand>(b3);
-
-    return msg;
-}
-
 static bool extractSysExBytes(const Event& event, std::vector<uint8_t>& out)
 {
     const size_t wordCount = event.midi20WordCount();
@@ -143,30 +105,76 @@ public:
         }
 
         const uint32_t* words = event.midi20Words();
-        const uint8_t status = (words[0] >> 20) & 0xF;
+        const Status status = static_cast<Status>((words[0] >> 20) & 0xF);
 
+        return processChunk(bytes.data(), bytes.size(), status, result);
+    }
+
+    bool process(const uint8_t* data, size_t size, std::vector<uint8_t>& result)
+    {
+        const bool hasStartByte = (data[0] == 0xF0);
+        const bool hasEndByte = (data[size - 1] == 0xF7);
+
+        Status status;
+
+        if (hasStartByte && hasEndByte) {
+            status = Status::Complete;
+        } else if (hasStartByte) {
+            status = Status::Start;
+        } else if (hasEndByte) {
+            status = Status::End;
+        } else {
+            status = m_inProgress ? Status::Continue : Status::Complete;
+        }
+
+        // Skip start & end bytes if present
+        const uint8_t* payload = data;
+        size_t payloadSize = size;
+
+        if (hasStartByte) {
+            payload += 1;
+            payloadSize -= 1;
+        }
+
+        if (payloadSize > 0 && hasEndByte) {
+            payloadSize -= 1;
+        }
+
+        return processChunk(payload, payloadSize, status, result);
+    }
+
+private:
+    enum class Status : uint8_t {
+        Complete = 0,
+        Start = 1,
+        Continue = 2,
+        End = 3,
+    };
+
+    bool processChunk(const uint8_t* data, size_t size, Status status, std::vector<uint8_t>& result)
+    {
         switch (status) {
-        case 0: { // COMPLETE
+        case Status::Complete: {
             m_buffer.clear();
             m_inProgress = false;
-            result = bytes;
+            result.assign(data, data + size);
             return true;
         }
-        case 1: { // START
-            m_buffer = bytes;
+        case Status::Start: {
+            m_buffer.assign(data, data + size);
             m_inProgress = true;
         } break;
-        case 2: { // CONTINUE
+        case Status::Continue: {
             if (!m_inProgress) {
                 return false;
             }
-            m_buffer.insert(m_buffer.end(), bytes.begin(), bytes.end());
+            m_buffer.insert(m_buffer.end(), data, data + size);
         } break;
-        case 3: { // END
+        case Status::End: {
             if (!m_inProgress) {
                 return false;
             }
-            m_buffer.insert(m_buffer.end(), bytes.begin(), bytes.end());
+            m_buffer.insert(m_buffer.end(), data, data + size);
             result = m_buffer;
             m_buffer.clear();
             m_inProgress = false;
@@ -177,16 +185,18 @@ public:
         return false;
     }
 
-private:
     std::vector<uint8_t> m_buffer;
     bool m_inProgress = false;
 };
 
+MMCParser::MMCParser()
+    : m_assembler(new SysExAssembler())
+{
+}
+
 MMCParser::~MMCParser()
 {
-    if (m_assembler) {
-        delete m_assembler;
-    }
+    delete m_assembler;
 }
 
 std::optional<MMCMessage> MMCParser::process(const Event& event)
@@ -195,16 +205,26 @@ std::optional<MMCMessage> MMCParser::process(const Event& event)
         return std::nullopt;
     }
 
-    if (std::optional<MMCMessage> msg = fastParseMMC(event)) {
-        return msg;
+    std::vector<uint8_t> sysex;
+    if (!m_assembler->process(event, sysex)) {
+        return std::nullopt;
     }
 
-    if (!m_assembler) {
-        m_assembler = new SysExAssembler();
+    if (!isMMC(sysex)) {
+        return std::nullopt;
+    }
+
+    return parseMMC(sysex);
+}
+
+std::optional<MMCMessage> MMCParser::process(const uint8_t* data, size_t size)
+{
+    if (!data || size == 0) {
+        return std::nullopt;
     }
 
     std::vector<uint8_t> sysex;
-    if (!m_assembler->process(event, sysex)) {
+    if (!m_assembler->process(data, size, sysex)) {
         return std::nullopt;
     }
 

--- a/src/framework/midiremote/mmc.h
+++ b/src/framework/midiremote/mmc.h
@@ -61,13 +61,14 @@ struct MMCMessage
 class MMCParser
 {
 public:
-    MMCParser() = default;
+    MMCParser();
     ~MMCParser();
 
     MMCParser(const MMCParser&) = delete;
     MMCParser& operator=(const MMCParser&) = delete;
 
     std::optional<MMCMessage> process(const midi::Event& event);
+    std::optional<MMCMessage> process(const uint8_t* data, size_t size);
 
     static std::optional<double> locateToSeconds(const MMCMessage& msg);
 

--- a/src/framework/midiremote/mmctypes.h
+++ b/src/framework/midiremote/mmctypes.h
@@ -24,11 +24,6 @@
 
 #include <cstdint>
 #include <vector>
-#include <optional>
-
-namespace muse::midi {
-struct Event;
-}
 
 namespace muse::midiremote {
 enum class MMCCommand : uint8_t
@@ -56,24 +51,5 @@ struct MMCMessage
     uint8_t deviceId = 0;
     MMCCommand command = MMCCommand::Unknown;
     std::vector<uint8_t> data;
-};
-
-class MMCParser
-{
-public:
-    MMCParser();
-    ~MMCParser();
-
-    MMCParser(const MMCParser&) = delete;
-    MMCParser& operator=(const MMCParser&) = delete;
-
-    std::optional<MMCMessage> process(const midi::Event& event);
-    std::optional<MMCMessage> process(const uint8_t* data, size_t size);
-
-    static std::optional<double> locateToSeconds(const MMCMessage& msg);
-
-private:
-    class SysExAssembler;
-    SysExAssembler* m_assembler = nullptr;
 };
 }

--- a/src/framework/midiremote/tests/CMakeLists.txt
+++ b/src/framework/midiremote/tests/CMakeLists.txt
@@ -21,7 +21,7 @@
 set(MODULE_TEST muse_midiremote_test)
 
 set(MODULE_TEST_SRC
-    ${CMAKE_CURRENT_LIST_DIR}/mmc_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mmcdecoder_tests.cpp
     )
 
 set(MODULE_TEST_LINK

--- a/src/framework/midiremote/tests/mmc_tests.cpp
+++ b/src/framework/midiremote/tests/mmc_tests.cpp
@@ -82,7 +82,7 @@ protected:
     }
 };
 
-TEST_F(MMCParserTests, Process_PlayCommand)
+TEST_F(MMCParserTests, Process_MidiEvents_PlayCommand)
 {
     // [GIVEN] Play command
     // SysEx: 7F <dev> 06 02
@@ -100,7 +100,39 @@ TEST_F(MMCParserTests, Process_PlayCommand)
     EXPECT_TRUE(msg->data.empty());
 }
 
-TEST_F(MMCParserTests, Process_LocateCommand_FragmentedSysEx)
+TEST_F(MMCParserTests, Process_ShortSysEx_PlayCommand)
+{
+    // [GIVEN] Short SysEx (no F0/F7)
+    constexpr uint8_t data[] = { 0x7F, 0x7F, 0x06, 0x02 };
+
+    // [WHEN] Parse MMC message
+    MMCParser parser;
+    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
+
+    // [THEN] Message is valid
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg->command, MMCCommand::Play);
+    EXPECT_EQ(msg->deviceId, 0x7F);
+    EXPECT_TRUE(msg->data.empty());
+}
+
+TEST_F(MMCParserTests, Process_FullSysEx_PlayCommand)
+{
+    // [GIVEN] Full SysEx (with start and end bytes)
+    constexpr uint8_t data[] = { 0xF0, 0x7F, 0x7F, 0x06, 0x02, 0xF7 };
+
+    // [WHEN] Parse MMC message
+    MMCParser parser;
+    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
+
+    // [THEN] Message is valid
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg->command, MMCCommand::Play);
+    EXPECT_EQ(msg->deviceId, 0x7F);
+    EXPECT_TRUE(msg->data.empty());
+}
+
+TEST_F(MMCParserTests, Process_MidiEvents_LocateCommand)
 {
     // [GIVEN] Locate command
     std::vector<Event> events = makeSysExEvents({
@@ -110,21 +142,44 @@ TEST_F(MMCParserTests, Process_LocateCommand_FragmentedSysEx)
     });
     ASSERT_EQ(events.size(), 2);
 
-    // [WHEN] Parse MMC message
+    // [WHEN] Process events incrementally
     MMCParser parser;
-    std::optional<MMCMessage> msg;
-    for (const Event& event : events) {
-        msg = parser.process(event);
-    }
+    std::optional<MMCMessage> msg1 = parser.process(events.at(0));
+    std::optional<MMCMessage> msg2 = parser.process(events.at(1));
 
-    // [THEN] Message is valid
-    ASSERT_TRUE(msg.has_value());
-    EXPECT_EQ(msg->command, MMCCommand::Locate);
-    EXPECT_EQ(msg->deviceId, 0x7F);
-    EXPECT_EQ(msg->data, (std::vector<uint8_t> { 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
+    // [THEN] No message until final event
+    EXPECT_FALSE(msg1.has_value());
+
+    ASSERT_TRUE(msg2.has_value());
+    EXPECT_EQ(msg2->command, MMCCommand::Locate);
+    EXPECT_EQ(msg2->deviceId, 0x7F);
+    EXPECT_EQ(msg2->data, (std::vector<uint8_t> { 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
 }
 
-TEST_F(MMCParserTests, Process_NonMMCMessage)
+TEST_F(MMCParserTests, Process_SysEx_LocateCommand)
+{
+    // [GIVEN] Full Locate message split into chunks
+    constexpr uint8_t chunk1[] = { 0xF0, 0x7F, 0x7F };                   // Start
+    constexpr uint8_t chunk2[] = { 0x06, 0x44, 0x06, 0x01 };             // Continue
+    constexpr uint8_t chunk3[] = { 0x96, 0x00, 0x15, 0x04, 0x00, 0xF7 }; // End
+
+    // [WHEN] Process chunks incrementally
+    MMCParser parser;
+    std::optional<MMCMessage> msg1 = parser.process(chunk1, sizeof(chunk1));
+    std::optional<MMCMessage> msg2 = parser.process(chunk2, sizeof(chunk2));
+    std::optional<MMCMessage> msg3 = parser.process(chunk3, sizeof(chunk3));
+
+    // [THEN] No message until final chunk
+    EXPECT_FALSE(msg1.has_value());
+    EXPECT_FALSE(msg2.has_value());
+
+    ASSERT_TRUE(msg3.has_value());
+    EXPECT_EQ(msg3->command, MMCCommand::Locate);
+    EXPECT_EQ(msg3->deviceId, 0x7F);
+    EXPECT_EQ(msg3->data, (std::vector<uint8_t>{ 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
+}
+
+TEST_F(MMCParserTests, Process_MidiEvents_NonMMCMessage)
 {
     // [GIVEN] Not MMC (missing 0x7F / 0x06)
     std::vector<Event> events = makeSysExEvents({ 0x01, 0x02, 0x03, 0x04 });
@@ -133,6 +188,19 @@ TEST_F(MMCParserTests, Process_NonMMCMessage)
     // [WHEN] Parse message
     MMCParser parser;
     std::optional<MMCMessage> msg = parser.process(events.front());
+
+    // [THEN] No message
+    EXPECT_FALSE(msg.has_value());
+}
+
+TEST_F(MMCParserTests, Process_SysEx_NonMMCMessage)
+{
+    // [GIVEN] Not MMC (missing 0x7F / 0x06)
+    constexpr uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
+
+     // [WHEN] Parse message
+    MMCParser parser;
+    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
 
     // [THEN] No message
     EXPECT_FALSE(msg.has_value());

--- a/src/framework/midiremote/tests/mmcdecoder_tests.cpp
+++ b/src/framework/midiremote/tests/mmcdecoder_tests.cpp
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-#include "midiremote/mmc.h"
+#include "midiremote/internal/mmcdecoder.h"
 #include "midi/midievent.h"
 
 using namespace muse::midi;
@@ -30,7 +30,7 @@ using namespace muse::midiremote;
 
 static constexpr double LOCATE_ERROR(0.000001);
 
-class MMCParserTests : public ::testing::Test
+class MMCDecoderTests : public ::testing::Test
 {
 protected:
     void SetUp() override {}
@@ -82,16 +82,16 @@ protected:
     }
 };
 
-TEST_F(MMCParserTests, Process_MidiEvents_PlayCommand)
+TEST_F(MMCDecoderTests, Process_MidiEvents_PlayCommand)
 {
     // [GIVEN] Play command
     // SysEx: 7F <dev> 06 02
     std::vector<Event> events = makeSysExEvents({ 0x7F, 0x7F, 0x06, 0x02 });
     ASSERT_EQ(events.size(), 1);
 
-    // [WHEN] Parse MMC message
-    MMCParser parser;
-    std::optional<MMCMessage> msg = parser.process(events.front());
+    // [WHEN] Decode MMC message
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg = decoder.decode(events.front());
 
     // [THEN] Message is valid
     ASSERT_TRUE(msg.has_value());
@@ -100,14 +100,14 @@ TEST_F(MMCParserTests, Process_MidiEvents_PlayCommand)
     EXPECT_TRUE(msg->data.empty());
 }
 
-TEST_F(MMCParserTests, Process_ShortSysEx_PlayCommand)
+TEST_F(MMCDecoderTests, Process_ShortSysEx_PlayCommand)
 {
     // [GIVEN] Short SysEx (no F0/F7)
     constexpr uint8_t data[] = { 0x7F, 0x7F, 0x06, 0x02 };
 
-    // [WHEN] Parse MMC message
-    MMCParser parser;
-    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
+    // [WHEN] Decode MMC message
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg = decoder.decode(data, sizeof(data));
 
     // [THEN] Message is valid
     ASSERT_TRUE(msg.has_value());
@@ -116,14 +116,14 @@ TEST_F(MMCParserTests, Process_ShortSysEx_PlayCommand)
     EXPECT_TRUE(msg->data.empty());
 }
 
-TEST_F(MMCParserTests, Process_FullSysEx_PlayCommand)
+TEST_F(MMCDecoderTests, Process_FullSysEx_PlayCommand)
 {
     // [GIVEN] Full SysEx (with start and end bytes)
     constexpr uint8_t data[] = { 0xF0, 0x7F, 0x7F, 0x06, 0x02, 0xF7 };
 
-    // [WHEN] Parse MMC message
-    MMCParser parser;
-    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
+    // [WHEN] Decode MMC message
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg = decoder.decode(data, sizeof(data));
 
     // [THEN] Message is valid
     ASSERT_TRUE(msg.has_value());
@@ -132,7 +132,7 @@ TEST_F(MMCParserTests, Process_FullSysEx_PlayCommand)
     EXPECT_TRUE(msg->data.empty());
 }
 
-TEST_F(MMCParserTests, Process_MidiEvents_LocateCommand)
+TEST_F(MMCDecoderTests, Process_MidiEvents_LocateCommand)
 {
     // [GIVEN] Locate command
     std::vector<Event> events = makeSysExEvents({
@@ -143,9 +143,9 @@ TEST_F(MMCParserTests, Process_MidiEvents_LocateCommand)
     ASSERT_EQ(events.size(), 2);
 
     // [WHEN] Process events incrementally
-    MMCParser parser;
-    std::optional<MMCMessage> msg1 = parser.process(events.at(0));
-    std::optional<MMCMessage> msg2 = parser.process(events.at(1));
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg1 = decoder.decode(events.at(0));
+    std::optional<MMCMessage> msg2 = decoder.decode(events.at(1));
 
     // [THEN] No message until final event
     EXPECT_FALSE(msg1.has_value());
@@ -156,7 +156,7 @@ TEST_F(MMCParserTests, Process_MidiEvents_LocateCommand)
     EXPECT_EQ(msg2->data, (std::vector<uint8_t> { 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
 }
 
-TEST_F(MMCParserTests, Process_SysEx_LocateCommand)
+TEST_F(MMCDecoderTests, Process_SysEx_LocateCommand)
 {
     // [GIVEN] Full Locate message split into chunks
     constexpr uint8_t chunk1[] = { 0xF0, 0x7F, 0x7F };                   // Start
@@ -164,10 +164,10 @@ TEST_F(MMCParserTests, Process_SysEx_LocateCommand)
     constexpr uint8_t chunk3[] = { 0x96, 0x00, 0x15, 0x04, 0x00, 0xF7 }; // End
 
     // [WHEN] Process chunks incrementally
-    MMCParser parser;
-    std::optional<MMCMessage> msg1 = parser.process(chunk1, sizeof(chunk1));
-    std::optional<MMCMessage> msg2 = parser.process(chunk2, sizeof(chunk2));
-    std::optional<MMCMessage> msg3 = parser.process(chunk3, sizeof(chunk3));
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg1 = decoder.decode(chunk1, sizeof(chunk1));
+    std::optional<MMCMessage> msg2 = decoder.decode(chunk2, sizeof(chunk2));
+    std::optional<MMCMessage> msg3 = decoder.decode(chunk3, sizeof(chunk3));
 
     // [THEN] No message until final chunk
     EXPECT_FALSE(msg1.has_value());
@@ -176,37 +176,37 @@ TEST_F(MMCParserTests, Process_SysEx_LocateCommand)
     ASSERT_TRUE(msg3.has_value());
     EXPECT_EQ(msg3->command, MMCCommand::Locate);
     EXPECT_EQ(msg3->deviceId, 0x7F);
-    EXPECT_EQ(msg3->data, (std::vector<uint8_t>{ 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
+    EXPECT_EQ(msg3->data, (std::vector<uint8_t> { 0x06, 0x01, 0x96, 0x00, 0x15, 0x04, 0x00 }));
 }
 
-TEST_F(MMCParserTests, Process_MidiEvents_NonMMCMessage)
+TEST_F(MMCDecoderTests, Process_MidiEvents_NonMMCMessage)
 {
     // [GIVEN] Not MMC (missing 0x7F / 0x06)
     std::vector<Event> events = makeSysExEvents({ 0x01, 0x02, 0x03, 0x04 });
     ASSERT_EQ(events.size(), 1);
 
-    // [WHEN] Parse message
-    MMCParser parser;
-    std::optional<MMCMessage> msg = parser.process(events.front());
+    // [WHEN] Decode MMC message
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg = decoder.decode(events.front());
 
     // [THEN] No message
     EXPECT_FALSE(msg.has_value());
 }
 
-TEST_F(MMCParserTests, Process_SysEx_NonMMCMessage)
+TEST_F(MMCDecoderTests, Process_SysEx_NonMMCMessage)
 {
     // [GIVEN] Not MMC (missing 0x7F / 0x06)
     constexpr uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
 
-     // [WHEN] Parse message
-    MMCParser parser;
-    std::optional<MMCMessage> msg = parser.process(data, sizeof(data));
+    // [WHEN] Decode MMC message
+    MMCDecoder decoder;
+    std::optional<MMCMessage> msg = decoder.decode(data, sizeof(data));
 
     // [THEN] No message
     EXPECT_FALSE(msg.has_value());
 }
 
-TEST_F(MMCParserTests, LocateToSeconds_WithFormatByte)
+TEST_F(MMCDecoderTests, LocateToSeconds_WithFormatByte)
 {
     // [GIVEN] format = 1, hr_byte = 96 (30 fps, 0h), min = 0, sec = 15, frame = 4, subframe = 0
     MMCMessage msg;
@@ -214,7 +214,8 @@ TEST_F(MMCParserTests, LocateToSeconds_WithFormatByte)
     msg.data = { 6, 1, 96, 0, 15, 4, 0 };
 
     // [WHEN] Convert msg to seconds
-    std::optional<double> secs = MMCParser::locateToSeconds(msg);
+    MMCDecoder decoder;
+    std::optional<double> secs = decoder.locateToSeconds(msg);
 
     // [THEN] Result is valid
     ASSERT_TRUE(secs.has_value());
@@ -223,7 +224,7 @@ TEST_F(MMCParserTests, LocateToSeconds_WithFormatByte)
     EXPECT_NEAR(secs.value(), expected, LOCATE_ERROR);
 }
 
-TEST_F(MMCParserTests, LocateToSeconds_WithoutFormatByte)
+TEST_F(MMCDecoderTests, LocateToSeconds_WithoutFormatByte)
 {
     // [GIVEN] hr_byte = 96 (30 fps), min = 0, sec = 15, frame = 4, subframe = 0
     MMCMessage msg;
@@ -231,7 +232,8 @@ TEST_F(MMCParserTests, LocateToSeconds_WithoutFormatByte)
     msg.data = { 6, 96, 0, 15, 4, 0 };
 
     // [WHEN] Convert msg to seconds
-    std::optional<double> secs = MMCParser::locateToSeconds(msg);
+    MMCDecoder decoder;
+    std::optional<double> secs = decoder.locateToSeconds(msg);
 
     // [THEN] Result is valid
     ASSERT_TRUE(secs.has_value());
@@ -240,7 +242,7 @@ TEST_F(MMCParserTests, LocateToSeconds_WithoutFormatByte)
     EXPECT_NEAR(secs.value(), expected, LOCATE_ERROR);
 }
 
-TEST_F(MMCParserTests, LocateToSeconds_InvalidFormat)
+TEST_F(MMCDecoderTests, LocateToSeconds_InvalidFormat)
 {
     // [GIVEN] Invalid msg
     MMCMessage msg;
@@ -248,7 +250,8 @@ TEST_F(MMCParserTests, LocateToSeconds_InvalidFormat)
     msg.data = { 6, 2, 96, 0, 15, 4, 0 }; // format != 1
 
     // [WHEN] Convert msg to seconds
-    std::optional<double> secs = MMCParser::locateToSeconds(msg);
+    MMCDecoder decoder;
+    std::optional<double> secs = decoder.locateToSeconds(msg);
 
     // [THEN]
     EXPECT_FALSE(secs.has_value());

--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -27,9 +27,10 @@ using namespace muse::vst;
 using namespace muse::audio;
 using namespace muse::audioplugins;
 
-VstFxProcessor::VstFxProcessor(IVstPluginInstancePtr instance, const AudioFxParams& params)
+VstFxProcessor::VstFxProcessor(IVstPluginInstancePtr instance, const AudioFxParams& params,
+                               const modularity::ContextPtr& iocCtx)
     : m_pluginPtr(instance),
-    m_vstAudioClient(std::make_unique<VstAudioClient>()),
+    m_vstAudioClient(std::make_unique<VstAudioClient>(iocCtx)),
     m_params(params)
 {
 }

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -35,7 +35,7 @@ namespace muse::vst {
 class VstFxProcessor : public muse::audio::IFxProcessor, public async::Asyncable
 {
 public:
-    explicit VstFxProcessor(IVstPluginInstancePtr instance, const muse::audio::AudioFxParams& params);
+    explicit VstFxProcessor(IVstPluginInstancePtr instance, const muse::audio::AudioFxParams& params, const modularity::ContextPtr& iocCtx);
 
     void init(const audio::OutputSpec& spec);
 

--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -55,7 +55,7 @@ IFxProcessorPtr VstFxResolver::createMasterFx(const AudioFxParams& fxParams, con
 
     IVstPluginInstancePtr pluginPtr = instancesRegister()->makeAndRegisterMasterFxPlugin(fxParams.resourceMeta.id, fxParams.chainOrder);
 
-    VstFxPtr fx = std::make_shared<VstFxProcessor>(pluginPtr, fxParams);
+    VstFxPtr fx = std::make_shared<VstFxProcessor>(pluginPtr, fxParams, iocContext());
     fx->init(outputSpec);
 
     return fx;
@@ -73,7 +73,7 @@ IFxProcessorPtr VstFxResolver::createTrackFx(const TrackId trackId, const AudioF
 
     IVstPluginInstancePtr pluginPtr = instancesRegister()->makeAndRegisterFxPlugin(fxParams.resourceMeta.id, trackId, fxParams.chainOrder);
 
-    VstFxPtr fx = std::make_shared<VstFxProcessor>(pluginPtr, fxParams);
+    VstFxPtr fx = std::make_shared<VstFxProcessor>(pluginPtr, fxParams, iocContext());
     fx->init(outputSpec);
 
     return fx;

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -40,7 +40,7 @@ static const std::set<Steinberg::Vst::CtrlNumber> SUPPORTED_CONTROLLERS = {
 VstSynthesiser::VstSynthesiser(const TrackId trackId, const muse::audio::AudioInputParams& params,
                                const modularity::ContextPtr& iocCtx)
     : AbstractSynthesizer(params, iocCtx),
-    m_vstAudioClient(std::make_unique<VstAudioClient>()),
+    m_vstAudioClient(std::make_unique<VstAudioClient>(iocCtx)),
     m_trackId(trackId)
 {
 }

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -21,13 +21,17 @@
  */
 #include "vstaudioclient.h"
 
+#include "midiremote/mmc.h"
+
 #include "log.h"
 
 using namespace muse;
 using namespace muse::vst;
 using namespace muse::mpe;
 using namespace muse::audio;
+using namespace muse::audio::engine;
 using namespace muse::audioplugins;
+using namespace muse::midiremote;
 
 static size_t noteEventKey(int pitch, int channel)
 {
@@ -36,19 +40,43 @@ static size_t noteEventKey(int pitch, int channel)
     return h1 ^ (h2 << 1);
 }
 
-VstAudioClient::VstAudioClient()
+static std::optional<TransportEvent> mmcToTransportEvent(const MMCMessage& msg)
+{
+    switch (msg.command) {
+    case MMCCommand::Play:
+        return TransportEvent::play();
+    case MMCCommand::Pause:
+        return TransportEvent::pause();
+    case MMCCommand::Stop:
+        return TransportEvent::stop();
+    case MMCCommand::Locate: {
+        const std::optional<double> pos = MMCParser::locateToSeconds(msg);
+        if (pos.has_value()) {
+            return TransportEvent::seek(pos.value());
+        }
+    } break;
+    default: break;
+    }
+
+    return std::nullopt;
+}
+
+VstAudioClient::VstAudioClient(const modularity::ContextPtr& iocCtx)
+    : muse::Contextable(iocCtx)
 {
     m_processContext.state = 0;
 }
 
 VstAudioClient::~VstAudioClient()
 {
-    if (!m_pluginComponent) {
-        return;
+    if (m_pluginComponent) {
+        m_pluginComponent->setActive(false);
+        m_pluginComponent->terminate();
     }
 
-    m_pluginComponent->setActive(false);
-    m_pluginComponent->terminate();
+    if (m_mmcParser) {
+        delete m_mmcParser;
+    }
 }
 
 void VstAudioClient::init(AudioPluginType type, IVstPluginInstancePtr instance)
@@ -59,6 +87,8 @@ void VstAudioClient::init(AudioPluginType type, IVstPluginInstancePtr instance)
 
     m_type = type;
     m_pluginPtr = std::move(instance);
+
+    transportEventsDispatcher(); // Force resolution outside audio callback
 }
 
 void VstAudioClient::loadSupportedParams()
@@ -154,7 +184,7 @@ bool VstAudioClient::handleEvent(const VstEvent& event)
         m_playingNotes.erase(key);
     }
 
-    if (m_eventList.addEvent(const_cast<VstEvent&>(event)) == Steinberg::kResultTrue) {
+    if (m_inputEvents.addEvent(const_cast<VstEvent&>(event)) == Steinberg::kResultTrue) {
         return true;
     }
 
@@ -179,8 +209,8 @@ void VstAudioClient::flushSound()
 
     flushBuffers();
 
-    m_eventList.clear();
-    m_paramChanges.clearQueue();
+    m_inputEvents.clear();
+    m_inputParamChanges.clearQueue();
 
     for (const auto& pair : m_playingNotes) {
         const VstEvent& noteOn = pair.second;
@@ -197,7 +227,7 @@ void VstAudioClient::flushSound()
         noteOff.noteOff.tuning = noteOn.noteOn.tuning;
         noteOff.noteOff.velocity = noteOn.noteOn.velocity;
 
-        m_eventList.addEvent(noteOff);
+        m_inputEvents.addEvent(noteOff);
     }
 
     for (PluginParamId id : m_playingParams) {
@@ -255,13 +285,15 @@ audio::samples_t VstAudioClient::process(float* output, samples_t samplesPerChan
     m_needUpdateState = false;
 
     if (m_type == AudioPluginType::Instrument) {
-        m_eventList.clear();
-        m_paramChanges.clearQueue();
+        m_inputEvents.clear();
+        m_inputParamChanges.clearQueue();
 
         fillOutputBufferInstrument(samplesPerChannel, output);
     } else {
         fillOutputBufferFx(samplesPerChannel, output);
     }
+
+    processOutputEvents();
 
     return samplesPerChannel;
 }
@@ -320,8 +352,9 @@ void VstAudioClient::setUpProcessData()
     }
 
     m_processContext.sampleRate = m_outputSpec.sampleRate;
-    m_processData.inputEvents = &m_eventList;
-    m_processData.inputParameterChanges = &m_paramChanges;
+    m_processData.inputEvents = &m_inputEvents;
+    m_processData.inputParameterChanges = &m_inputParamChanges;
+    m_processData.outputEvents = &m_outputEvents;
     m_processData.processContext = &m_processContext;
 
     if (m_needUnprepareProcessData) {
@@ -470,6 +503,52 @@ void VstAudioClient::fillOutputBufferFx(samples_t sampleCount, float* output)
     }
 }
 
+void VstAudioClient::processOutputEvents()
+{
+    if (!transportEventsDispatcher()) {
+        return;
+    }
+
+    const int32_t count = m_outputEvents.getEventCount();
+    if (count == 0) {
+        return;
+    }
+
+    TransportEvents events;
+
+    for (int32_t i = 0; i < count; ++i) {
+        VstEvent vstEvent;
+        if (m_outputEvents.getEvent(i, vstEvent) != Steinberg::kResultOk) {
+            continue;
+        }
+
+        if (vstEvent.type != Steinberg::Vst::Event::kDataEvent
+            || vstEvent.data.type != Steinberg::Vst::DataEvent::kMidiSysEx) {
+            continue;
+        }
+
+        if (!m_mmcParser) {
+            m_mmcParser = new MMCParser();
+        }
+
+        std::optional<MMCMessage> msg = m_mmcParser->process(vstEvent.data.bytes, vstEvent.data.size);
+        if (!msg.has_value()) {
+            continue;
+        }
+
+        std::optional<TransportEvent> event = mmcToTransportEvent(msg.value());
+        if (event.has_value()) {
+            events.push_back(event.value());
+        }
+    }
+
+    m_outputEvents.clear();
+
+    if (!events.empty()) {
+        transportEventsDispatcher()->dispatch(events);
+    }
+}
+
 void VstAudioClient::ensureActivity()
 {
     if (m_isActive) {
@@ -545,7 +624,7 @@ void VstAudioClient::flushBuffers()
 void VstAudioClient::addParamChange(const ParamChangeEvent& param)
 {
     Steinberg::int32 dummyIdx = 0;
-    Steinberg::Vst::IParamValueQueue* queue = m_paramChanges.addParameterData(param.paramId, dummyIdx);
+    Steinberg::Vst::IParamValueQueue* queue = m_inputParamChanges.addParameterData(param.paramId, dummyIdx);
     if (queue) {
         queue->addPoint(0, param.value, dummyIdx);
     }

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -21,8 +21,6 @@
  */
 #include "vstaudioclient.h"
 
-#include "midiremote/mmc.h"
-
 #include "log.h"
 
 using namespace muse;
@@ -40,7 +38,7 @@ static size_t noteEventKey(int pitch, int channel)
     return h1 ^ (h2 << 1);
 }
 
-static std::optional<TransportEvent> mmcToTransportEvent(const MMCMessage& msg)
+static std::optional<TransportEvent> mmcToTransportEvent(const IMMCDecoderPtr& decoder, const MMCMessage& msg)
 {
     switch (msg.command) {
     case MMCCommand::Play:
@@ -50,7 +48,7 @@ static std::optional<TransportEvent> mmcToTransportEvent(const MMCMessage& msg)
     case MMCCommand::Stop:
         return TransportEvent::stop();
     case MMCCommand::Locate: {
-        const std::optional<double> pos = MMCParser::locateToSeconds(msg);
+        const std::optional<double> pos = decoder->locateToSeconds(msg);
         if (pos.has_value()) {
             return TransportEvent::seek(pos.value());
         }
@@ -73,10 +71,6 @@ VstAudioClient::~VstAudioClient()
         m_pluginComponent->setActive(false);
         m_pluginComponent->terminate();
     }
-
-    if (m_mmcParser) {
-        delete m_mmcParser;
-    }
 }
 
 void VstAudioClient::init(AudioPluginType type, IVstPluginInstancePtr instance)
@@ -87,6 +81,10 @@ void VstAudioClient::init(AudioPluginType type, IVstPluginInstancePtr instance)
 
     m_type = type;
     m_pluginPtr = std::move(instance);
+
+    if (mmcDecoderFactory()) {
+        m_mmcDecoder = mmcDecoderFactory()->makeDecoder();
+    }
 
     transportEventsDispatcher(); // Force resolution outside audio callback
 }
@@ -505,7 +503,7 @@ void VstAudioClient::fillOutputBufferFx(samples_t sampleCount, float* output)
 
 void VstAudioClient::processOutputEvents()
 {
-    if (!transportEventsDispatcher()) {
+    if (!m_mmcDecoder || !transportEventsDispatcher()) {
         return;
     }
 
@@ -527,16 +525,12 @@ void VstAudioClient::processOutputEvents()
             continue;
         }
 
-        if (!m_mmcParser) {
-            m_mmcParser = new MMCParser();
-        }
-
-        std::optional<MMCMessage> msg = m_mmcParser->process(vstEvent.data.bytes, vstEvent.data.size);
+        std::optional<MMCMessage> msg = m_mmcDecoder->decode(vstEvent.data.bytes, vstEvent.data.size);
         if (!msg.has_value()) {
             continue;
         }
 
-        std::optional<TransportEvent> event = mmcToTransportEvent(msg.value());
+        std::optional<TransportEvent> event = mmcToTransportEvent(m_mmcDecoder, msg.value());
         if (event.has_value()) {
             events.push_back(event.value());
         }

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -27,17 +27,14 @@
 #include "../vsttypes.h"
 
 #include "modularity/ioc.h"
-
 #include "audio/engine/itransporteventsdispatcher.h"
-
-namespace muse::midiremote {
-class MMCParser;
-}
+#include "midiremote/immcdecoderfactory.h"
 
 namespace muse::vst {
 class VstAudioClient : public muse::Contextable
 {
     muse::ContextInject<muse::audio::engine::ITransportEventsDispatcher> transportEventsDispatcher = { this };
+    muse::GlobalInject<muse::midiremote::IMMCDecoderFactory> mmcDecoderFactory;
 
 public:
     VstAudioClient(const modularity::ContextPtr& iocCtx);
@@ -108,6 +105,6 @@ private:
     audioplugins::AudioPluginType m_type = audioplugins::AudioPluginType::Undefined;
     audio::OutputSpec m_outputSpec;
 
-    midiremote::MMCParser* m_mmcParser = nullptr;
+    midiremote::IMMCDecoderPtr m_mmcDecoder;
 };
 }

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -26,11 +26,21 @@
 #include "../ivstplugininstance.h"
 #include "../vsttypes.h"
 
+#include "modularity/ioc.h"
+
+#include "audio/engine/itransporteventsdispatcher.h"
+
+namespace muse::midiremote {
+class MMCParser;
+}
+
 namespace muse::vst {
-class VstAudioClient
+class VstAudioClient : public muse::Contextable
 {
+    muse::ContextInject<muse::audio::engine::ITransportEventsDispatcher> transportEventsDispatcher = { this };
+
 public:
-    VstAudioClient();
+    VstAudioClient(const modularity::ContextPtr& iocCtx);
     ~VstAudioClient();
 
     void init(audioplugins::AudioPluginType type, IVstPluginInstancePtr instance);
@@ -62,6 +72,8 @@ private:
     void fillOutputBufferInstrument(muse::audio::samples_t sampleCount, float* output);
     void fillOutputBufferFx(muse::audio::samples_t sampleCount, float* output);
 
+    void processOutputEvents();
+
     void ensureActivity();
     void disableActivity();
 
@@ -78,8 +90,9 @@ private:
     std::vector<int> m_activeOutputBusses;
     std::vector<int> m_activeInputBusses;
 
-    VstEventList m_eventList;
-    VstParameterChanges m_paramChanges;
+    VstEventList m_inputEvents;
+    VstParameterChanges m_inputParamChanges;
+    VstEventList m_outputEvents;
     VstProcessData m_processData;
     VstProcessContext m_processContext;
     VstProcessMode m_processMode = VstProcessMode::kRealtime;
@@ -94,5 +107,7 @@ private:
 
     audioplugins::AudioPluginType m_type = audioplugins::AudioPluginType::Undefined;
     audio::OutputSpec m_outputSpec;
+
+    midiremote::MMCParser* m_mmcParser = nullptr;
 };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MMC decoding made pluggable with a factory-based decoder and integrated into MIDI remote and VST paths.
  * VST/audio clients now use context-aware components and separate input/output event buffers.
  * Added a transport-events interface and concrete implementation for routing transport commands.

* **Bug Fixes**
  * Playback controls (play/pause/stop/resume) now short-circuit redundant state changes to avoid extra work.

* **Tests**
  * Decoder tests updated for incremental assembly and varied SysEx input forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->