### PR TITLE
[4.7.0] Fix #33109: fix crash when CLI finishes before audio engine is fully initialized

### DIFF
--- a/src/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/src/framework/audio/main/internal/startaudiocontroller.cpp
@@ -290,13 +290,14 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
 void StartAudioController::stopAudioProcessing()
 {
 #ifndef Q_OS_WASM
-    if (m_isAudioStarted.val) {
-        m_rpcChannel->send(rpc::make_request(Method::EngineDeinit), [this](const Msg&) {
+    m_rpcChannel->send(rpc::make_request(Method::EngineDeinit), [this](const Msg&) {
+        if (m_isAudioStarted.val) {
             m_isAudioStarted.set(false);
-        });
-    }
+        }
+    });
 
-    while (m_isAudioStarted.val) {
+    do {
+        // Ensure that RPC process() is called at least once
         m_rpcChannel->process();
 
         if (!m_isAudioStarted.val) {
@@ -306,7 +307,7 @@ void StartAudioController::stopAudioProcessing()
         std::this_thread::yield();
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(10ms);
-    }
+    } while (m_isAudioStarted.val);
 
     audioDriverController()->close();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio shutdown reliability: the system now always sends the deinitialization request and guarantees at least one shutdown processing step runs, ensuring cleanup completes consistently even when the audio state appears already cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->