### PR TITLE
[audio] Replaced from isActive to Mode

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -537,6 +537,11 @@ enum class RenderMode {
     OfflineMode
 };
 
+inline bool isModeActive(RenderMode mode)
+{
+    return mode == RenderMode::RealTimeMode || mode == RenderMode::OfflineMode;
+}
+
 //! NOTE When commands arrive at the engine, it exec them.
 //! These can be quick commands like changing the volume,
 //! or longer commands like add a new track.

--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -530,16 +530,16 @@ struct SoundPreset
 
 using SoundPresetList = std::vector<SoundPreset>;
 
-enum class RenderMode {
-    Undefined = -1,
-    RealTimeMode,
-    IdleMode,
-    OfflineMode
+enum class ProcessMode {
+    Undefined = 0,
+    Idle,
+    Playing,
+    PlayingOffline
 };
 
-inline bool isModeActive(RenderMode mode)
+inline bool isModePlaying(ProcessMode mode)
 {
-    return mode == RenderMode::RealTimeMode || mode == RenderMode::OfflineMode;
+    return mode == ProcessMode::Playing || mode == ProcessMode::PlayingOffline;
 }
 
 //! NOTE When commands arrive at the engine, it exec them.

--- a/src/framework/audio/common/audioutils.h
+++ b/src/framework/audio/common/audioutils.h
@@ -122,15 +122,4 @@ inline bool isOnlineAudioResource(const AudioResourceMeta& meta)
 
     return val == 1;
 }
-
-inline samples_t minSamplesToReserve(RenderMode mode)
-{
-    // Idle: render as little as possible for lower latency
-    if (mode == RenderMode::IdleMode) {
-        return 128;
-    }
-
-    // Active: render more for better quality (rendering is usually much heavier in this scenario)
-    return 1024;
-}
 }

--- a/src/framework/audio/engine/iaudiosource.h
+++ b/src/framework/audio/engine/iaudiosource.h
@@ -34,8 +34,8 @@ class IAudioSource
 public:
     virtual ~IAudioSource() = default;
 
-    virtual bool isActive() const = 0;
-    virtual void setIsActive(bool arg) = 0;
+    virtual void setMode(const RenderMode mode) = 0;
+    virtual RenderMode mode() const = 0;
 
     //! set current output spec. Called by destination.
     virtual void setOutputSpec(const OutputSpec& spec) = 0;

--- a/src/framework/audio/engine/iaudiosource.h
+++ b/src/framework/audio/engine/iaudiosource.h
@@ -34,8 +34,8 @@ class IAudioSource
 public:
     virtual ~IAudioSource() = default;
 
-    virtual void setMode(const RenderMode mode) = 0;
-    virtual RenderMode mode() const = 0;
+    virtual void setMode(const ProcessMode mode) = 0;
+    virtual ProcessMode mode() const = 0;
 
     //! set current output spec. Called by destination.
     virtual void setOutputSpec(const OutputSpec& spec) = 0;

--- a/src/framework/audio/engine/internal/abstractaudiosource.cpp
+++ b/src/framework/audio/engine/internal/abstractaudiosource.cpp
@@ -25,12 +25,12 @@ using namespace muse;
 using namespace muse::audio;
 using namespace muse::audio::engine;
 
-void AbstractAudioSource::setMode(const RenderMode mode)
+void AbstractAudioSource::setMode(const ProcessMode mode)
 {
     m_mode = mode;
 }
 
-RenderMode AbstractAudioSource::mode() const
+ProcessMode AbstractAudioSource::mode() const
 {
     return m_mode;
 }

--- a/src/framework/audio/engine/internal/abstractaudiosource.cpp
+++ b/src/framework/audio/engine/internal/abstractaudiosource.cpp
@@ -25,19 +25,19 @@ using namespace muse;
 using namespace muse::audio;
 using namespace muse::audio::engine;
 
+void AbstractAudioSource::setMode(const RenderMode mode)
+{
+    m_mode = mode;
+}
+
+RenderMode AbstractAudioSource::mode() const
+{
+    return m_mode;
+}
+
 void AbstractAudioSource::setOutputSpec(const OutputSpec& spec)
 {
     m_outputSpec = spec;
-}
-
-bool AbstractAudioSource::isActive() const
-{
-    return m_isActive;
-}
-
-void AbstractAudioSource::setIsActive(bool isActive)
-{
-    m_isActive = isActive;
 }
 
 async::Channel<unsigned int> AbstractAudioSource::audioChannelsCountChanged() const

--- a/src/framework/audio/engine/internal/abstractaudiosource.h
+++ b/src/framework/audio/engine/internal/abstractaudiosource.h
@@ -30,17 +30,17 @@ class AbstractAudioSource : public IAudioSource
 public:
     virtual ~AbstractAudioSource() = default;
 
-    virtual void setOutputSpec(const OutputSpec& spec) override;
+    virtual void setMode(const RenderMode mode) override;
+    RenderMode mode() const override;
 
-    bool isActive() const override;
-    void setIsActive(bool arg) override;
+    virtual void setOutputSpec(const OutputSpec& spec) override;
 
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
 protected:
+    RenderMode m_mode = RenderMode::Undefined;
     OutputSpec m_outputSpec;
     async::Channel<unsigned int> m_streamsCountChanged;
-    bool m_isActive = false;
 };
 }
 

--- a/src/framework/audio/engine/internal/abstractaudiosource.h
+++ b/src/framework/audio/engine/internal/abstractaudiosource.h
@@ -30,15 +30,15 @@ class AbstractAudioSource : public IAudioSource
 public:
     virtual ~AbstractAudioSource() = default;
 
-    virtual void setMode(const RenderMode mode) override;
-    RenderMode mode() const override;
+    virtual void setMode(const ProcessMode mode) override;
+    ProcessMode mode() const override;
 
     virtual void setOutputSpec(const OutputSpec& spec) override;
 
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
 protected:
-    RenderMode m_mode = RenderMode::Undefined;
+    ProcessMode m_mode = ProcessMode::Undefined;
     OutputSpec m_outputSpec;
     async::Channel<unsigned int> m_streamsCountChanged;
 };

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -47,30 +47,15 @@ AudioContext::AudioContext(const modularity::IoCID& ctxId)
 
 Ret AudioContext::init(const RenderConstraints& consts)
 {
-    OutputSpec outputSpec = audioEngine()->outputSpec();
-
     m_mixer->init(consts.desiredAudioThreadNumber, consts.minTrackCountForMultithreading);
-    m_mixer->setOutputSpec(outputSpec);
     m_mixer->setPlayhead(std::dynamic_pointer_cast<IPlayhead>(m_player));
-    m_mixer->setIsActive(m_player->isActive());
-    m_mixer->setIsIdle(audioEngine()->mode() == RenderMode::IdleMode);
+
+    OutputSpec outputSpec = audioEngine()->outputSpec();
+    setOutputSpec(outputSpec);
+    setMode(RenderMode::IdleMode);
 
     m_player->isActiveChanged().onReceive(this, [this](bool isActive) {
-        m_mixer->setIsActive(isActive);
-    });
-
-    audioEngine()->modeChanged().onReceive(this, [this](RenderMode mode) {
-        m_prevActiveTrackId = INVALID_TRACK_ID;
-
-        if (mode == RenderMode::IdleMode) {
-            m_mixer->setTracksToProcessWhenIdle(m_tracksToProcessWhenIdle);
-        }
-
-        m_mixer->setIsIdle(mode == RenderMode::IdleMode);
-    });
-
-    audioEngine()->outputSpecChanged().onReceive(this, [this](const OutputSpec& outputSpec) {
-        m_mixer->setOutputSpec(outputSpec);
+        setMode(isActive ? RenderMode::RealTimeMode : RenderMode::IdleMode);
     });
 
     return make_ret(Ret::Code::Ok);
@@ -98,6 +83,24 @@ void AudioContext::deinit()
     m_inputParamsChanged = async::Channel<TrackId, AudioInputParams>();
 
     async_disconnectAll();
+}
+
+// Config
+void AudioContext::setMode(const RenderMode mode)
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+    if (mode == RenderMode::IdleMode) {
+        m_mixer->setTracksToProcessWhenIdle(m_tracksToProcessWhenIdle);
+    }
+    m_mixer->setIsIdle(mode == RenderMode::IdleMode);
+    m_mixer->setMode(mode);
+}
+
+void AudioContext::setOutputSpec(const OutputSpec& outputSpec)
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+    m_outputSpec = outputSpec;
+    m_mixer->setOutputSpec(outputSpec);
 }
 
 // Setup tracks
