### PR TITLE
[audio] added audio context init/deinit

### DIFF
--- a/src/framework/audio/common/audioerrors.h
+++ b/src/framework/audio/common/audioerrors.h
@@ -61,6 +61,7 @@ enum class Err {
     UnknownPluginType = 351,
     InvalidAudioOutput = 352,
     InvalidSynth = 353,
+    AudioContextAlreadyExists = 354,
 
     // clock
     InvalidTimeLoop = 360,

--- a/src/framework/audio/common/audioerrors.h
+++ b/src/framework/audio/common/audioerrors.h
@@ -62,6 +62,7 @@ enum class Err {
     InvalidAudioOutput = 352,
     InvalidSynth = 353,
     AudioContextAlreadyExists = 354,
+    InvalidContext = 355,
 
     // clock
     InvalidTimeLoop = 360,

--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -56,6 +56,8 @@ using volume_dbfs_t = db_t;
 using gain_t = float;
 using balance_t = float;
 
+using AudioCtxId = uint8_t;
+
 using TrackId = int32_t;
 using TrackIdList = std::vector<TrackId>;
 using TrackName = std::string;
@@ -93,12 +95,6 @@ struct OutputSpec {
     }
 
     inline bool operator!=(const OutputSpec& other) const { return !this->operator==(other); }
-};
-
-struct RenderConstraints {
-    // mixer
-    size_t desiredAudioThreadNumber = 0;
-    size_t minTrackCountForMultithreading = 0;
 };
 
 enum class SoundTrackType {

--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -39,14 +39,9 @@
 #include "log.h"
 
 namespace muse::audio {
-using msecs_t = muse::msecs_t;
 using secs_t = muse::secs_t;
-
-inline secs_t milisecsToSecs(msecs_t ms) { return secs_t(ms.raw() / 1000.0); }
-inline secs_t microsecsToSecs(msecs_t us) { return secs_t(us.raw() / 1000000.0); }
-
-inline msecs_t secsToMilisecs(secs_t s) { return msecs_t(s.raw() * 1000.0); }
-inline msecs_t secsToMicrosecs(secs_t s) { return msecs_t(s.raw() * 1000000.0); }
+using msecs_t = muse::msecs_t;
+using usecs_t = muse::usecs_t;
 
 using samples_t = uint64_t;
 using sample_rate_t = uint64_t;

--- a/src/framework/audio/common/rpc/contextrpcchannel.cpp
+++ b/src/framework/audio/common/rpc/contextrpcchannel.cpp
@@ -24,9 +24,18 @@
 
 using namespace muse::audio::rpc;
 
+ContextRpcChannel::~ContextRpcChannel()
+{
+    for (auto id : m_streams) {
+        m_controller->removeStream(id);
+    }
+}
+
 void ContextRpcChannel::send(const Msg& msg, const Handler& onResponse)
 {
-    m_controller->send(msg, onResponse);
+    Msg newMsg = msg;
+    newMsg.ctxId = contextId();
+    m_controller->send(newMsg, onResponse);
 }
 
 void ContextRpcChannel::onRequest(MsgCode code, Handler h)
@@ -42,11 +51,13 @@ void ContextRpcChannel::onNotification(MsgCode code, Handler h)
 void ContextRpcChannel::addStream(std::shared_ptr<IRpcStream> s)
 {
     s->setCtxId(contextId());
+    m_streams.insert(s->streamId());
     m_controller->addStream(s);
 }
 
 void ContextRpcChannel::removeStream(StreamId id)
 {
+    m_streams.erase(id);
     m_controller->removeStream(id);
 }
 

--- a/src/framework/audio/common/rpc/contextrpcchannel.h
+++ b/src/framework/audio/common/rpc/contextrpcchannel.h
@@ -33,6 +33,8 @@ public:
     ContextRpcChannel(const muse::modularity::ContextPtr& ctx, std::shared_ptr<IContextRpcChannelController> controller)
         : Contextable(ctx), m_controller(controller) {}
 
+    ~ContextRpcChannel();
+
     inline CtxId contextId() const
     {
         assert(iocContext());
@@ -56,5 +58,6 @@ public:
 
 private:
     std::shared_ptr<IContextRpcChannelController> m_controller;
+    std::set<StreamId> m_streams;
 };
 }

--- a/src/framework/audio/common/rpc/irpcchannel.h
+++ b/src/framework/audio/common/rpc/irpcchannel.h
@@ -43,6 +43,9 @@ enum class MsgCode {
     EngineRunning, // notification
     EngineDeinit,
 
+    ContextInit,
+    ContextDeinit,
+
     // Config
     EngineConfigChanged,
 
@@ -138,6 +141,9 @@ inline std::string to_string(MsgCode m)
     case MsgCode::EngineRunning: return "EngineRunning";
     case MsgCode::EngineInit: return "EngineInit";
     case MsgCode::EngineDeinit: return "EngineDeinit";
+
+    case MsgCode::ContextInit: return "ContextInit";
+    case MsgCode::ContextDeinit: return "ContextDeinit";
 
     // Config
     case MsgCode::EngineConfigChanged: return "EngineConfigChanged";

--- a/src/framework/audio/engine/iaudioengineconfiguration.h
+++ b/src/framework/audio/engine/iaudioengineconfiguration.h
@@ -43,8 +43,5 @@ public:
     virtual async::Channel<bool> isLazyProcessingOfOnlineSoundsEnabledChanged() const = 0;
 
     virtual AudioInputParams defaultAudioInputParams() const = 0;
-
-    virtual size_t desiredAudioThreadNumber() const = 0;
-    virtual size_t minTrackCountForMultithreading() const = 0;
 };
 }

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -36,7 +36,7 @@ using namespace muse;
 using namespace muse::audio;
 using namespace muse::audio::engine;
 
-AudioContext::AudioContext(const modularity::IoCID& ctxId)
+AudioContext::AudioContext(const AudioCtxId& ctxId)
     : m_ctxId(ctxId)
 {
     UNUSED(m_ctxId); // just for information
@@ -45,9 +45,9 @@ AudioContext::AudioContext(const modularity::IoCID& ctxId)
     m_mixer = std::make_shared<Mixer>();
 }
 
-Ret AudioContext::init(const RenderConstraints& consts)
+Ret AudioContext::init()
 {
-    m_mixer->init(consts.desiredAudioThreadNumber, consts.minTrackCountForMultithreading);
+    m_mixer->init();
     m_mixer->setPlayhead(std::static_pointer_cast<IPlayhead>(m_player));
 
     OutputSpec outputSpec = audioEngine()->outputSpec();

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -42,9 +42,9 @@ class AudioContext : public IAudioContext, public IGetTrackSource, public async:
     GlobalInject<IAudioEngineConfiguration> configuration;
 
 public:
-    AudioContext(const modularity::IoCID& ctxId);
+    AudioContext(const AudioCtxId& ctxId);
 
-    Ret init(const RenderConstraints& consts) override;
+    Ret init() override;
     void deinit() override;
 
     // Config
@@ -147,7 +147,7 @@ private:
     size_t tracksBeingProcessedCount() const;
     Ret doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackFormat& format);
 
-    modularity::IoCID m_ctxId = 0;
+    AudioCtxId m_ctxId = 0;
 
     OutputSpec m_outputSpec;
     std::shared_ptr<EnginePlayer> m_player;

--- a/src/framework/audio/engine/internal/audioengine.cpp
+++ b/src/framework/audio/engine/internal/audioengine.cpp
@@ -25,6 +25,7 @@
 #include "global/defer.h"
 
 #include "audio/common/audiosanitizer.h"
+#include "audio/common/audioerrors.h"
 
 #include "audiocontext.h"
 
@@ -38,7 +39,6 @@ static constexpr int MAX_SUPPORTED_AUDIO_CHANNELS = 2;
 
 AudioEngine::AudioEngine()
 {
-    m_context = std::make_shared<AudioContext>(0);
 }
 
 AudioEngine::~AudioEngine()
@@ -76,43 +76,53 @@ void AudioEngine::deinit()
     ONLY_AUDIO_ENGINE_THREAD;
     if (m_inited) {
         m_inited = false;
-        m_context = nullptr;
+
+        for (auto& p : m_contexts) {
+            p.second->deinit();
+        }
+        m_contexts.clear();
     }
 }
 
