### PR TITLE
[4.7.0] Fix #33153: Linked text in About dialog no longer works

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTextLabel.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTextLabel.qml
@@ -42,10 +42,6 @@ Text {
         pixelSize: ui.theme.bodyFont.pixelSize
     }
 
-    onLinkActivated: function(link) {
-        Qt.openUrlExternally(link)
-    }
-
     Loader {
         id: mouseAreaLoader
         anchors.fill: parent
@@ -56,8 +52,12 @@ Text {
             cursorShape: root.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
             hoverEnabled: true
 
-            onPressed: {
+            onClicked: {
                 ui.tooltip.hide(root, true)
+
+                if (Boolean(root.hoveredLink)) {
+                    Qt.openUrlExternally(root.hoveredLink)
+                }
             }
 
             onContainsMouseChanged: {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced link activation behavior to prevent unintended navigation, ensuring that navigation only occurs when clicking on valid, detected links
  * Improved tooltip visibility management to properly hide tooltips when interacting with text elements
  * Refined click handling logic for better accuracy and stability in text-based interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->