@@ -347,6 +350,12 @@ RetVal<TrackName> AudioContext::trackName(const TrackId trackId) const
     }
 
     return RetVal<TrackName>::make_ret((int)Err::InvalidTrackId, "no track");
+}
+
+sample_rate_t AudioContext::sampleRate() const
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+    return m_outputSpec.sampleRate;
 }
 
 ITrackAudioInputPtr AudioContext::trackSource(const TrackId trackId) const
@@ -746,7 +755,7 @@ Ret AudioContext::doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackForm
     using namespace muse::audio::soundtrack;
 
     const secs_t totalDuration = m_player->duration();
-    auto writer = std::make_shared<SoundTrackWriter>(dstDevice, format, totalDuration, m_mixer->mixedSource());
+    auto writer = std::make_shared<SoundTrackWriter>(dstDevice, format, totalDuration, m_mixer);
 
     writer->progress().progressChanged().onReceive(this, [this](int64_t current, int64_t total, std::string /*title*/) {
         m_saveSoundTracksProgress.progress.send(current, total, SaveSoundTrackStage::WritingSoundTrack);
@@ -759,7 +768,18 @@ Ret AudioContext::doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackForm
         }
     });
 
+    setMode(RenderMode::OfflineMode);
     Ret ret = writer->write();
+
+    //! NOTE Restore source (mixer) state
+    // Changes to the source and audio engine state
+    // must be performed via execOperation - so that synchronization with the audio driver process works
+    IAudioEngine::Operation func = [this]() {
+        m_mixer->setOutputSpec(audioEngine()->outputSpec());
+        setMode(RenderMode::IdleMode);
+    };
+    audioEngine()->execOperation(OperationType::LongOperation, func);
+
     m_player->seek(0);
 
     m_saveSoundTracksProgress.aborted.disconnect(this);

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -52,10 +52,10 @@ Ret AudioContext::init(const RenderConstraints& consts)
 
     OutputSpec outputSpec = audioEngine()->outputSpec();
     setOutputSpec(outputSpec);
-    setMode(RenderMode::IdleMode);
+    setMode(ProcessMode::Idle);
 
     m_player->isActiveChanged().onReceive(this, [this](bool isActive) {
-        setMode(isActive ? RenderMode::RealTimeMode : RenderMode::IdleMode);
+        setMode(isActive ? ProcessMode::Playing : ProcessMode::Idle);
     });
 
     return make_ret(Ret::Code::Ok);
@@ -86,13 +86,13 @@ void AudioContext::deinit()
 }
 
 // Config
-void AudioContext::setMode(const RenderMode mode)
+void AudioContext::setMode(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
-    if (mode == RenderMode::IdleMode) {
+    if (mode == ProcessMode::Idle) {
         m_mixer->setTracksToProcessWhenIdle(m_tracksToProcessWhenIdle);
     }
-    m_mixer->setIsIdle(mode == RenderMode::IdleMode);
+    m_mixer->setIsIdle(mode == ProcessMode::Idle);
     m_mixer->setMode(mode);
 }
 
@@ -768,7 +768,7 @@ Ret AudioContext::doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackForm
         }
     });
 
-    setMode(RenderMode::OfflineMode);
+    setMode(ProcessMode::PlayingOffline);
     Ret ret = writer->write();
 
     //! NOTE Restore source (mixer) state
@@ -776,7 +776,7 @@ Ret AudioContext::doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackForm
     // must be performed via execOperation - so that synchronization with the audio driver process works
     IAudioEngine::Operation func = [this]() {
         m_mixer->setOutputSpec(audioEngine()->outputSpec());
-        setMode(RenderMode::IdleMode);
+        setMode(ProcessMode::Idle);
     };
     audioEngine()->execOperation(OperationType::LongOperation, func);
 

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -48,7 +48,7 @@ public:
     void deinit() override;
 
     // Config
-    void setMode(const RenderMode newMode) override;
+    void setMode(const ProcessMode newMode) override;
     void setOutputSpec(const OutputSpec& outputSpec) override;
 
     // Tracks

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -47,6 +47,10 @@ public:
     Ret init(const RenderConstraints& consts) override;
     void deinit() override;
 
+    // Config
+    void setMode(const RenderMode newMode) override;
+    void setOutputSpec(const OutputSpec& outputSpec) override;
+
     // Tracks
     RetVal2<TrackId, AudioParams> addTrack(const std::string& trackName, io::IODevice* playbackData, const AudioParams& params) override;
     RetVal2<TrackId, AudioParams> addTrack(const std::string& trackName, const mpe::PlaybackData& playbackData,
@@ -134,6 +138,7 @@ private:
     const Track* track(const TrackId id) const;
 
     // IGetTrackSource
+    sample_rate_t sampleRate() const override;
     ITrackAudioInputPtr trackSource(const TrackId trackId) const override;
     std::vector<ITrackAudioInputPtr> allTracksSources() const override;
     // -----
@@ -145,6 +150,7 @@ private:
 
     modularity::IoCID m_ctxId = 0;
 
+    OutputSpec m_outputSpec;
     IEnginePlayerPtr m_player = nullptr;
     std::shared_ptr<Mixer> m_mixer;
 

--- a/src/framework/audio/engine/internal/audioengine.cpp
+++ b/src/framework/audio/engine/internal/audioengine.cpp
@@ -46,7 +46,7 @@ AudioEngine::~AudioEngine()
     ONLY_AUDIO_MAIN_OR_ENGINE_THREAD;
 }
 
-Ret AudioEngine::init(const OutputSpec& outputSpec, const RenderConstraints& consts)
+Ret AudioEngine::init(const OutputSpec& outputSpec)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -63,9 +63,6 @@ Ret AudioEngine::init(const OutputSpec& outputSpec, const RenderConstraints& con
            << ", audioChannelCount: " << outputSpec.audioChannelCount;
 
     m_outputSpec = outputSpec;
-    m_renderConsts = consts;
-
-    setMode(RenderMode::IdleMode);
 
     m_operationType = OperationType::NoOperation;
 
@@ -130,6 +127,9 @@ void AudioEngine::setOutputSpec(const OutputSpec& outputSpec)
            << ", audioChannelCount: " << outputSpec.audioChannelCount;
 
     m_outputSpec = outputSpec;
+
+    m_context->setOutputSpec(outputSpec);
+
     m_outputSpecChanged.send(outputSpec);
 }
 
@@ -141,30 +141,6 @@ OutputSpec AudioEngine::outputSpec() const
 async::Channel<OutputSpec> AudioEngine::outputSpecChanged() const
 {
     return m_outputSpecChanged;
-}
-
-RenderMode AudioEngine::mode() const
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
-    return m_mode;
-}
-
-void AudioEngine::setMode(const RenderMode newMode)
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
-    if (newMode == m_mode) {
-        return;
-    }
-
-    m_mode = newMode;
-    m_modeChanged.send(m_mode);
-}
-
-async::Channel<RenderMode> AudioEngine::modeChanged() const
-{
-    return m_modeChanged;
 }
 
 void AudioEngine::execOperation(OperationType type, const Operation& func)
@@ -211,28 +187,25 @@ samples_t AudioEngine::process(float* buffer, samples_t samplesPerChannel)
         return fillSilent(buffer, samplesPerChannel);
     }
 
