### PR TITLE
Fix #32261: Add zoom orientation for list type selections

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
@@ -28,7 +28,6 @@
 #include <QQuickItem>
 #include <QTimer>
 #include <QtMath>
-
 #include "defer.h"
 #include "log.h"
 
@@ -337,6 +336,14 @@ PointF NotationViewInputController::findZoomFocusPoint() const
         // No selection: zoom at the center of the view
         resultX = m_view->width() / 2;
         resultY = m_view->height() / 2;
+    } else if (selection->state() == mu::engraving::SelState::LIST) {
+        RectF rectResult;
+        for (const mu::engraving::EngravingItem* element : selection->elements()) {
+            rectResult = rectResult.united(element->canvasBoundingRect());
+        }
+        PointF result = m_view->fromLogical(rectResult.center());
+        resultX = result.x();
+        resultY = result.y();
     } else {
         // Selection: zoom at the center of the selection
         PointF result = m_view->fromLogical(selection->canvasBoundingRect().center());


### PR DESCRIPTION
Resolves: #32261 

The zoom orientation for list selections didn't have defined behavior, and was defaulting to the top left corner. Fixed by uniting positions of individual objects within a selection rather than treating them as a range.

We performed manual testing, as automatic testing would have required mouse/keyboard inputs that were difficult to automate. We've attached the video of our manual testing below:

https://github.com/user-attachments/assets/b8e59179-53dd-4111-92d8-8bf3f327856b

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)