### PR TITLE
Fix #33033: Use NSFloatingWindowLevel instead of attaching/detaching parent and child windows [4.7.0]

### DIFF
--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionViewerDialog.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionViewerDialog.qml
@@ -34,7 +34,7 @@ StyledDialogView {
     contentWidth: viewer.width
     contentHeight: viewer.height
 
-    nativeChildWindow: true
+    alwaysAboveApp: true
 
     ExtensionViewer {
         id: viewer

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -185,14 +185,14 @@ fixup_qml_module_dependencies(muse_uicomponents_qml)
 
 if (OS_IS_MAC)
     target_sources(muse_uicomponents_qml PRIVATE
-        internal/platform/macos/macoschildwindowcontroller.mm
-        internal/platform/macos/macoschildwindowcontroller.h
+        internal/platform/macos/macoswindowlevelcontroller.mm
+        internal/platform/macos/macoswindowlevelcontroller.h
         internal/platform/macos/macospopupviewclosecontroller.mm
         internal/platform/macos/macospopupviewclosecontroller.h
         )
 
     set_source_files_properties(
-        internal/platform/macos/macoschildwindowcontroller.mm
+        internal/platform/macos/macoswindowlevelcontroller.mm
         internal/platform/macos/macospopupviewclosecontroller.mm
         PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION ON

--- a/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.cpp
@@ -28,7 +28,7 @@
 #include <QStyle>
 
 #ifdef Q_OS_MAC
-#include "internal/platform/macos/macoschildwindowcontroller.h"
+#include "internal/platform/macos/macoswindowlevelcontroller.h"
 #endif
 
 #include "log.h"
@@ -101,12 +101,6 @@ void DialogView::beforeOpen()
 
 void DialogView::onHidden()
 {
-#ifdef Q_OS_MAC
-    if (m_nativeChildWindow) {
-        MacOSChildWindowController::detachWindow(m_view);
-    }
-#endif
-
     WindowView::onHidden();
 
     windowsController()->unregWindow(m_view->winId());
@@ -115,8 +109,8 @@ void DialogView::onHidden()
 void DialogView::afterShow()
 {
 #ifdef Q_OS_MAC
-    if (m_nativeChildWindow) {
-        MacOSChildWindowController::attachWindow(m_view, m_parentWindow);
+    if (m_alwaysAboveApp) {
+        MacOSWindowLevelController::setAlwaysAboveApp(m_view);
     }
 #endif
 }
@@ -263,19 +257,19 @@ void DialogView::setResizable(bool resizable)
     }
 }
 
-bool DialogView::nativeChildWindow() const
+bool DialogView::alwaysAboveApp() const
 {
-    return m_nativeChildWindow;
+    return m_alwaysAboveApp;
 }
 
-void DialogView::setNativeChildWindow(bool nativeChildWindow)
+void DialogView::setAlwaysAboveApp(bool alwaysAbove)
 {
-    if (m_nativeChildWindow == nativeChildWindow) {
+    if (m_alwaysAboveApp == alwaysAbove) {
         return;
     }
 
-    m_nativeChildWindow = nativeChildWindow;
-    emit nativeChildWindowChanged();
+    m_alwaysAboveApp = alwaysAbove;
+    emit alwaysAboveAppChanged();
 }
 
 QVariantMap DialogView::ret() const

--- a/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dialogview.h
@@ -43,7 +43,7 @@ class DialogView : public WindowView
     Q_PROPERTY(bool modal READ modal WRITE setModal NOTIFY modalChanged)
     Q_PROPERTY(bool frameless READ frameless WRITE setFrameless NOTIFY framelessChanged)
     Q_PROPERTY(bool resizable READ resizable WRITE setResizable NOTIFY resizableChanged)
-    Q_PROPERTY(bool nativeChildWindow READ nativeChildWindow WRITE setNativeChildWindow NOTIFY nativeChildWindowChanged)
+    Q_PROPERTY(bool alwaysAboveApp READ alwaysAboveApp WRITE setAlwaysAboveApp NOTIFY alwaysAboveAppChanged)
     Q_PROPERTY(QVariantMap ret READ ret WRITE setRet NOTIFY retChanged)
 
     ContextInject<IApplication> application = { this };
@@ -68,8 +68,8 @@ public:
     bool resizable() const;
     void setResizable(bool resizable);
 
-    bool nativeChildWindow() const;
-    void setNativeChildWindow(bool nativeChildWindow);
+    bool alwaysAboveApp() const;
+    void setAlwaysAboveApp(bool alwaysAbove);
 
     QVariantMap ret() const;
     void setRet(QVariantMap ret);
@@ -87,7 +87,7 @@ signals:
     void modalChanged(bool modal);
     void framelessChanged(bool frameless);
     void resizableChanged(bool resizable);
-    void nativeChildWindowChanged();
+    void alwaysAboveAppChanged();
     void retChanged(QVariantMap ret);
 
 private:
@@ -104,7 +104,7 @@ private:
     QString m_title;
     bool m_modal = true;
     bool m_frameless = false;
-    bool m_nativeChildWindow = false;
+    bool m_alwaysAboveApp = false;
     QVariantMap m_ret;
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/platform/macos/macoswindowlevelcontroller.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/platform/macos/macoswindowlevelcontroller.h
@@ -24,10 +24,9 @@
 class QWindow;
 
 namespace muse::uicomponents {
-class MacOSChildWindowController
+class MacOSWindowLevelController
 {
 public:
-    static void attachWindow(QWindow* childWindow, QWindow* parentWindow);
-    static void detachWindow(QWindow* childWindow);
+    static void setAlwaysAboveApp(QWindow* window);
 };
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/platform/macos/macoswindowlevelcontroller.mm
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/platform/macos/macoswindowlevelcontroller.mm
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "macoschildwindowcontroller.h"
+#include "macoswindowlevelcontroller.h"
 
 #include <Cocoa/Cocoa.h>
 #include <QWindow>
@@ -37,35 +37,12 @@ static NSWindow* nsWindowForQWindow(QWindow* window)
     return [nsView window];
 }
 
-void MacOSChildWindowController::attachWindow(QWindow* childWindow, QWindow* parentWindow)
+void MacOSWindowLevelController::setAlwaysAboveApp(QWindow* window)
 {
-    NSWindow* child = nsWindowForQWindow(childWindow);
-    NSWindow* parent = nsWindowForQWindow(parentWindow);
-    if (!child || !parent || child == parent) {
+    NSWindow* nsWindow = nsWindowForQWindow(window);
+    if (!nsWindow) {
         return;
     }
-
-    NSWindow* currentParent = [child parentWindow];
-    if (currentParent && currentParent != parent) {
-        [currentParent removeChildWindow:child];
-    }
-
-    [child orderFront:nil];
-
-    if ([child parentWindow] != parent) {
-        [parent addChildWindow:child ordered:NSWindowAbove];
-    }
-}
-
-void MacOSChildWindowController::detachWindow(QWindow* childWindow)
-{
-    NSWindow* child = nsWindowForQWindow(childWindow);
-    if (!child) {
-        return;
-    }
-
-    NSWindow* parent = [child parentWindow];
-    if (parent) {
-        [parent removeChildWindow:child];
-    }
+    [nsWindow setLevel:NSFloatingWindowLevel];
+    [nsWindow setHidesOnDeactivate:YES];
 }

--- a/src/framework/vst/qml/Muse/Vst/VstEditorDialog.qml
+++ b/src/framework/vst/qml/Muse/Vst/VstEditorDialog.qml
@@ -33,7 +33,7 @@ StyledDialogView {
     contentHeight: editor.implicitHeight
     contentWidth: editor.implicitWidth
 
-    nativeChildWindow: true
+    alwaysAboveApp: true
 
     VstEditor {
         id: editor


### PR DESCRIPTION
Resolves: #33033
Resolves: #33076
Resolves: #31431

A brief rundown on the history of this system:

- Initially we used [alwaysOnTop logic](https://github.com/musescore/MuseScore/pull/17139/changes/36ba67858396edc6adb665423f8d050a9343a44c#diff-85d1a0c960fa6356dece2492f8cdf6a44a53463d110de04cfdc469473cd541faR211-R219) which sent our plugins/extensions all the way to the front without exception. This was problematic because plugin windows would be displayed in front of any sub-windows/menus.
- We then implemented [parenting logic](https://github.com/musescore/MuseScore/pull/32741/changes/b8395f6db2b74bbdf4b8f4bc438e8315ce522e38) so that plugin/extension windows were set as children of the main window. While this ensured that plugins/extensions weren't sent any further forward than they needed to be, this resulted in them "moving with" the main window and disappearing when placed on separate screens.

From what I can tell - we should actually be using Apple's [NSWindow.Level](https://developer.apple.com/documentation/appkit/nswindow/level-swift.struct) system here. This system defines a series of levels where "the bottom window in a level will obscure the top window of the next level down". For the purposes of plugins/extensions, the most appropriate level seems to be `NSFloatingWindowLevel`.

In future we should investigate where else to set these levels (e.g. in popups - `NSPopUpMenuWindowLevel`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * macOS dialog handling updated so extension viewer and plugin editor dialogs now stay above the app instead of acting as native child windows.
  * Window-level management consolidated to a single "always above app" behavior for more consistent stacking and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->