-    if (m_mode == RenderMode::RealTimeMode // playing
-        || m_mode == RenderMode::IdleMode) { // individual events can be played
-        // check current operation
-        switch (m_operationType) {
-        case OperationType::Undefined: {
-            UNREACHABLE;
-            return fillSilent(buffer, samplesPerChannel);
-        }
-        case OperationType::NoOperation: {
-            // normal playing
-            return m_context->process(buffer, samplesPerChannel);
-        }
-        case OperationType::QuickOperation: {
-            // wait
-            LOGD() << "wait end of quick operation";
-            std::scoped_lock<std::mutex> lock(m_quickOperationWaitMutex);
-            return m_context->process(buffer, samplesPerChannel);
-        }
-        case OperationType::LongOperation: {
-            return fillSilent(buffer, samplesPerChannel);
-        }
-        }
+    // check current operation
+    switch (m_operationType) {
+    case OperationType::Undefined: {
+        UNREACHABLE;
+        return fillSilent(buffer, samplesPerChannel);
+    }
+    case OperationType::NoOperation: {
+        // normal playing
+        return m_context->process(buffer, samplesPerChannel);
+    }
+    case OperationType::QuickOperation: {
+        // wait
+        LOGD() << "wait end of quick operation";
+        std::scoped_lock<std::mutex> lock(m_quickOperationWaitMutex);
+        return m_context->process(buffer, samplesPerChannel);
+    }
+    case OperationType::LongOperation: {
+        return fillSilent(buffer, samplesPerChannel);
+    }
     }
 
     return fillSilent(buffer, samplesPerChannel);

--- a/src/framework/audio/engine/internal/audioengine.h
+++ b/src/framework/audio/engine/internal/audioengine.h
@@ -38,7 +38,7 @@ public:
     AudioEngine();
     ~AudioEngine();
 
-    Ret init(const OutputSpec& outputSpec, const RenderConstraints& consts) override;
+    Ret init(const OutputSpec& outputSpec) override;
     void deinit() override;
 
     std::shared_ptr<IAudioContext> context(const modularity::IoCID& ctxId) const override;
@@ -47,10 +47,6 @@ public:
     void setOutputSpec(const OutputSpec& outputSpec) override;
     OutputSpec outputSpec() const override;
     async::Channel<OutputSpec> outputSpecChanged() const override;
-
-    RenderMode mode() const override;
-    void setMode(const RenderMode newMode) override;
-    async::Channel<RenderMode> modeChanged() const override;
 
     void execOperation(OperationType type, const Operation& func) override;
     OperationType operation() const override;
@@ -70,14 +66,9 @@ private:
     OutputSpec m_outputSpec;
     async::Channel<OutputSpec> m_outputSpecChanged;
 
-    std::atomic<RenderMode> m_mode = RenderMode::Undefined;
-    async::Channel<RenderMode> m_modeChanged;
-
     std::atomic<bool> m_processing = false;
     std::atomic<OperationType> m_operationType = OperationType::Undefined;
     std::mutex m_quickOperationWaitMutex;
-
-    RenderConstraints m_renderConsts;
 };
 }
 

--- a/src/framework/audio/engine/internal/enginecontroller.cpp
+++ b/src/framework/audio/engine/internal/enginecontroller.cpp
@@ -90,7 +90,7 @@ void EngineController::init(const OutputSpec& outputSpec, const AudioEngineConfi
     consts.minTrackCountForMultithreading = configuration()->minTrackCountForMultithreading();
 
     // Setup audio engine
-    audioEngine()->init(outputSpec, consts);
+    audioEngine()->init(outputSpec);
 
     audioEngine()->context()->init(consts);
 

--- a/src/framework/audio/engine/internal/engineplayer.cpp
+++ b/src/framework/audio/engine/internal/engineplayer.cpp
@@ -33,7 +33,7 @@ using namespace muse::audio::engine;
 using namespace muse::async;
 
 EnginePlayer::EnginePlayer(IGetTrackSource* getTracks)
-    : m_getTracks(getTracks)
+    : m_trackSource(getTracks)
 {
     m_status.set(PlaybackStatus::Stopped);
     m_isActive.set(false);
@@ -159,7 +159,6 @@ void EnginePlayer::play(const secs_t delay)
     }
 
     m_countDown = delay;
-    audioEngine()->setMode(RenderMode::RealTimeMode);
     m_status.set(PlaybackStatus::Running);
 }
 
@@ -173,8 +172,12 @@ void EnginePlayer::seek(const secs_t newPosition, const bool flushSound)
     //     return;
     // }
 
+    IF_ASSERT_FAILED(m_trackSource) {
+        return;
+    }
+
     m_flushSoundOnSeek = flushSound;
-    m_currentPosition = TimePosition::fromTime(newPosition, audioEngine()->outputSpec().sampleRate);
+    m_currentPosition = TimePosition::fromTime(newPosition, m_trackSource->sampleRate());
     m_timeChanged.send(m_currentPosition.time());
     seekAllTracks(newPosition);
     m_flushSoundOnSeek = true;
@@ -188,7 +191,6 @@ void EnginePlayer::stop()
         return;
     }
 
-    audioEngine()->setMode(RenderMode::IdleMode);
     m_status.set(PlaybackStatus::Stopped);
     m_countDown = 0.;
     seek(0.);
@@ -203,7 +205,6 @@ void EnginePlayer::pause()
         return;
     }
 
-    audioEngine()->setMode(RenderMode::IdleMode);
     m_status.set(PlaybackStatus::Paused);
     m_notYetReadyToPlayTrackIdSet.clear();
 }
@@ -218,7 +219,6 @@ void EnginePlayer::resume(const secs_t delay)
 
     m_countDown = delay;
     seek(m_currentPosition.time());
-    audioEngine()->setMode(RenderMode::RealTimeMode);
     m_status.set(PlaybackStatus::Running);
 }
 
