### PR TITLE
[4.7.0] Fix VST Crashes

### DIFF
--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -92,7 +92,10 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isActive());
+
+        if (m_audioSource) {
+            fx->setPlaying(m_audioSource->isActive());
+        }
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_params.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -137,7 +137,7 @@ void VstAudioClient::setIsPlaying(const bool newPlaying)
         m_processContext.state &= ~playingFlag;
     }
 
-    m_needUpdateState = true;
+    m_needUpdateState = m_isActive;
 }
 
 void VstAudioClient::setOutputSpec(const audio::OutputSpec& spec)
@@ -149,6 +149,7 @@ void VstAudioClient::setOutputSpec(const audio::OutputSpec& spec)
     m_processData.numSamples = static_cast<Steinberg::int32>(spec.samplesPerChannel);
     m_outputSpec = spec;
     m_needUnprepareProcessData = true;
+    m_needUpdateState = false;
 
     updateProcessSetup();
 }
@@ -161,6 +162,7 @@ void VstAudioClient::setProcessMode(VstProcessMode mode)
 
     m_processMode = mode;
     m_needUnprepareProcessData = true;
+    m_needUpdateState = false;
 
     updateProcessSetup();
 }

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -67,10 +67,10 @@ VstAudioClient::VstAudioClient(const modularity::ContextPtr& iocCtx)
 
 VstAudioClient::~VstAudioClient()
 {
-    if (m_pluginComponent) {
-        m_pluginComponent->setActive(false);
-        m_pluginComponent->terminate();
-    }
+    // Do not call setActive(false) or terminate() here.
+    // The component lifecycle is managed by VstPluginInstance,
+    // which defers cleanup to the main thread so that any open
+    // editor view is destroyed first (required by ZENOLOGY).
 }
 
 void VstAudioClient::init(AudioPluginType type, IVstPluginInstancePtr instance)

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -129,17 +129,43 @@ void VstPluginInstance::load()
             return;
         }
 
-        auto controller = m_pluginProvider->controller();
-
+        PluginControllerPtr controller = m_pluginProvider->controller();
         if (!controller) {
             return;
         }
 
         controller->setComponentHandler(m_componentHandlerPtr);
+        syncControllerToComponentState();
 
         m_isLoaded = true;
         m_loadingCompleted.notify();
     }, threadSecurer()->mainThreadId());
+}
+
+void VstPluginInstance::syncControllerToComponentState()
+{
+    // Synchronize controller to the component's default state.
+    // Some plugins (e.g. Roland Cloud ZENOLOGY) rely on this to
+    // fully initialize internal data structures; without it the
+    // controller may crash when the editor UI is opened.
+    PluginComponentPtr component = m_pluginProvider->component();
+    PluginControllerPtr controller = m_pluginProvider->controller();
+
+    if (!component || !controller) {
+        return;
+    }
+
+    m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+    m_componentStateBuffer.setSize(0);
+
+    if (component->getState(&m_componentStateBuffer) != Steinberg::kResultOk) {
+        return;
+    }
+
+    if (m_componentStateBuffer.getSize() > 0) {
+        m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+        controller->setComponentState(&m_componentStateBuffer);
+    }
 }
 
 void VstPluginInstance::rescanParams()
@@ -181,6 +207,7 @@ void VstPluginInstance::stateBufferFromString(VstMemoryStream& buffer, char* str
         return;
     }
 
+    buffer.setSize(0);
     buffer.write(strData, static_cast<Steinberg::int32>(strSize), nullptr);
     buffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
 }

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -25,8 +25,10 @@
 #include "modularity/ioc.h"
 #include "vstpluginprovider.h"
 
-#include "log.h"
 #include "async/async.h"
+
+#include "defer.h"
+#include "log.h"
 
 using namespace muse;
 using namespace muse::vst;
