### PR TITLE
fix: omit group separator in QmlDataFormatter to prevent spinbox validator rejection

### DIFF
--- a/src/framework/ui/view/qmldataformatter.cpp
+++ b/src/framework/ui/view/qmldataformatter.cpp
@@ -33,6 +33,7 @@ QmlDataFormatter::QmlDataFormatter(QObject* parent)
 QString QmlDataFormatter::formatReal(double value, int decimals) const
 {
     QLocale locale;
+    locale.setNumberOptions(QLocale::OmitGroupSeparator);
     QString formatted = locale.toString(value, 'f', decimals);
     if (decimals > 0) {
         // Remove trailing zeros after the decimal separator


### PR DESCRIPTION
Resolves: #32960 

Percentage spinboxes in the Properties panel (e.g. fermata time stretch, measure width) were snapping to their minimum value when entering numbers ≥ 1000. Fixed by preventing the number formatter from adding thousands separators (e.g. "1,000"), which the input field's validator did not recognize as a valid number.


- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)
