### PR TITLE
Fix crash on edit bracket

### DIFF
--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -61,7 +61,9 @@ void EIDRegister::removeItem(const EngravingObject* item)
     // NOTE: needed only when elements are removed during read (e.g. broken spanners)
 
     auto itemIter = m_itemToEid.find(const_cast<EngravingObject*>(item));
-    DO_ASSERT(itemIter != m_itemToEid.end());
+    IF_ASSERT_FAILED(itemIter != m_itemToEid.end()) {
+        return;
+    }
 
     EID eid = (*itemIter).second;
     DO_ASSERT(eid.isValid());

--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -56,6 +56,24 @@ void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
 #endif
 }
 
+void EIDRegister::removeItem(const EngravingObject* item)
+{
+    // NOTE: needed only when elements are removed during read (e.g. broken spanners)
+
+    auto itemIter = m_itemToEid.find(const_cast<EngravingObject*>(item));
+    DO_ASSERT(itemIter != m_itemToEid.end());
+
+    EID eid = (*itemIter).second;
+    DO_ASSERT(eid.isValid());
+
+    m_itemToEid.erase(itemIter);
+
+    auto eidIter = m_eidToItem.find(eid);
+    DO_ASSERT(eidIter != m_eidToItem.end());
+
+    m_eidToItem.erase(eidIter);
+}
+
 EngravingObject* EIDRegister::itemFromEID(const EID& eid) const
 {
     auto iter = m_eidToItem.find(eid);

--- a/src/engraving/infrastructure/eidregister.h
+++ b/src/engraving/infrastructure/eidregister.h
@@ -37,6 +37,7 @@ public:
 
     EID newEIDForItem(const EngravingObject* item);
     void registerItemEID(const EID& eid, const EngravingObject* item);
+    void removeItem(const EngravingObject* item);
 
     EngravingObject* itemFromEID(const EID& eid) const;
     EID EIDFromItem(const EngravingObject* item) const;

--- a/src/engraving/rw/read460/readcontext.cpp
+++ b/src/engraving/rw/read460/readcontext.cpp
@@ -23,6 +23,7 @@
 #include "readcontext.h"
 
 #include "dom/linkedobjects.h"
+#include "dom/masterscore.h"
 #include "dom/score.h"
 #include "dom/trill.h"
 #include "editing/undo.h"
@@ -329,6 +330,10 @@ void ReadContext::clearOrphanedConnectors()
                         deletedLinks.insert(ornament->links());
                     }
                 }
+            }
+
+            if (conn->eid().isValid()) {
+                conn->masterScore()->eidRegister()->removeItem(conn);
             }
 
             delete conn;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4869,7 +4869,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
     m_editData.s = event->text();
 
     // Brackets get deleted during layout with their system, so the best we can do to maintain
-    // the bracket selected is to store their indices and use them find the new ones
+    // the bracket selected is to store their indices and use them to find the new ones
     bool isBracket = m_editData.element->isBracket();
     size_t bracketIndex = muse::nidx;
     size_t systemIndex = muse::nidx;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4868,17 +4868,19 @@ void NotationInteraction::editElement(QKeyEvent* event)
     m_editData.key = event->key();
     m_editData.s = event->text();
 
-    // Brackets may be deleted and replaced
+    // Brackets get deleted during layout with their system, so the best we can do to maintain
+    // the bracket selected is to store their indices and use them find the new ones
     bool isBracket = m_editData.element->isBracket();
-    const mu::engraving::System* system = nullptr;
     size_t bracketIndex = muse::nidx;
+    size_t systemIndex = muse::nidx;
 
     if (isBracket) {
-        const mu::engraving::Bracket* bracket = mu::engraving::toBracket(m_editData.element);
-        system = bracket->system();
+        const Bracket* bracket = toBracket(m_editData.element);
+        System* system = bracket->system();
 
         if (system) {
             bracketIndex = muse::indexOf(system->brackets(), bracket);
+            systemIndex = muse::indexOf(score()->systems(), system);
         }
     } else if (m_editData.element->isHarmony()) {
         if (isTextEditingStarted() && (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
@@ -4892,10 +4894,14 @@ void NotationInteraction::editElement(QKeyEvent* event)
     }
 
     if (handleKeyPress(event)) {
-        if (isBracket && system && bracketIndex != muse::nidx) {
-            mu::engraving::EngravingItem* bracket = system->brackets().at(bracketIndex);
-            m_editData.element = bracket;
-            select({ bracket }, SelectType::SINGLE);
+        if (isBracket && bracketIndex != muse::nidx && systemIndex != muse::nidx) {
+            // Try to restore selected bracket
+            System* system = systemIndex < score()->systems().size() ? score()->systems().at(systemIndex) : nullptr;
+            EngravingItem* bracket = system && bracketIndex < system->brackets().size() ? system->brackets().at(bracketIndex) : nullptr;
+            if (bracket) {
+                m_editData.element = bracket;
+                select({ bracket }, SelectType::SINGLE);
+            }
         }
 
         if (isGripEditStarted()) {


### PR DESCRIPTION
First commit resolves https://github.com/musescore/MuseScore/issues/24348

Second commit resolves another read-after-free bug I discovered while investigatig the first issue, yet again caused by the [spanner writing system](https://github.com/musescore/MuseScore/issues/23688#:~:text=Score/part%20links-,Spanners,else%20had%20already%20stored%20references%20to%20them%2C%20which%20then%20become%20invalidated.,-Score/parts). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public operation to remove engraving items from the ID registry.

* **Bug Fixes**
  * Ensure orphaned connector cleanup properly unregisters items from the ID registry during deletion.
  * Improved bracket selection restoration after layout updates so brackets remain correctly selected when editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->