### PR TITLE
Fix #33043: Glitchy behaviour when moving VST between screens (Windows) [4.7.0]

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -138,7 +138,7 @@ void VstView::init()
         return;
     }
 
-    updateScreenMetrics();
+    updateScreenMetrics(window()->screen());
 
     m_view->setFrame(this);
 
@@ -152,17 +152,25 @@ void VstView::init()
         return;
     }
 
-    // Do not rely on `QWindow::screenChanged` signal, which often does not get emitted though it should.
-    // Proactively check for screen resolution changes instead.
+    connect(window(), &QWindow::screenChanged, this, [this](QScreen* screen) {
+        updateScreenMetrics(screen);
+
+        QMetaObject::invokeMethod(this, [this] {
+            updateViewGeometry();
+        }, Qt::QueuedConnection);
+    });
+
+    // Do not only rely on `QWindow::screenChanged` signal, which often does not get emitted though it should.
+    // Proactively check for screen resolution changes.
     connect(&m_screenMetricsTimer, &QTimer::timeout, this, [this]() {
         QWindow* win = window();
         if (!win) {
             return;
         }
-        const QScreen* const screen = win->screen();
+        QScreen* screen = win->screen();
         if (m_currentScreen != screen || m_screenMetrics.availableSize != screen->availableSize()
             || !is_equal(m_screenMetrics.devicePixelRatio, screen->devicePixelRatio())) {
-            updateScreenMetrics();
+            updateScreenMetrics(screen);
             updateViewGeometry();
         }
     });
@@ -323,9 +331,9 @@ bool VstView::nativeEventFilter(const QByteArray& eventType, void* message, qint
     return false;
 }
 
-void VstView::updateScreenMetrics()
+void VstView::updateScreenMetrics(QScreen* screen)
 {
-    m_currentScreen = window()->screen();
+    m_currentScreen = screen;
     m_screenMetrics.availableSize = m_currentScreen->availableSize();
 #ifdef Q_OS_MAC
     constexpr auto devicePixelRatio = 1.0;
@@ -333,13 +341,6 @@ void VstView::updateScreenMetrics()
     const auto devicePixelRatio = m_currentScreen->devicePixelRatio();
 #endif
     m_screenMetrics.devicePixelRatio = devicePixelRatio;
-}
-
-void VstView::updateViewGeometry()
-{
-    if (!m_view) {
-        return;
-    }
 
 #ifdef Q_OS_WIN
     Steinberg::FUnknownPtr<IPluginContentScaleHandler> scalingHandler(m_view);
@@ -347,6 +348,13 @@ void VstView::updateViewGeometry()
         scalingHandler->setContentScaleFactor(m_screenMetrics.devicePixelRatio);
     }
 #endif
+}
+
+void VstView::updateViewGeometry()
+{
+    if (!m_view) {
+        return;
+    }
 
     Steinberg::ViewRect size;
     m_view->getSize(&size);

--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -341,6 +341,13 @@ void VstView::updateViewGeometry()
         return;
     }
 
+#ifdef Q_OS_WIN
+    Steinberg::FUnknownPtr<IPluginContentScaleHandler> scalingHandler(m_view);
+    if (scalingHandler) {
+        scalingHandler->setContentScaleFactor(m_screenMetrics.devicePixelRatio);
+    }
+#endif
+
     Steinberg::ViewRect size;
     m_view->getSize(&size);
 

--- a/src/framework/vst/qml/Muse/Vst/vstview.h
+++ b/src/framework/vst/qml/Muse/Vst/vstview.h
@@ -92,7 +92,7 @@ private:
         double devicePixelRatio = 0.0;
     };
 
-    void updateScreenMetrics();
+    void updateScreenMetrics(QScreen* screen);
     void updateViewGeometry();
 
     int m_instanceId = -1;


### PR DESCRIPTION
Resolves: #33043

On my end it's still slightly buggy, but the situation is vastly improved. The problem was introduced when we started using QML for VST dialogs (`oldview` vs `newview`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display scaling and monitor-change handling for VST plugins — the UI now updates immediately when the plugin’s screen or scale changes and continues to detect size and DPI changes reliably.
  * On Windows, plugins correctly apply the current content scale factor so interfaces render and resize accurately on high‑DPI displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->