### PR TITLE
[win] fixed installer auto launch

### DIFF
--- a/buildscripts/packaging/Windows/Installer/WIX.template.in
+++ b/buildscripts/packaging/Windows/Installer/WIX.template.in
@@ -65,7 +65,7 @@
         </UI>
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch $(var.ProdName)" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
-        <Property Id="WixShellExecTarget" Value="[#CM_FP_bin.$(var.ExeName)]" />
+        <Property Id="WixShellExecTarget" Value="[INSTALL_ROOT]bin\$(var.ExeName)" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
         <Component Id="RegisterTypes" Directory="TARGETDIR" Guid="76707452-ee26-4f9a-9650-2cf2c70a6448">


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Windows installer may not have correctly launched the application after installation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->