### PR TITLE
fix(engraving): correct Q_PROPERTY READ for markIrregularMeasures

### DIFF
--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -336,7 +336,7 @@ class Score : public apiv1::ScoreElement, public muse::Contextable
      * @q_property {Boolean}
      * @since 4.6
      */
-    Q_PROPERTY(bool markIrregularMeasures READ showSoundFlags WRITE setMarkIrregularMeasures)
+    Q_PROPERTY(bool markIrregularMeasures READ markIrregularMeasures WRITE setMarkIrregularMeasures)
 
     /** APIDOC
      * Whether instrument names are displayed


### PR DESCRIPTION
Fixes #33121

## What changed

The `apiv1::Score` Q_PROPERTY for `markIrregularMeasures` was declared with the wrong READ accessor:

```cpp
Q_PROPERTY(bool markIrregularMeasures READ showSoundFlags WRITE setMarkIrregularMeasures)
```

A QML plugin reading `score.markIrregularMeasures` got the value of `showSoundFlags` instead of `markIrregularMeasures`. The setter was correct, which made this silent on writes but wrong on reads.

The `apiv1::Score` class already exposes the correct getter at `src/engraving/api/v1/score.h:516`:

```cpp
bool markIrregularMeasures() { return score()->markIrregularMeasures(); }
```

Fix: point the Q_PROPERTY READ at it.

```cpp
Q_PROPERTY(bool markIrregularMeasures READ markIrregularMeasures WRITE setMarkIrregularMeasures)
```

One-line change, no behavior change for the setter, no public API surface change.
