### PR TITLE
Fix check for language updates with 'system default' language

### DIFF
--- a/src/framework/languages/internal/languagesservice.cpp
+++ b/src/framework/languages/internal/languagesservice.cpp
@@ -368,7 +368,7 @@ Progress LanguagesService::update(const QString& languageCode)
 
     downloadServerLanguagesInfo(
         effectiveLanguageCode,
-        [this, languageCode, progress]( const RetVal<QJsonObject>& res) mutable {
+        [this, effectiveLanguageCode, progress]( const RetVal<QJsonObject>& res) mutable {
         if (!res.ret) {
             LOGE() << "Failed to download server languages info: " << res.ret.toString();
             progress.finish(res.ret);
@@ -376,9 +376,10 @@ Progress LanguagesService::update(const QString& languageCode)
         }
 
         QJsonObject serverLanguagesInfo = res.val;
-        QStringList languagesToUpdate = this->languagesToUpdate(languageCode, serverLanguagesInfo);
+        QStringList languagesToUpdate = this->languagesToUpdate(effectiveLanguageCode, serverLanguagesInfo);
 
         if (languagesToUpdate.isEmpty()) {
+            m_languageUpdateInProgress = false;
             progress.finish(make_ret(Err::AlreadyUpToDate));
             return;
         }


### PR DESCRIPTION
Resolves: #32218

The check for language updates was not working for "system default" because the "system" language code was being used instead of the effective code.

There was also a bug where the languageUpdateInProgress status was not reset in the case where the language was already up to date, and thus one was not able to check for language updates again. This has also been fixed.
