### PR TITLE
Fix #308890: Recognize 'H' in chord symbols even in non-German setup

### DIFF
--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -1109,7 +1109,7 @@ int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseType& no
             r = 4;
         } else if (ss == "la") {
             r = 5;
-        } else if (ss == "si") {
+        } else if (ss == "si" || ss == "ti") { // accept "ti" too, silently turn into "si"
             r = 6;
         } else {
             return Tpc::TPC_INVALID;

--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -1128,6 +1128,7 @@ int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseType& no
             break;
         case 'a':   r = 5;
             break;
+        case 'h':   // allow for German 'h' too, silently turn into 'b'
         case 'b':   r = 6;
             break;
         default:    return Tpc::TPC_INVALID;

--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -755,6 +755,7 @@ int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseType& no
             break;
         case 'a':   r = 5;
             break;
+        case 'h':   // allow for German 'h' too, silently turn into 'b'
         case 'b':   r = 6;
             break;
         default:    return Tpc::TPC_INVALID;

--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -724,19 +724,19 @@ int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseType& no
             noteCase = NoteCaseType::UPPER;
         }
         String ss = s.toLower().left(2);
-        if (ss == "do") {
+        if (ss == "do" || ss == "dó") {
             r = 0;
         } else if (ss == "re" || ss == "ré") {
             r = 1;
         } else if (ss == "mi") {
             r = 2;
-        } else if (ss == "fa") {
+        } else if (ss == "fa" || ss == "fá") {
             r = 3;
         } else if (ss == "so") {    // sol, but only check first 2 characters
             r = 4;
-        } else if (ss == "la") {
+        } else if (ss == "la" || ss == "lá") {
             r = 5;
-        } else if (ss == "si") {
+        } else if (ss == "si" || ss == "ti") { // accept "ti" too, silently turn into "si"
             r = 6;
         } else {
             return Tpc::TPC_INVALID;


### PR DESCRIPTION
just silently turn it into  "B"
Similar for "ti", just silently turn into "si" and also accept the accented versions

Resolves: [#308890](https://musescore.org/en/node/308890)