### PR TITLE
[audio] audio RPС improvements

### DIFF
--- a/src/framework/audio/common/rpc/contextrpcchannel.cpp
+++ b/src/framework/audio/common/rpc/contextrpcchannel.cpp
@@ -38,10 +38,10 @@ void ContextRpcChannel::send(const Msg& msg, const Handler& onResponse)
     globalChannel()->send(m, h);
 }
 
-void ContextRpcChannel::onMethod(Method method, Handler h)
+void ContextRpcChannel::onRequest(MsgCode code, Handler h)
 {
     if (h) {
-        globalChannel()->onMethod(method, [this, h](const Msg& msg) {
+        globalChannel()->onRequest(code, [this, h](const Msg& msg) {
             if (msg.ctxId == contextId()) {
                 h(msg);
             } else if (msg.type == MsgType::Notification) { // Notifications are not contextual yet
@@ -50,7 +50,23 @@ void ContextRpcChannel::onMethod(Method method, Handler h)
         });
     } else {
         // reset
-        globalChannel()->onMethod(method, nullptr);
+        globalChannel()->onRequest(code, nullptr);
+    }
+}
+
+void ContextRpcChannel::onNotification(MsgCode code, Handler h)
+{
+    if (h) {
+        globalChannel()->onNotification(code, [this, h](const Msg& msg) {
+            if (msg.ctxId == contextId()) {
+                h(msg);
+            } else if (msg.type == MsgType::Notification) { // Notifications are not contextual yet
+                h(msg);
+            }
+        });
+    } else {
+        // reset
+        globalChannel()->onNotification(code, nullptr);
     }
 }
 

--- a/src/framework/audio/common/rpc/contextrpcchannel.h
+++ b/src/framework/audio/common/rpc/contextrpcchannel.h
@@ -35,7 +35,8 @@ public:
 
     // IContextRpcChannel
     void send(const Msg& msg, const Handler& onResponse = nullptr) override;
-    void onMethod(Method method, Handler h) override;
+    void onRequest(MsgCode code, Handler h) override;
+    void onNotification(MsgCode code, Handler h) override;
 
     // IStreamRpcChannel
     void addStream(std::shared_ptr<IRpcStream> s) override;

--- a/src/framework/audio/common/rpc/icontextrpcchannel.h
+++ b/src/framework/audio/common/rpc/icontextrpcchannel.h
@@ -32,7 +32,8 @@ public:
     virtual ~IContextRpcChannel() = default;
 
     virtual void send(const Msg& msg, const Handler& onResponse = nullptr) = 0;
-    virtual void onMethod(Method method, Handler h) = 0;
+    virtual void onRequest(MsgCode code, Handler h) = 0;
+    virtual void onNotification(MsgCode code, Handler h) = 0;
 
     // stream (async/channel)
     template<typename ... Types>

--- a/src/framework/audio/common/rpc/irpcchannel.h
+++ b/src/framework/audio/common/rpc/irpcchannel.h
@@ -35,7 +35,7 @@ namespace muse::audio::rpc {
 using CallId = uint64_t;
 using CtxId = uint8_t;
 
-enum class Method {
+enum class MsgCode {
     Undefined = 0,
 
     // Init / Deinit
@@ -116,88 +116,110 @@ enum class Method {
 
     // Transport
     TransportEventReceived,
+
+    // Streams
+    FirstStream = 100,
+    PlaybackDataMainStream,
+    PlaybackDataOffStream,
+    AudioSignalStream,
+    AudioMasterSignalStream,
+    PlaybackStatusStream,
+    PlaybackPositionStream,
+    InputProcessingProgressStream,
+    SaveSoundTrackProgressStream
 };
 
-inline std::string to_string(Method m)
+inline std::string to_string(MsgCode m)
 {
     switch (m) {
-    case Method::Undefined: return "Undefined";
+    case MsgCode::Undefined: return "Undefined";
 
     // Init / Deinit
-    case Method::EngineRunning: return "EngineRunning";
-    case Method::EngineInit: return "EngineInit";
-    case Method::EngineDeinit: return "EngineDeinit";
+    case MsgCode::EngineRunning: return "EngineRunning";
+    case MsgCode::EngineInit: return "EngineInit";
+    case MsgCode::EngineDeinit: return "EngineDeinit";
 
     // Config
-    case Method::EngineConfigChanged: return "EngineConfigChanged";
+    case MsgCode::EngineConfigChanged: return "EngineConfigChanged";
 
     // AudioEngine
-    case Method::SetOutputSpec: return "SetOutputSpec";
+    case MsgCode::SetOutputSpec: return "SetOutputSpec";
 
     // Tracks
-    case Method::RemoveTrack: return "RemoveTrack";
-    case Method::RemoveAllTracks: return "RemoveAllTracks";
-    case Method::GetTrackIdList: return "GetTrackIdList";
-    case Method::GetTrackName: return "GetTrackName";
-    case Method::AddTrackWithPlaybackData: return "AddTrackWithPlaybackData";
-    case Method::AddTrackWithIODevice: return "AddTrackWithIODevice";
-    case Method::AddAuxTrack: return "AddAuxTrack";
-    case Method::TrackAdded: return "TrackAdded";
-    case Method::TrackRemoved: return "TrackRemoved";
+    case MsgCode::RemoveTrack: return "RemoveTrack";
+    case MsgCode::RemoveAllTracks: return "RemoveAllTracks";
+    case MsgCode::GetTrackIdList: return "GetTrackIdList";
+    case MsgCode::GetTrackName: return "GetTrackName";
+    case MsgCode::AddTrackWithPlaybackData: return "AddTrackWithPlaybackData";
+    case MsgCode::AddTrackWithIODevice: return "AddTrackWithIODevice";
+    case MsgCode::AddAuxTrack: return "AddAuxTrack";
+    case MsgCode::TrackAdded: return "TrackAdded";
+    case MsgCode::TrackRemoved: return "TrackRemoved";
 
-    case Method::GetAvailableInputResources: return "GetAvailableInputResources";
-    case Method::GetAvailableSoundPresets: return "GetAvailableSoundPresets";
+    case MsgCode::GetAvailableInputResources: return "GetAvailableInputResources";
+    case MsgCode::GetAvailableSoundPresets: return "GetAvailableSoundPresets";
 
-    case Method::GetInputParams: return "GetInputParams";
-    case Method::SetInputParams: return "SetInputParams";
-    case Method::GetInputProcessingProgress: return "GetInputProcessingProgress";
-    case Method::InputParamsChanged: return "InputParamsChanged";
+    case MsgCode::GetInputParams: return "GetInputParams";
+    case MsgCode::SetInputParams: return "SetInputParams";
+    case MsgCode::GetInputProcessingProgress: return "GetInputProcessingProgress";
+    case MsgCode::InputParamsChanged: return "InputParamsChanged";
 
-    case Method::ProcessInput: return "ProcessInput";
+    case MsgCode::ProcessInput: return "ProcessInput";
 
-    case Method::ClearCache: return "ClearCache";
-    case Method::ClearSources: return "ClearSources";
+    case MsgCode::ClearCache: return "ClearCache";
+    case MsgCode::ClearSources: return "ClearSources";
 
     // Play
-    case Method::PrepareToPlay: return "PrepareToPlay";
-    case Method::Play: return "Play";
-    case Method::Seek: return "Seek";
-    case Method::Stop: return "Stop";
-    case Method::Pause: return "Pause";
-    case Method::Resume: return "Resume";
-    case Method::SetDuration: return "SetDuration";
-    case Method::SetLoop: return "SetLoop";
-    case Method::ResetLoop: return "ResetLoop";
-    case Method::GetPlaybackStatus: return "GetPlaybackStatus";
-    case Method::GetPlaybackPosition: return "GetPlaybackPosition";
+    case MsgCode::PrepareToPlay: return "PrepareToPlay";
+    case MsgCode::Play: return "Play";
+    case MsgCode::Seek: return "Seek";
+    case MsgCode::Stop: return "Stop";
+    case MsgCode::Pause: return "Pause";
+    case MsgCode::Resume: return "Resume";
+    case MsgCode::SetDuration: return "SetDuration";
+    case MsgCode::SetLoop: return "SetLoop";
+    case MsgCode::ResetLoop: return "ResetLoop";
+    case MsgCode::GetPlaybackStatus: return "GetPlaybackStatus";
+    case MsgCode::GetPlaybackPosition: return "GetPlaybackPosition";
 
     // Output
-    case Method::GetOutputParams: return "GetOutputParams";
-    case Method::SetOutputParams: return "SetOutputParams";
-    case Method::GetMasterOutputParams: return "GetMasterOutputParams";
-    case Method::SetMasterOutputParams: return "SetMasterOutputParams";
-    case Method::ClearMasterOutputParams: return "ClearMasterOutputParams";
-    case Method::OutputParamsChanged: return "OutputParamsChanged";
-    case Method::MasterOutputParamsChanged: return "MasterOutputParamsChanged";
+    case MsgCode::GetOutputParams: return "GetOutputParams";
+    case MsgCode::SetOutputParams: return "SetOutputParams";
+    case MsgCode::GetMasterOutputParams: return "GetMasterOutputParams";
+    case MsgCode::SetMasterOutputParams: return "SetMasterOutputParams";
+    case MsgCode::ClearMasterOutputParams: return "ClearMasterOutputParams";
+    case MsgCode::OutputParamsChanged: return "OutputParamsChanged";
+    case MsgCode::MasterOutputParamsChanged: return "MasterOutputParamsChanged";
 
-    case Method::GetSignalChanges: return "GetSignalChanges";
-    case Method::GetMasterSignalChanges: return "GetMasterSignalChanges";
+    case MsgCode::GetSignalChanges: return "GetSignalChanges";
+    case MsgCode::GetMasterSignalChanges: return "GetMasterSignalChanges";
 
-    case Method::GetAvailableOutputResources: return "GetAvailableOutputResources";
+    case MsgCode::GetAvailableOutputResources: return "GetAvailableOutputResources";
 
-    case Method::SaveSoundTrack: return "SaveSoundTrack";
-    case Method::AbortSavingAllSoundTracks: return "AbortSavingAllSoundTracks";
-    case Method::GetSaveSoundTrackProgress: return "GetSaveSoundTrackProgress";
+    case MsgCode::SaveSoundTrack: return "SaveSoundTrack";
+    case MsgCode::AbortSavingAllSoundTracks: return "AbortSavingAllSoundTracks";
+    case MsgCode::GetSaveSoundTrackProgress: return "GetSaveSoundTrackProgress";
 
-    case Method::ClearAllFx: return "ClearAllFx";
+    case MsgCode::ClearAllFx: return "ClearAllFx";
 
     // SoundFont
-    case Method::LoadSoundFonts: return "LoadSoundFonts";
-    case Method::AddSoundFont: return "AddSoundFont";
-    case Method::AddSoundFontData: return "AddSoundFontData";
+    case MsgCode::LoadSoundFonts: return "LoadSoundFonts";
+    case MsgCode::AddSoundFont: return "AddSoundFont";
+    case MsgCode::AddSoundFontData: return "AddSoundFontData";
 
     // Transport
-    case Method::TransportEventReceived: return "TransportEventReceived";
+    case MsgCode::TransportEventReceived: return "TransportEventReceived";
+
+    // Streams
+    case MsgCode::FirstStream: return "FirstStream";
+    case MsgCode::PlaybackDataMainStream: return "PlaybackDataMainStream";
+    case MsgCode::PlaybackDataOffStream: return "PlaybackDataOffStream";
+    case MsgCode::AudioSignalStream: return "AudioSignalStream";
+    case MsgCode::AudioMasterSignalStream: return "AudioMasterSignalStream";
+    case MsgCode::PlaybackStatusStream: return "PlaybackStatusStream";
+    case MsgCode::PlaybackPositionStream: return "PlaybackPositionStream";
+    case MsgCode::InputProcessingProgressStream: return "InputProcessingProgressStream";
+    case MsgCode::SaveSoundTrackProgressStream: return "SaveSoundTrackProgressStream";
     }
 
     assert(false && "unknown enum value");
@@ -229,49 +251,15 @@ inline std::string to_string(MsgType t)
 struct Msg {
     CallId callId = 0;
     CtxId ctxId = 0;   // 0 - global, >0 - contextual
-    Method method = Method::Undefined;
+    MsgCode code = MsgCode::Undefined;
     MsgType type = MsgType::Undefined;
     ByteArray data;
 };
 
+using StreamId = CallId;
+using StreamName = MsgCode;
+using StreamMsg = Msg;
 using Handler = std::function<void (const Msg& msg)>;
-
-// stream
-enum class StreamName {
-    Undefined = 100,
-
-    PlaybackDataMainStream,
-    PlaybackDataOffStream,
-
-    AudioSignalStream,
-    AudioMasterSignalStream,
-
-    PlaybackStatusStream,
-    PlaybackPositionStream,
-
-    InputProcessingProgressStream,
-    SaveSoundTrackProgressStream
-};
-
-inline std::string to_string(StreamName n)
-{
-    switch (n) {
-    case StreamName::Undefined: return "Undefined";
-    case StreamName::PlaybackDataMainStream: return "PlaybackDataMainStream";
-    case StreamName::PlaybackDataOffStream: return "PlaybackDataOffStream";
-    case StreamName::AudioSignalStream: return "AudioSignalStream";
-    case StreamName::AudioMasterSignalStream: return "AudioMasterSignalStream";
-    case StreamName::PlaybackStatusStream: return "PlaybackStatusStream";
-    case StreamName::PlaybackPositionStream: return "PlaybackPositionStream";
-    case StreamName::InputProcessingProgressStream: return "InputProcessingProgressStream";
-    case StreamName::SaveSoundTrackProgressStream: return "SaveSoundTrackProgressStream";
-    }
-
-    assert(false && "unknown enum value");
-    return std::to_string(static_cast<int>(n));
-}
-
-using StreamId = uint32_t;
 
 inline StreamId& last_stream_id()
 {
@@ -290,14 +278,7 @@ inline StreamId new_stream_id()
     return last_stream_id();
 }
 
-struct StreamMsg {
-    CtxId ctxId = 0;   // 0 - global, >0 - contextual
-    StreamName name = StreamName::Undefined;
-    StreamId streamId = 0;
-    ByteArray data;
-};
-
-using StreamHandler = std::function<void (const StreamMsg& msg)>;
+using StreamHandler = std::function<void (const Msg& msg)>;
 
 enum class StreamType {
     Undefined = 0,
@@ -377,7 +358,8 @@ public:
     virtual void process() = 0;
 
     virtual void send(const Msg& msg, const Handler& onResponse = nullptr) = 0;
-    virtual void onMethod(Method method, Handler h) = 0;
+    virtual void onRequest(MsgCode code, Handler h) = 0;
+    virtual void onNotification(MsgCode code, Handler h) = 0;
     virtual void listenAll(Handler h) = 0;
 
     // stream (async/channel)
@@ -398,6 +380,11 @@ public:
     }
 };
 
+inline StreamMsg make_stream_msg(CtxId ctxId, StreamId id, StreamName name, const ByteArray& data = ByteArray())
+{
+    return StreamMsg{ id, ctxId, name, MsgType::Stream, data };
+}
+
 template<typename ... Types>
 void RpcStream<Types...>::init()
 {
@@ -409,7 +396,7 @@ void RpcStream<Types...>::init()
     case StreamType::Send: {
         m_ch.onReceive(this, [this](const Types... args) {
                 ByteArray data = RpcPacker::pack(args ...);
-                m_rpc->sendStream(StreamMsg { m_ctxId, m_name, m_streamId, data });
+                m_rpc->sendStream(make_stream_msg(m_ctxId, m_streamId, m_name, data));
             });
     } break;
     case StreamType::Receive: {
@@ -469,11 +456,11 @@ inline CallId new_call_id()
     return lastId;
 }
 
-inline Msg make_request(Method m, const ByteArray& data = ByteArray())
+inline Msg make_request(MsgCode m, const ByteArray& data = ByteArray())
 {
     Msg msg;
     msg.callId = new_call_id();
-    msg.method = m;
+    msg.code = m;
     msg.type = MsgType::Request;
     msg.data = data;
     return msg;
@@ -484,17 +471,17 @@ inline Msg make_response(const Msg& req, const ByteArray& data = ByteArray())
     Msg msg;
     msg.ctxId = req.ctxId;
     msg.callId = req.callId;
-    msg.method = req.method;
+    msg.code = req.code;
     msg.type = MsgType::Response;
     msg.data = data;
     return msg;
 }
 
-inline Msg make_notification(Method m, const ByteArray& data = ByteArray())
+inline Msg make_notification(MsgCode m, const ByteArray& data = ByteArray())
 {
     Msg msg;
     msg.callId = new_call_id();
-    msg.method = m;
+    msg.code = m;
     msg.type = MsgType::Notification;
     msg.data = data;
     return msg;

--- a/src/framework/audio/common/rpc/platform/general/generalrpcchannel.cpp
+++ b/src/framework/audio/common/rpc/platform/general/generalrpcchannel.cpp
@@ -71,18 +71,11 @@ void GeneralRpcChannel::process()
 
 void GeneralRpcChannel::send(const Msg& msg, const Handler& onResponse)
 {
-    if (msg.type == MsgType::Stream) {
-        RPCLOG() << "ctxId: " << msg.ctxId
-                 << ", stream: " << to_string(static_cast<StreamName>(msg.method))
-                 << ", streamId: " << msg.callId
-                 << ", data.size: " << msg.data.size();
-    } else {
-        RPCLOG() << "ctxId: " << msg.ctxId
-                 << ", callId: " << msg.callId
-                 << ", method: " << to_string(msg.method)
-                 << ", type: " << to_string(msg.type)
-                 << ", data.size: " << msg.data.size();
-    }
+    RPCLOG() << "ctxId: " << msg.ctxId
+             << ", callId: " << msg.callId
+             << ", code: " << to_string(msg.code)
+             << ", type: " << to_string(msg.type)
+             << ", data.size: " << msg.data.size();
 
     if (s_isMainThread) {
         if (onResponse) {
@@ -101,59 +94,67 @@ void GeneralRpcChannel::send(const Msg& msg, const Handler& onResponse)
 
 void GeneralRpcChannel::receive(RpcData& to, const Msg& m) const
 {
-    if (m.type == MsgType::Stream) {
-        RPCLOG() << "ctxId: " << m.ctxId
-                 << ", stream: " << to_string(static_cast<StreamName>(m.method))
-                 << ", streamId: " << m.callId
-                 << ", data.size: " << m.data.size();
-    } else {
-        RPCLOG() << "ctxId: " << m.ctxId
-                 << ", callId: " << m.callId
-                 << ", method: " << to_string(m.method)
-                 << ", type: " << to_string(m.type)
-                 << ", data.size: " << m.data.size();
-    }
+    RPCLOG() << "ctxId: " << m.ctxId
+             << ", callId: " << m.callId
+             << ", code: " << to_string(m.code)
+             << ", type: " << to_string(m.type)
+             << ", data.size: " << m.data.size();
 
     // all
     if (to.listenerAll) {
         to.listenerAll(m);
     }
 
-    // if stream
-    if (m.type == MsgType::Stream) {
-        StreamMsg msg;
-        msg.ctxId = m.ctxId;
-        msg.streamId = m.callId;
-        msg.name = static_cast<StreamName>(m.method);
-        msg.data = m.data;
-        receive(to, msg);
-        return;
-    }
-
-    // by method
-    {
-        auto it = to.onMethods.find(m.method);
-        if (it != to.onMethods.end() && it->second) {
+    switch (m.type) {
+    case MsgType::Stream: {
+        auto it = to.onStreams.find(m.callId);
+        if (it != to.onStreams.end() && it->second) {
             it->second(m);
         }
-    }
-
-    // by callId (response)
-    if (m.type == MsgType::Response) {
-        auto it = to.onResponses.find(m.callId);
-        if (it != to.onResponses.end() && it->second) {
+    } break;
+    case MsgType::Request: {
+        auto it = to.onRequests.find(m.code);
+        if (it != to.onRequests.end() && it->second) {
             it->second(m);
+        }
+    } break;
+    case MsgType::Notification: {
+        auto it = to.onNotifications.find(m.code);
+        if (it != to.onNotifications.end() && it->second) {
+            it->second(m);
+        }
+    } break;
+    case MsgType::Response: {
+        auto it = to.onResponses.find(m.callId);
+        if (it != to.onResponses.end()) {
+            if (it->second) {
+                it->second(m);
+            }
             to.onResponses.erase(it);
         }
+    } break;
+    default: {
+        UNREACHABLE;
+        break;
+    }
     }
 }
 
-void GeneralRpcChannel::onMethod(Method method, Handler h)
+void GeneralRpcChannel::onRequest(MsgCode code, Handler h)
 {
     if (s_isMainThread) {
-        m_mainRpcData.onMethods[method] = h;
+        m_mainRpcData.onRequests[code] = h;
     } else {
-        m_engineRpcData.onMethods[method] = h;
+        m_engineRpcData.onRequests[code] = h;
+    }
+}
+
+void GeneralRpcChannel::onNotification(MsgCode code, Handler h)
+{
+    if (s_isMainThread) {
+        m_mainRpcData.onNotifications[code] = h;
+    } else {
+        m_engineRpcData.onNotifications[code] = h;
     }
 }
 
@@ -168,21 +169,7 @@ void GeneralRpcChannel::listenAll(Handler h)
 
 void GeneralRpcChannel::sendStream(const StreamMsg& msg)
 {
-    Msg m;
-    m.ctxId = msg.ctxId;
-    m.type = MsgType::Stream;
-    m.callId = msg.streamId;
-    m.method = static_cast<Method>(msg.name);
-    m.data = msg.data;
-    send(m);
-}
-
-void GeneralRpcChannel::receive(RpcData& to, const StreamMsg& m) const
-{
-    auto it = to.onStreams.find(m.streamId);
-    if (it != to.onStreams.end() && it->second) {
-        it->second(m);
-    }
+    send(msg);
 }
 
 void GeneralRpcChannel::addStream(std::shared_ptr<IRpcStream> s)

--- a/src/framework/audio/common/rpc/platform/general/generalrpcchannel.h
+++ b/src/framework/audio/common/rpc/platform/general/generalrpcchannel.h
@@ -39,7 +39,8 @@ public:
     // IRpcChannel
     // msgs
     void send(const Msg& msg, const Handler& onResponse = nullptr) override;
-    void onMethod(Method method, Handler h) override;
+    void onRequest(MsgCode code, Handler h) override;
+    void onNotification(MsgCode code, Handler h) override;
     void listenAll(Handler h) override;
 
     // stream
@@ -53,7 +54,8 @@ private:
     struct RpcData {
         // msgs
         Handler listenerAll;
-        std::map<Method, Handler> onMethods;
+        std::map<MsgCode, Handler> onRequests;
+        std::map<MsgCode, Handler> onNotifications;
         std::map<CallId, Handler> onResponses;
 
         // stream
@@ -62,7 +64,6 @@ private:
     };
 
     void receive(RpcData& to, const Msg& m) const;
-    void receive(RpcData& to, const StreamMsg& m) const;
 
     RpcData m_engineRpcData;
     RpcData m_mainRpcData;

--- a/src/framework/audio/common/rpc/platform/web/webrpcchannel.cpp
+++ b/src/framework/audio/common/rpc/platform/web/webrpcchannel.cpp
@@ -43,9 +43,6 @@ static constexpr size_t DEFAULT_CAPACITY = 1024 * 200;
 static std::vector<uint8_t> buffer = {};
 static std::function<void(const ByteArray&)> g_rpcListen = nullptr;
 
-static constexpr uint8_t MSG_ID = 1;
-static constexpr uint8_t STREAM_ID = 2;
-
 static void rpcSend(const uint8_t* data, size_t size)
 {
     emscripten::val jsArray = emscripten::val::global("Uint8Array").new_(
@@ -104,7 +101,7 @@ void WebRpcChannel::send(const Msg& msg, const Handler& onResponse)
 {
     RPCLOG() << "ctxId: " << msg.ctxId
              << ", callId: " << msg.callId
-             << ", method: " << to_string(msg.method)
+             << ", method: " << to_string(msg.code)
              << ", type: " << to_string(msg.type)
              << ", data.size: " << msg.data.size();
 
@@ -113,7 +110,7 @@ void WebRpcChannel::send(const Msg& msg, const Handler& onResponse)
     // makes sense if the reserve is greater than the current capacity
     buffer.reserve(std::max(msg.data.size(), DEFAULT_CAPACITY));
 
-    msgpack::pack(buffer, MSG_ID, msg.ctxId, msg.callId, (uint8_t)msg.method, (uint8_t)msg.type, msg.data.constVData());
+    msgpack::pack(buffer, msg.ctxId, msg.callId, (uint8_t)msg.code, (uint8_t)msg.type, msg.data.constVData());
 
     IF_ASSERT_FAILED(buffer.size() > 0) {
         return;
@@ -132,35 +129,22 @@ void WebRpcChannel::receive(const ByteArray& data)
         return;
     }
     muse::msgpack::Cursor cursor(data.constData(), data.size());
-    uint8_t msgId = 0;
-    msgpack::unpack(cursor, msgId);
 
-    if (msgId == MSG_ID) {
-        Msg msg;
-        uint8_t method = 0;
-        uint8_t type = 0;
-        msgpack::unpack(cursor, msg.ctxId, msg.callId, method, type, msg.data.vdata());
-        msg.method = static_cast<Method>(method);
-        msg.type = static_cast<MsgType>(type);
+    Msg msg;
+    uint8_t code = 0;
+    uint8_t type = 0;
+    msgpack::unpack(cursor, msg.ctxId, msg.callId, code, type, msg.data.vdata());
+    msg.code = static_cast<MsgCode>(code);
+    msg.type = static_cast<MsgType>(type);
 
-        receive(msg);
-    } else if (msgId == STREAM_ID) {
-        StreamMsg msg;
-        uint8_t name = 0;
-        msgpack::unpack(cursor, msg.ctxId, name, msg.streamId, msg.data.vdata());
-        msg.name = static_cast<StreamName>(name);
-
-        receive(msg);
-    } else {
-        UNREACHABLE;
-    }
+    receive(msg);
 }
 
 void WebRpcChannel::receive(const Msg& msg)
 {
     RPCLOG() << "ctxId: " << msg.ctxId
              << ", callId: " << msg.callId
-             << ", method: " << to_string(msg.method)
+             << ", code: " << to_string(msg.code)
              << ", type: " << to_string(msg.type)
              << ", data.size: " << msg.data.size();
 
@@ -168,41 +152,49 @@ void WebRpcChannel::receive(const Msg& msg)
     if (m_data.listenerAll) {
         m_data.listenerAll(msg);
     }
-
-    // by method
-    {
-        auto it = m_data.onMethods.find(msg.method);
-        if (it != m_data.onMethods.end() && it->second) {
+    switch (msg.type) {
+    case MsgType::Stream: {
+        auto it = m_data.onStreams.find(msg.callId);
+        if (it != m_data.onStreams.end() && it->second) {
             it->second(msg);
         }
-    }
-
-    // by callId (response)
-    if (msg.type == MsgType::Response) {
-        auto it = m_data.onResponses.find(msg.callId);
-        if (it != m_data.onResponses.end() && it->second) {
+    } break;
+    case MsgType::Request: {
+        auto it = m_data.onRequests.find(msg.code);
+        if (it != m_data.onRequests.end() && it->second) {
             it->second(msg);
+        }
+    } break;
+    case MsgType::Notification: {
+        auto it = m_data.onNotifications.find(msg.code);
+        if (it != m_data.onNotifications.end() && it->second) {
+            it->second(msg);
+        }
+    } break;
+    case MsgType::Response: {
+        auto it = m_data.onResponses.find(msg.callId);
+        if (it != m_data.onResponses.end()) {
+            if (it->second) {
+                it->second(msg);
+            }
             m_data.onResponses.erase(it);
         }
+    } break;
+    default: {
+        UNREACHABLE;
+        break;
+    }
     }
 }
 
-void WebRpcChannel::receive(const StreamMsg& msg)
+void WebRpcChannel::onRequest(MsgCode code, Handler h)
 {
-    RPCLOG() << "ctxId: " << msg.ctxId
-             << ", stream: " << to_string(msg.name)
-             << ", streamId: " << msg.streamId
-             << ", data.size: " << msg.data.size();
-
-    auto it = m_data.onStreams.find(msg.streamId);
-    if (it != m_data.onStreams.end() && it->second) {
-        it->second(msg);
-    }
+    m_data.onRequests[code] = h;
 }
 
-void WebRpcChannel::onMethod(Method method, Handler h)
+void WebRpcChannel::onNotification(MsgCode code, Handler h)
 {
-    m_data.onMethods[method] = h;
+    m_data.onNotifications[code] = h;
 }
 
 void WebRpcChannel::listenAll(Handler h)
@@ -231,23 +223,7 @@ void WebRpcChannel::removeStream(StreamId id)
 
 void WebRpcChannel::sendStream(const StreamMsg& msg)
 {
-    RPCLOG() << "ctxId: " << msg.ctxId
-             << ", stream: " << to_string(msg.name)
-             << ", streamId: " << msg.streamId
-             << ", data.size: " << msg.data.size();
-
-    // clear but keep capacity
-    buffer.clear();
-    // makes sense if the reserve is greater than the current capacity
-    buffer.reserve(std::max(msg.data.size(), DEFAULT_CAPACITY));
-
-    msgpack::pack(buffer, STREAM_ID, msg.ctxId, (uint8_t)msg.name, msg.streamId, msg.data.constVData());
-
-    IF_ASSERT_FAILED(buffer.size() > 0) {
-        return;
-    }
-
-    rpcSend(&buffer[0], buffer.size());
+    send(msg);
 }
 
 void WebRpcChannel::onStream(StreamId id, StreamHandler h)

--- a/src/framework/audio/common/rpc/platform/web/webrpcchannel.h
+++ b/src/framework/audio/common/rpc/platform/web/webrpcchannel.h
@@ -35,7 +35,8 @@ public:
     void process() override;
 
     void send(const Msg& msg, const Handler& onResponse = nullptr) override;
-    void onMethod(Method method, Handler h) override;
+    void onRequest(MsgCode code, Handler h) override;
+    void onNotification(MsgCode code, Handler h) override;
     void listenAll(Handler h) override;
 
     void addStream(std::shared_ptr<IRpcStream> s) override;
@@ -47,12 +48,12 @@ private:
 
     void receive(const ByteArray& data);
     void receive(const Msg& msg);
-    void receive(const StreamMsg& msg);
 
     struct RpcData {
         // msgs
         Handler listenerAll;
-        std::map<Method, Handler> onMethods;
+        std::map<MsgCode, Handler> onRequests;
+        std::map<MsgCode, Handler> onNotifications;
         std::map<CallId, Handler> onResponses;
 
         // stream

--- a/src/framework/audio/engine/internal/enginecontroller.cpp
+++ b/src/framework/audio/engine/internal/enginecontroller.cpp
@@ -43,7 +43,7 @@ using namespace muse::audio::synth;
 EngineController::EngineController(std::shared_ptr<rpc::IRpcChannel> rpcChannel)
     : m_rpcChannel(rpcChannel)
 {
-    m_rpcChannel->onMethod(rpc::Method::EngineInit, [this](const rpc::Msg& msg) {
+    m_rpcChannel->onRequest(rpc::MsgCode::EngineInit, [this](const rpc::Msg& msg) {
         OutputSpec spec;
         AudioEngineConfig conf;
 
@@ -56,7 +56,7 @@ EngineController::EngineController(std::shared_ptr<rpc::IRpcChannel> rpcChannel)
         m_rpcChannel->send(rpc::make_response(msg));
     });
 
-    m_rpcChannel->onMethod(rpc::Method::EngineDeinit, [this](const rpc::Msg& msg) {
+    m_rpcChannel->onRequest(rpc::MsgCode::EngineDeinit, [this](const rpc::Msg& msg) {
         deinit();
         m_rpcChannel->send(rpc::make_response(msg));
     });
@@ -72,7 +72,7 @@ void EngineController::onStartRunning()
 
     //! NOTE We inform that the engine is running and can receive messages
     //! (it has not yet been initialized)
-    m_rpcChannel->send(rpc::make_notification(rpc::Method::EngineRunning));
+    m_rpcChannel->send(rpc::make_notification(rpc::MsgCode::EngineRunning));
 }
 
 void EngineController::init(const OutputSpec& outputSpec, const AudioEngineConfig& conf)

--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -54,7 +54,7 @@ void EngineRpcController::init()
     ONLY_AUDIO_RPC_THREAD;
 
     // AudioEngine
-    onLongMethod(Method::SetOutputSpec, [this](const Msg& msg) {
+    onLongRequest(MsgCode::SetOutputSpec, [this](const Msg& msg) {
         OutputSpec spec;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, spec)) {
             return;
@@ -63,7 +63,7 @@ void EngineRpcController::init()
     });
 
     // Soundfont
-    onLongMethod(Method::LoadSoundFonts, [this](const Msg& msg) {
+    onLongRequest(MsgCode::LoadSoundFonts, [this](const Msg& msg) {
         std::vector<synth::SoundFontUri> uris;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, uris)) {
             return;
@@ -72,7 +72,7 @@ void EngineRpcController::init()
         soundFontRepository()->loadSoundFonts(uris);
     });
 
-    onLongMethod(Method::AddSoundFont, [this](const Msg& msg) {
+    onLongRequest(MsgCode::AddSoundFont, [this](const Msg& msg) {
         synth::SoundFontUri uri;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, uri)) {
             return;
@@ -81,7 +81,7 @@ void EngineRpcController::init()
         soundFontRepository()->addSoundFont(uri);
     });
 
-    onLongMethod(Method::AddSoundFontData, [this](const Msg& msg) {
+    onLongRequest(MsgCode::AddSoundFontData, [this](const Msg& msg) {
         synth::SoundFontUri uri;
         ByteArray data;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, uri, data)) {
@@ -92,7 +92,7 @@ void EngineRpcController::init()
     });
 
     // Engine Conf
-    onLongMethod(Method::EngineConfigChanged, [this](const Msg& msg) {
+    onLongRequest(MsgCode::EngineConfigChanged, [this](const Msg& msg) {
         AudioEngineConfig conf;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, conf)) {
             return;
@@ -104,33 +104,33 @@ void EngineRpcController::init()
     // AudioContext
     // Notification
     audioContext()->trackAdded().onReceive(this, [this](TrackId trackId) {
-        channel()->send(rpc::make_notification(Method::TrackAdded, RpcPacker::pack(trackId)));
+        channel()->send(rpc::make_notification(MsgCode::TrackAdded, RpcPacker::pack(trackId)));
     });
 
     audioContext()->trackRemoved().onReceive(this, [this](TrackId trackId) {
-        channel()->send(rpc::make_notification(Method::TrackRemoved, RpcPacker::pack(trackId)));
+        channel()->send(rpc::make_notification(MsgCode::TrackRemoved, RpcPacker::pack(trackId)));
     });
 
     audioContext()->inputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioInputParams& params) {
-        channel()->send(rpc::make_notification(Method::InputParamsChanged, RpcPacker::pack(trackId, params)));
+        channel()->send(rpc::make_notification(MsgCode::InputParamsChanged, RpcPacker::pack(trackId, params)));
     });
 
     audioContext()->outputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioOutputParams& params) {
-        channel()->send(rpc::make_notification(Method::OutputParamsChanged, RpcPacker::pack(trackId, params)));
+        channel()->send(rpc::make_notification(MsgCode::OutputParamsChanged, RpcPacker::pack(trackId, params)));
     });
 
     audioContext()->masterOutputParamsChanged().onReceive(this, [this](const AudioOutputParams& params) {
-        channel()->send(rpc::make_notification(Method::MasterOutputParamsChanged, RpcPacker::pack(params)));
+        channel()->send(rpc::make_notification(MsgCode::MasterOutputParamsChanged, RpcPacker::pack(params)));
     });
 
     // Tracks
-    onQuickMethod(Method::GetTrackIdList, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetTrackIdList, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         RetVal<TrackIdList> ret = audioContext()->trackIdList();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onQuickMethod(Method::GetTrackName, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetTrackName, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -140,7 +140,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onLongMethod(Method::AddTrackWithPlaybackData, [this](const Msg& msg) {
+    onLongRequest(MsgCode::AddTrackWithPlaybackData, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackName trackName;
         mpe::PlaybackData playbackData;
@@ -222,7 +222,7 @@ void EngineRpcController::init()
         }
     });
 
-    onLongMethod(Method::AddTrackWithIODevice, [this](const Msg& msg) {
+    onLongRequest(MsgCode::AddTrackWithIODevice, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackName trackName;
         uint64_t devicePtr = 0;
@@ -236,7 +236,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onLongMethod(Method::AddAuxTrack, [this](const Msg& msg) {
+    onLongRequest(MsgCode::AddAuxTrack, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackName trackName;
         AudioOutputParams outputParams;
@@ -247,7 +247,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onLongMethod(Method::RemoveTrack, [this](const Msg& msg) {
+    onLongRequest(MsgCode::RemoveTrack, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -256,12 +256,12 @@ void EngineRpcController::init()
         audioContext()->removeTrack(trackId);
     });
 
-    onLongMethod(Method::RemoveAllTracks, [this](const Msg&) {
+    onLongRequest(MsgCode::RemoveAllTracks, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->removeAllTracks();
     });
 
-    onQuickMethod(Method::GetAvailableInputResources, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetAvailableInputResources, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         AudioResourceMetaList list = audioContext()->availableInputResources();
         //! NOTE The list can be large.
@@ -270,7 +270,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(rpc::Options { list.size() * 300 }, list)));
     });
 
-    onQuickMethod(Method::GetAvailableSoundPresets, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetAvailableSoundPresets, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         AudioResourceMeta meta;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, meta)) {
@@ -280,7 +280,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(list)));
     });
 
-    onQuickMethod(Method::GetInputParams, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetInputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -290,7 +290,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onLongMethod(Method::SetInputParams, [this](const Msg& msg) {
+    onLongRequest(MsgCode::SetInputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         AudioInputParams params;
@@ -300,7 +300,7 @@ void EngineRpcController::init()
         audioContext()->setInputParams(trackId, params);
     });
 
-    onLongMethod(Method::ProcessInput, [this](const Msg& msg) {
+    onLongRequest(MsgCode::ProcessInput, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -310,7 +310,7 @@ void EngineRpcController::init()
         audioContext()->processInput(trackId);
     });
 
-    onQuickMethod(Method::GetInputProcessingProgress, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetInputProcessingProgress, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -326,7 +326,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret.ret, ret.val.isStarted, streamId)));
     });
 
-    onLongMethod(Method::ClearCache, [this](const Msg& msg) {
+    onLongRequest(MsgCode::ClearCache, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -336,20 +336,20 @@ void EngineRpcController::init()
         audioContext()->clearCache(trackId);
     });
 
-    onLongMethod(Method::ClearSources, [this](const Msg&) {
+    onLongRequest(MsgCode::ClearSources, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->clearSources();
     });
 
     // Play
-    onQuickMethod(Method::PrepareToPlay, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::PrepareToPlay, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->prepareToPlay().onResolve(this, [this, msg](const Ret& ret) {
             channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
         });
     });
 
-    onQuickMethod(Method::Play, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::Play, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         secs_t delay = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, delay)) {
@@ -358,7 +358,7 @@ void EngineRpcController::init()
         audioContext()->play(delay);
     });
 
-    onQuickMethod(Method::Seek, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::Seek, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         secs_t newPosition = 0;
         bool flushSound = false;
@@ -368,17 +368,17 @@ void EngineRpcController::init()
         audioContext()->seek(newPosition, flushSound);
     });
 
-    onQuickMethod(Method::Stop, [this](const Msg&) {
+    onQuickRequest(MsgCode::Stop, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->stop();
     });
 
-    onQuickMethod(Method::Pause, [this](const Msg&) {
+    onQuickRequest(MsgCode::Pause, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->pause();
     });
 
-    onQuickMethod(Method::Resume, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::Resume, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         secs_t delay = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, delay)) {
@@ -387,7 +387,7 @@ void EngineRpcController::init()
         audioContext()->resume(delay);
     });
 
-    onQuickMethod(Method::SetDuration, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::SetDuration, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         secs_t duration = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, duration)) {
@@ -396,7 +396,7 @@ void EngineRpcController::init()
         audioContext()->setDuration(duration);
     });
 
-    onQuickMethod(Method::SetLoop, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::SetLoop, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         secs_t from = 0;
         secs_t to = 0;
@@ -407,12 +407,12 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onQuickMethod(Method::ResetLoop, [this](const Msg&) {
+    onQuickRequest(MsgCode::ResetLoop, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->resetLoop();
     });
 
-    onQuickMethod(Method::GetPlaybackStatus, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetPlaybackStatus, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
 
         PlaybackStatus status = audioContext()->playbackStatus();
@@ -421,7 +421,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(status, streamId)));
     });
 
-    onQuickMethod(Method::GetPlaybackPosition, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetPlaybackPosition, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
 
         secs_t pos = audioContext()->playbackPosition();
@@ -432,7 +432,7 @@ void EngineRpcController::init()
 
     // Output
 
-    onQuickMethod(Method::GetOutputParams, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -442,7 +442,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onQuickMethod(Method::SetOutputParams, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::SetOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         AudioOutputParams params;
@@ -452,13 +452,13 @@ void EngineRpcController::init()
         audioContext()->setOutputParams(trackId, params);
     });
 
-    onQuickMethod(Method::GetMasterOutputParams, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetMasterOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         RetVal<AudioOutputParams> ret = audioContext()->masterOutputParams();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onQuickMethod(Method::SetMasterOutputParams, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::SetMasterOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         AudioOutputParams params;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, params)) {
@@ -467,18 +467,18 @@ void EngineRpcController::init()
         audioContext()->setMasterOutputParams(params);
     });
 
-    onQuickMethod(Method::ClearMasterOutputParams, [this](const Msg&) {
+    onQuickRequest(MsgCode::ClearMasterOutputParams, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->clearMasterOutputParams();
     });
 
-    onQuickMethod(Method::GetAvailableOutputResources, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetAvailableOutputResources, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         AudioResourceMetaList list = audioContext()->availableOutputResources();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(list)));
     });
 
-    onQuickMethod(Method::GetSignalChanges, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetSignalChanges, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -498,7 +498,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(res)));
     });
 
-    onQuickMethod(Method::GetMasterSignalChanges, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetMasterSignalChanges, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         RetVal<AudioSignalChanges> ret = audioContext()->masterSignalChanges();
         StreamId streamId = 0;
@@ -513,7 +513,7 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(res)));
     });
 
-    onLongMethod(Method::SaveSoundTrack, [this](const Msg& msg) {
+    onLongRequest(MsgCode::SaveSoundTrack, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         SoundTrackFormat format;
         uintptr_t dstDevicePtr = 0;
@@ -526,12 +526,12 @@ void EngineRpcController::init()
         });
     });
 
-    onLongMethod(Method::AbortSavingAllSoundTracks, [this](const Msg&) {
+    onLongRequest(MsgCode::AbortSavingAllSoundTracks, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->abortSavingAllSoundTracks();
     });
 
-    onQuickMethod(Method::GetSaveSoundTrackProgress, [this](const Msg& msg) {
+    onQuickRequest(MsgCode::GetSaveSoundTrackProgress, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
         SaveSoundTrackProgress ch = audioContext()->saveSoundTrackProgressChanged();
         ch.onReceive(this, [this](int64_t current, int64_t total, SaveSoundTrackStage stage) {
@@ -547,36 +547,36 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(m_saveSoundTrackProgressStreamId)));
     });
 
-    onQuickMethod(Method::ClearAllFx, [this](const Msg&) {
+    onQuickRequest(MsgCode::ClearAllFx, [this](const Msg&) {
         ONLY_AUDIO_RPC_THREAD;
         audioContext()->clearAllFx();
     });
 }
 
-void EngineRpcController::onLongMethod(rpc::Method method, const rpc::Handler& h)
+void EngineRpcController::onLongRequest(rpc::MsgCode code, const rpc::Handler& h)
 {
-    onMethod(OperationType::LongOperation, method, h);
+    onRequest(OperationType::LongOperation, code, h);
 }
 
-void EngineRpcController::onQuickMethod(rpc::Method method, const Handler& h)
+void EngineRpcController::onQuickRequest(rpc::MsgCode code, const Handler& h)
 {
-    onMethod(OperationType::QuickOperation, method, h);
+    onRequest(OperationType::QuickOperation, code, h);
 }
 
-void EngineRpcController::onMethod(OperationType type, rpc::Method method, const Handler& handler)
+void EngineRpcController::onRequest(OperationType type, rpc::MsgCode code, const Handler& handler)
 {
-    m_usedMethods.push_back(method);
+    m_usedRequests.push_back(code);
 
-    channel()->onMethod(method, [this, type, method, handler](const Msg& msg) {
-        IAudioEngine::Operation func = [this, method, handler, msg]() {
+    channel()->onRequest(code, [this, type, code, handler](const Msg& msg) {
+        IAudioEngine::Operation func = [this, code, handler, msg]() {
             if (m_terminated) {
                 return;
             }
 
-            UNUSED(method);
+            UNUSED(code);
             BEGIN_METHOD_DURATION
             handler(msg);
-            END_METHOD_DURATION(method)
+            END_METHOD_DURATION(code)
         };
         audioEngine()->execOperation(type, func);
     });
@@ -594,8 +594,8 @@ void EngineRpcController::deinit()
     audioContext()->outputParamsChanged().disconnect(this);
     audioContext()->masterOutputParamsChanged().disconnect(this);
 
-    for (const Method& m : m_usedMethods) {
-        channel()->onMethod(m, nullptr);
+    for (const MsgCode& m : m_usedRequests) {
+        channel()->onRequest(m, nullptr);
     }
-    m_usedMethods.clear();
+    m_usedRequests.clear();
 }

--- a/src/framework/audio/engine/internal/enginerpccontroller.h
+++ b/src/framework/audio/engine/internal/enginerpccontroller.h
@@ -49,11 +49,11 @@ private:
 
     std::shared_ptr<IAudioContext> audioContext() const;
 
-    void onLongMethod(rpc::Method method, const rpc::Handler& h);
-    void onQuickMethod(rpc::Method method, const rpc::Handler& h);
-    void onMethod(OperationType type, rpc::Method method, const rpc::Handler& h);
+    void onLongRequest(rpc::MsgCode code, const rpc::Handler& h);
+    void onQuickRequest(rpc::MsgCode code, const rpc::Handler& h);
+    void onRequest(OperationType type, rpc::MsgCode code, const rpc::Handler& h);
 
-    std::vector<rpc::Method> m_usedMethods;
+    std::vector<rpc::MsgCode> m_usedRequests;
     std::atomic<bool> m_terminated = false;
 
     struct PendingTrack {

--- a/src/framework/audio/engine/internal/transporteventsdispatcher.cpp
+++ b/src/framework/audio/engine/internal/transporteventsdispatcher.cpp
@@ -41,7 +41,7 @@ void TransportEventsDispatcher::init()
 
     m_eventsReceived.onReceive(this, [this](const TransportEvents& events) {
         for (const TransportEvent& event : events) {
-            rpcChannel()->send(rpc::make_request(Method::TransportEventReceived, RpcPacker::pack(event)));
+            rpcChannel()->send(rpc::make_notification(MsgCode::TransportEventReceived, RpcPacker::pack(event)));
         }
     });
 }

--- a/src/framework/audio/main/internal/audioconfiguration.cpp
+++ b/src/framework/audio/main/internal/audioconfiguration.cpp
@@ -103,7 +103,7 @@ AudioEngineConfig AudioConfiguration::engineConfig() const
 
 void AudioConfiguration::onEngineConfigChanged()
 {
-    rpcChannel()->send(rpc::make_notification(rpc::Method::EngineConfigChanged, rpc::RpcPacker::pack(engineConfig())));
+    rpcChannel()->send(rpc::make_notification(rpc::MsgCode::EngineConfigChanged, rpc::RpcPacker::pack(engineConfig())));
 }
 
 std::string AudioConfiguration::defaultAudioApi() const

--- a/src/framework/audio/main/internal/audiodrivercontroller.cpp
+++ b/src/framework/audio/main/internal/audiodrivercontroller.cpp
@@ -388,7 +388,7 @@ void AudioDriverController::updateOutputSpec()
     }
 
     IAudioDriver::Spec activeSpec = m_audioDriver->activeSpec();
-    rpcChannel()->send(rpc::make_request(Method::SetOutputSpec, RpcPacker::pack(activeSpec.output)));
+    rpcChannel()->send(rpc::make_request(MsgCode::SetOutputSpec, RpcPacker::pack(activeSpec.output)));
 }
 
 std::vector<samples_t> AudioDriverController::availableOutputDeviceBufferSizes() const

--- a/src/framework/audio/main/internal/playback.cpp
+++ b/src/framework/audio/main/internal/playback.cpp
@@ -38,7 +38,7 @@ void Playback::init()
 {
     ONLY_AUDIO_MAIN_THREAD;
 
-    channel()->onMethod(Method::TrackAdded, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::TrackAdded, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -47,7 +47,7 @@ void Playback::init()
         m_trackAdded.send(trackId);
     });
 
-    channel()->onMethod(Method::TrackRemoved, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::TrackRemoved, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
@@ -56,7 +56,7 @@ void Playback::init()
         m_trackRemoved.send(trackId);
     });
 
-    channel()->onMethod(Method::InputParamsChanged, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::InputParamsChanged, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
         TrackId trackId = 0;
         AudioInputParams params;
@@ -66,7 +66,7 @@ void Playback::init()
         m_inputParamsChanged.send(trackId, params);
     });
 
-    channel()->onMethod(Method::OutputParamsChanged, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::OutputParamsChanged, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
         TrackId trackId = 0;
         AudioOutputParams params;
@@ -76,7 +76,7 @@ void Playback::init()
         m_outputParamsChanged.send(trackId, params);
     });
 
-    channel()->onMethod(Method::MasterOutputParamsChanged, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::MasterOutputParamsChanged, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
         AudioOutputParams params;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, params)) {
@@ -90,11 +90,11 @@ void Playback::deinit()
 {
     ONLY_AUDIO_MAIN_THREAD;
 
-    channel()->onMethod(Method::TrackAdded, nullptr);
-    channel()->onMethod(Method::TrackRemoved, nullptr);
-    channel()->onMethod(Method::InputParamsChanged, nullptr);
-    channel()->onMethod(Method::OutputParamsChanged, nullptr);
-    channel()->onMethod(Method::MasterOutputParamsChanged, nullptr);
+    channel()->onNotification(MsgCode::TrackAdded, nullptr);
+    channel()->onNotification(MsgCode::TrackRemoved, nullptr);
+    channel()->onNotification(MsgCode::InputParamsChanged, nullptr);
+    channel()->onNotification(MsgCode::OutputParamsChanged, nullptr);
+    channel()->onNotification(MsgCode::MasterOutputParamsChanged, nullptr);
 }
 
 bool Playback::isAudioStarted() const
@@ -152,7 +152,7 @@ async::Promise<TrackIdList> Playback::trackIdList() const
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<TrackIdList>([this](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetTrackIdList);
+        Msg msg = rpc::make_request(MsgCode::GetTrackIdList);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<TrackIdList> ret;
@@ -174,7 +174,7 @@ async::Promise<RetVal<TrackName> > Playback::trackName(const TrackId trackId) co
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<RetVal<TrackName> >([this, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetTrackName, RpcPacker::pack(trackId));
+        Msg msg = rpc::make_request(MsgCode::GetTrackName, RpcPacker::pack(trackId));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<TrackName> ret;
@@ -204,7 +204,7 @@ async::Promise<TrackId, AudioParams> Playback::addTrack(const TrackName& trackNa
 
         ByteArray data = RpcPacker::pack(trackName, reinterpret_cast<uint64_t>(playbackData), params);
 
-        Msg msg = rpc::make_request(Method::AddTrackWithIODevice, data);
+        Msg msg = rpc::make_request(MsgCode::AddTrackWithIODevice, data);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioParams> ret;
@@ -236,7 +236,7 @@ async::Promise<TrackId, AudioParams> Playback::addTrack(const TrackName& trackNa
 
         ByteArray data = RpcPacker::pack(trackName, playbackData, params, mainStreamId, offStreamId);
 
-        Msg msg = rpc::make_request(Method::AddTrackWithPlaybackData, data);
+        Msg msg = rpc::make_request(MsgCode::AddTrackWithPlaybackData, data);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioParams> ret;
@@ -259,7 +259,7 @@ async::Promise<TrackId, AudioOutputParams> Playback::addAuxTrack(const TrackName
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<TrackId, AudioOutputParams>([this, trackName, outputParams](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::AddAuxTrack, RpcPacker::pack(trackName, outputParams));
+        Msg msg = rpc::make_request(MsgCode::AddAuxTrack, RpcPacker::pack(trackName, outputParams));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioOutputParams> ret;
@@ -279,14 +279,14 @@ async::Promise<TrackId, AudioOutputParams> Playback::addAuxTrack(const TrackName
 void Playback::removeTrack(const TrackId trackId)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::RemoveTrack, RpcPacker::pack(trackId));
+    Msg msg = rpc::make_request(MsgCode::RemoveTrack, RpcPacker::pack(trackId));
     channel()->send(msg);
 }
 
 void Playback::removeAllTracks()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::RemoveAllTracks);
+    Msg msg = rpc::make_request(MsgCode::RemoveAllTracks);
     channel()->send(msg);
 }
 
@@ -305,7 +305,7 @@ async::Promise<AudioResourceMetaList> Playback::availableInputResources() const
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioResourceMetaList>([this](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetAvailableInputResources);
+        Msg msg = rpc::make_request(MsgCode::GetAvailableInputResources);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             AudioResourceMetaList list;
@@ -323,7 +323,7 @@ async::Promise<SoundPresetList> Playback::availableSoundPresets(const AudioResou
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<SoundPresetList>([this, resourceMeta](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetAvailableSoundPresets, RpcPacker::pack(resourceMeta));
+        Msg msg = rpc::make_request(MsgCode::GetAvailableSoundPresets, RpcPacker::pack(resourceMeta));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             SoundPresetList list;
@@ -342,7 +342,7 @@ async::Promise<AudioInputParams> Playback::inputParams(const TrackId trackId) co
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioInputParams>([this, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetInputParams, RpcPacker::pack(trackId));
+        Msg msg = rpc::make_request(MsgCode::GetInputParams, RpcPacker::pack(trackId));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioInputParams> ret;
@@ -363,7 +363,7 @@ async::Promise<AudioInputParams> Playback::inputParams(const TrackId trackId) co
 void Playback::setInputParams(const TrackId trackId, const AudioInputParams& params)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::SetInputParams, RpcPacker::pack(trackId, params));
+    Msg msg = rpc::make_request(MsgCode::SetInputParams, RpcPacker::pack(trackId, params));
     channel()->send(msg);
 }
 
@@ -375,7 +375,7 @@ async::Channel<TrackId, AudioInputParams> Playback::inputParamsChanged() const
 void Playback::processInput(const TrackId trackId) const
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ProcessInput, RpcPacker::pack(trackId));
+    Msg msg = rpc::make_request(MsgCode::ProcessInput, RpcPacker::pack(trackId));
     channel()->send(msg);
 }
 
@@ -384,7 +384,7 @@ muse::async::Promise<InputProcessingProgress> Playback::inputProcessingProgress(
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<InputProcessingProgress>([this, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetInputProcessingProgress, RpcPacker::pack(trackId));
+        Msg msg = rpc::make_request(MsgCode::GetInputProcessingProgress, RpcPacker::pack(trackId));
         channel()->send(msg, [this, resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             Ret ret;
@@ -410,14 +410,14 @@ muse::async::Promise<InputProcessingProgress> Playback::inputProcessingProgress(
 void Playback::clearCache(const TrackId trackId) const
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ClearCache, RpcPacker::pack(trackId));
+    Msg msg = rpc::make_request(MsgCode::ClearCache, RpcPacker::pack(trackId));
     channel()->send(msg);
 }
 
 void Playback::clearSources()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ClearSources);
+    Msg msg = rpc::make_request(MsgCode::ClearSources);
     channel()->send(msg);
 }
 
@@ -428,7 +428,7 @@ async::Promise<AudioOutputParams> Playback::outputParams(const TrackId trackId) 
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioOutputParams>([this, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetOutputParams, RpcPacker::pack(trackId));
+        Msg msg = rpc::make_request(MsgCode::GetOutputParams, RpcPacker::pack(trackId));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioOutputParams> ret;
@@ -449,7 +449,7 @@ async::Promise<AudioOutputParams> Playback::outputParams(const TrackId trackId) 
 void Playback::setOutputParams(const TrackId trackId, const AudioOutputParams& params)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::SetOutputParams, RpcPacker::pack(trackId, params));
+    Msg msg = rpc::make_request(MsgCode::SetOutputParams, RpcPacker::pack(trackId, params));
     channel()->send(msg);
 }
 
@@ -463,7 +463,7 @@ async::Promise<AudioOutputParams> Playback::masterOutputParams() const
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioOutputParams>([this](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetMasterOutputParams);
+        Msg msg = rpc::make_request(MsgCode::GetMasterOutputParams);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioOutputParams> ret;
@@ -484,14 +484,14 @@ async::Promise<AudioOutputParams> Playback::masterOutputParams() const
 void Playback::setMasterOutputParams(const AudioOutputParams& params)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::SetMasterOutputParams, RpcPacker::pack(params));
+    Msg msg = rpc::make_request(MsgCode::SetMasterOutputParams, RpcPacker::pack(params));
     channel()->send(msg);
 }
 
 void Playback::clearMasterOutputParams()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ClearMasterOutputParams);
+    Msg msg = rpc::make_request(MsgCode::ClearMasterOutputParams);
     channel()->send(msg);
 }
 
@@ -505,7 +505,7 @@ async::Promise<AudioResourceMetaList> Playback::availableOutputResources() const
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioResourceMetaList>([this](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetAvailableOutputResources);
+        Msg msg = rpc::make_request(MsgCode::GetAvailableOutputResources);
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             AudioResourceMetaList list;
@@ -523,7 +523,7 @@ async::Promise<AudioSignalChanges> Playback::signalChanges(const TrackId trackId
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioSignalChanges>([this, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetSignalChanges, RpcPacker::pack(trackId));
+        Msg msg = rpc::make_request(MsgCode::GetSignalChanges, RpcPacker::pack(trackId));
         channel()->send(msg, [this, resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<StreamId> ret;
@@ -548,7 +548,7 @@ async::Promise<AudioSignalChanges> Playback::masterSignalChanges() const
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<AudioSignalChanges>([this](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::GetMasterSignalChanges);
+        Msg msg = rpc::make_request(MsgCode::GetMasterSignalChanges);
         channel()->send(msg, [this, resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<StreamId> ret;
@@ -573,7 +573,7 @@ async::Promise<bool> Playback::saveSoundTrack(const SoundTrackFormat& format, io
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<bool>([this, format, &dstDevice](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::SaveSoundTrack, RpcPacker::pack(format, reinterpret_cast<uintptr_t>(&dstDevice)));
+        Msg msg = rpc::make_request(MsgCode::SaveSoundTrack, RpcPacker::pack(format, reinterpret_cast<uintptr_t>(&dstDevice)));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             Ret ret;
@@ -594,14 +594,14 @@ async::Promise<bool> Playback::saveSoundTrack(const SoundTrackFormat& format, io
 void Playback::abortSavingAllSoundTracks()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::AbortSavingAllSoundTracks);
+    Msg msg = rpc::make_request(MsgCode::AbortSavingAllSoundTracks);
     channel()->send(msg);
 }
 
 SaveSoundTrackProgress Playback::saveSoundTrackProgressChanged() const
 {
     if (!m_saveSoundTrackProgressStreamInited) {
-        Msg msg = rpc::make_request(Method::GetSaveSoundTrackProgress);
+        Msg msg = rpc::make_request(MsgCode::GetSaveSoundTrackProgress);
         channel()->send(msg, [this](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             StreamId streamId = 0;
@@ -628,6 +628,6 @@ SaveSoundTrackProgress Playback::saveSoundTrackProgressChanged() const
 void Playback::clearAllFx()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ClearAllFx);
+    Msg msg = rpc::make_request(MsgCode::ClearAllFx);
     channel()->send(msg);
 }

--- a/src/framework/audio/main/internal/player.cpp
+++ b/src/framework/audio/main/internal/player.cpp
@@ -42,7 +42,7 @@ void Player::init()
             m_playbackStatus = st;
         });
 
-        Msg msg = rpc::make_request(Method::GetPlaybackStatus);
+        Msg msg = rpc::make_request(MsgCode::GetPlaybackStatus);
         channel()->send(msg, [this](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             PlaybackStatus status = PlaybackStatus::Stopped;
@@ -62,7 +62,7 @@ void Player::init()
             m_playbackPosition = newPos;
         });
 
-        Msg msg = rpc::make_request(Method::GetPlaybackPosition);
+        Msg msg = rpc::make_request(MsgCode::GetPlaybackPosition);
         channel()->send(msg, [this](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             secs_t pos = 0.0;
@@ -83,7 +83,7 @@ async::Promise<Ret> Player::prepareToPlay()
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<Ret>([this](auto resolve, auto) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::PrepareToPlay);
+        Msg msg = rpc::make_request(MsgCode::PrepareToPlay);
         channel()->send(msg, [resolve](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             Ret ret;
@@ -101,7 +101,7 @@ async::Promise<Ret> Player::prepareToPlay()
 void Player::play(const secs_t delay)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::Play, RpcPacker::pack(delay));
+    Msg msg = rpc::make_request(MsgCode::Play, RpcPacker::pack(delay));
     channel()->send(msg);
 }
 
@@ -113,35 +113,35 @@ void Player::seek(const secs_t newPosition, const bool flushSound)
         return;
     }
 
-    Msg msg = rpc::make_request(Method::Seek, RpcPacker::pack(newPosition, flushSound));
+    Msg msg = rpc::make_request(MsgCode::Seek, RpcPacker::pack(newPosition, flushSound));
     channel()->send(msg);
 }
 
 void Player::stop()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::Stop);
+    Msg msg = rpc::make_request(MsgCode::Stop);
     channel()->send(msg);
 }
 
 void Player::pause()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::Pause);
+    Msg msg = rpc::make_request(MsgCode::Pause);
     channel()->send(msg);
 }
 
 void Player::resume(const secs_t delay)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::Resume, RpcPacker::pack(delay));
+    Msg msg = rpc::make_request(MsgCode::Resume, RpcPacker::pack(delay));
     channel()->send(msg);
 }
 
 void Player::setDuration(const secs_t duration)
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::SetDuration, RpcPacker::pack(duration));
+    Msg msg = rpc::make_request(MsgCode::SetDuration, RpcPacker::pack(duration));
     channel()->send(msg);
 }
 
@@ -150,7 +150,7 @@ async::Promise<bool> Player::setLoop(const secs_t from, const secs_t to)
     ONLY_AUDIO_MAIN_THREAD;
     return async::make_promise<bool>([this, from, to](auto resolve, auto reject) {
         ONLY_AUDIO_MAIN_THREAD;
-        Msg msg = rpc::make_request(Method::SetLoop, RpcPacker::pack(from, to));
+        Msg msg = rpc::make_request(MsgCode::SetLoop, RpcPacker::pack(from, to));
         channel()->send(msg, [resolve, reject](const Msg& res) {
             ONLY_AUDIO_MAIN_THREAD;
             Ret ret;
@@ -171,7 +171,7 @@ async::Promise<bool> Player::setLoop(const secs_t from, const secs_t to)
 void Player::resetLoop()
 {
     ONLY_AUDIO_MAIN_THREAD;
-    Msg msg = rpc::make_request(Method::ResetLoop);
+    Msg msg = rpc::make_request(MsgCode::ResetLoop);
     channel()->send(msg);
 }
 

--- a/src/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/src/framework/audio/main/internal/startaudiocontroller.cpp
@@ -81,7 +81,7 @@ void StartAudioController::th_setupEngine()
 
 void StartAudioController::init()
 {
-    m_rpcChannel->onMethod(rpc::Method::EngineRunning, [this](const rpc::Msg&) {
+    m_rpcChannel->onNotification(rpc::MsgCode::EngineRunning, [this](const rpc::Msg&) {
         soundFontController()->loadSoundFonts();
 
         m_isEngineRunning.set(true);
@@ -223,7 +223,7 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
 
     AudioEngineConfig conf = configuration()->engineConfig();
     auto sendEngineInit = [this, activeSpec, conf]() {
-        m_rpcChannel->send(rpc::make_request(Method::EngineInit, RpcPacker::pack(activeSpec.output, conf)), [this](const Msg&) {
+        m_rpcChannel->send(rpc::make_request(MsgCode::EngineInit, RpcPacker::pack(activeSpec.output, conf)), [this](const Msg&) {
             m_isAudioStarted.set(true);
         });
     };
@@ -243,7 +243,7 @@ void StartAudioController::stopAudioProcessing()
 {
 #ifndef Q_OS_WASM
     if (m_isAudioStarted.val) {
-        m_rpcChannel->send(rpc::make_request(Method::EngineDeinit), [this](const Msg&) {
+        m_rpcChannel->send(rpc::make_request(MsgCode::EngineDeinit), [this](const Msg&) {
             m_isAudioStarted.set(false);
         });
     }

--- a/src/framework/audio/main/internal/transporteventscontroller.cpp
+++ b/src/framework/audio/main/internal/transporteventscontroller.cpp
@@ -32,7 +32,7 @@ void TransportEventsController::init()
 {
     ONLY_AUDIO_MAIN_THREAD;
 
-    channel()->onMethod(Method::TransportEventReceived, [this](const Msg& msg) {
+    channel()->onNotification(MsgCode::TransportEventReceived, [this](const Msg& msg) {
         ONLY_AUDIO_MAIN_THREAD;
 
         TransportEvent event;
@@ -48,7 +48,7 @@ void TransportEventsController::deinit()
 {
     ONLY_AUDIO_MAIN_THREAD;
 
-    channel()->onMethod(Method::TransportEventReceived, nullptr);
+    channel()->onNotification(MsgCode::TransportEventReceived, nullptr);
 }
 
 void TransportEventsController::onEventReceived(const TransportEvent& event)

--- a/src/framework/audio/main/platform/general/generalsoundfontcontroller.cpp
+++ b/src/framework/audio/main/platform/general/generalsoundfontcontroller.cpp
@@ -68,10 +68,10 @@ void GeneralSoundFontController::loadSoundFonts(const std::vector<io::path_t>& p
     for (const io::path_t& p : paths) {
         uris.push_back(synth::SoundFontUri::fromLocalFile(p));
     }
-    channel()->send(rpc::make_request(Method::LoadSoundFonts, RpcPacker::pack(uris)));
+    channel()->send(rpc::make_request(MsgCode::LoadSoundFonts, RpcPacker::pack(uris)));
 }
 
 void GeneralSoundFontController::addSoundFont(const synth::SoundFontUri& uri)
 {
-    channel()->send(rpc::make_request(Method::AddSoundFont, RpcPacker::pack(uri)));
+    channel()->send(rpc::make_request(MsgCode::AddSoundFont, RpcPacker::pack(uri)));
 }


### PR DESCRIPTION


1. Previously, there was a distinction between method messages and stream messages (for optimization purposes, stream messages are sent frequently, and we wanted to reduce their size). However, the order in which method and stream messages are received turned out to be important. Therefore, this distinction was de facto removed. Now this distinction has been completely removed (only the semantic distinction remains).

2. There's now a clear distinction between request and notification subscriptions. This is primarily done to improve semantics, making it clearer which is which.