@@ -183,13 +185,17 @@ void VstPluginInstance::rescanParams()
 {
     ONLY_AUDIO_OR_MAIN_THREAD(threadSecurer);
 
+    if (m_updatingState) {
+        return;
+    }
+
     if (!m_pluginProvider) {
         LOGE() << "Plugin provider is not initialized";
         return;
     }
 
-    auto component = m_pluginProvider->component();
-    auto controller = m_pluginProvider->controller();
+    PluginComponentPtr component = m_pluginProvider->component();
+    PluginControllerPtr controller = m_pluginProvider->controller();
 
     if (!controller || !component) {
         return;
@@ -312,8 +318,8 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
         return;
     }
 
-    auto controller = m_pluginProvider->controller();
-    auto component = m_pluginProvider->component();
+    PluginControllerPtr controller = m_pluginProvider->controller();
+    PluginComponentPtr component = m_pluginProvider->component();
 
     if (!controller || !component) {
         LOGE() << "Unable to update settings for VST plugin";
@@ -327,6 +333,11 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
         return;
     }
 
+    m_updatingState = true;
+    DEFER {
+        m_updatingState = false;
+    };
+
     try {
         if (componentState != config.end() && !componentState->second.empty()) {
             stateBufferFromString(m_componentStateBuffer, const_cast<char*>(componentState->second.c_str()), componentState->second.size());
@@ -335,7 +346,7 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
             controller->setComponentState(&m_componentStateBuffer);
         }
     } catch (...) {
-        LOGW() << "Unexpected VST plugin exception";
+        LOGW() << "Component state restore failed: " << m_resourceId;
     }
 
     try {
@@ -345,7 +356,7 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
             controller->setState(&m_controllerStateBuffer);
         }
     } catch (...) {
-        LOGW() << "Unexpected VST plugin exception";
+        LOGW() << "Controller state restore failed: " << m_resourceId;
     }
 }
 

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -202,24 +202,34 @@ void VstPluginInstance::rescanParams()
     }
 
     m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
-    m_controllerStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
-
     m_componentStateBuffer.setSize(0);
+
+    Steinberg::tresult res = component->getState(&m_componentStateBuffer);
+    if (res != Steinberg::kResultOk && res != Steinberg::kNotImplemented) {
+        LOGW() << "Component state scan failed: " << m_resourceId;
+        return;
+    }
+
+    m_controllerStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
     m_controllerStateBuffer.setSize(0);
+
+    res = controller->getState(&m_controllerStateBuffer);
+    if (res != Steinberg::kResultOk && res != Steinberg::kNotImplemented) {
+        LOGW() << "Controller state scan failed: " << m_resourceId;
+        return;
+    }
 
     muse::audio::AudioUnitConfig updatedConfig;
 
