### PR TITLE
TableSortFilterProxyModel

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1108,7 +1108,7 @@ Rectangle {
             valueTitle: "Age"
 
             model: ListModel {
-                ListElement {
+                 ListElement {
                     name: "Alex"
                     age: 12
                     valueType: "Int"
@@ -1116,13 +1116,8 @@ Rectangle {
                     max: 15
                 }
                 ListElement {
-                    name: "Tony"
-                    age: 15
-                    valueType: "Int"
-                }
-                ListElement {
-                    name: "Fred"
-                    age: 10
+                    name: "Anna"
+                    age: 11
                     valueType: "Int"
                 }
                 ListElement {
@@ -1131,8 +1126,13 @@ Rectangle {
                     valueType: "Int"
                 }
                 ListElement {
-                    name: "Anna"
-                    age: 11
+                    name: "Fred"
+                    age: 10
+                    valueType: "Int"
+                }
+                ListElement {
+                    name: "Tony"
+                    age: 15
                     valueType: "Int"
                 }
             }
@@ -1168,6 +1168,10 @@ Rectangle {
                 }
 
                 return null
+            }
+
+            sortOrderProvider: function(column) {
+                return tableProxy.columnSortOrder(column)
             }
 
             onHorizontalHeaderClicked: function (column) {

--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1152,7 +1152,13 @@ Rectangle {
                 id: tableModel
             }
 
-            model: tableModel
+            TableSortFilterProxyModel {
+                id: tableProxy
+
+                sourceModel: tableModel
+            }
+
+            model: tableProxy
 
             headerCapitalization: Font.Capitalize
 
@@ -1162,6 +1168,10 @@ Rectangle {
                 }
 
                 return null
+            }
+
+            onHorizontalHeaderClicked: function (column) {
+                tableProxy.toggleColumnSort(column)
             }
 
             Component {

--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1108,7 +1108,7 @@ Rectangle {
             valueTitle: "Age"
 
             model: ListModel {
-                 ListElement {
+                ListElement {
                     name: "Alex"
                     age: 12
                     valueType: "Int"
@@ -1174,9 +1174,8 @@ Rectangle {
                 return null
             }
 
-            sortOrderProvider: function(column) {
-                return tableProxy.columnSortOrder(column)
-            }
+            sortIndicatorColumn: tableProxy.sortIndicatorColumn
+            sortIndicatorOrder: tableProxy.sortIndicatorOrder
 
             onHorizontalHeaderClicked: function (column) {
                 tableProxy.toggleColumnSort(column)

--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1161,6 +1161,10 @@ Rectangle {
             model: tableProxy
 
             headerCapitalization: Font.Capitalize
+            horizontalHeaderNavigationEnabled: true
+
+            navigationPanel.section: navSec
+            navigationPanel.order: 2
 
             sourceComponentCallback: function(type) {
                 switch(type) {

--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1189,6 +1189,10 @@ Rectangle {
                     property int row
                     property int column
 
+                    property NavigationPanel navigationPanel
+                    property int navigationRow
+                    property int navigationColumnStart
+
                     property string accessibleName: label.text
 
                     signal changed(string stub)

--- a/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/MuseScore/AppShell/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -1145,8 +1145,8 @@ Rectangle {
         StyledTableView  {
             id: tableView
 
-            width: 560
-            height: 226
+            width: 1100
+            height: 360
 
             TestTableViewModel {
                 id: tableModel

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -80,6 +80,8 @@ qt_add_qml_module(muse_uicomponents_qml
         sortfilterproxymodel.h
         shortcutoverridemodel.cpp
         shortcutoverridemodel.h
+        tablesortfilterproxymodel.cpp
+        tablesortfilterproxymodel.h
         toolbaritem.cpp
         toolbaritem.h
         validators/doubleinputvalidator.cpp

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -77,6 +77,7 @@ Item {
     }
 
     signal handleItem(var index, var item)
+    signal horizontalHeaderClicked(int column)
 
     QtObject {
         id: prv
@@ -135,6 +136,10 @@ Item {
 
             onFormatChangeRequested: function(formatId) {
                 display.currentFormatId = formatId
+            }
+
+            onClicked: {
+                root.horizontalHeaderClicked(index)
             }
         }
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -34,6 +34,8 @@ Item {
     property alias model: tableView.model
     property var sourceComponentCallback
 
+    property var sortOrderProvider: null
+
     property bool showVerticalHeader: false
     property bool horizontalHeaderNavigationEnabled: true
     property bool displayTruncatedTextOnHover: false
@@ -83,9 +85,16 @@ Item {
     QtObject {
         id: prv
 
+        property int sortRevision: 0
         property real valueItemWidth: 126
         property real spacing: 4
         property real sideMargin: 30
+    }
+
+    Connections {
+        target: root.model
+        ignoreUnknownSignals: true
+        function onSortChanged() { prv.sortRevision++ }
     }
 
     Rectangle {
@@ -119,6 +128,8 @@ Item {
             availableFormats: display.availableFormats
 
             headerCapitalization: root.headerCapitalization
+
+            sortOrder: root.sortOrderProvider ? (prv.sortRevision, root.sortOrderProvider(index)) : ColumnSortOrder.Unsorted
 
             navigation.panel: root.navigationPanel
             navigation.row: 0

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -36,6 +36,7 @@ Item {
 
     property bool showVerticalHeader: false
     property bool horizontalHeaderNavigationEnabled: true
+    property bool displayTruncatedTextOnHover: false
 
     property var currentEditedCell: null
 
@@ -242,6 +243,7 @@ Item {
             preferredWidth: hHeaderData.preferredWidth
 
             sourceComponentCallback: root.sourceComponentCallback
+            displayTruncatedTextOnHover: root.displayTruncatedTextOnHover
 
             isSelected: tableView.selectionModel.hasSelection && tableView.selectionModel.isSelected(tableView.model.index(row, column))
             evenMargins: showVerticalHeader

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -34,7 +34,8 @@ Item {
     property alias model: tableView.model
     property var sourceComponentCallback
 
-    property var sortOrderProvider: null
+    property int sortIndicatorColumn: -1
+    property int sortIndicatorOrder: ColumnSortOrder.Unsorted
 
     property bool showVerticalHeader: false
     property bool horizontalHeaderNavigationEnabled: true
@@ -85,16 +86,9 @@ Item {
     QtObject {
         id: prv
 
-        property int sortRevision: 0
         property real valueItemWidth: 126
         property real spacing: 4
         property real sideMargin: 30
-    }
-
-    Connections {
-        target: root.model
-        ignoreUnknownSignals: true
-        function onSortChanged() { prv.sortRevision++ }
     }
 
     Rectangle {
@@ -129,7 +123,7 @@ Item {
 
             headerCapitalization: root.headerCapitalization
 
-            sortOrder: root.sortOrderProvider ? (prv.sortRevision, root.sortOrderProvider(index)) : ColumnSortOrder.Unsorted
+            sortOrder: index === root.sortIndicatorColumn ? root.sortIndicatorOrder : ColumnSortOrder.Unsorted
 
             navigation.panel: root.navigationPanel
             navigation.row: 0

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -146,6 +146,20 @@ Item {
                 }
             }
 
+            TableView.onReused: {
+                // Sorting can cause header items to be reused for different columns,
+                // invalidating indices and thereby navigation focus.
+
+                if (!root.navigationPanel.isNavigationOnHeaders) {
+                    return
+                }
+
+                const idx = root.navigationPanel.navigationIndexForRestore
+                if (idx && index === idx.x) {
+                    navigation.requestActive(true)
+                }
+            }
+
             onFormatChangeRequested: function(formatId) {
                 display.currentFormatId = formatId
             }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/abstracttableviewmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/abstracttableviewmodel.cpp
@@ -89,10 +89,6 @@ ItemMultiSelectionModel* AbstractTableViewModel::selectionModel() const
 
 void AbstractTableViewModel::setTable(const QVector<QVector<TableViewCell*> >& table)
 {
-    if (table.isEmpty()) {
-        return;
-    }
-
     for (const auto& row : std::as_const(m_table)) {
         for (TableViewCell* cell : row) {
             if (cell) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewCell.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewCell.qml
@@ -39,6 +39,7 @@ TableViewDelegate {
 
     property bool isSelected: false
     property bool evenMargins: false
+    property bool displayTruncatedTextOnHover: false
 
     property alias navigation: listItem.navigation
 
@@ -517,6 +518,7 @@ TableViewDelegate {
                             text: root.cellType === TableViewCellType.List ? root.itemData.current : val
                             textFormat: Text.PlainText
                             horizontalAlignment: Text.AlignLeft
+                            displayTruncatedTextOnHover: root.displayTruncatedTextOnHover
                         }
                     }
                 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewColumn.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewColumn.qml
@@ -38,6 +38,8 @@ Item {
 
     property int headerCapitalization: Font.AllUppercase
 
+    property int sortOrder: ColumnSortOrder.Unsorted
+
     property NavigationControl navigation: NavigationControl {
         name: root.objectName !== "" ? root.objectName : "TableViewColumn"
         enabled: root.enabled && root.visible
@@ -96,6 +98,16 @@ Item {
             opacity: ui.theme.buttonOpacityNormal
         }
 
+        StyledIconLabel {
+            id: sorterIcon
+            Layout.alignment: Qt.AlignVCenter
+
+            visible: root.sortOrder !== ColumnSortOrder.Unsorted
+            iconCode: root.sortOrder === ColumnSortOrder.Ascending ? IconCode.SMALL_ARROW_DOWN : IconCode.SMALL_ARROW_UP
+
+            opacity: ui.theme.buttonOpacityNormal
+        }
+
         MenuButton {
             Layout.alignment: Qt.AlignVCenter
             Layout.preferredWidth: 16
@@ -139,6 +151,11 @@ Item {
 
             PropertyChanges {
                 target: titleLabel
+                opacity: ui.theme.buttonOpacityHover
+            }
+
+            PropertyChanges {
+                target: sorterIcon
                 opacity: ui.theme.buttonOpacityHover
             }
         }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h
@@ -47,6 +47,8 @@ public:
     Val value() const;
     void setValue(const Val& value);
 
+    virtual Val sortValue() const { return m_val; }
+
     void setRequestChangeFunction(const std::function<bool(int, int, const Val&)>& func);
 
     QVariant value_property() const;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/tableviewlistcell.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/tableviewlistcell.h
@@ -41,6 +41,8 @@ public:
     QString current() const;
     void setCurrent(const QString& current);
 
+    Val sortValue() const override { return Val(m_current); }
+
 signals:
     void currentChanged();
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "tablesortfilterproxymodel.h"
+
+#include "framework/global/types/val.h"
+#include "framework/uicomponents/qml/Muse/UiComponents/itemmultiselectionmodel.h"
+#include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h"
+#include "framework/uicomponents/view/modelutils.h"
+
+namespace muse::uicomponents {
+TableSortFilterProxyModel::TableSortFilterProxyModel(QObject* parent)
+    : QSortFilterProxyModel(parent),
+    m_selectionModel(new muse::uicomponents::ItemMultiSelectionModel(this))
+{
+    m_selectionModel->setModel(this);
+    setDynamicSortFilter(true);
+    muse::uicomponents::ModelUtils::connectRowCountChangedSignal(this, &TableSortFilterProxyModel::rowCountChanged);
+}
+
+QItemSelectionModel* TableSortFilterProxyModel::selectionModel() const
+{
+    return m_selectionModel;
+}
+
+void TableSortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
+{
+    QSortFilterProxyModel::setSourceModel(sourceModel);
+    if (sourceModel) {
+        const int cols = sourceModel->columnCount();
+        m_sortPipeline.erase(
+            std::remove_if(m_sortPipeline.begin(), m_sortPipeline.end(),
+                           [cols](const SortKey& k) { return k.column < 0 || k.column >= cols; }),
+            m_sortPipeline.end());
+    }
+    reapplySort();
+}
+
+void TableSortFilterProxyModel::toggleColumnSort(int column)
+{
+    auto it = std::find_if(m_sortPipeline.begin(), m_sortPipeline.end(),
+                           [column](const SortKey& k) { return k.column == column; });
+
+    if (it == m_sortPipeline.end()) {
+        m_sortPipeline.push_back({ column, true });
+        if (static_cast<int>(m_sortPipeline.size()) > m_maxSortKeys) {
+            m_sortPipeline.erase(m_sortPipeline.begin());
+        }
+    } else {
+        const bool ascending = !it->ascending;
+        m_sortPipeline.erase(it);
+        m_sortPipeline.push_back({ column, ascending });
+    }
+
+    reapplySort();
+}
+
+void TableSortFilterProxyModel::clearSort()
+{
+    if (m_sortPipeline.empty()) {
+        return;
+    }
+    m_sortPipeline.clear();
+    reapplySort();
+}
+
+void TableSortFilterProxyModel::invalidateFilters()
+{
+    beginFilterChange();
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+}
+
+int TableSortFilterProxyModel::mapRowToSource(int proxyRow) const
+{
+    const QModelIndex idx = mapToSource(index(proxyRow, 0));
+    return idx.isValid() ? idx.row() : -1;
+}
+
+void TableSortFilterProxyModel::reapplySort()
+{
+    if (!sourceModel()) {
+        return;
+    }
+    if (m_sortPipeline.empty()) {
+        sort(-1);
+        return;
+    }
+    invalidate();
+    sort(0, Qt::AscendingOrder);
+}
+
+bool TableSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
+{
+    Q_UNUSED(sourceParent);
+    return acceptsRow(sourceRow);
+}
+
+bool TableSortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
+{
+    for (auto it = m_sortPipeline.rbegin(); it != m_sortPipeline.rend(); ++it) {
+        const int cmp = compareCells(it->column, left.row(), right.row());
+        if (cmp == 0) {
+            continue;
+        }
+        return it->ascending ? (cmp < 0) : (cmp > 0);
+    }
+    return false;
+}
+
+bool TableSortFilterProxyModel::acceptsRow(int sourceRow) const
+{
+    Q_UNUSED(sourceRow);
+    return true;
+}
+
+int TableSortFilterProxyModel::compareCells(int column, int leftSourceRow, int rightSourceRow) const
+{
+    QAbstractItemModel* src = sourceModel();
+    if (!src) {
+        return 0;
+    }
+    const QModelIndex leftIdx = src->index(leftSourceRow, column);
+    const QModelIndex rightIdx = src->index(rightSourceRow, column);
+    const QVariant leftData = src->data(leftIdx);
+    const QVariant rightData = src->data(rightIdx);
+
+    muse::Val leftVal;
+    muse::Val rightVal;
+    if (leftData.canConvert<muse::uicomponents::TableViewCell*>()
+        && rightData.canConvert<muse::uicomponents::TableViewCell*>()) {
+        auto* l = leftData.value<muse::uicomponents::TableViewCell*>();
+        auto* r = rightData.value<muse::uicomponents::TableViewCell*>();
+        if (l && r) {
+            leftVal = l->value();
+            rightVal = r->value();
+        }
+    } else {
+        leftVal = muse::Val::fromQVariant(leftData);
+        rightVal = muse::Val::fromQVariant(rightData);
+    }
+
+    if (leftVal < rightVal) {
+        return -1;
+    }
+    if (rightVal < leftVal) {
+        return 1;
+    }
+    return 0;
+}
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -24,7 +24,23 @@
 #include "framework/global/types/val.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/itemmultiselectionmodel.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h"
+#include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewlistcell.h"
 #include "framework/uicomponents/view/modelutils.h"
+
+namespace {
+muse::Val extractSortValue(const QVariant& data)
+{
+    if (data.canConvert<muse::uicomponents::TableViewCell*>()) {
+        if (auto* cell = data.value<muse::uicomponents::TableViewCell*>()) {
+            if (auto* listCell = qobject_cast<muse::uicomponents::TableViewListCell*>(cell)) {
+                return muse::Val(listCell->current());
+            }
+            return cell->value();
+        }
+    }
+    return muse::Val::fromQVariant(data);
+}
+}
 
 namespace muse::uicomponents {
 TableSortFilterProxyModel::TableSortFilterProxyModel(QObject* parent)
@@ -56,16 +72,19 @@ void TableSortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
 
 void TableSortFilterProxyModel::toggleColumnSort(int column)
 {
-    auto it = std::find_if(m_sortPipeline.begin(), m_sortPipeline.end(),
-                           [column](const SortKey& k) { return k.column == column; });
+    const auto it = std::find_if(m_sortPipeline.begin(), m_sortPipeline.end(),
+                                 [column](const SortKey& k) { return k.column == column; });
 
     if (it == m_sortPipeline.end()) {
         m_sortPipeline.push_back({ column, true });
         if (static_cast<int>(m_sortPipeline.size()) > m_maxSortKeys) {
             m_sortPipeline.erase(m_sortPipeline.begin());
         }
+    } else if (it == m_sortPipeline.end() - 1) {
+        // Only toggle sort order if this column is already the primary sort key
+        it->ascending = !it->ascending;
     } else {
-        const bool ascending = !it->ascending;
+        const bool ascending = it->ascending;
         m_sortPipeline.erase(it);
         m_sortPipeline.push_back({ column, ascending });
     }
@@ -104,6 +123,7 @@ void TableSortFilterProxyModel::reapplySort()
         return;
     }
     invalidate();
+    //! Note: trigger a sort - what column and order we specify doesn't matter. The ordering is determined by the sort pipeline in `lessThan()`
     sort(0, Qt::AscendingOrder);
 }
 
@@ -137,25 +157,9 @@ int TableSortFilterProxyModel::compareCells(int column, int leftSourceRow, int r
     if (!src) {
         return 0;
     }
-    const QModelIndex leftIdx = src->index(leftSourceRow, column);
-    const QModelIndex rightIdx = src->index(rightSourceRow, column);
-    const QVariant leftData = src->data(leftIdx);
-    const QVariant rightData = src->data(rightIdx);
 
-    muse::Val leftVal;
-    muse::Val rightVal;
-    if (leftData.canConvert<muse::uicomponents::TableViewCell*>()
-        && rightData.canConvert<muse::uicomponents::TableViewCell*>()) {
-        auto* l = leftData.value<muse::uicomponents::TableViewCell*>();
-        auto* r = rightData.value<muse::uicomponents::TableViewCell*>();
-        if (l && r) {
-            leftVal = l->value();
-            rightVal = r->value();
-        }
-    } else {
-        leftVal = muse::Val::fromQVariant(leftData);
-        rightVal = muse::Val::fromQVariant(rightData);
-    }
+    const Val leftVal = extractSortValue(src->data(src->index(leftSourceRow, column)));
+    const Val rightVal = extractSortValue(src->data(src->index(rightSourceRow, column)));
 
     if (leftVal < rightVal) {
         return -1;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -81,8 +81,13 @@ void TableSortFilterProxyModel::toggleColumnSort(int column)
             m_sortPipeline.erase(m_sortPipeline.begin());
         }
     } else if (it == m_sortPipeline.end() - 1) {
-        // Only toggle sort order if this column is already the primary sort key
-        it->ascending = !it->ascending;
+        // Only Cycle through sort order if this column is already the primary sort key
+        if (!it->ascending) {
+            // descending -> unsorted state transition ; just remove from the sort pipeline.
+            m_sortPipeline.erase(it);
+        } else {
+            it->ascending = false;
+        }
     } else {
         const bool ascending = it->ascending;
         m_sortPipeline.erase(it);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -53,6 +53,22 @@ QItemSelectionModel* TableSortFilterProxyModel::selectionModel() const
     return m_selectionModel;
 }
 
+int TableSortFilterProxyModel::sortIndicatorColumn() const
+{
+    if (m_sortPipeline.empty() || m_sortPipeline.back().column != m_sortIconColumn) {
+        return -1;
+    }
+    return m_sortIconColumn;
+}
+
+ColumnSortOrder::Type TableSortFilterProxyModel::sortIndicatorOrder() const
+{
+    if (m_sortPipeline.empty() || m_sortPipeline.back().column != m_sortIconColumn) {
+        return ColumnSortOrder::Type::Unsorted;
+    }
+    return m_sortPipeline.back().ascending ? ColumnSortOrder::Type::Ascending : ColumnSortOrder::Type::Descending;
+}
+
 void TableSortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
 {
     QSortFilterProxyModel::setSourceModel(sourceModel);
@@ -111,20 +127,6 @@ int TableSortFilterProxyModel::mapRowToSource(int proxyRow) const
 {
     const QModelIndex idx = mapToSource(index(proxyRow, 0));
     return idx.isValid() ? idx.row() : -1;
-}
-
-ColumnSortOrder::Type TableSortFilterProxyModel::columnSortOrder(int column) const
-{
-    if (column != m_sortIconColumn) {
-        return ColumnSortOrder::Type::Unsorted;
-    }
-
-    const auto it = std::find_if(m_sortPipeline.begin(), m_sortPipeline.end(),
-                                 [column](const SortKey& k) { return k.column == column; });
-    if (it != m_sortPipeline.end() - 1) {
-        return ColumnSortOrder::Type::Unsorted;
-    }
-    return it->ascending ? ColumnSortOrder::Type::Ascending : ColumnSortOrder::Type::Descending;
 }
 
 void TableSortFilterProxyModel::reapplySort()

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -77,11 +77,8 @@ void TableSortFilterProxyModel::toggleColumnSort(int column)
 
     if (it == m_sortPipeline.end()) {
         m_sortPipeline.push_back({ column, true });
-        if (static_cast<int>(m_sortPipeline.size()) > m_maxSortKeys) {
-            m_sortPipeline.erase(m_sortPipeline.begin());
-        }
     } else if (it == m_sortPipeline.end() - 1) {
-        // Only Cycle through sort order if this column is already the primary sort key
+        // Only cycle through sort order if this column is already the primary sort key
         if (!it->ascending) {
             // descending -> unsorted state transition ; just remove from the sort pipeline.
             m_sortPipeline.erase(it);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -24,7 +24,6 @@
 #include "framework/global/types/val.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/itemmultiselectionmodel.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h"
-#include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewlistcell.h"
 #include "framework/uicomponents/view/modelutils.h"
 
 namespace {
@@ -32,10 +31,7 @@ muse::Val extractSortValue(const QVariant& data)
 {
     if (data.canConvert<muse::uicomponents::TableViewCell*>()) {
         if (auto* cell = data.value<muse::uicomponents::TableViewCell*>()) {
-            if (auto* listCell = qobject_cast<muse::uicomponents::TableViewListCell*>(cell)) {
-                return muse::Val(listCell->current());
-            }
-            return cell->value();
+            return cell->sortValue();
         }
     }
     return muse::Val::fromQVariant(data);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.cpp
@@ -94,6 +94,8 @@ void TableSortFilterProxyModel::toggleColumnSort(int column)
         m_sortPipeline.push_back({ column, ascending });
     }
 
+    m_sortIconColumn = column;
+
     reapplySort();
 }
 
@@ -118,6 +120,20 @@ int TableSortFilterProxyModel::mapRowToSource(int proxyRow) const
     return idx.isValid() ? idx.row() : -1;
 }
 
+ColumnSortOrder::Type TableSortFilterProxyModel::columnSortOrder(int column) const
+{
+    if (column != m_sortIconColumn) {
+        return ColumnSortOrder::Type::Unsorted;
+    }
+
+    const auto it = std::find_if(m_sortPipeline.begin(), m_sortPipeline.end(),
+                                 [column](const SortKey& k) { return k.column == column; });
+    if (it != m_sortPipeline.end() - 1) {
+        return ColumnSortOrder::Type::Unsorted;
+    }
+    return it->ascending ? ColumnSortOrder::Type::Ascending : ColumnSortOrder::Type::Descending;
+}
+
 void TableSortFilterProxyModel::reapplySort()
 {
     if (!sourceModel()) {
@@ -125,11 +141,12 @@ void TableSortFilterProxyModel::reapplySort()
     }
     if (m_sortPipeline.empty()) {
         sort(-1);
-        return;
+    } else {
+        invalidate();
+        //! Note: trigger a sort - what column and order we specify doesn't matter. The ordering is determined by the sort pipeline in `lessThan()`
+        sort(0, Qt::AscendingOrder);
     }
-    invalidate();
-    //! Note: trigger a sort - what column and order we specify doesn't matter. The ordering is determined by the sort pipeline in `lessThan()`
-    sort(0, Qt::AscendingOrder);
+    emit sortChanged();
 }
 
 bool TableSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <qqmlintegration.h>
+
+#include <QSortFilterProxyModel>
+#include <QItemSelectionModel>
+
+#include <vector>
+
+namespace muse::uicomponents {
+/**
+ * @brief Table-aware sort/filter proxy.
+ *
+ * @details Unlike the list-oriented SortFilterProxyModel in the muse framework,
+ * this class sorts by column and supports a stable multi-key sort pipeline.
+ * Subclasses override acceptsRow() and compareCells() to plug in domain-specific
+ * filter predicates and per-column comparators.
+ */
+class TableSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QItemSelectionModel* selectionModel READ selectionModel CONSTANT)
+    Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
+
+public:
+    explicit TableSortFilterProxyModel(QObject* parent = nullptr);
+
+    QItemSelectionModel* selectionModel() const;
+
+    void setSourceModel(QAbstractItemModel* sourceModel) override;
+
+    Q_INVOKABLE void toggleColumnSort(int column);
+    Q_INVOKABLE void clearSort();
+    Q_INVOKABLE void invalidateFilters();
+    Q_INVOKABLE int mapRowToSource(int proxyRow) const;
+
+signals:
+    void rowCountChanged();
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+    bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
+
+    // Return true to include sourceRow in the filtered view. Default: accept all.
+    virtual bool acceptsRow(int sourceRow) const;
+
+    // Per-column comparison, returning <0 / 0 / >0. The default extracts
+    // TableViewCell values from AbstractTableViewModel-style sources and
+    // compares them via muse::Val; override for domain-specific ordering.
+    virtual int compareCells(int column, int leftSourceRow, int rightSourceRow) const;
+
+    void setMaxSortKeys(int maxKeys) { m_maxSortKeys = maxKeys; }
+
+private:
+    void reapplySort();
+
+    struct SortKey {
+        int column = -1;
+        bool ascending = true;
+    };
+    std::vector<SortKey> m_sortPipeline;
+
+    QItemSelectionModel* m_selectionModel = nullptr;
+    int m_maxSortKeys = 3;
+};
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
@@ -29,6 +29,19 @@
 #include <vector>
 
 namespace muse::uicomponents {
+namespace ColumnSortOrder {
+Q_NAMESPACE;
+QML_ELEMENT;
+
+enum class Type {
+    Unsorted = -1,
+    Ascending = 0,
+    Descending = 1
+};
+
+Q_ENUM_NS(Type)
+}
+
 /**
  * @brief Table-aware sort/filter proxy.
  *
@@ -56,9 +69,11 @@ public:
     Q_INVOKABLE void clearSort();
     Q_INVOKABLE void invalidateFilters();
     Q_INVOKABLE int mapRowToSource(int proxyRow) const;
+    Q_INVOKABLE ColumnSortOrder::Type columnSortOrder(int column) const;
 
 signals:
     void rowCountChanged();
+    void sortChanged();
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
@@ -82,6 +97,7 @@ private:
         bool ascending = true;
     };
     std::vector<SortKey> m_sortPipeline;
+    int m_sortIconColumn = -1;
 
     QItemSelectionModel* m_selectionModel = nullptr;
     int m_maxSortKeys = 3;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
@@ -87,8 +87,6 @@ protected:
     // compares them via muse::Val; override for domain-specific ordering.
     virtual int compareCells(int column, int leftSourceRow, int rightSourceRow) const;
 
-    void setMaxSortKeys(int maxKeys) { m_maxSortKeys = maxKeys; }
-
 private:
     void reapplySort();
 
@@ -100,6 +98,5 @@ private:
     int m_sortIconColumn = -1;
 
     QItemSelectionModel* m_selectionModel = nullptr;
-    int m_maxSortKeys = 3;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/tablesortfilterproxymodel.h
@@ -57,11 +57,16 @@ class TableSortFilterProxyModel : public QSortFilterProxyModel
 
     Q_PROPERTY(QItemSelectionModel* selectionModel READ selectionModel CONSTANT)
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
+    Q_PROPERTY(int sortIndicatorColumn READ sortIndicatorColumn NOTIFY sortChanged)
+    Q_PROPERTY(ColumnSortOrder::Type sortIndicatorOrder READ sortIndicatorOrder NOTIFY sortChanged)
 
 public:
     explicit TableSortFilterProxyModel(QObject* parent = nullptr);
 
     QItemSelectionModel* selectionModel() const;
+
+    int sortIndicatorColumn() const;
+    ColumnSortOrder::Type sortIndicatorOrder() const;
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
 
@@ -69,7 +74,6 @@ public:
     Q_INVOKABLE void clearSort();
     Q_INVOKABLE void invalidateFilters();
     Q_INVOKABLE int mapRowToSource(int proxyRow) const;
-    Q_INVOKABLE ColumnSortOrder::Type columnSortOrder(int column) const;
 
 signals:
     void rowCountChanged();

--- a/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.cpp
@@ -38,7 +38,7 @@ void TestTableViewModel::load()
     QVector<TableViewCell*> row1 = {
         makeCell(Val("Text 1")),
         makeCell(Val(ValList { Val("Item 1"), Val("Item 2") }), Val("Item 1")),
-        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val("12h34m56.789 s")),
         makeCell(Val(0.0)),
         makeCell(Val("00h00m00.000 s")),
     };
@@ -67,6 +67,14 @@ void TestTableViewModel::load()
     setTable(table);
 }
 
+bool TestTableViewModel::doCellValueChangeRequested(int row, int column, const Val& value)
+{
+    Q_UNUSED(row);
+    Q_UNUSED(column);
+    Q_UNUSED(value);
+    return true;
+}
+
 MenuItemList TestTableViewModel::makeAvailableFormats()
 {
     MenuItemList items;
@@ -76,7 +84,7 @@ MenuItemList TestTableViewModel::makeAvailableFormats()
 
     ui::UiAction action;
 
-    action.code = "defaul";
+    action.code = "default";
     action.title = TranslatableString::untranslatable("Default");
     MenuItem* item1 = new MenuItem(action);
     item1->setState(enabledState);
@@ -87,7 +95,7 @@ MenuItemList TestTableViewModel::makeAvailableFormats()
     action.title = TranslatableString::untranslatable("Accent");
     MenuItem* item2 = new MenuItem(action);
     item2->setState(enabledState);
-    item1->setSelectable(true);
+    item2->setSelectable(true);
     items << item2;
 
     return items;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.cpp
@@ -35,23 +35,80 @@ void TestTableViewModel::load()
 {
     QVector<QVector<TableViewCell*> > table;
 
-    QVector<TableViewCell*> row1 = {
-        makeCell(Val("Text 1")),
-        makeCell(Val(ValList { Val("Item 1"), Val("Item 2") }), Val("Item 1")),
-        makeCell(Val("12h34m56.789 s")),
-        makeCell(Val(0.0)),
-        makeCell(Val("00h00m00.000 s")),
-    };
-    table.append(row1);
+    const ValList listOptions { Val("Item 1"), Val("Item 2"), Val("Item 3") };
+    const ValList colorOptions { Val("Red"), Val("Green"), Val("Blue") };
 
-    QVector<TableViewCell*> row2 = {
-        makeCell(Val("Text 2")),
-        makeCell(Val(ValList { Val("Item 1"), Val("Item 2") }), Val("Item 2")),
+    table.append({
+        makeCell(Val("Charlie")),
+        makeCell(Val(listOptions), Val("Item 2")),
+        makeCell(Val("12h34m56.789 s")),
+        makeCell(Val(3.5)),
+        makeCell(Val("00h05m12.000 s")),
+        makeCell(Val(colorOptions), Val("Red")),
+    });
+
+    table.append({
+        makeCell(Val("Alpha")),
+        makeCell(Val(listOptions), Val("Item 3")),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(-1.25)),
+        makeCell(Val("01h22m07.500 s")),
+        makeCell(Val(colorOptions), Val("Green")),
+    });
+
+    table.append({
+        makeCell(Val("Echo")),
+        makeCell(Val(listOptions), Val("Item 1")),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(10.0)),
+        makeCell(Val("00h00m45.250 s")),
+        makeCell(Val(colorOptions), Val("Blue")),
+    });
+
+    table.append({
+        makeCell(Val("Bravo")),
+        makeCell(Val(listOptions), Val("Item 1")),
         makeCell(Val("00h00m00.000 s")),
         makeCell(Val(0.0)),
+        makeCell(Val("02h15m30.000 s")),
+        makeCell(Val(colorOptions), Val("Green")),
+    });
+
+    table.append({
+        makeCell(Val("Foxtrot")),
+        makeCell(Val(listOptions), Val("Item 3")),
         makeCell(Val("00h00m00.000 s")),
-    };
-    table.append(row2);
+        makeCell(Val(7.75)),
+        makeCell(Val("00h45m00.000 s")),
+        makeCell(Val(colorOptions), Val("Blue")),
+    });
+
+    table.append({
+        makeCell(Val("Delta")),
+        makeCell(Val(listOptions), Val("Item 2")),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(2.0)),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(colorOptions), Val("Red")),
+    });
+
+    table.append({
+        makeCell(Val("Bravo")),
+        makeCell(Val(listOptions), Val("Item 2")),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(5.0)),
+        makeCell(Val("00h12m00.000 s")),
+        makeCell(Val(colorOptions), Val("Blue")),
+    });
+
+    table.append({
+        makeCell(Val("Golf")),
+        makeCell(Val(listOptions), Val("Item 1")),
+        makeCell(Val("00h00m00.000 s")),
+        makeCell(Val(-3.0)),
+        makeCell(Val("03h00m00.000 s")),
+        makeCell(Val(colorOptions), Val("Green")),
+    });
 
     QList<TableViewHeader*> hHeaders = {
         makeHorizontalHeader("Column 1", TableViewCellType::Type::String, TableViewCellEditMode::Mode::DoubleClick, 100),
@@ -59,7 +116,8 @@ void TestTableViewModel::load()
         makeHorizontalHeader("Column 3", static_cast<TableViewCellType::Type>(TestTableViewCellType::Type::Custom),
                              TableViewCellEditMode::Mode::StartInEdit, 200, makeAvailableFormats()),
         makeHorizontalHeader("Column 4", TableViewCellType::Type::Double, TableViewCellEditMode::Mode::StartInEdit, 200),
-        makeHorizontalHeader("Column 5", TableViewCellType::Type::String, TableViewCellEditMode::Mode::StartInEdit, 300)
+        makeHorizontalHeader("Column 5", TableViewCellType::Type::String, TableViewCellEditMode::Mode::StartInEdit, 300),
+        makeHorizontalHeader("Column 6", TableViewCellType::Type::List, TableViewCellEditMode::Mode::DoubleClick, 100),
     };
 
     setHorizontalHeaders(hHeaders);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/testtableviewmodel.h
@@ -47,6 +47,9 @@ public:
 
     void load();
 
+protected:
+    bool doCellValueChangeRequested(int row, int column, const Val& value) override;
+
 private:
     MenuItemList makeAvailableFormats();
 };


### PR DESCRIPTION
Needed for Audacity PR https://github.com/audacity/audacity/pull/10649

* Allow empty table views: Audacity's plugin manager has filters that may yield no match. In that case, the displayed table should be empty.
* Bubble up horizontal-header click: so that table views can react to those clicks, here to order the table rows after the clicked column, like is standard behavior.
* expose `displayTruncatedTextOnHover` property of `StyledTableView`: in lieu of tooltips
* Introduces `TableSortFilterProxyModel` in the framework and integrates it for demo in the component gallery's existing table demo. Video here: https://github.com/audacity/audacity/pull/10649#issuecomment-4287348743

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
