### PR TITLE
[4.7.0] VST: fix blank view when moving/resizing on Windows

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -23,6 +23,10 @@
 
 #include <QQuickWindow>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 #ifdef Q_OS_LINUX
 #define USE_LINUX_RUNLOOP
 #endif
@@ -80,7 +84,7 @@ static FIDString currentPlatformUiType()
 }
 
 VstView::VstView(QQuickItem* parent)
-    : QQuickItem(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
+    : QQuickItem(parent), QAbstractNativeEventFilter(), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
     FUNKNOWN_CTOR; // IPlugFrame
 
@@ -148,10 +152,25 @@ void VstView::init()
     updateViewGeometry();
 
     m_vstWindow->show();
+
+#ifdef Q_OS_WIN
+    HWND winHwnd = reinterpret_cast<HWND>(m_vstWindow->winId());
+    HWND viewHwnd = GetWindow(winHwnd, GW_CHILD);
+    m_rootHandle = GetAncestor(winHwnd, GA_ROOT);
+
+    if (viewHwnd && IsWindow(viewHwnd)) {
+        m_plugViewHandle = viewHwnd;
+        qApp->installNativeEventFilter(this);
+    }
+#endif
 }
 
 void VstView::deinit()
 {
+#ifdef Q_OS_WIN
+    qApp->removeNativeEventFilter(this);
+#endif
+
     m_screenMetricsTimer.stop();
 
     if (m_view) {
@@ -160,6 +179,8 @@ void VstView::deinit()
         m_view->removed();
 #endif
         m_view = nullptr;
+        m_plugViewHandle = nullptr;
+        m_rootHandle = nullptr;
 
         m_vstWindow->hide();
         delete m_vstWindow;
@@ -223,6 +244,61 @@ Steinberg::tresult VstView::resizeView(Steinberg::IPlugView* view, Steinberg::Vi
     m_resizeViewCalled = false;
 
     return Steinberg::kResultTrue;
+}
+
+bool VstView::nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result)
+{
+#ifdef Q_OS_WIN
+    if (!m_vstWindow || !m_vstWindow->isVisible() || !m_plugViewHandle || !m_rootHandle) {
+        return false;
+    }
+
+    if (eventType != QByteArrayLiteral("windows_generic_MSG")) {
+        return false;
+    }
+
+    const MSG* msg = static_cast<MSG*>(message);
+    if (!msg->hwnd) {
+        return false;
+    }
+    if (msg->message != WM_ERASEBKGND && msg->message != WM_WINDOWPOSCHANGED) {
+        return false;
+    }
+
+    if (msg->hwnd != m_rootHandle) {
+        const HWND root = GetAncestor(msg->hwnd, GA_ROOT);
+        if (root != m_rootHandle) {
+            return false;
+        }
+    }
+
+    if (msg->message == WM_ERASEBKGND) {
+        *result = 1;
+        return true; // tell Windows: "already erased"
+    }
+
+    if (msg->message == WM_WINDOWPOSCHANGED && !m_updatePending) {
+        m_updatePending = true;
+        QTimer::singleShot(16, this, [this]() { // ~60 FPS
+            m_updatePending = false;
+
+            HWND hwnd = reinterpret_cast<HWND>(m_plugViewHandle);
+            if (!hwnd || !IsWindow(hwnd)) {
+                m_plugViewHandle = nullptr;
+                return;
+            }
+
+            RedrawWindow(hwnd, nullptr, nullptr,
+                         RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
+        });
+    }
+#else
+    Q_UNUSED(eventType);
+    Q_UNUSED(message);
+    Q_UNUSED(result);
+#endif
+
+    return false;
 }
 
 void VstView::updateScreenMetrics()

--- a/src/framework/vst/qml/Muse/Vst/vstview.h
+++ b/src/framework/vst/qml/Muse/Vst/vstview.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QQuickItem>
+#include <QAbstractNativeEventFilter>
 #include <QTimer>
 #include <qqmlintegration.h>
 
@@ -30,7 +31,7 @@
 
 namespace muse::vst {
 class RunLoop;
-class VstView : public QQuickItem, public Steinberg::IPlugFrame, public muse::Contextable
+class VstView : public QQuickItem, public QAbstractNativeEventFilter, public Steinberg::IPlugFrame, public muse::Contextable
 {
     Q_OBJECT
 
@@ -84,6 +85,8 @@ signals:
     void minimumWidthChanged();
 
 private:
+    bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override;
+
     struct ScreenMetrics {
         QSize availableSize;
         double devicePixelRatio = 0.0;
@@ -105,7 +108,11 @@ private:
     // different padding properties it exposes.
     QWindow* m_vstWindow = nullptr;
 
+    void* m_plugViewHandle = nullptr;
+    void* m_rootHandle = nullptr;
+
     bool m_resizeViewCalled = false;
+    bool m_updatePending = false;
 
     QScreen* m_currentScreen = nullptr;
     ScreenMetrics m_screenMetrics;


### PR DESCRIPTION
Also resolves: https://github.com/musescore/MuseScore/issues/29711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability for VST plugin windows on Windows by preventing unnecessary background erases and reducing redundant redraws when plugin windows move or resize, eliminating flicker and excessive repaints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->