### PR TITLE
Fix spacing between fields in video preferences section

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/internal/FFmpegSection.qml
+++ b/src/preferences/qml/MuseScore/Preferences/internal/FFmpegSection.qml
@@ -50,7 +50,7 @@ BaseSection {
             Layout.fillWidth: true
             height: 24
 
-            spacing: 24
+            spacing: 8
 
             FilePicker {
                 id: ffmpegDirPicker


### PR DESCRIPTION
Adapt the spacing between the text field and two buttons in the `Preferences > video` section, so that they will be evenly spaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the FFmpeg preferences section for a more refined visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->