### PR TITLE
Fix deadlock on Async::queueData

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/async.h
+++ b/src/framework/global/thirdparty/kors_async/async/async.h
@@ -99,27 +99,35 @@ private:
 
     QueueData* queueData(const std::thread::id& sendTh, const std::thread::id& receiveTh)
     {
-        std::scoped_lock lock(m_mutex);
-        for (QueueData* d : m_queues) {
-            if (d->sendTh == sendTh && d->receiveTh == receiveTh) {
-                return d;
+        // lookup
+        {
+            std::scoped_lock lock(m_mutex);
+            for (QueueData* d : m_queues) {
+                if (d->sendTh == sendTh && d->receiveTh == receiveTh) {
+                    return d;
+                }
             }
         }
 
-        QueueData* d = new QueueData();
-        d->sendTh = sendTh;
-        d->receiveTh = receiveTh;
-        m_queues.push_back(d);
+        // create new
+        QueueData* d = nullptr;
+        {
+            std::scoped_lock lock(m_mutex);
+            d = new QueueData();
+            d->sendTh = sendTh;
+            d->receiveTh = receiveTh;
+            m_queues.push_back(d);
 
-        d->queue.port2()->onMessage([d](const CallMsg& m) {
-            if (m.receiver) {
-                if (d->isConnected(m.receiver)) {
+            d->queue.port2()->onMessage([d](const CallMsg& m) {
+                if (m.receiver) {
+                    if (d->isConnected(m.receiver)) {
+                        m.func->call(nullptr);
+                    }
+                } else {
                     m.func->call(nullptr);
                 }
-            } else {
-                m.func->call(nullptr);
-            }
-        });
+            });
+        }
 
         QueuePool::instance()->regPort(sendTh, d->queue.port1());           // send
         QueuePool::instance()->regPort(receiveTh, d->queue.port2());        // receive


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

Move QueuePool::regPort calls outside the m_mutex critical section to avoid a deadlock.

When some thread calls `Async::call(.., mainThreadId)` for the first time, queueData creates a new queue and calls regPort while holding m_mutex. If the main thread is simultaneously in processMessages (holding ThreadData::mutex) and a message callback calls Async::call, both threads deadlock.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
