### PR TITLE
[4.7.0] Fix #33089: Music plays after being deleted

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -869,8 +869,8 @@ void PlaybackModel::clearExpiredEvents(const int tickFrom, const int tickTo, con
     }
 
     if (tickFrom == 0 && lastMeasure->endTick().ticks() == tickTo) {
-        removeEventsFromRange(trackFrom, trackTo);
-        removeTrackEvents(METRONOME_TRACK_ID);
+        removeEventsFromRange(trackFrom, trackTo, -1 /*timestampFrom*/, -1 /*timestampTo*/, trackChanges);
+        removeTrackEvents(METRONOME_TRACK_ID, -1 /*timestampFrom*/, -1 /*timestampTo*/, trackChanges);
         return;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback stability by enhancing event handling during expiration and removal operations, ensuring all modifications are properly tracked for downstream notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->