### PR TITLE
[4.7] fixed video export abort

### DIFF
--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -387,7 +387,7 @@ int FluidSequencer::expressionLevel(const mpe::dynamic_level_t dynamicLevel) con
 
     dynamic_level_t result = RealRound(MIN_SUPPORTED_VOLUME + (stepCount * VOLUME_STEP), 0);
 
-    return std::min(result, MAX_SUPPORTED_DYNAMICS_LEVEL);
+    return std::clamp((int)result, MIN_SUPPORTED_VOLUME, MAX_SUPPORTED_VOLUME);
 }
 
 int FluidSequencer::pitchBendLevel(const mpe::pitch_level_t pitchLevel) const

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -281,6 +281,12 @@ void VideoWriter::abort()
     if (m_audioWriter) {
         m_audioWriter->abort();
     }
+
+    // Wait abort completion
+    while (!m_isCompleted || !m_audioCompleted) {
+        application()->processEvents();
+        QThread::yieldCurrentThread();
+    }
 }
 
 std::optional<VideoWriter::ScoreRestoreData> VideoWriter::prepareScore(INotationPtr notation, Config& config)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MIDI volume values are now strictly clamped to the supported MIDI controller range, preventing out-of-range dynamics from being generated or logged.
  * Video export abort now blocks until both video and audio operations have fully finished, ensuring clean termination and preventing incomplete exports or lingering background tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->