### PR TITLE
Fix playback after default instrument changes

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1058,6 +1058,7 @@ void PlaybackController::resetCurrentSequence()
     playback()->removeSequence(m_currentSequenceId);
 
     m_instrumentTrackIdMap.clear();
+    m_pendingInstrumentTrackAddRequests.clear();
     m_auxTrackIdMap.clear();
 
     m_isRangeSelection = false;
@@ -1073,6 +1074,11 @@ void PlaybackController::resetCurrentSequence()
 
 void PlaybackController::addTrack(const InstrumentTrackId& instrumentTrackId, const TrackAddFinished& onFinished)
 {
+    if (muse::contains(m_instrumentTrackIdMap, instrumentTrackId)
+        || muse::contains(m_pendingInstrumentTrackAddRequests, instrumentTrackId)) {
+        return;
+    }
+
     if (notationPlayback()->metronomeTrackId() == instrumentTrackId) {
         doAddTrack(instrumentTrackId, muse::trc("playback", "Metronome"), onFinished);
         return;
@@ -1114,10 +1120,34 @@ void PlaybackController::doAddTrack(const InstrumentTrackId& instrumentTrackId, 
         return;
     }
 
+    if (muse::contains(m_instrumentTrackIdMap, instrumentTrackId)
+        || muse::contains(m_pendingInstrumentTrackAddRequests, instrumentTrackId)) {
+        return;
+    }
+
     mpe::PlaybackData playbackData = notationPlayback()->trackPlaybackData(instrumentTrackId);
     if (!playbackData.isValid()) {
         return;
     }
+
+    const TrackSequenceId sequenceId = m_currentSequenceId;
+    const uint64_t requestId = ++m_nextInstrumentTrackAddRequestId;
+    m_pendingInstrumentTrackAddRequests[instrumentTrackId] = requestId;
+
+    auto requestIsCurrent = [this, instrumentTrackId, requestId]() {
+        auto it = m_pendingInstrumentTrackAddRequests.find(instrumentTrackId);
+        return it != m_pendingInstrumentTrackAddRequests.cend() && it->second == requestId;
+    };
+
+    auto clearCurrentRequest = [this, instrumentTrackId, requestId]() {
+        auto it = m_pendingInstrumentTrackAddRequests.find(instrumentTrackId);
+        if (it != m_pendingInstrumentTrackAddRequests.cend() && it->second == requestId) {
+            m_pendingInstrumentTrackAddRequests.erase(it);
+            return true;
+        }
+
+        return false;
+    };
 
     AudioInputParams inParams = audioSettings()->trackInputParams(instrumentTrackId);
     AudioOutputParams outParams = trackOutputParams(instrumentTrackId);
@@ -1147,16 +1177,34 @@ void PlaybackController::doAddTrack(const InstrumentTrackId& instrumentTrackId, 
 
     uint64_t playbackKey = notationPlaybackKey();
 
-    playback()->addTrack(m_currentSequenceId, title, std::move(playbackData), { std::move(inParams), std::move(outParams) })
-    .onResolve(this, [this, title, instrumentTrackId, playbackKey, onFinished, originMeta](const TrackId trackId,
-                                                                                           const AudioParams& appliedParams) {
+    playback()->addTrack(sequenceId, title, std::move(playbackData), { std::move(inParams), std::move(outParams) })
+    .onResolve(this, [this, title, instrumentTrackId, playbackKey, sequenceId, onFinished, originMeta,
+                      requestIsCurrent, clearCurrentRequest](const TrackId trackId, const AudioParams& appliedParams) {
         //! NOTE It may be that while we were adding a track, the notation was already closed (or opened another)
         //! This situation can be if the notation was opened and immediately closed.
         if (notationPlaybackKey() != playbackKey) {
+            const bool wasCurrentRequest = clearCurrentRequest();
+            playback()->removeTrack(sequenceId, trackId);
+            if (wasCurrentRequest) {
+                onFinished();
+            }
+            return;
+        }
+
+        if (!requestIsCurrent()) {
+            playback()->removeTrack(sequenceId, trackId);
+            return;
+        }
+
+        if (!muse::contains(notationPlayback()->existingTrackIdSet(), instrumentTrackId)) {
+            clearCurrentRequest();
+            playback()->removeTrack(sequenceId, trackId);
+            onFinished();
             return;
         }
 
         m_instrumentTrackIdMap.insert({ instrumentTrackId, trackId });
+        clearCurrentRequest();
 
         const bool trackNewlyAdded = !audioSettings()->trackHasExistingOutputParams(instrumentTrackId);
         audioSettings()->setTrackInputParams(instrumentTrackId, appliedParams.in);
@@ -1184,7 +1232,11 @@ void PlaybackController::doAddTrack(const InstrumentTrackId& instrumentTrackId, 
             }
         }
     })
-    .onReject(this, [instrumentTrackId, onFinished](int code, const std::string& msg) {
+    .onReject(this, [this, instrumentTrackId, onFinished, clearCurrentRequest](int code, const std::string& msg) {
+        if (!clearCurrentRequest()) {
+            return;
+        }
+
         LOGE() << "can't add a new track, code: [" << code << "] " << msg;
 
         onFinished();
@@ -1436,6 +1488,7 @@ void PlaybackController::subscribeOnAudioParamsChanges()
 void PlaybackController::setupSequenceTracks()
 {
     m_instrumentTrackIdMap.clear();
+    m_pendingInstrumentTrackAddRequests.clear();
 
     if (!masterNotationParts()) {
         return;

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
 #include "actions/iactionsdispatcher.h"
@@ -256,6 +258,8 @@ private:
     muse::async::Asyncable m_seqAsyncReceiver; //! HACK - see PlaybackController::setupSequenceTracks
 
     InstrumentTrackIdMap m_instrumentTrackIdMap;
+    std::unordered_map<engraving::InstrumentTrackId, uint64_t> m_pendingInstrumentTrackAddRequests;
+    uint64_t m_nextInstrumentTrackAddRequestId = 0;
     AuxTrackIdMap m_auxTrackIdMap;
 
     muse::Progress m_loadingProgress;


### PR DESCRIPTION
Resolves: #32975  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate concurrent additions of the same instrument track by skipping already active or pending add requests.
  * Clear pending add requests during sequence resets and track setup to avoid stale operations.
  * Ensure aborted or outdated add results are discarded without completing, and missing tracks trigger safe cleanup.
  * Improve rejection handling to clear pending state and avoid spurious completion callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->