### PR TITLE
Fix MacOS VST Window Closing Crash

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -157,10 +157,8 @@ void VstView::deinit()
     m_screenMetricsTimer.stop();
 
     if (m_view) {
-        m_view->setFrame(nullptr);
-#ifndef Q_OS_MAC
         m_view->removed();
-#endif
+        m_view->setFrame(nullptr);
         m_view = nullptr;
 
         m_vstWindow->hide();

--- a/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
+++ b/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
@@ -64,10 +64,8 @@ VstViewDialog::~VstViewDialog()
 void VstViewDialog::deinit()
 {
     if (m_view) {
-        m_view->setFrame(nullptr);
-#ifndef Q_OS_MAC
         m_view->removed();
-#endif
+        m_view->setFrame(nullptr);
         m_view = nullptr;
     }
 
@@ -199,7 +197,9 @@ void VstViewDialog::showEvent(QShowEvent* ev)
 
 void VstViewDialog::closeEvent(QCloseEvent* ev)
 {
-    deinit();
+    if (m_instance) {
+        m_instance->loadingCompleted().disconnect(this);
+    }
 
     TopLevelDialog::closeEvent(ev);
 }


### PR DESCRIPTION
Resolves: #33019  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
The current fix takes inspiration from Ardour:
[libs/ardour/vst3_plugin.cc](https://github.com/Ardour/ardour/blob/master/libs/ardour/vst3_plugin.cc)
[gtk2_ardour/vst3_nsview_plugin_ui.mm](https://github.com/Ardour/ardour/blob/master/gtk2_ardour/vst3_nsview_plugin_ui.mm)
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