@@ -293,22 +293,22 @@ Channel<bool> EnginePlayer::isActiveChanged() const
 
 void EnginePlayer::seekAllTracks(const secs_t newPosition)
 {
-    IF_ASSERT_FAILED(m_getTracks) {
+    IF_ASSERT_FAILED(m_trackSource) {
         return;
     }
 
-    for (const auto& source : m_getTracks->allTracksSources()) {
+    for (const auto& source : m_trackSource->allTracksSources()) {
         source->seek(secsToMicrosecs(newPosition), m_flushSoundOnSeek);
     }
 }
 
 void EnginePlayer::flushAllTracks()
 {
-    IF_ASSERT_FAILED(m_getTracks) {
+    IF_ASSERT_FAILED(m_trackSource) {
         return;
     }
 
-    for (const auto& source : m_getTracks->allTracksSources()) {
+    for (const auto& source : m_trackSource->allTracksSources()) {
         source->flush();
     }
 }
@@ -317,14 +317,14 @@ void EnginePlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReadyC
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    IF_ASSERT_FAILED(m_getTracks) {
+    IF_ASSERT_FAILED(m_trackSource) {
         return;
     }
 
     std::vector<ITrackAudioInputPtr> notYetReadyToPlayTracks;
     m_notYetReadyToPlayTrackIdSet.clear();
 
-    for (const auto& source : m_getTracks->allTracksSources()) {
+    for (const auto& source : m_trackSource->allTracksSources()) {
         source->prepareToPlay();
 
         if (!source->readyToPlay()) {
@@ -347,7 +347,7 @@ void EnginePlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReadyC
                 allTracksReadyCallback();
             }
 
-            ITrackAudioInputPtr source = m_getTracks->trackSource(trackId);
+            ITrackAudioInputPtr source = m_trackSource->trackSource(trackId);
             IF_ASSERT_FAILED(source) {
                 return;
             }

--- a/src/framework/audio/engine/internal/engineplayer.h
+++ b/src/framework/audio/engine/internal/engineplayer.h
@@ -20,13 +20,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_AUDIO_ENGINEPLAYER_H
-#define MUSE_AUDIO_ENGINEPLAYER_H
+#pragma once
 
+#include "global/types/retval.h"
+#include "global/async/channel.h"
 #include "global/async/asyncable.h"
-
-#include "modularity/ioc.h"
-#include "iaudioengine.h"
 
 #include "../iengineplayer.h"
 #include "../iplayhead.h"
@@ -36,8 +34,6 @@
 namespace muse::audio::engine {
 class EnginePlayer : public IEnginePlayer, public IPlayhead, public async::Asyncable
 {
-    GlobalInject<engine::IAudioEngine> audioEngine;
-
 public:
     explicit EnginePlayer(IGetTrackSource* getTracks);
 
@@ -88,7 +84,7 @@ private:
     using AllTracksReadyCallback = std::function<void ()>;
     void prepareAllTracksToPlay(AllTracksReadyCallback allTracksReadyCallback);
 
-    IGetTrackSource* m_getTracks = nullptr;
+    IGetTrackSource* m_trackSource = nullptr;
 
     ValCh<PlaybackStatus> m_status;
     ValCh<bool> m_isActive;
@@ -107,5 +103,3 @@ private:
     std::set<TrackId> m_notYetReadyToPlayTrackIdSet;
 };
 }
-
-#endif // MUSE_AUDIO_ENGINEPLAYER_H

--- a/src/framework/audio/engine/internal/eventaudiosource.cpp
+++ b/src/framework/audio/engine/internal/eventaudiosource.cpp
@@ -58,7 +58,7 @@ TrackId EventAudioSource::trackId() const
     return m_trackId;
 }
 
-void EventAudioSource::setMode(const RenderMode mode)
+void EventAudioSource::setMode(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -74,12 +74,12 @@ void EventAudioSource::setMode(const RenderMode mode)
     m_synth->flushSound();
 }
 
-RenderMode EventAudioSource::mode() const
+ProcessMode EventAudioSource::mode() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
     if (!m_synth) {
-        return RenderMode::Undefined;
+        return ProcessMode::Undefined;
     }
 
     return m_synth->mode();
@@ -202,7 +202,7 @@ void EventAudioSource::applyInputParams(const AudioInputParams& requiredParams)
     if (ctx.isValid()) {
         restoreSynthCtx(ctx);
     } else {
-        m_synth->setMode(RenderMode::IdleMode);
+        m_synth->setMode(ProcessMode::Idle);
     }
 
     m_params = m_synth->params();

--- a/src/framework/audio/engine/internal/eventaudiosource.cpp
+++ b/src/framework/audio/engine/internal/eventaudiosource.cpp
@@ -39,11 +39,13 @@ EventAudioSource::EventAudioSource(const TrackId trackId,
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    m_playbackData.offStream.onReceive(this, [onOffStreamReceived, trackId](const PlaybackEventsMap&,
-                                                                            const DynamicLevelLayers&,
-                                                                            bool) {
-        onOffStreamReceived(trackId);
-    });
+    if (onOffStreamReceived) {
+        m_playbackData.offStream.onReceive(this, [onOffStreamReceived, trackId](const PlaybackEventsMap&,
+                                                                                const DynamicLevelLayers&,
+                                                                                bool) {
+            onOffStreamReceived(trackId);
+        });
+    }
 }
 
 EventAudioSource::~EventAudioSource()
@@ -56,18 +58,7 @@ TrackId EventAudioSource::trackId() const
     return m_trackId;
 }
 
-bool EventAudioSource::isActive() const
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
-    if (!m_synth) {
-        return false;
-    }
-
-    return m_synth->isActive();
-}
-
-void EventAudioSource::setIsActive(const bool active)
+void EventAudioSource::setMode(const RenderMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -75,12 +66,23 @@ void EventAudioSource::setIsActive(const bool active)
         return;
     }
 
-    if (m_synth->isActive() == active) {
+    if (m_synth->mode() == mode) {
         return;
     }
 
-    m_synth->setIsActive(active);
+    m_synth->setMode(mode);
     m_synth->flushSound();
+}
+
+RenderMode EventAudioSource::mode() const
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+
+    if (!m_synth) {
+        return RenderMode::Undefined;
+    }
+
+    return m_synth->mode();
 }
 
 void EventAudioSource::setOutputSpec(const OutputSpec& spec)
@@ -200,7 +202,7 @@ void EventAudioSource::applyInputParams(const AudioInputParams& requiredParams)
     if (ctx.isValid()) {
         restoreSynthCtx(ctx);
     } else {
-        m_synth->setIsActive(false);
+        m_synth->setMode(RenderMode::IdleMode);
     }
 
     m_params = m_synth->params();
@@ -295,13 +297,13 @@ EventAudioSource::SynthCtx EventAudioSource::currentSynthCtx() const
         return SynthCtx();
     }
 
-    return { m_synth->isActive(), m_synth->playbackPosition() };
+    return { m_synth->mode(), m_synth->playbackPosition() };
 }
 
 void EventAudioSource::restoreSynthCtx(const SynthCtx& ctx)
 {
     m_synth->setPlaybackPosition(ctx.playbackPosition);
-    m_synth->setIsActive(ctx.isActive);
+    m_synth->setMode(ctx.mode);
 }
 
 void EventAudioSource::setupSource()

--- a/src/framework/audio/engine/internal/eventaudiosource.h
+++ b/src/framework/audio/engine/internal/eventaudiosource.h
@@ -44,9 +44,8 @@ public:
 
     TrackId trackId() const override;
 
-    bool isActive() const override;
-    void setIsActive(const bool active) override;
-
+    void setMode(const RenderMode mode) override;
+    RenderMode mode() const override;
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
@@ -72,7 +71,7 @@ public:
 private:
     struct SynthCtx
     {
-        bool isActive = false;
+        RenderMode mode = RenderMode::Undefined;
         msecs_t playbackPosition = -1;
 
         bool isValid() const

--- a/src/framework/audio/engine/internal/eventaudiosource.h
+++ b/src/framework/audio/engine/internal/eventaudiosource.h
@@ -44,8 +44,8 @@ public:
 
     TrackId trackId() const override;
 
-    void setMode(const RenderMode mode) override;
-    RenderMode mode() const override;
+    void setMode(const ProcessMode mode) override;
+    ProcessMode mode() const override;
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
@@ -71,7 +71,7 @@ public:
 private:
     struct SynthCtx
     {
-        RenderMode mode = RenderMode::Undefined;
+        ProcessMode mode = ProcessMode::Undefined;
         msecs_t playbackPosition = -1;
 
         bool isValid() const

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -92,25 +92,13 @@ Ret SoundTrackWriter::write()
         return false;
     }
 
-    audioEngine()->setMode(RenderMode::OfflineMode);
-
     m_source->setOutputSpec(m_encoderPtr->format().outputSpec);
-    m_source->setIsActive(true);
+    m_source->setMode(RenderMode::OfflineMode);
 
     DEFER {
         if (!m_isAborted) {
             m_encoderPtr->end();
         }
-
-        //! NOTE Changes to the source and audio engine state
-        // must be performed via execOperation - so that synchronization with the audio driver process works
-        IAudioEngine::Operation func = [this]() {
-            audioEngine()->setMode(RenderMode::IdleMode);
-
-            m_source->setOutputSpec(audioEngine()->outputSpec());
-            m_source->setIsActive(false);
-        };
-        audioEngine()->execOperation(OperationType::LongOperation, func);
 
         m_isAborted = false;
     };

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -93,7 +93,7 @@ Ret SoundTrackWriter::write()
     }
 
     m_source->setOutputSpec(m_encoderPtr->format().outputSpec);
-    m_source->setMode(RenderMode::OfflineMode);
+    m_source->setMode(ProcessMode::PlayingOffline);
 
     DEFER {
         if (!m_isAborted) {

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.h
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.h
@@ -43,7 +43,6 @@ namespace muse::audio::soundtrack {
 class SoundTrackWriter : public async::Asyncable
 {
     muse::GlobalInject<rpc::IRpcChannel> rpcChannel;
-    muse::GlobalInject<engine::IAudioEngine> audioEngine;
 
 public:
     SoundTrackWriter(io::IODevice& dstDevice, const SoundTrackFormat& format, const secs_t totalDuration, engine::IAudioSourcePtr source);

--- a/src/framework/audio/engine/internal/iaudiocontext.h
+++ b/src/framework/audio/engine/internal/iaudiocontext.h
@@ -25,7 +25,6 @@
 #include "global/async/promise.h"
 #include "global/async/channel.h"
 #include "audio/common/audiotypes.h"
-#include "../iaudiosource.h"
 
 namespace muse::audio::engine {
 class IAudioContext
@@ -33,8 +32,13 @@ class IAudioContext
 public:
     virtual ~IAudioContext() = default;
 
+    // Init
     virtual Ret init(const RenderConstraints& consts) = 0;
     virtual void deinit() = 0;
+
+    // Config
+    virtual void setMode(const RenderMode newMode) = 0;
+    virtual void setOutputSpec(const OutputSpec& outputSpec) = 0;
 
     // Tracks
     virtual RetVal2<TrackId, AudioParams> addTrack(const TrackName& trackName, io::IODevice* playbackData, const AudioParams& params) = 0;

--- a/src/framework/audio/engine/internal/iaudiocontext.h
+++ b/src/framework/audio/engine/internal/iaudiocontext.h
@@ -37,7 +37,7 @@ public:
     virtual void deinit() = 0;
 
     // Config
-    virtual void setMode(const RenderMode newMode) = 0;
+    virtual void setMode(const ProcessMode newMode) = 0;
     virtual void setOutputSpec(const OutputSpec& outputSpec) = 0;
 
     // Tracks

--- a/src/framework/audio/engine/internal/iaudioengine.h
+++ b/src/framework/audio/engine/internal/iaudioengine.h
@@ -40,7 +40,7 @@ class IAudioEngine : MODULE_GLOBAL_INTERFACE
 public:
     virtual ~IAudioEngine() = default;
 
-    virtual Ret init(const OutputSpec& outputSpec, const RenderConstraints& consts) = 0;
+    virtual Ret init(const OutputSpec& outputSpec) = 0;
     virtual void deinit() = 0;
 
     virtual std::shared_ptr<IAudioContext> context(const modularity::IoCID& ctxId = 0) const = 0;
@@ -49,10 +49,6 @@ public:
     virtual void setOutputSpec(const OutputSpec& outputSpec) = 0;
     virtual OutputSpec outputSpec() const = 0;
     virtual async::Channel<OutputSpec> outputSpecChanged() const = 0;
-
-    virtual RenderMode mode() const = 0;
-    virtual void setMode(const RenderMode newMode) = 0;
-    virtual async::Channel<RenderMode> modeChanged() const = 0;
 
     using Operation = std::function<void ()>;
     virtual void execOperation(OperationType type, const Operation& func) = 0;

--- a/src/framework/audio/engine/internal/igettracksource.h
+++ b/src/framework/audio/engine/internal/igettracksource.h
@@ -32,6 +32,7 @@ class IGetTrackSource
 public:
     virtual ~IGetTrackSource() = default;
 
+    virtual sample_rate_t sampleRate() const = 0;
     virtual ITrackAudioInputPtr trackSource(const TrackId trackId) const = 0;
     virtual std::vector<ITrackAudioInputPtr> allTracksSources() const = 0;
 };

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -94,13 +94,12 @@ Ret Mixer::addChannel(ITrackAudioOutputPtr output)
 
         updateNonMutedTrackCount();
 
-        ITrackAudioInputPtr source = std::static_pointer_cast<ITrackAudioInput>(channel->source());
-
-        if (source) {
-            if (channel->muted()) {
-                source->setIsActive(false);
-            } else {
-                source->setIsActive(isActive());
+        if (channel->muted()) {
+            channel->setMode(RenderMode::IdleMode);
+        } else {
+            channel->setMode(mode());
+            ITrackAudioInputPtr source = std::static_pointer_cast<ITrackAudioInput>(channel->source());
+            if (source) {
                 source->seek(secsToMicrosecs(playbackPosition().time()));
             }
         }
@@ -332,26 +331,26 @@ bool Mixer::useMultithreading() const
 #endif
 }
 
-void Mixer::setIsActive(bool arg)
+void Mixer::setMode(const RenderMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    AbstractAudioSource::setIsActive(arg);
+    AbstractAudioSource::setMode(mode);
 
     for (auto& t : m_tracks) {
         if (!t.channel->muted()) {
-            t.channel->setIsActive(arg);
+            t.channel->setMode(mode);
         }
     }
 
     for (auto& aux : m_auxChannelInfoList) {
         if (!aux.channel->muted()) {
-            aux.channel->setIsActive(arg);
+            aux.channel->setMode(mode);
         }
     }
 
     for (IFxProcessorPtr& fx : m_masterFxProcessors) {
-        fx->setPlaying(arg);
+        fx->setPlaying(isModeActive(mode));
     }
 }
 
@@ -389,7 +388,7 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
 
     for (IFxProcessorPtr& fx : m_masterFxProcessors) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(m_isActive);
+        fx->setPlaying(isModeActive(m_mode));
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_masterParams.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -95,7 +95,7 @@ Ret Mixer::addChannel(ITrackAudioOutputPtr output)
         updateNonMutedTrackCount();
 
         if (channel->muted()) {
-            channel->setMode(RenderMode::IdleMode);
+            channel->setMode(ProcessMode::Idle);
         } else {
             channel->setMode(mode());
             ITrackAudioInputPtr source = std::static_pointer_cast<ITrackAudioInput>(channel->source());
@@ -331,7 +331,7 @@ bool Mixer::useMultithreading() const
 #endif
 }
 
-void Mixer::setMode(const RenderMode mode)
+void Mixer::setMode(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -350,7 +350,7 @@ void Mixer::setMode(const RenderMode mode)
     }
 
     for (IFxProcessorPtr& fx : m_masterFxProcessors) {
-        fx->setPlaying(isModeActive(mode));
+        fx->setPlaying(isModePlaying(mode));
     }
 }
 
@@ -388,7 +388,7 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
 
     for (IFxProcessorPtr& fx : m_masterFxProcessors) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isModeActive(m_mode));
+        fx->setPlaying(isModePlaying(m_mode));
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_masterParams.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);

--- a/src/framework/audio/engine/internal/mixer.h
+++ b/src/framework/audio/engine/internal/mixer.h
@@ -70,7 +70,7 @@ public:
     void setTracksToProcessWhenIdle(const std::unordered_set<TrackId>& trackIds);
 
     // IAudioSource
-    void setMode(const RenderMode mode) override;
+    void setMode(const ProcessMode mode) override;
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
 

--- a/src/framework/audio/engine/internal/mixer.h
+++ b/src/framework/audio/engine/internal/mixer.h
@@ -70,10 +70,9 @@ public:
     void setTracksToProcessWhenIdle(const std::unordered_set<TrackId>& trackIds);
 
     // IAudioSource
+    void setMode(const RenderMode mode) override;
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
-
-    void setIsActive(bool arg) override;
 
     samples_t process(float* outBuffer, samples_t samplesPerChannel) override;
 

--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -93,7 +93,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isActive());
+        fx->setPlaying(isModeActive(mode()));
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_params.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
@@ -149,23 +149,24 @@ AudioSignalChanges MixerChannel::audioSignalChanges() const
     return m_audioSignalNotifier.audioSignalChanges;
 }
 
-bool MixerChannel::isActive() const
+RenderMode MixerChannel::mode() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
-
-    return m_audioSource ? m_audioSource->isActive() : true;
+    return m_mode;
 }
 