-std::shared_ptr<IAudioContext> AudioEngine::context(const modularity::IoCID& ctxId) const
+RetVal<std::shared_ptr<IAudioContext> > AudioEngine::addAudioContext(const AudioCtxId& ctxId)
 {
-    UNUSED(ctxId);
-    return m_context;
-/*
+    ONLY_AUDIO_ENGINE_THREAD;
+
+    using RetType = RetVal<std::shared_ptr<IAudioContext> >;
+
+    if (m_contexts.find(ctxId) != m_contexts.end()) {
+        return RetType::make_ret(Err::AudioContextAlreadyExists);
+    }
+    auto ctx = std::make_shared<AudioContext>(ctxId);
+    Ret ret = ctx->init();
+    if (ret) {
+        m_contexts[ctxId] = ctx;
+    }
+
+    return RetType::make_ok(ctx);
+}
+
+std::shared_ptr<IAudioContext> AudioEngine::context(const AudioCtxId& ctxId) const
+{
     auto it = m_contexts.find(ctxId);
     if (it != m_contexts.end()) {
         return it->second;
     }
-    auto context = std::make_shared<AudioContext>(ctxId);
-    m_contexts[ctxId] = context;
-    return context;
-*/
+    return nullptr;
 }
 
-void AudioEngine::destroyContext(const modularity::IoCID& ctxId)
+void AudioEngine::destroyContext(const AudioCtxId& ctxId)
 {
-    UNUSED(ctxId);
-/*
     auto it = m_contexts.find(ctxId);
     if (it != m_contexts.end()) {
+        it->second->deinit();
         m_contexts.erase(it);
     }
-*/
 }
 
 void AudioEngine::setOutputSpec(const OutputSpec& outputSpec)
 {
     ONLY_AUDIO_ENGINE_THREAD;
-
-    IF_ASSERT_FAILED(m_context) {
-        return;
-    }
 
     IF_ASSERT_FAILED(outputSpec.audioChannelCount <= MAX_SUPPORTED_AUDIO_CHANNELS) {
         return;
@@ -128,7 +138,9 @@ void AudioEngine::setOutputSpec(const OutputSpec& outputSpec)
 
     m_outputSpec = outputSpec;
 
-    m_context->setOutputSpec(outputSpec);
+    for (auto& p : m_contexts) {
+        p.second->setOutputSpec(outputSpec);
+    }
 
     m_outputSpecChanged.send(outputSpec);
 }
@@ -195,13 +207,23 @@ samples_t AudioEngine::process(float* buffer, samples_t samplesPerChannel)
     }
     case OperationType::NoOperation: {
         // normal playing
-        return m_context->process(buffer, samplesPerChannel);
+        //! TODO mix all contexts audio
+        samples_t totalProcessedSamples = 0;
+        for (auto& p : m_contexts) {
+            totalProcessedSamples = p.second->process(buffer, samplesPerChannel);
+        }
+        return totalProcessedSamples;
     }
     case OperationType::QuickOperation: {
         // wait
         LOGD() << "wait end of quick operation";
         std::scoped_lock<std::mutex> lock(m_quickOperationWaitMutex);
-        return m_context->process(buffer, samplesPerChannel);
+        //! TODO mix all contexts audio
+        samples_t totalProcessedSamples = 0;
+        for (auto& p : m_contexts) {
+            totalProcessedSamples = p.second->process(buffer, samplesPerChannel);
+        }
+        return totalProcessedSamples;
     }
     case OperationType::LongOperation: {
         return fillSilent(buffer, samplesPerChannel);

--- a/src/framework/audio/engine/internal/audioengine.cpp
+++ b/src/framework/audio/engine/internal/audioengine.cpp
@@ -93,12 +93,14 @@ RetVal<std::shared_ptr<IAudioContext> > AudioEngine::addAudioContext(const Audio
     if (m_contexts.find(ctxId) != m_contexts.end()) {
         return RetType::make_ret(Err::AudioContextAlreadyExists);
     }
+
     auto ctx = std::make_shared<AudioContext>(ctxId);
     Ret ret = ctx->init();
-    if (ret) {
-        m_contexts[ctxId] = ctx;
+    if (!ret) {
+        return RetType::make_ret(ret);
     }
 
+    m_contexts[ctxId] = ctx;
     return RetType::make_ok(ctx);
 }
 

--- a/src/framework/audio/engine/internal/audioengine.h
+++ b/src/framework/audio/engine/internal/audioengine.h
@@ -41,8 +41,9 @@ public:
     Ret init(const OutputSpec& outputSpec) override;
     void deinit() override;
 
-    std::shared_ptr<IAudioContext> context(const modularity::IoCID& ctxId) const override;
-    void destroyContext(const modularity::IoCID& ctxId) override;
+    RetVal<std::shared_ptr<IAudioContext> > addAudioContext(const AudioCtxId& ctxId) override;
+    std::shared_ptr<IAudioContext> context(const AudioCtxId& ctxId) const override;
+    void destroyContext(const AudioCtxId& ctxId) override;
 
     void setOutputSpec(const OutputSpec& outputSpec) override;
     OutputSpec outputSpec() const override;
@@ -59,9 +60,7 @@ private:
 
     std::atomic<bool> m_inited = false;
 
-    // Temporarily one context, for the transition phase
-    std::shared_ptr<AudioContext> m_context;
-    //mutable std::map<modularity::IoCID, std::shared_ptr<AudioContext> > m_contexts;
+    std::map<AudioCtxId, std::shared_ptr<AudioContext> > m_contexts;
 
     OutputSpec m_outputSpec;
     async::Channel<OutputSpec> m_outputSpecChanged;

--- a/src/framework/audio/engine/internal/audioengineconfiguration.cpp
+++ b/src/framework/audio/engine/internal/audioengineconfiguration.cpp
@@ -93,14 +93,3 @@ AudioInputParams AudioEngineConfiguration::defaultAudioInputParams() const
 
     return result;
 }
-
-size_t AudioEngineConfiguration::desiredAudioThreadNumber() const
-{
-    return 0;
-}
-
-size_t AudioEngineConfiguration::minTrackCountForMultithreading() const
-{
-    // Start mutlithreading-processing only when there are more or equal number of tracks
-    return 2;
-}

--- a/src/framework/audio/engine/internal/audioengineconfiguration.h
+++ b/src/framework/audio/engine/internal/audioengineconfiguration.h
@@ -42,9 +42,6 @@ public:
 
     AudioInputParams defaultAudioInputParams() const override;
 
-    size_t desiredAudioThreadNumber() const override;
-    size_t minTrackCountForMultithreading() const override;
-
 private:
 
     AudioEngineConfig m_conf;

--- a/src/framework/audio/engine/internal/enginecontroller.cpp
+++ b/src/framework/audio/engine/internal/enginecontroller.cpp
@@ -85,14 +85,8 @@ void EngineController::init(const OutputSpec& outputSpec, const AudioEngineConfi
     synthResolver()->init(configuration()->defaultAudioInputParams(), outputSpec);
     // ------------------------------------------------------------
 
-    RenderConstraints consts;
-    consts.desiredAudioThreadNumber = configuration()->desiredAudioThreadNumber();
-    consts.minTrackCountForMultithreading = configuration()->minTrackCountForMultithreading();
-
     // Setup audio engine
     audioEngine()->init(outputSpec);
-
-    audioEngine()->context()->init(consts);
 
     transportEventsDispatcher()->init();
 }
@@ -101,7 +95,6 @@ void EngineController::deinit()
 {
     //! AUDIO THREAD
     m_rpcController->deinit();
-    audioEngine()->context()->deinit();
     audioEngine()->deinit();
 }
 

--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -44,9 +44,12 @@
 using namespace muse::audio::engine;
 using namespace muse::audio::rpc;
 
-std::shared_ptr<IAudioContext> EngineRpcController::audioContext() const
+std::shared_ptr<IAudioContext> EngineRpcController::audioContext(rpc::CtxId ctxId) const
 {
-    return audioEngine()->context();
+    IF_ASSERT_FAILED(ctxId > 0) {
+        return nullptr;
+    }
+    return audioEngine()->context(static_cast<AudioCtxId>(ctxId));
 }
 
 void EngineRpcController::init()
@@ -102,31 +105,62 @@ void EngineRpcController::init()
     });
 
     // AudioContext
