### PR TITLE
[4.7.0] VST: remove min & max buttons on Windows

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -40,6 +40,25 @@
 
 using namespace muse::vst;
 
+#ifdef Q_OS_WIN
+static void removeMinMaxButtons(HWND window)
+{
+    IF_ASSERT_FAILED(window && IsWindow(window)) {
+        return;
+    }
+
+    // Remove the minimize & maximize buttons
+    LONG style = GetWindowLong(window, GWL_STYLE);
+    style &= ~(WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+    SetWindowLong(window, GWL_STYLE, style);
+
+    // Force redraw of non-client area
+    SetWindowPos(window, nullptr, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
+#endif
+
 ::Steinberg::uint32 PLUGIN_API VstView::addRef()
 {
     return ::Steinberg::FUnknownPrivate::atomicAdd(__funknownRefCount, 1);
@@ -156,12 +175,15 @@ void VstView::init()
 #ifdef Q_OS_WIN
     HWND winHwnd = reinterpret_cast<HWND>(m_vstWindow->winId());
     HWND viewHwnd = GetWindow(winHwnd, GW_CHILD);
-    m_rootHandle = GetAncestor(winHwnd, GA_ROOT);
+    HWND rootHandle = GetAncestor(winHwnd, GA_ROOT);
+    m_rootHandle = rootHandle;
 
     if (viewHwnd && IsWindow(viewHwnd)) {
         m_plugViewHandle = viewHwnd;
         qApp->installNativeEventFilter(this);
     }
+
+    removeMinMaxButtons(rootHandle);
 #endif
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VST plugin windows on Windows no longer show minimize and maximize buttons, giving a cleaner plugin window appearance.
  * Window chrome updates are applied immediately so the plugin window reflects the change without requiring manual refresh.
  * Improved handling of window references to avoid visual glitches or crashes when adjusting window decorations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->