### PR TITLE
Fix input by duration getting stuck when arriving at the same note

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3121,6 +3121,7 @@ void Score::padToggle(Pad p, bool toggleForSelectionOnly)
 
                     for (const NoteVal& nval : m_is.notes()) {
                         if (chord && chord->findNote(nval.pitch)) {
+                            m_is.moveToNextInputPos();
                             continue;
                         }
 


### PR DESCRIPTION
Resolves: #27640

Fixes bug which caused input by duration to stop moving forward when the newly inputted note reached a position where a note with the same pitch was already in place.