-void MixerChannel::setIsActive(bool arg)
+void MixerChannel::setMode(const RenderMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
+    m_mode = mode;
+
     if (m_audioSource) {
-        m_audioSource->setIsActive(arg);
+        m_audioSource->setMode(mode);
     }
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
-        fx->setPlaying(arg);
+        fx->setPlaying(isModeActive(mode));
     }
 }
 

--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -93,7 +93,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isModeActive(mode()));
+        fx->setPlaying(isModePlaying(mode()));
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_params.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
@@ -149,13 +149,13 @@ AudioSignalChanges MixerChannel::audioSignalChanges() const
     return m_audioSignalNotifier.audioSignalChanges;
 }
 
-RenderMode MixerChannel::mode() const
+ProcessMode MixerChannel::mode() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_mode;
 }
 
-void MixerChannel::setMode(const RenderMode mode)
+void MixerChannel::setMode(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -166,7 +166,7 @@ void MixerChannel::setMode(const RenderMode mode)
     }
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
-        fx->setPlaying(isModeActive(mode));
+        fx->setPlaying(isModePlaying(mode));
     }
 }
 

--- a/src/framework/audio/engine/internal/mixerchannel.h
+++ b/src/framework/audio/engine/internal/mixerchannel.h
@@ -63,8 +63,8 @@ public:
 
     AudioSignalChanges audioSignalChanges() const override;
 