-    // Notification
-    audioContext()->trackAdded().onReceive(this, [this](TrackId trackId) {
-        channel()->send(rpc::make_notification(MsgCode::TrackAdded, RpcPacker::pack(trackId)));
+
+    // Init / Deinit
+    onQuickRequest(MsgCode::ContextInit, [this](const Msg& msg) {
+        ONLY_AUDIO_RPC_THREAD;
+
+        RetVal<std::shared_ptr<IAudioContext> > ret = audioEngine()->addAudioContext(msg.ctxId);
+        if (ret.ret) {
+            const std::shared_ptr<IAudioContext>& audioContext = ret.val;
+            // Notification
+            audioContext->trackAdded().onReceive(this, [this](TrackId trackId) {
+                channel()->send(rpc::make_notification(MsgCode::TrackAdded, RpcPacker::pack(trackId)));
+            });
+
+            audioContext->trackRemoved().onReceive(this, [this](TrackId trackId) {
+                channel()->send(rpc::make_notification(MsgCode::TrackRemoved, RpcPacker::pack(trackId)));
+            });
+
+            audioContext->inputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioInputParams& params) {
+                channel()->send(rpc::make_notification(MsgCode::InputParamsChanged, RpcPacker::pack(trackId, params)));
+            });
+
+            audioContext->outputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioOutputParams& params) {
+                channel()->send(rpc::make_notification(MsgCode::OutputParamsChanged, RpcPacker::pack(trackId, params)));
+            });
+
+            audioContext->masterOutputParamsChanged().onReceive(this, [this](const AudioOutputParams& params) {
+                channel()->send(rpc::make_notification(MsgCode::MasterOutputParamsChanged, RpcPacker::pack(params)));
+            });
+        }
+
+        channel()->send(rpc::make_response(msg, RpcPacker::pack(ret.ret)));
     });
 
-    audioContext()->trackRemoved().onReceive(this, [this](TrackId trackId) {
-        channel()->send(rpc::make_notification(MsgCode::TrackRemoved, RpcPacker::pack(trackId)));
-    });
+    onQuickRequest(MsgCode::ContextDeinit, [this](const Msg& msg) {
+        ONLY_AUDIO_RPC_THREAD;
+        auto audioContext = this->audioContext(msg.ctxId);
+        IF_ASSERT_FAILED(audioContext) {
+            return;
+        }
 
-    audioContext()->inputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioInputParams& params) {
-        channel()->send(rpc::make_notification(MsgCode::InputParamsChanged, RpcPacker::pack(trackId, params)));
-    });
+        audioContext->trackAdded().disconnect(this);
+        audioContext->trackRemoved().disconnect(this);
+        audioContext->inputParamsChanged().disconnect(this);
+        audioContext->outputParamsChanged().disconnect(this);
+        audioContext->masterOutputParamsChanged().disconnect(this);
 
-    audioContext()->outputParamsChanged().onReceive(this, [this](TrackId trackId, const AudioOutputParams& params) {
-        channel()->send(rpc::make_notification(MsgCode::OutputParamsChanged, RpcPacker::pack(trackId, params)));
-    });
+        audioEngine()->destroyContext(msg.ctxId);
 
-    audioContext()->masterOutputParamsChanged().onReceive(this, [this](const AudioOutputParams& params) {
-        channel()->send(rpc::make_notification(MsgCode::MasterOutputParamsChanged, RpcPacker::pack(params)));
+        Ret ret = make_ok();
+        channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
     // Tracks
     onQuickRequest(MsgCode::GetTrackIdList, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        RetVal<TrackIdList> ret = audioContext()->trackIdList();
+        RetVal<TrackIdList> ret = audioContext(msg.ctxId)->trackIdList();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -136,7 +170,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
             return;
         }
-        RetVal<TrackName> ret = audioContext()->trackName(trackId);
+        RetVal<TrackName> ret = audioContext(msg.ctxId)->trackName(trackId);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -164,7 +198,7 @@ void EngineRpcController::init()
 
         auto addTrackAndSendResponse = [this](const Msg& msg, const TrackName& trackName,
                                               const mpe::PlaybackData& playbackData, const AudioParams& params) {
-            RetVal2<TrackId, AudioParams> ret = audioContext()->addTrack(trackName, playbackData, params);
+            RetVal2<TrackId, AudioParams> ret = audioContext(msg.ctxId)->addTrack(trackName, playbackData, params);
             channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
         };
 
@@ -232,7 +266,7 @@ void EngineRpcController::init()
         }
         io::IODevice* device = reinterpret_cast<io::IODevice*>(devicePtr);
 
-        RetVal2<TrackId, AudioParams> ret = audioContext()->addTrack(trackName, device, params);
+        RetVal2<TrackId, AudioParams> ret = audioContext(msg.ctxId)->addTrack(trackName, device, params);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -243,7 +277,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackName, outputParams)) {
             return;
         }