-    if (component->getState(&m_componentStateBuffer) == Steinberg::kResultOk
-        && m_componentStateBuffer.getSize() > 0) {
+    if (m_componentStateBuffer.getSize() > 0) {
         updatedConfig.emplace(COMPONENT_STATE_KEY, std::string(m_componentStateBuffer.getData(), m_componentStateBuffer.getSize()));
     }
 
-    if (controller->getState(&m_controllerStateBuffer) == Steinberg::kResultOk
-        && m_controllerStateBuffer.getSize() > 0) {
+    if (m_controllerStateBuffer.getSize() > 0) {
         updatedConfig.emplace(CONTROLLER_STATE_KEY, std::string(m_controllerStateBuffer.getData(), m_controllerStateBuffer.getSize()));
     }
 
-    m_pluginSettingsChanges.send(std::move(updatedConfig));
+    m_pluginSettingsChanges.send(updatedConfig);
 }
 
 void VstPluginInstance::stateBufferFromString(VstMemoryStream& buffer, char* strData, const size_t strSize) const
@@ -341,9 +351,11 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
     try {
         if (componentState != config.end() && !componentState->second.empty()) {
             stateBufferFromString(m_componentStateBuffer, const_cast<char*>(componentState->second.c_str()), componentState->second.size());
-            component->setState(&m_componentStateBuffer);
-            m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
-            controller->setComponentState(&m_componentStateBuffer);
+
+            if (component->setState(&m_componentStateBuffer) == Steinberg::kResultOk) {
+                m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+                controller->setComponentState(&m_componentStateBuffer);
+            }
         }
     } catch (...) {
         LOGW() << "Component state restore failed: " << m_resourceId;

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -185,7 +185,7 @@ void VstPluginInstance::rescanParams()
 {
     ONLY_AUDIO_OR_MAIN_THREAD(threadSecurer);
 
-    if (m_updatingState) {
+    if (!m_isLoaded || m_updatingState) {
         return;
     }
 

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -331,6 +331,7 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
         if (componentState != config.end() && !componentState->second.empty()) {
             stateBufferFromString(m_componentStateBuffer, const_cast<char*>(componentState->second.c_str()), componentState->second.size());
             component->setState(&m_componentStateBuffer);
+            m_componentStateBuffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
             controller->setComponentState(&m_componentStateBuffer);
         }
     } catch (...) {

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -203,11 +203,15 @@ void VstPluginInstance::rescanParams()
 
     muse::audio::AudioUnitConfig updatedConfig;
 
-    component->getState(&m_componentStateBuffer);
-    updatedConfig.emplace(COMPONENT_STATE_KEY, std::string(m_componentStateBuffer.getData(), m_componentStateBuffer.getSize()));
+    if (component->getState(&m_componentStateBuffer) == Steinberg::kResultOk
+        && m_componentStateBuffer.getSize() > 0) {
+        updatedConfig.emplace(COMPONENT_STATE_KEY, std::string(m_componentStateBuffer.getData(), m_componentStateBuffer.getSize()));
+    }
 
-    controller->getState(&m_controllerStateBuffer);
-    updatedConfig.emplace(CONTROLLER_STATE_KEY, std::string(m_controllerStateBuffer.getData(), m_controllerStateBuffer.getSize()));
+    if (controller->getState(&m_controllerStateBuffer) == Steinberg::kResultOk
+        && m_controllerStateBuffer.getSize() > 0) {
+        updatedConfig.emplace(CONTROLLER_STATE_KEY, std::string(m_controllerStateBuffer.getData(), m_controllerStateBuffer.getSize()));
+    }
 
     m_pluginSettingsChanges.send(std::move(updatedConfig));
 }
@@ -317,26 +321,28 @@ void VstPluginInstance::updatePluginConfig(const muse::audio::AudioUnitConfig& c
     }
 
     auto componentState = config.find(COMPONENT_STATE_KEY.data());
-    if (componentState == config.end()) {
-        return;
-    }
-
     auto controllerState = config.find(CONTROLLER_STATE_KEY.data());
-    if (controllerState == config.end()) {
+
+    if (componentState == config.end() && controllerState == config.end()) {
         return;
     }
 
     try {
-        stateBufferFromString(m_componentStateBuffer, const_cast<char*>(componentState->second.c_str()), componentState->second.size());
-        component->setState(&m_componentStateBuffer);
-        controller->setComponentState(&m_componentStateBuffer);
+        if (componentState != config.end() && !componentState->second.empty()) {
+            stateBufferFromString(m_componentStateBuffer, const_cast<char*>(componentState->second.c_str()), componentState->second.size());
+            component->setState(&m_componentStateBuffer);
+            controller->setComponentState(&m_componentStateBuffer);
+        }
     } catch (...) {
         LOGW() << "Unexpected VST plugin exception";
     }
 
     try {
-        stateBufferFromString(m_controllerStateBuffer, const_cast<char*>(controllerState->second.data()), controllerState->second.size());
-        controller->setState(&m_controllerStateBuffer);
+        if (controllerState != config.end() && !controllerState->second.empty()) {
+            stateBufferFromString(m_controllerStateBuffer, const_cast<char*>(controllerState->second.data()),
+                                  controllerState->second.size());
+            controller->setState(&m_controllerStateBuffer);
+        }
     } catch (...) {
         LOGW() << "Unexpected VST plugin exception";
     }

--- a/src/framework/vst/internal/vstplugininstance.cpp
+++ b/src/framework/vst/internal/vstplugininstance.cpp
@@ -63,7 +63,18 @@ VstPluginInstance::~VstPluginInstance()
 
         repo()->removePluginModule(resourceId);
 
-        //! NOTE: the order of destruction is important here
+        //! NOTE: the order of destruction is important here.
+        //! Deactivate the component before the provider destroys it.
+        //! This must happen on the main thread, after any editor view
+        //! has been closed, to avoid crashes in plugins (e.g. ZENOLOGY)
+        //! that free editor-dependent resources in setActive(false).
+        if (provider) {
+            auto component = provider->component();
+            if (component) {
+                component->setActive(false);
+            }
+        }
+
         provider.reset();
         module.reset();
     }, threadSecurer()->mainThreadId());

--- a/src/framework/vst/internal/vstplugininstance.h
+++ b/src/framework/vst/internal/vstplugininstance.h
@@ -95,6 +95,8 @@ private:
     std::atomic_bool m_isLoaded = false;
     async::Notification m_loadingCompleted;
 
+    std::atomic_bool m_updatingState = false;
+
     mutable std::mutex m_mutex;
 };
 }

