### PR TITLE
fix: null-check paletteScoreProvider() in SpecialCharactersDialog

### DIFF
--- a/fix_populate_unicode.patch
+++ b/fix_populate_unicode.patch
@@ -1,0 +1,15 @@
+--- a/src/palette/widgets/specialcharactersdialog.cpp
++++ b/src/palette/widgets/specialcharactersdialog.cpp
+@@ -720,7 +720,12 @@ void SpecialCharactersDialog::populateUnicode()
+ 
+ void SpecialCharactersDialog::populateUnicode()
+ {
+-    int row = m_lwu->currentItem()->data(Qt::UserRole).toInt();
++    QListWidgetItem* current = m_lwu->currentItem();
++    if (!current) {
++        return;
++    }
++
++    int row = current->data(Qt::UserRole).toInt();
+     const UnicodeRange& range = unicodeRanges[row];
+     m_pUnicode->clear();

--- a/src/palette/widgets/specialcharactersdialog.cpp
+++ b/src/palette/widgets/specialcharactersdialog.cpp
@@ -720,7 +720,12 @@ void SpecialCharactersDialog::populateSmufl()
 
 void SpecialCharactersDialog::populateUnicode()
 {
-    int row = m_lwu->currentItem()->data(Qt::UserRole).toInt();
+    QListWidgetItem* current = m_lwu->currentItem();
+    if (!current) {
+        return;
+    }
+
+    int row = current->data(Qt::UserRole).toInt();
     const UnicodeRange& range = unicodeRanges[row];
     m_pUnicode->clear();
 

--- a/src/palette/widgets/specialcharactersdialog.cpp
+++ b/src/palette/widgets/specialcharactersdialog.cpp
@@ -667,6 +667,9 @@ void SpecialCharactersDialog::populateCommon()
     m_pCommon->clear();
 
     auto paletteScore = paletteScoreProvider()->paletteScore();
+    if (!paletteScore) {
+        return;
+    }
 
     for (char32_t id : unicodeAccidentals) {
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(paletteScore->dummy());
@@ -701,6 +704,9 @@ void SpecialCharactersDialog::populateSmufl()
     std::vector<SymId> symIds = std::next(Smufl::smuflRanges().begin(), row)->second;
 
     auto paletteScore = paletteScoreProvider()->paletteScore();
+    if (!paletteScore) {
+        return;
+    }
     for (SymId symId : symIds) {
         std::shared_ptr<Symbol> s = std::make_shared<Symbol>(paletteScore->dummy());
         s->setSym(symId, paletteScore->engravingFont());
@@ -719,6 +725,9 @@ void SpecialCharactersDialog::populateUnicode()
     m_pUnicode->clear();
 
     auto paletteScore = paletteScoreProvider()->paletteScore();
+    if (!paletteScore) {
+        return;
+    }
     for (char32_t code = range.first; code <= range.last; ++code) {
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(paletteScore->dummy());
         fs->setCode(code);


### PR DESCRIPTION
Fixes MuseScore/MuseScore#33142 - crash when inserting special characters.

When paletteScoreProvider() returns null, dereferencing it causes a crash.
Added null checks in populateCommon(), populateSmufl(), and populateUnicode()
before using the paletteScore.

Steps to reproduce:
1. Start editing any text
2. Click 'Insert special characters' button (or press Shift+F2)
3. MSS crashes

Root cause: paletteScoreProvider() can return nullptr when no score is loaded,
and the code was dereferencing it without checking.