-        RetVal2<TrackId, AudioOutputParams> ret = audioContext()->addAuxTrack(trackName, outputParams);
+        RetVal2<TrackId, AudioOutputParams> ret = audioContext(msg.ctxId)->addAuxTrack(trackName, outputParams);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -253,17 +287,17 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
             return;
         }
-        audioContext()->removeTrack(trackId);
+        audioContext(msg.ctxId)->removeTrack(trackId);
     });
 
-    onLongRequest(MsgCode::RemoveAllTracks, [this](const Msg&) {
+    onLongRequest(MsgCode::RemoveAllTracks, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->removeAllTracks();
+        audioContext(msg.ctxId)->removeAllTracks();
     });
 
     onQuickRequest(MsgCode::GetAvailableInputResources, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        AudioResourceMetaList list = audioContext()->availableInputResources();
+        AudioResourceMetaList list = audioContext(msg.ctxId)->availableInputResources();
         //! NOTE The list can be large.
         //! There can be many re-allocations, because of this it takes a long time to pack.
         //! Let's add a reserve. 300 is approximately the size of one element, we get empirically.
@@ -276,7 +310,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, meta)) {
             return;
         }
-        SoundPresetList list = audioContext()->availableSoundPresets(meta);
+        SoundPresetList list = audioContext(msg.ctxId)->availableSoundPresets(meta);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(list)));
     });
 
@@ -286,7 +320,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
             return;
         }
-        RetVal<AudioInputParams> ret = audioContext()->inputParams(trackId);
+        RetVal<AudioInputParams> ret = audioContext(msg.ctxId)->inputParams(trackId);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -297,7 +331,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId, params)) {
             return;
         }
-        audioContext()->setInputParams(trackId, params);
+        audioContext(msg.ctxId)->setInputParams(trackId, params);
     });
 
     onLongRequest(MsgCode::ProcessInput, [this](const Msg& msg) {
@@ -307,7 +341,7 @@ void EngineRpcController::init()
             return;
         }
 
-        audioContext()->processInput(trackId);
+        audioContext(msg.ctxId)->processInput(trackId);
     });
 
     onQuickRequest(MsgCode::GetInputProcessingProgress, [this](const Msg& msg) {
@@ -317,7 +351,7 @@ void EngineRpcController::init()
             return;
         }
 
-        RetVal<InputProcessingProgress> ret = audioContext()->inputProcessingProgress(trackId);
+        RetVal<InputProcessingProgress> ret = audioContext(msg.ctxId)->inputProcessingProgress(trackId);
         StreamId streamId = 0;
         if (ret.ret) {
             streamId = channel()->addSendStream(StreamName::InputProcessingProgressStream, ret.val.processedChannel);
@@ -333,18 +367,18 @@ void EngineRpcController::init()
             return;
         }
 
-        audioContext()->clearCache(trackId);
+        audioContext(msg.ctxId)->clearCache(trackId);
     });
 
-    onLongRequest(MsgCode::ClearSources, [this](const Msg&) {
+    onLongRequest(MsgCode::ClearSources, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->clearSources();
+        audioContext(msg.ctxId)->clearSources();
     });
 
     // Play
     onQuickRequest(MsgCode::PrepareToPlay, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->prepareToPlay().onResolve(this, [this, msg](const Ret& ret) {
+        audioContext(msg.ctxId)->prepareToPlay().onResolve(this, [this, msg](const Ret& ret) {
             channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
         });
     });
@@ -355,7 +389,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, delay)) {
             return;
         }
-        audioContext()->play(delay);
+        audioContext(msg.ctxId)->play(delay);
     });
 
     onQuickRequest(MsgCode::Seek, [this](const Msg& msg) {
@@ -365,17 +399,17 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, newPosition, flushSound)) {
             return;
         }
-        audioContext()->seek(newPosition, flushSound);
+        audioContext(msg.ctxId)->seek(newPosition, flushSound);
     });
 
-    onQuickRequest(MsgCode::Stop, [this](const Msg&) {
+    onQuickRequest(MsgCode::Stop, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->stop();
+        audioContext(msg.ctxId)->stop();
     });
 
-    onQuickRequest(MsgCode::Pause, [this](const Msg&) {
+    onQuickRequest(MsgCode::Pause, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->pause();
+        audioContext(msg.ctxId)->pause();
     });
 
     onQuickRequest(MsgCode::Resume, [this](const Msg& msg) {
@@ -384,7 +418,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, delay)) {
             return;
         }
-        audioContext()->resume(delay);
+        audioContext(msg.ctxId)->resume(delay);
     });
 
     onQuickRequest(MsgCode::SetDuration, [this](const Msg& msg) {
@@ -393,7 +427,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, duration)) {
             return;
         }
-        audioContext()->setDuration(duration);
+        audioContext(msg.ctxId)->setDuration(duration);
     });
 
     onQuickRequest(MsgCode::SetLoop, [this](const Msg& msg) {
@@ -403,20 +437,20 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, from, to)) {
             return;
         }
-        Ret ret = audioContext()->setLoop(from, to);
+        Ret ret = audioContext(msg.ctxId)->setLoop(from, to);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
-    onQuickRequest(MsgCode::ResetLoop, [this](const Msg&) {
+    onQuickRequest(MsgCode::ResetLoop, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->resetLoop();
+        audioContext(msg.ctxId)->resetLoop();
     });
 
     onQuickRequest(MsgCode::GetPlaybackStatus, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
 
-        PlaybackStatus status = audioContext()->playbackStatus();
-        async::Channel<PlaybackStatus> ch = audioContext()->playbackStatusChanged();
+        PlaybackStatus status = audioContext(msg.ctxId)->playbackStatus();
+        async::Channel<PlaybackStatus> ch = audioContext(msg.ctxId)->playbackStatusChanged();
         StreamId streamId = channel()->addSendStream(StreamName::PlaybackStatusStream, ch);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(status, streamId)));
     });
@@ -424,8 +458,8 @@ void EngineRpcController::init()
     onQuickRequest(MsgCode::GetPlaybackPosition, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
 
-        secs_t pos = audioContext()->playbackPosition();
-        async::Channel<secs_t> ch = audioContext()->playbackPositionChanged();
+        secs_t pos = audioContext(msg.ctxId)->playbackPosition();
+        async::Channel<secs_t> ch = audioContext(msg.ctxId)->playbackPositionChanged();
         StreamId streamId = channel()->addSendStream(StreamName::PlaybackPositionStream, ch);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(pos, streamId)));
     });
@@ -438,7 +472,7 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
             return;
         }
-        RetVal<AudioOutputParams> ret = audioContext()->outputParams(trackId);
+        RetVal<AudioOutputParams> ret = audioContext(msg.ctxId)->outputParams(trackId);
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -449,12 +483,12 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId, params)) {
             return;
         }
-        audioContext()->setOutputParams(trackId, params);
+        audioContext(msg.ctxId)->setOutputParams(trackId, params);
     });
 
     onQuickRequest(MsgCode::GetMasterOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        RetVal<AudioOutputParams> ret = audioContext()->masterOutputParams();
+        RetVal<AudioOutputParams> ret = audioContext(msg.ctxId)->masterOutputParams();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
     });
 