--- a/src/framework/vst/internal/vstplugininstance.h
+++ b/src/framework/vst/internal/vstplugininstance.h
@@ -77,6 +77,7 @@ public:
 private:
     void rescanParams();
     void stateBufferFromString(VstMemoryStream& buffer, char* strData, const size_t strSize) const;
+    void syncControllerToComponentState();
 
     VstPluginInstanceId m_id = 0;
     muse::audio::AudioResourceId m_resourceId;

--- a/src/framework/vst/internal/vstpluginprovider.cpp
+++ b/src/framework/vst/internal/vstpluginprovider.cpp
@@ -36,21 +36,7 @@ public:
     {
     }
 
-    bool init()
-    {
-        if (!initialize()) {
-            return false;
-        }
-
-        IF_ASSERT_FAILED(controller) {
-            return false;
-        }
-
-        controller->queryInterface(Steinberg::Vst::IMidiMapping_iid, (void**)&midiMapping);
-
-        return true;
-    }
-
+private:
     PluginMidiMappingPtr midiMapping;
 };
 
@@ -65,7 +51,7 @@ VstPluginProvider::~VstPluginProvider()
 
 bool VstPluginProvider::init()
 {
-    return m_impl->init();
+    return m_impl->initialize();
 }
 
 PluginComponentPtr VstPluginProvider::component() const
@@ -80,5 +66,8 @@ PluginControllerPtr VstPluginProvider::controller() const
 
 PluginMidiMappingPtr VstPluginProvider::midiMapping() const
 {
+    if (!m_impl->midiMapping && m_impl->controller) {
+        m_impl->controller->queryInterface(Steinberg::Vst::IMidiMapping_iid, (void**)&m_impl->midiMapping);
+    }
     return m_impl->midiMapping;
 }

--- a/src/playback/qml/MuseScore/Playback/inputresourceitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/inputresourceitem.cpp
@@ -181,6 +181,7 @@ void InputResourceItem::setParamsRecourceMeta(const AudioResourceMeta& newMeta)
     requestToCloseNativeEditorView();
 
     m_currentInputParams.resourceMeta = newMeta;
+    m_currentInputParams.configuration.clear();
 
     emit titleChanged();
     emit isBlankChanged();

--- a/src/playback/qml/MuseScore/Playback/outputresourceitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/outputresourceitem.cpp
@@ -185,6 +185,7 @@ void OutputResourceItem::updateCurrentFxParams(const AudioResourceMeta& newMeta)
     audio::AudioFxParams newParams = m_currentFxParams;
     newParams.categories = audio::audioFxCategoriesFromString(newMeta.attributeVal(audio::CATEGORIES_ATTRIBUTE));
     newParams.resourceMeta = newMeta;
+    newParams.configuration.clear();
     newParams.active = newMeta.isValid();
 
     setParams(newParams);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33014
Resolves: https://github.com/musescore/MuseScore/issues/24529
Resolves: https://github.com/musescore/MuseScore/issues/20341
Resolves: https://github.com/musescore/MuseScore/issues/18755
Resolves: https://github.com/musescore/MuseScore/issues/17123
Resolves: https://github.com/musescore/MuseScore/issues/16144

Also ports: https://github.com/musescore/MuseScore/pull/32841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust plugin lifecycle and teardown to avoid shutdown crashes.
  * Fewer redundant FX/audio-processor state updates for more stable playback.
  * Controller state now syncs to component defaults on load for correct plugin behavior.
  * Prevented redundant configuration/state emissions during internal updates.
  * Fixed stale configuration when switching input or effect resources.
  * Improved error reporting for component vs controller state restore.
  * Deferred and lazy controller queries to avoid premature initialization work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->