-    bool isActive() const override;
-    void setIsActive(bool arg) override;
+    RenderMode mode() const override;
+    void setMode(const RenderMode mode) override;
 
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
@@ -78,6 +78,7 @@ private:
 
     TrackId m_trackId = -1;
 
+    RenderMode m_mode = RenderMode::Undefined;
     OutputSpec m_outputSpec;
     AudioOutputParams m_params;
 

--- a/src/framework/audio/engine/internal/mixerchannel.h
+++ b/src/framework/audio/engine/internal/mixerchannel.h
@@ -63,8 +63,8 @@ public:
 
     AudioSignalChanges audioSignalChanges() const override;
 
-    RenderMode mode() const override;
-    void setMode(const RenderMode mode) override;
+    ProcessMode mode() const override;
+    void setMode(const ProcessMode mode) override;
 
     void setOutputSpec(const OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
@@ -78,7 +78,7 @@ private:
 
     TrackId m_trackId = -1;
 
-    RenderMode m_mode = RenderMode::Undefined;
+    ProcessMode m_mode = ProcessMode::Undefined;
     OutputSpec m_outputSpec;
     AudioOutputParams m_params;
 

--- a/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.cpp
@@ -33,10 +33,20 @@ AbstractSynthesizer::AbstractSynthesizer(const AudioInputParams& params)
     : m_params(params)
 {
     ONLY_AUDIO_ENGINE_THREAD;
+}
 
-    audioEngine()->modeChanged().onReceive(this, [this](RenderMode mode) {
-        updateRenderingMode(mode);
-    });
+void AbstractSynthesizer::setMode(const RenderMode mode)
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+
+    m_mode = mode;
+}
+
+RenderMode AbstractSynthesizer::mode() const
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+
+    return m_mode;
 }
 
 const AudioInputParams& AbstractSynthesizer::params() const
@@ -82,11 +92,6 @@ async::Notification AbstractSynthesizer::readyToPlayChanged() const
     return m_readyToPlayChanged;
 }
 
-void AbstractSynthesizer::updateRenderingMode(const RenderMode /*mode*/)
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-}
-
 bool AbstractSynthesizer::hasPendingChunks() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
@@ -109,13 +114,6 @@ InputProcessingProgress AbstractSynthesizer::inputProcessingProgress() const
 void AbstractSynthesizer::clearCache()
 {
     ONLY_AUDIO_ENGINE_THREAD;
-}
-
-RenderMode AbstractSynthesizer::currentRenderMode() const
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
-    return audioEngine()->mode();
 }
 
 muse::audio::msecs_t AbstractSynthesizer::samplesToMsecs(const samples_t samplesPerChannel, const samples_t sampleRate) const

--- a/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.cpp
@@ -35,14 +35,14 @@ AbstractSynthesizer::AbstractSynthesizer(const AudioInputParams& params)
     ONLY_AUDIO_ENGINE_THREAD;
 }
 
-void AbstractSynthesizer::setMode(const RenderMode mode)
+void AbstractSynthesizer::setMode(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
     m_mode = mode;
 }
 
-RenderMode AbstractSynthesizer::mode() const
+ProcessMode AbstractSynthesizer::mode() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 

--- a/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.h
+++ b/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.h
@@ -27,7 +27,6 @@
 #include "mpe/events.h"
 
 #include "global/modularity/ioc.h"
-#include "../iaudioengine.h"
 #include "../../iaudioengineconfiguration.h"
 
 #include "audio/common/audiotypes.h"
@@ -38,11 +37,13 @@ class AbstractSynthesizer : public ISynthesizer, public async::Asyncable
 {
 public:
     muse::GlobalInject<engine::IAudioEngineConfiguration> config;
-    muse::GlobalInject<engine::IAudioEngine> audioEngine;
 
 public:
     AbstractSynthesizer(const audio::AudioInputParams& params);
     virtual ~AbstractSynthesizer() = default;
+
+    virtual void setMode(const RenderMode mode) override;
+    RenderMode mode() const override;
 
     const audio::AudioInputParams& params() const override;
     async::Channel<audio::AudioInputParams> paramsChanged() const override;
@@ -62,12 +63,11 @@ public:
 protected:
     virtual void setupSound(const mpe::PlaybackSetupData& setupData) = 0;
     virtual void setupEvents(const mpe::PlaybackData& playbackData) = 0;
-    virtual void updateRenderingMode(const RenderMode mode);
-
-    audio::RenderMode currentRenderMode() const;
 
     msecs_t samplesToMsecs(const samples_t samplesPerChannel, const samples_t sampleRate) const;
     samples_t microSecsToSamples(const msecs_t msec, const samples_t sampleRate) const;
+
+    RenderMode m_mode = RenderMode::Undefined;
 
     mpe::PlaybackSetupData m_setupData;
 

--- a/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.h
+++ b/src/framework/audio/engine/internal/synthesizers/abstractsynthesizer.h
@@ -42,8 +42,8 @@ public:
     AbstractSynthesizer(const audio::AudioInputParams& params);
     virtual ~AbstractSynthesizer() = default;
 
-    virtual void setMode(const RenderMode mode) override;
-    RenderMode mode() const override;
+    virtual void setMode(const ProcessMode mode) override;
+    ProcessMode mode() const override;
 
     const audio::AudioInputParams& params() const override;
     async::Channel<audio::AudioInputParams> paramsChanged() const override;
@@ -67,7 +67,7 @@ protected:
     msecs_t samplesToMsecs(const samples_t samplesPerChannel, const samples_t sampleRate) const;
     samples_t microSecsToSamples(const msecs_t msec, const samples_t sampleRate) const;
 
-    RenderMode m_mode = RenderMode::Undefined;
+    ProcessMode m_mode = ProcessMode::Undefined;
 
     mpe::PlaybackSetupData m_setupData;
 

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -259,6 +259,18 @@ bool FluidSynth::handleEvent(const midi::Event& event)
     return ret == FLUID_OK;
 }
 