@@ -464,17 +498,17 @@ void EngineRpcController::init()
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, params)) {
             return;
         }
-        audioContext()->setMasterOutputParams(params);
+        audioContext(msg.ctxId)->setMasterOutputParams(params);
     });
 
-    onQuickRequest(MsgCode::ClearMasterOutputParams, [this](const Msg&) {
+    onQuickRequest(MsgCode::ClearMasterOutputParams, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->clearMasterOutputParams();
+        audioContext(msg.ctxId)->clearMasterOutputParams();
     });
 
     onQuickRequest(MsgCode::GetAvailableOutputResources, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        AudioResourceMetaList list = audioContext()->availableOutputResources();
+        AudioResourceMetaList list = audioContext(msg.ctxId)->availableOutputResources();
         channel()->send(rpc::make_response(msg, RpcPacker::pack(list)));
     });
 
@@ -485,7 +519,7 @@ void EngineRpcController::init()
             return;
         }
 
-        RetVal<AudioSignalChanges> ret = audioContext()->signalChanges(trackId);
+        RetVal<AudioSignalChanges> ret = audioContext(msg.ctxId)->signalChanges(trackId);
         StreamId streamId = 0;
         if (ret.ret) {
             streamId = channel()->addSendStream(StreamName::AudioSignalStream, ret.val);
@@ -500,7 +534,7 @@ void EngineRpcController::init()
 
     onQuickRequest(MsgCode::GetMasterSignalChanges, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        RetVal<AudioSignalChanges> ret = audioContext()->masterSignalChanges();
+        RetVal<AudioSignalChanges> ret = audioContext(msg.ctxId)->masterSignalChanges();
         StreamId streamId = 0;
         if (ret.ret) {
             streamId = channel()->addSendStream(StreamName::AudioMasterSignalStream, ret.val);
@@ -521,19 +555,19 @@ void EngineRpcController::init()
             return;
         }
         io::IODevice& dstDevice = *reinterpret_cast<io::IODevice*>(dstDevicePtr);
-        audioContext()->saveSoundTrack(dstDevice, format).onResolve(this, [this, msg](const Ret& ret) {
+        audioContext(msg.ctxId)->saveSoundTrack(dstDevice, format).onResolve(this, [this, msg](const Ret& ret) {
             channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
         });
     });
 
-    onLongRequest(MsgCode::AbortSavingAllSoundTracks, [this](const Msg&) {
+    onLongRequest(MsgCode::AbortSavingAllSoundTracks, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->abortSavingAllSoundTracks();
+        audioContext(msg.ctxId)->abortSavingAllSoundTracks();
     });
 
     onQuickRequest(MsgCode::GetSaveSoundTrackProgress, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        SaveSoundTrackProgress ch = audioContext()->saveSoundTrackProgressChanged();
+        SaveSoundTrackProgress ch = audioContext(msg.ctxId)->saveSoundTrackProgressChanged();
         ch.onReceive(this, [this](int64_t current, int64_t total, SaveSoundTrackStage stage) {
             ONLY_AUDIO_RPC_THREAD;
             m_saveSoundTrackProgressStream.send(current, total, stage);
@@ -547,9 +581,9 @@ void EngineRpcController::init()
         channel()->send(rpc::make_response(msg, RpcPacker::pack(m_saveSoundTrackProgressStreamId)));
     });
 
-    onQuickRequest(MsgCode::ClearAllFx, [this](const Msg&) {
+    onQuickRequest(MsgCode::ClearAllFx, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        audioContext()->clearAllFx();
+        audioContext(msg.ctxId)->clearAllFx();
     });
 }
 
@@ -587,12 +621,6 @@ void EngineRpcController::deinit()
     ONLY_AUDIO_RPC_THREAD;
 
     m_terminated = true;
-
-    audioContext()->trackAdded().disconnect(this);
-    audioContext()->trackRemoved().disconnect(this);
-    audioContext()->inputParamsChanged().disconnect(this);
-    audioContext()->outputParamsChanged().disconnect(this);
-    audioContext()->masterOutputParamsChanged().disconnect(this);
 
     for (const MsgCode& m : m_usedRequests) {
         channel()->onRequest(m, nullptr);

--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -23,6 +23,7 @@
 
 #include "audio/common/audiosanitizer.h"
 #include "audio/common/rpc/rpcpacker.h"
+#include "audio/common/audioerrors.h"
 
 #include "log.h"
 
@@ -49,7 +50,11 @@ std::shared_ptr<IAudioContext> EngineRpcController::audioContext(rpc::CtxId ctxI
     IF_ASSERT_FAILED(ctxId > 0) {
         return nullptr;
     }
-    return audioEngine()->context(static_cast<AudioCtxId>(ctxId));
+    auto audioContext = audioEngine()->context(static_cast<AudioCtxId>(ctxId));
+    IF_ASSERT_FAILED(audioContext) {
+        return nullptr;
+    }
+    return audioContext;
 }
 
 void EngineRpcController::init()
@@ -112,6 +117,10 @@ void EngineRpcController::init()
 
         RetVal<std::shared_ptr<IAudioContext> > ret = audioEngine()->addAudioContext(msg.ctxId);
         if (ret.ret) {
+            IF_ASSERT_FAILED(ret.val) {
+                return;
+            }
+
             const std::shared_ptr<IAudioContext>& audioContext = ret.val;
             // Notification
             audioContext->trackAdded().onReceive(this, [this](TrackId trackId) {
@@ -160,18 +169,28 @@ void EngineRpcController::init()
     // Tracks
     onQuickRequest(MsgCode::GetTrackIdList, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
-        RetVal<TrackIdList> ret = audioContext(msg.ctxId)->trackIdList();
-        channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
+        if (auto actx = audioContext(msg.ctxId)) {
+            RetVal<TrackIdList> ret = actx->trackIdList();
+            channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
+        } else {
+            channel()->send(rpc::make_response(msg, RpcPacker::pack(RetVal<TrackIdList>::make_ret(Err::InvalidContext))));
+        }
     });
 
     onQuickRequest(MsgCode::GetTrackName, [this](const Msg& msg) {
         ONLY_AUDIO_RPC_THREAD;
+
         TrackId trackId = 0;
         IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
             return;
         }
-        RetVal<TrackName> ret = audioContext(msg.ctxId)->trackName(trackId);
-        channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
+
+        if (auto actx = audioContext(msg.ctxId)) {
+            RetVal<TrackName> ret = actx->trackName(trackId);
+            channel()->send(rpc::make_response(msg, RpcPacker::pack(ret)));
+        } else {
+            channel()->send(rpc::make_response(msg, RpcPacker::pack(RetVal<TrackName>::make_ret(Err::InvalidContext))));
+        }
     });
 
     onLongRequest(MsgCode::AddTrackWithPlaybackData, [this](const Msg& msg) {

--- a/src/framework/audio/engine/internal/enginerpccontroller.h
+++ b/src/framework/audio/engine/internal/enginerpccontroller.h
@@ -47,7 +47,7 @@ public:
 
 private:
 
-    std::shared_ptr<IAudioContext> audioContext() const;
+    std::shared_ptr<IAudioContext> audioContext(rpc::CtxId ctxId) const;
 
     void onLongRequest(rpc::MsgCode code, const rpc::Handler& h);
     void onQuickRequest(rpc::MsgCode code, const rpc::Handler& h);

--- a/src/framework/audio/engine/internal/iaudiocontext.h
+++ b/src/framework/audio/engine/internal/iaudiocontext.h
@@ -33,7 +33,7 @@ public:
     virtual ~IAudioContext() = default;
 
     // Init
-    virtual Ret init(const RenderConstraints& consts) = 0;
+    virtual Ret init() = 0;
     virtual void deinit() = 0;
 
     // Config

--- a/src/framework/audio/engine/internal/iaudioengine.h
+++ b/src/framework/audio/engine/internal/iaudioengine.h
@@ -26,7 +26,6 @@
 #include "modularity/imoduleinterface.h"
 
 #include "global/async/channel.h"
-#include "global/modularity/ioc.h"
 
 #include "audio/common/audiotypes.h"
 
@@ -43,8 +42,9 @@ public:
     virtual Ret init(const OutputSpec& outputSpec) = 0;
     virtual void deinit() = 0;
 
-    virtual std::shared_ptr<IAudioContext> context(const modularity::IoCID& ctxId = 0) const = 0;
-    virtual void destroyContext(const modularity::IoCID& ctxId) = 0;
+    virtual RetVal<std::shared_ptr<IAudioContext> > addAudioContext(const AudioCtxId& ctxId) = 0;
+    virtual std::shared_ptr<IAudioContext> context(const AudioCtxId& ctxId) const = 0;
+    virtual void destroyContext(const AudioCtxId& ctxId) = 0;
 
     virtual void setOutputSpec(const OutputSpec& outputSpec) = 0;
     virtual OutputSpec outputSpec() const = 0;

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -39,30 +39,26 @@ using namespace muse::async;
 using namespace muse::audio;
 using namespace muse::audio::engine;
 
+constexpr size_t MIN_TRACK_COUNT_FOR_MULTITHREADING = 2;
+
 Mixer::~Mixer()
 {
     ONLY_AUDIO_MAIN_OR_ENGINE_THREAD;
     delete m_taskScheduler;
 }
 
-void Mixer::init(size_t desiredAudioThreadNumber, size_t minTrackCountForMultithreading)
+void Mixer::init()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
 #ifdef MUSE_THREADS_SUPPORT
-    m_taskScheduler = new TaskScheduler(static_cast<thread_pool_size_t>(desiredAudioThreadNumber));
+    m_taskScheduler = new TaskScheduler();
 
     if (!m_taskScheduler->setThreadsPriority(ThreadPriority::High)) {
         LOGE() << "Unable to change audio threads priority";
     }
 
     AudioSanitizer::setMixerThreads(m_taskScheduler->threadIdSet());
-
-    m_minTrackCountForMultithreading = minTrackCountForMultithreading;
-
-#else
-    UNUSED(desiredAudioThreadNumber);
-    UNUSED(minTrackCountForMultithreading);
 #endif
 }
 
@@ -315,12 +311,12 @@ void Mixer::updateNonMutedTrackCount()
 bool Mixer::useMultithreading() const
 {
 #ifdef MUSE_THREADS_SUPPORT
-    if (m_nonMutedTrackCount < m_minTrackCountForMultithreading) {
+    if (m_nonMutedTrackCount < MIN_TRACK_COUNT_FOR_MULTITHREADING) {
         return false;
     }
 
     if (m_isIdle) {
-        if (m_tracksToProcessWhenIdle.size() < m_minTrackCountForMultithreading) {
+        if (m_tracksToProcessWhenIdle.size() < MIN_TRACK_COUNT_FOR_MULTITHREADING) {
             return false;
         }
     }

--- a/src/framework/audio/engine/internal/mixer.h
+++ b/src/framework/audio/engine/internal/mixer.h
@@ -49,7 +49,7 @@ class Mixer : public AbstractAudioSource, public async::Asyncable, public std::e
 public:
     ~Mixer() override;
 
-    void init(size_t desiredAudioThreadNumber, size_t minTrackCountForMultithreading);
+    void init();
 
     IAudioSourcePtr mixedSource();
 
@@ -99,7 +99,6 @@ private:
 
     TaskScheduler* m_taskScheduler = nullptr;
 
-    size_t m_minTrackCountForMultithreading = 0;
     size_t m_nonMutedTrackCount = 0;
 
     AudioOutputParams m_masterParams;

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -383,7 +383,7 @@ void FluidSynth::flushSound()
 
 TimePosition FluidSynth::playbackPosition() const
 {
-    return TimePosition::fromTime(muse::msecs_to_secs(m_sequencer.playbackPosition()), m_outputSpec.sampleRate);
+    return TimePosition::fromTime(muse::usecs_to_secs(m_sequencer.playbackPosition().raw()), m_outputSpec.sampleRate);
 }
 
 void FluidSynth::setPlaybackPosition(const TimePosition& position)
@@ -392,7 +392,10 @@ void FluidSynth::setPlaybackPosition(const TimePosition& position)
         return;
     }
 
-    m_sequencer.setPlaybackPosition(muse::secs_to_msecs(position.time()));
+    //! NOTE Don't trust that msecs_t is used everywhere here,
+    // in fact, usecs_t (microseconds) is stored there.
+    const usecs_t usecs = muse::secs_to_usecs(position.time());
+    m_sequencer.setPlaybackPosition(msecs_t(usecs.raw()));
 
     if (m_sequencer.isActive()) {
         setExpressionLevel(m_sequencer.currentExpressionLevel());

--- a/src/framework/audio/main/audiomodule.cpp
+++ b/src/framework/audio/main/audiomodule.cpp
@@ -149,14 +149,13 @@ modularity::IContextSetup* AudioModule::newContext(const muse::modularity::Conte
 void AudioContext::registerExports()
 {
     m_actionsController = std::make_shared<AudioActionsController>(iocContext());
-    m_mainPlayback = std::make_shared<Playback>(iocContext());
     m_transportEventsController = std::make_shared<TransportEventsController>(iocContext());
 
 #ifndef Q_OS_WASM
     ioc()->registerExport<ISoundFontInstallScenario>(mname, new GeneralSoundFontInstallScenario(iocContext()));
 #endif
 
-    ioc()->registerExport<IPlayback>(mname, m_mainPlayback);
+    ioc()->registerExport<IPlayback>(mname, new Playback(iocContext()));
 
     //! NOTE The real RPC channel itself is one global one.
     // But for each context there is a wrapper
@@ -184,12 +183,10 @@ void AudioContext::onInit(const IApplication::RunMode& mode)
     m_audioInited = true;
 
     m_actionsController->init();
-    m_mainPlayback->init();
     m_transportEventsController->init();
 }
 
 void AudioContext::onDeinit()
 {
-    m_mainPlayback->deinit();
     m_transportEventsController->deinit();
 }

--- a/src/framework/audio/main/audiomodule.h
+++ b/src/framework/audio/main/audiomodule.h
@@ -82,7 +82,6 @@ public:
 private:
     std::shared_ptr<AudioActionsController> m_actionsController;
     std::shared_ptr<TransportEventsController> m_transportEventsController;
-    std::shared_ptr<Playback> m_mainPlayback;
 
     bool m_audioInited = false;
 };

--- a/src/framework/audio/main/internal/playback.cpp
+++ b/src/framework/audio/main/internal/playback.cpp
@@ -34,7 +34,7 @@ using namespace muse::audio;
 using namespace muse::audio::rpc;
 using namespace muse::async;
 
-void Playback::init()
+async::Promise<Ret> Playback::init()
 {
     ONLY_AUDIO_MAIN_THREAD;
 
@@ -84,6 +84,40 @@ void Playback::init()
         }
         m_masterOutputParamsChanged.send(params);
     });
+
+    return async::make_promise<Ret>([this](auto resolve, auto /*reject*/) {
+        ONLY_AUDIO_MAIN_THREAD;
+
+        auto initContext = [this, resolve]() {
+            Msg msg = rpc::make_request(MsgCode::ContextInit);
+            channel()->send(msg, [this, resolve](const Msg& res) {
+                ONLY_AUDIO_MAIN_THREAD;
+                Ret ret;
+                IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
+                    return;
+                }
+                m_inited.set(ret.success());
+                (void)resolve(ret);
+            });
+        };
+
+        LOGD() << "isAudioStarted: " << startAudioController()->isAudioStarted();
+        if (startAudioController()->isAudioStarted()) {
+            initContext();
+        } else {
+            startAudioController()->isAudioStartedChanged().onReceive(this, [this, initContext](bool arg) {
+                LOGD() << "isAudioStartedChanged: " << arg;
+                if (arg) {
+                    initContext();
+                } else {
+                    LOGE() << "audio not started";
+                }
+                startAudioController()->isAudioStartedChanged().disconnect(this);
+            });
+        }
+
+        return Promise<Ret>::dummy_result();
+    }, PromiseType::AsyncByPromise);
 }
 
 void Playback::deinit()
@@ -95,53 +129,26 @@ void Playback::deinit()
     channel()->onNotification(MsgCode::InputParamsChanged, nullptr);
     channel()->onNotification(MsgCode::OutputParamsChanged, nullptr);
     channel()->onNotification(MsgCode::MasterOutputParamsChanged, nullptr);
-}
 
-bool Playback::isAudioStarted() const
-{
-    return startAudioController()->isAudioStarted();
-}
-
-async::Channel<bool> Playback::isAudioStartedChanged() const
-{
-    return startAudioController()->isAudioStartedChanged();
-}
-
-Promise<bool> Playback::initPlayback()
-{
-    ONLY_AUDIO_MAIN_THREAD;
-
-    return async::make_promise<bool>([this](auto resolve, auto /*reject*/) {
-        ONLY_AUDIO_MAIN_THREAD;
-
-        LOGD() << "isAudioStarted: " << startAudioController()->isAudioStarted();
-        if (startAudioController()->isAudioStarted()) {
-            (void)resolve(true);
-        } else {
-            startAudioController()->isAudioStartedChanged().onReceive(this, [this, resolve](bool arg) {
-                LOGD() << "isAudioStartedChanged: " << arg;
-                if (arg) {
-                    (void)resolve(true);
-                } else {
-                    LOGE() << "audio not started";
-                }
-                startAudioController()->isAudioStartedChanged().disconnect(this);
-            });
-        }
-
-        return Promise<bool>::dummy_result();
-    }, PromiseType::AsyncByPromise);
-}
-
-void Playback::deinitPlayback()
-{
-    ONLY_AUDIO_MAIN_THREAD;
     m_saveSoundTrackProgressStream = SaveSoundTrackProgress();
+
+    channel()->send(rpc::make_request(MsgCode::ContextDeinit));
+    m_inited.set(false);
+}
+
+bool Playback::isInited() const
+{
+    return m_inited.val;
+}
+
+async::Channel<bool> Playback::initedChanged() const
+{
+    return m_inited.ch;
 }
 
 IPlayerPtr Playback::player() const
 {
-    std::shared_ptr<Player> p = std::make_shared<Player>();
+    std::shared_ptr<Player> p = std::make_shared<Player>(iocContext());
     p->init();
     return p;
 }

--- a/src/framework/audio/main/internal/playback.cpp
+++ b/src/framework/audio/main/internal/playback.cpp
@@ -94,6 +94,7 @@ async::Promise<Ret> Playback::init()
                 ONLY_AUDIO_MAIN_THREAD;
                 Ret ret;
                 IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
+                    (void)resolve(muse::make_ret(Ret::Code::InternalError));
                     return;
                 }
                 m_inited.set(ret.success());
@@ -131,6 +132,8 @@ void Playback::deinit()
     channel()->onNotification(MsgCode::MasterOutputParamsChanged, nullptr);
 
     m_saveSoundTrackProgressStream = SaveSoundTrackProgress();
+    m_saveSoundTrackProgressStreamInited = false;
+    m_saveSoundTrackProgressStreamId = 0;
 
     channel()->send(rpc::make_request(MsgCode::ContextDeinit));
     m_inited.set(false);

--- a/src/framework/audio/main/internal/playback.h
+++ b/src/framework/audio/main/internal/playback.h
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_AUDIO_SEQUENCER_H
-#define MUSE_AUDIO_SEQUENCER_H
+#pragma once
 
 #include "../iplayback.h"
 #include "global/async/asyncable.h"
+#include "global/types/retval.h"
 
 #include "modularity/ioc.h"
 #include "common/rpc/icontextrpcchannel.h"
@@ -44,16 +44,11 @@ public:
     Playback(const muse::modularity::ContextPtr& ctx)
         : Contextable(ctx) {}
 
-    void init();
-    void deinit();
-
-    // 0. Check is audio system started
-    bool isAudioStarted() const override;
-    async::Channel<bool> isAudioStartedChanged() const override;
-
-    // 1. Init playback (temporary)
-    async::Promise<bool> initPlayback() override;
-    void deinitPlayback() override;
+    // 1. Init
+    async::Promise<Ret> init() override;
+    bool isInited() const override;
+    async::Channel<bool> initedChanged() const override;
+    void deinit() override;
 
     // 2. Setup tracks
     async::Promise<TrackIdList> trackIdList() const override;
@@ -109,6 +104,8 @@ public:
 
 private:
 
+    ValCh<bool> m_inited;
+
     async::Channel<TrackId> m_trackAdded;
     async::Channel<TrackId> m_trackRemoved;
     async::Channel<TrackId, AudioInputParams> m_inputParamsChanged;
@@ -120,5 +117,3 @@ private:
     mutable rpc::StreamId m_saveSoundTrackProgressStreamId = 0;
 };
 }
-
-#endif // MUSE_AUDIO_SEQUENCER_H

--- a/src/framework/audio/main/internal/player.h
+++ b/src/framework/audio/main/internal/player.h
@@ -28,15 +28,16 @@
 #include "global/async/asyncable.h"
 
 #include "modularity/ioc.h"
-#include "audio/common/rpc/irpcchannel.h"
+#include "audio/common/rpc/icontextrpcchannel.h"
 
 namespace muse::audio {
-class Player : public IPlayer, public async::Asyncable
+class Player : public IPlayer, public Contextable, public async::Asyncable
 {
-    GlobalInject<rpc::IRpcChannel> channel;
+    ContextInject<rpc::IContextRpcChannel> channel = { this };
 
 public:
-    Player() = default;
+    Player(const muse::modularity::ContextPtr& ctx)
+        : Contextable(ctx) {}
 
     void init();
 

--- a/src/framework/audio/main/iplayback.h
+++ b/src/framework/audio/main/iplayback.h
@@ -47,13 +47,11 @@ public:
 
     // A quick guide how to playback something:
 
-    // 0. Check is audio system started
-    virtual bool isAudioStarted() const = 0;
-    virtual async::Channel<bool> isAudioStartedChanged() const = 0;
-
-    // 1. Init playback (temporary)
-    virtual async::Promise<bool> initPlayback() = 0;
-    virtual void deinitPlayback() = 0;
+    // 1. Init
+    virtual async::Promise<Ret> init() = 0;
+    virtual bool isInited() const = 0;
+    virtual async::Channel<bool> initedChanged() const = 0;
+    virtual void deinit() = 0;
 
     // 2. Setup tracks
     virtual async::Promise<TrackIdList> trackIdList() const = 0;

--- a/src/framework/global/types/secs.h
+++ b/src/framework/global/types/secs.h
@@ -27,7 +27,11 @@
 namespace muse {
 using secs_t = number_t<double>;
 using msecs_t = number_t<int64_t>;
+using usecs_t = number_t<int64_t>;
 
 inline secs_t msecs_to_secs(msecs_t msecs) { return secs_t(msecs.raw() / 1000.0); }
 inline msecs_t secs_to_msecs(secs_t secs) { return msecs_t(static_cast<int64_t>(std::llround(secs.raw() * 1000.0))); }
+
+inline secs_t usecs_to_secs(usecs_t usecs) { return secs_t(usecs.raw() / 1000000.0); }
+inline usecs_t secs_to_usecs(secs_t secs) { return usecs_t(static_cast<int64_t>(std::llround(secs.raw() * 1000000.0))); }
 }

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -295,7 +295,10 @@ void MuseSamplerWrapper::setPlaybackPosition(const muse::audio::TimePosition& po
         return;
     }
 
-    m_sequencer.setPlaybackPosition(muse::secs_to_msecs(position.time()));
+    //! NOTE Don't trust that msecs_t is used everywhere here,
+    // in fact, usecs_t (microseconds) is stored there.
+    const usecs_t usecs = muse::secs_to_usecs(position.time());
+    m_sequencer.setPlaybackPosition(msecs_t(usecs.raw()));
 
     IF_ASSERT_FAILED(m_samplerLib && m_sampler) {
         return;
@@ -462,7 +465,7 @@ void MuseSamplerWrapper::updateRenderingProgress(ms_RenderingRangeList list, int
         }
 
         chunksDurationUs += info._end_us - info._start_us;
-        chunks.push_back({ audio::microsecsToSecs(info._start_us), audio::microsecsToSecs(info._end_us) });
+        chunks.push_back({ muse::usecs_to_secs(info._start_us), muse::usecs_to_secs(info._end_us) });
     }
 
     // Start progress

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -176,7 +176,10 @@ void VstSynthesiser::setPlaybackPosition(const muse::audio::TimePosition& positi
         return;
     }
 
-    m_sequencer.setPlaybackPosition(muse::secs_to_msecs(position.time()));
+    //! NOTE Don't trust that msecs_t is used everywhere here,
+    // in fact, usecs_t (microseconds) is stored there.
+    const usecs_t usecs = muse::secs_to_usecs(position.time());
+    m_sequencer.setPlaybackPosition(msecs_t(usecs.raw()));
 
     m_currentPosition = position;
 

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -176,7 +176,7 @@ void NotationPlayback::triggerCountIn(muse::midi::tick_t tick, muse::secs_t& cou
 {
     muse::mpe::duration_t durationInMicrosecs = 0;
     m_playbackModel.triggerCountIn(tick, durationInMicrosecs);
-    countInDuration = audio::microsecsToSecs(durationInMicrosecs);
+    countInDuration = muse::usecs_to_secs(durationInMicrosecs);
 }
 
 void NotationPlayback::triggerControllers(const muse::mpe::ControllerChangeEventList& list, notation::staff_idx_t staffIdx, int tick)

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -144,8 +144,8 @@ void PlaybackController::init()
 
         m_loadingProgress.start();
 
-        playback()->initPlayback().onResolve(this, [this](const bool& success) {
-            if (success) {
+        playback()->init().onResolve(this, [this](const Ret& ret) {
+            if (ret) {
                 setupPlayback();
             }
         });
@@ -1058,7 +1058,7 @@ void PlaybackController::resetPlayback()
 
     m_currentTick = 0;
 
-    playback()->deinitPlayback();
+    playback()->deinit();
 
     m_instrumentTrackIdMap.clear();
     m_auxTrackIdMap.clear();

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1498,7 +1498,7 @@ void PlaybackController::setupPlayer()
         updateCurrentTempo();
 
         secs_t endSecs = totalPlayTime();
-        if (pos + milisecsToSecs(1) >= endSecs) {
+        if (pos + muse::msecs_to_secs(1) >= endSecs) {
             stop();
         }
     });

--- a/src/playback/internal/soundprofilesrepository.cpp
+++ b/src/playback/internal/soundprofilesrepository.cpp
@@ -40,15 +40,15 @@ void SoundProfilesRepository::init()
     museProfile.name = config()->museSoundsProfileName();
     m_profilesMap.emplace(museProfile.name, std::move(museProfile));
 
-    if (playback()->isAudioStarted()) {
+    if (playback()->isInited()) {
         refresh();
         return;
     }
 
-    playback()->isAudioStartedChanged().onReceive(this, [this](bool started) {
-        if (started) {
+    playback()->initedChanged().onReceive(this, [this](bool inited) {
+        if (inited) {
             refresh();
-            playback()->isAudioStartedChanged().disconnect(this);
+            playback()->initedChanged().disconnect(this);
         }
     });
 }

--- a/src/playback/playbacktypes.h
+++ b/src/playback/playbacktypes.h
@@ -67,12 +67,12 @@ static const QTime ZERO_TIME(0, 0, 0, 0);
 
 inline QTime timeFromSeconds(muse::audio::secs_t seconds)
 {
-    return ZERO_TIME.addMSecs(muse::audio::secsToMilisecs(seconds));
+    return ZERO_TIME.addMSecs(muse::secs_to_msecs(seconds));
 }
 
 inline muse::audio::secs_t timeToSeconds(const QTime& time)
 {
-    return muse::audio::milisecsToSecs(ZERO_TIME.msecsTo(time));
+    return muse::msecs_to_secs(ZERO_TIME.msecsTo(time));
 }
 
 enum class SoundProfileType {


### PR DESCRIPTION


Now the audio context is created and initialized when the playback of window is initialized.
Essentially, we already have support for multiple audio contexts.
All that's left is to add a super mixer :) 