+void FluidSynth::setMode(const RenderMode mode)
+{
+    if (m_mode == mode) {
+        return;
+    }
+
+    AbstractSynthesizer::setMode(mode);
+
+    m_sequencer.setActive(isModeActive(mode));
+    toggleExpressionController();
+}
+
 void FluidSynth::setOutputSpec(const OutputSpec& spec)
 {
     if (m_outputSpec == spec) {
@@ -369,17 +381,6 @@ void FluidSynth::flushSound()
     m_flushSoundRequested = true;
 }
 
-bool FluidSynth::isActive() const
-{
-    return m_sequencer.isActive();
-}
-
-void FluidSynth::setIsActive(const bool isActive)
-{
-    m_sequencer.setActive(isActive);
-    toggleExpressionController();
-}
-
 msecs_t FluidSynth::playbackPosition() const
 {
     return m_sequencer.playbackPosition();
@@ -389,7 +390,7 @@ void FluidSynth::setPlaybackPosition(const msecs_t newPosition)
 {
     m_sequencer.setPlaybackPosition(newPosition);
 
-    if (isActive()) {
+    if (m_sequencer.isActive()) {
         setExpressionLevel(m_sequencer.currentExpressionLevel());
     }
 }
@@ -467,7 +468,7 @@ async::Channel<unsigned int> FluidSynth::audioChannelsCountChanged() const
 
 void FluidSynth::toggleExpressionController()
 {
-    if (isActive()) {
+    if (m_sequencer.isActive()) {
         setExpressionLevel(m_sequencer.currentExpressionLevel());
     } else {
         setExpressionLevel(m_sequencer.naturalExpressionLevel());

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -259,7 +259,7 @@ bool FluidSynth::handleEvent(const midi::Event& event)
     return ret == FLUID_OK;
 }
 
-void FluidSynth::setMode(const RenderMode mode)
+void FluidSynth::setMode(const ProcessMode mode)
 {
     if (m_mode == mode) {
         return;
@@ -267,7 +267,7 @@ void FluidSynth::setMode(const RenderMode mode)
 
     AbstractSynthesizer::setMode(mode);
 
-    m_sequencer.setActive(isModeActive(mode));
+    m_sequencer.setActive(isModePlaying(mode));
     toggleExpressionController();
 }
 

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -65,7 +65,7 @@ public:
     samples_t process(float* buffer, samples_t samplesPerChannel) override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
-    void setMode(const RenderMode mode) override;
+    void setMode(const ProcessMode mode) override;
     void setOutputSpec(const OutputSpec& spec) override;
 
     bool isValid() const override;

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -45,6 +45,7 @@ public:
     FluidSynth(const audio::AudioSourceParams& params);
 
     Ret init(const OutputSpec& spec);
+
     Ret addSoundFonts(const std::vector<io::path_t>& sfonts);
     void setPreset(const std::optional<midi::Program>& preset);
 
@@ -57,15 +58,14 @@ public:
 
     void flushSound() override; // all channels
 
-    bool isActive() const override;
-    void setIsActive(const bool isActive) override;
-
     msecs_t playbackPosition() const override;
     void setPlaybackPosition(const msecs_t newPosition) override;
 
     unsigned int audioChannelsCount() const override;
     samples_t process(float* buffer, samples_t samplesPerChannel) override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
+
+    void setMode(const RenderMode mode) override;
     void setOutputSpec(const OutputSpec& spec) override;
 
     bool isValid() const override;

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -97,9 +97,35 @@ MuseSamplerWrapper::~MuseSamplerWrapper()
     m_samplerLib->destroy(m_sampler);
 }
 
+void MuseSamplerWrapper::setMode(const muse::audio::RenderMode mode)
+{
+    AbstractSynthesizer::setMode(mode);
+
+    if (!m_samplerLib || !m_sampler) {
+        return;
+    }
+
+    m_sequencer.updateMainStream();
+
+    const bool isOffline = m_mode == RenderMode::OfflineMode;
+
+    if (!isOffline && m_offlineModeStarted) {
+        m_samplerLib->stopOfflineMode(m_sampler);
+        m_offlineModeStarted = false;
+    }
+
+    if (isOffline && !m_offlineModeStarted) {
+        LOGI() << "Start offline mode, sampleRate: " << m_outputSpec.sampleRate;
+        m_samplerLib->startOfflineMode(m_sampler, m_outputSpec.sampleRate);
+        m_offlineModeStarted = true;
+    }
+
+    setIsActive(isModeActive(mode));
+}
+
 void MuseSamplerWrapper::setOutputSpec(const audio::OutputSpec& spec)
 {
-    const bool isOffline = currentRenderMode() == RenderMode::OfflineMode;
+    const bool isOffline = m_mode == RenderMode::OfflineMode;
     const bool shouldReinitSampler = !m_sampler
                                      || (m_outputSpec.sampleRate != spec.sampleRate && !isOffline)
                                      || (m_outputSpec.samplesPerChannel != spec.samplesPerChannel && !isOffline);
@@ -114,11 +140,7 @@ void MuseSamplerWrapper::setOutputSpec(const audio::OutputSpec& spec)
 
     m_outputSpec = spec;
 
-    if (isOffline && !m_offlineModeStarted) {
-        LOGI() << "Start offline mode, sampleRate: " << spec.sampleRate;
-        m_samplerLib->startOfflineMode(m_sampler, spec.sampleRate);
-        m_offlineModeStarted = true;
-    }
+    setMode(m_mode);
 }
 
 unsigned int MuseSamplerWrapper::audioChannelsCount() const
@@ -157,7 +179,7 @@ samples_t MuseSamplerWrapper::process(float* buffer, samples_t samplesPerChannel
         }
     }
 
-    if (currentRenderMode() == RenderMode::OfflineMode) {
+    if (m_mode == RenderMode::OfflineMode) {
         if (m_samplerLib->processOffline(m_sampler, m_bus) != ms_Result_OK) {
             return 0;
         }
@@ -241,22 +263,6 @@ const mpe::PlaybackData& MuseSamplerWrapper::playbackData() const
     ONLY_AUDIO_ENGINE_THREAD;
 
     return m_sequencer.playbackData();
-}
-
-void MuseSamplerWrapper::updateRenderingMode(const RenderMode mode)
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
-    if (!m_samplerLib || !m_sampler) {
-        return;
-    }
-
-    m_sequencer.updateMainStream();
-
-    if (mode != RenderMode::OfflineMode && m_offlineModeStarted) {
-        m_samplerLib->stopOfflineMode(m_sampler);
-        m_offlineModeStarted = false;
-    }
 }
 
 const TrackList& MuseSamplerWrapper::allTracks() const

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -97,7 +97,7 @@ MuseSamplerWrapper::~MuseSamplerWrapper()
     m_samplerLib->destroy(m_sampler);
 }
 
-void MuseSamplerWrapper::setMode(const muse::audio::RenderMode mode)
+void MuseSamplerWrapper::setMode(const muse::audio::ProcessMode mode)
 {
     AbstractSynthesizer::setMode(mode);
 
@@ -107,7 +107,7 @@ void MuseSamplerWrapper::setMode(const muse::audio::RenderMode mode)
 
     m_sequencer.updateMainStream();
 
-    const bool isOffline = m_mode == RenderMode::OfflineMode;
+    const bool isOffline = m_mode == ProcessMode::PlayingOffline;
 
     if (!isOffline && m_offlineModeStarted) {
         m_samplerLib->stopOfflineMode(m_sampler);
@@ -120,12 +120,12 @@ void MuseSamplerWrapper::setMode(const muse::audio::RenderMode mode)
         m_offlineModeStarted = true;
     }
 
-    setIsActive(isModeActive(mode));
+    setIsActive(isModePlaying(mode));
 }
 
 void MuseSamplerWrapper::setOutputSpec(const audio::OutputSpec& spec)
 {
-    const bool isOffline = m_mode == RenderMode::OfflineMode;
+    const bool isOffline = m_mode == ProcessMode::PlayingOffline;
     const bool shouldReinitSampler = !m_sampler
                                      || (m_outputSpec.sampleRate != spec.sampleRate && !isOffline)
                                      || (m_outputSpec.samplesPerChannel != spec.samplesPerChannel && !isOffline);
@@ -179,7 +179,7 @@ samples_t MuseSamplerWrapper::process(float* buffer, samples_t samplesPerChannel
         }
     }
 
-    if (m_mode == RenderMode::OfflineMode) {
+    if (m_mode == ProcessMode::PlayingOffline) {
         if (m_samplerLib->processOffline(m_sampler, m_bus) != ms_Result_OK) {
             return 0;
         }

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -41,6 +41,7 @@ public:
     MuseSamplerWrapper(MuseSamplerLibHandlerPtr samplerLib, const InstrumentInfo& instrument, const muse::audio::AudioSourceParams& params);
     ~MuseSamplerWrapper() override;
 
+    void setMode(const muse::audio::RenderMode mode) override;
     void setOutputSpec(const audio::OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
@@ -62,16 +63,14 @@ private:
     void setupEvents(const mpe::PlaybackData& playbackData) override;
     const mpe::PlaybackData& playbackData() const override;
 
-    void updateRenderingMode(const muse::audio::RenderMode mode) override;
-
     // IMuseSamplerTracks
     const TrackList& allTracks() const override;
     ms_Track addTrack() override;
 
     muse::audio::msecs_t playbackPosition() const override;
     void setPlaybackPosition(const muse::audio::msecs_t newPosition) override;
-    bool isActive() const override;
-    void setIsActive(bool active) override;
+    bool isActive() const;
+    void setIsActive(bool active);
 
     bool initSampler(const muse::audio::sample_rate_t sampleRate, const muse::audio::samples_t blockSize);
 

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -41,7 +41,7 @@ public:
     MuseSamplerWrapper(MuseSamplerLibHandlerPtr samplerLib, const InstrumentInfo& instrument, const muse::audio::AudioSourceParams& params);
     ~MuseSamplerWrapper() override;
 
-    void setMode(const muse::audio::RenderMode mode) override;
+    void setMode(const muse::audio::ProcessMode mode) override;
     void setOutputSpec(const audio::OutputSpec& spec) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;

--- a/src/framework/stubs/audio/synthesizerstub.cpp
+++ b/src/framework/stubs/audio/synthesizerstub.cpp
@@ -112,12 +112,12 @@ bool SynthesizerStub::isValid() const
     return false;
 }
 
-RenderMode SynthesizerStub::mode() const
+ProcessMode SynthesizerStub::mode() const
 {
-    return RenderMode::Undefined;
+    return ProcessMode::Undefined;
 }
 
-void SynthesizerStub::setMode(const RenderMode)
+void SynthesizerStub::setMode(const ProcessMode)
 {
 }
 

--- a/src/framework/stubs/audio/synthesizerstub.cpp
+++ b/src/framework/stubs/audio/synthesizerstub.cpp
@@ -112,12 +112,12 @@ bool SynthesizerStub::isValid() const
     return false;
 }
 
-bool SynthesizerStub::isActive() const
+RenderMode SynthesizerStub::mode() const
 {
-    return false;
+    return RenderMode::Undefined;
 }
 
-void SynthesizerStub::setIsActive(bool)
+void SynthesizerStub::setMode(const RenderMode)
 {
 }
 

--- a/src/framework/stubs/audio/synthesizerstub.h
+++ b/src/framework/stubs/audio/synthesizerstub.h
@@ -57,8 +57,8 @@ public:
     void flushSound() override;
 
     bool isValid() const override;
-    RenderMode mode() const override;
-    void setMode(const RenderMode mode) override;
+    ProcessMode mode() const override;
+    void setMode(const ProcessMode mode) override;
 
     bool hasPendingChunks() const override;
     void processInput() override;

--- a/src/framework/stubs/audio/synthesizerstub.h
+++ b/src/framework/stubs/audio/synthesizerstub.h
@@ -57,8 +57,8 @@ public:
     void flushSound() override;
 
     bool isValid() const override;
-    bool isActive() const override;
-    void setIsActive(bool arg) override;
+    RenderMode mode() const override;
+    void setMode(const RenderMode mode) override;
 
     bool hasPendingChunks() const override;
     void processInput() override;

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -89,15 +89,6 @@ void VstSynthesiser::init(const OutputSpec& spec)
     });
 }
 
-void VstSynthesiser::updateRenderingMode(const RenderMode mode)
-{
-    if (mode == RenderMode::OfflineMode) {
-        m_vstAudioClient->setProcessMode(VstProcessMode::kOffline);
-    } else {
-        m_vstAudioClient->setProcessMode(VstProcessMode::kRealtime);
-    }
-}
-
 void VstSynthesiser::toggleVolumeGain(const bool isActive)
 {
     static constexpr muse::audio::gain_t NON_ACTIVE_GAIN = 0.5f;
@@ -153,21 +144,25 @@ const mpe::PlaybackData& VstSynthesiser::playbackData() const
     return m_sequencer.playbackData();
 }
 
-bool VstSynthesiser::isActive() const
+void VstSynthesiser::setMode(const muse::audio::RenderMode mode)
 {
-    return m_sequencer.isActive();
-}
-
-void VstSynthesiser::setIsActive(const bool isActive)
-{
-    if (m_sequencer.isActive() == isActive) {
+    if (m_mode == mode) {
         return;
     }
 
+    AbstractSynthesizer::setMode(mode);
+
+    bool isActive = isModeActive(mode);
     m_sequencer.setActive(isActive);
     toggleVolumeGain(isActive);
     m_vstAudioClient->setIsPlaying(isActive);
     m_vstAudioClient->setIsActive(isActive);
+
+    if (mode == RenderMode::OfflineMode) {
+        m_vstAudioClient->setProcessMode(VstProcessMode::kOffline);
+    } else {
+        m_vstAudioClient->setProcessMode(VstProcessMode::kRealtime);
+    }
 }
 
 muse::audio::msecs_t VstSynthesiser::playbackPosition() const
@@ -180,7 +175,7 @@ void VstSynthesiser::setPlaybackPosition(const muse::audio::msecs_t newPosition)
     m_sequencer.setPlaybackPosition(newPosition);
     m_currentPositionSamples = microSecsToSamples(newPosition, m_outputSpec.sampleRate);
 
-    if (isActive()) {
+    if (m_sequencer.isActive()) {
         m_vstAudioClient->setVolumeGain(m_sequencer.currentGain());
     }
 }

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -144,7 +144,7 @@ const mpe::PlaybackData& VstSynthesiser::playbackData() const
     return m_sequencer.playbackData();
 }
 
-void VstSynthesiser::setMode(const muse::audio::RenderMode mode)
+void VstSynthesiser::setMode(const muse::audio::ProcessMode mode)
 {
     if (m_mode == mode) {
         return;
@@ -152,13 +152,13 @@ void VstSynthesiser::setMode(const muse::audio::RenderMode mode)
 
     AbstractSynthesizer::setMode(mode);
 
-    bool isActive = isModeActive(mode);
+    bool isActive = isModePlaying(mode);
     m_sequencer.setActive(isActive);
     toggleVolumeGain(isActive);
     m_vstAudioClient->setIsPlaying(isActive);
     m_vstAudioClient->setIsActive(isActive);
 
-    if (mode == RenderMode::OfflineMode) {
+    if (mode == ProcessMode::PlayingOffline) {
         m_vstAudioClient->setProcessMode(VstProcessMode::kOffline);
     } else {
         m_vstAudioClient->setProcessMode(VstProcessMode::kRealtime);

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -57,8 +57,7 @@ public:
     void setupEvents(const mpe::PlaybackData& playbackData) override;
     const mpe::PlaybackData& playbackData() const override;
 
-    bool isActive() const override;
-    void setIsActive(const bool isActive) override;
+    void setMode(const muse::audio::RenderMode mode) override;
 
     muse::audio::msecs_t playbackPosition() const override;
     void setPlaybackPosition(const muse::audio::msecs_t newPosition) override;
@@ -70,7 +69,6 @@ public:
     muse::audio::samples_t process(float* buffer, muse::audio::samples_t samplesPerChannel) override;
 
 private:
-    void updateRenderingMode(const audio::RenderMode mode) override;
 
     void toggleVolumeGain(const bool isActive);
     audio::samples_t processSequence(const VstSequencer::EventSequence& sequence, const audio::samples_t samples, float* buffer);

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -57,7 +57,7 @@ public:
     void setupEvents(const mpe::PlaybackData& playbackData) override;
     const mpe::PlaybackData& playbackData() const override;
 
-    void setMode(const muse::audio::RenderMode mode) override;
+    void setMode(const muse::audio::ProcessMode mode) override;
 
     muse::audio::msecs_t playbackPosition() const override;
     void setPlaybackPosition(const muse::audio::msecs_t newPosition) override;


### PR DESCRIPTION

* Moved the mode from Audio Engine to Audio Context
* Replaced from is Active to Mode because some sources (VST, Muse Sampler) need to know in which mode to work.