### PR TITLE
Add singleinstance handler

### DIFF
--- a/src/framework/multiwindows/CMakeLists.txt
+++ b/src/framework/multiwindows/CMakeLists.txt
@@ -26,6 +26,9 @@ target_sources(muse_multiwindows PRIVATE
     imultiwindowsprovider.h
     iprojectprovider.h
     resourcelockguard.h
+    singleinstance.h
+
+    internal/singleinstance.cpp
 
     internal/multiwindowsuiactions.cpp
     internal/multiwindowsuiactions.h

--- a/src/framework/multiwindows/internal/multiprocess/ipc/ipcserver.cpp
+++ b/src/framework/multiwindows/internal/multiprocess/ipc/ipcserver.cpp
@@ -25,11 +25,6 @@
 #include <QLocalSocket>
 #include <QThread>
 
-#ifdef Q_OS_UNIX
-#include <QFile>
-#include <QDir>
-#endif
-
 #include "async/async.h"
 #include "ipclock.h"
 #include "ipclog.h"
@@ -56,13 +51,11 @@ bool IpcServer::listen(const QString& serverName)
 
     bool ok = m_server->listen(serverName);
 
-#ifdef Q_OS_UNIX
-    // Workaround
     if (!ok && m_server->serverError() == QAbstractSocket::AddressInUseError) {
-        QFile::remove(QDir::cleanPath(QDir::tempPath()) + QLatin1Char('/') + serverName);
+        LOGW() << "stale endpoint for " << serverName << ", removing";
+        QLocalServer::removeServer(serverName);
         ok = m_server->listen(serverName);
     }
-#endif
 
     if (!ok) {
         LOGE() << "failed listen: " << m_server->errorString();

--- a/src/framework/multiwindows/internal/singleinstance.cpp
+++ b/src/framework/multiwindows/internal/singleinstance.cpp
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../singleinstance.h"
+
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#include "multiprocess/ipc/ipc.h"
+#include "multiprocess/ipc/ipclock.h"
+
+#include "log.h"
+
+namespace muse::mi {
+static const QString SINGLE_INSTANCE_ACTIVATE("single_instance_activate");
+constexpr int ACK_WAIT_MSEC = 5000;
+}
+
+bool muse::mi::activateExistingInstance(const QString& applicationId, const QStringList& args)
+{
+    if (applicationId.isEmpty()) {
+        LOGE() << "empty applicationId";
+        return false;
+    }
+
+    ipc::IpcLock lock(applicationId);
+    ipc::IpcLockGuard guard(&lock);
+
+    QLocalSocket socket;
+    socket.connectToServer(applicationId);
+    if (!socket.waitForConnected(ipc::TIMEOUT_MSEC)) {
+        LOGD() << "no listener for " << applicationId << "; this is the first instance";
+        return false;
+    }
+
+    ipc::Msg msg;
+    msg.type = ipc::MsgType::Notify;
+    msg.method = SINGLE_INSTANCE_ACTIVATE;
+    msg.args = args;
+
+    QByteArray data;
+    ipc::serialize(msg, data);
+
+    if (!ipc::writeToSocket(&socket, data)) {
+        LOGE() << "failed to write activation message";
+        return false;
+    }
+
+    if (!socket.waitForReadyRead(ACK_WAIT_MSEC)) {
+        LOGW() << "no ack from existing instance within " << ACK_WAIT_MSEC << "ms";
+        return false;
+    }
+
+    const QByteArray ack = socket.readAll();
+    if (ack != ipc::ACK) {
+        LOGW() << "unexpected ack payload: " << ack;
+        return false;
+    }
+
+    socket.disconnectFromServer();
+    LOGI() << "handoff acked by existing " << applicationId;
+    return true;
+}
+
+namespace muse::mi {
+SingleInstanceListener::SingleInstanceListener() = default;
+
+SingleInstanceListener::~SingleInstanceListener()
+{
+    stop();
+}
+
+bool SingleInstanceListener::start(const QString& applicationId)
+{
+    if (m_server) {
+        return true;
+    }
+    if (applicationId.isEmpty()) {
+        LOGE() << "empty applicationId";
+        return false;
+    }
+
+    m_server = new QLocalServer();
+
+    bool ok = m_server->listen(applicationId);
+
+    if (!ok && m_server->serverError() == QAbstractSocket::AddressInUseError) {
+        LOGW() << "stale endpoint for " << applicationId << ", removing";
+        QLocalServer::removeServer(applicationId);
+        ok = m_server->listen(applicationId);
+    }
+
+    if (!ok) {
+        LOGE() << "failed to listen on " << applicationId << ": " << m_server->errorString();
+        delete m_server;
+        m_server = nullptr;
+        return false;
+    }
+
+    QObject::connect(m_server, &QLocalServer::newConnection, m_server, [this]() {
+        onNewConnection();
+    });
+
+    LOGI() << "single-instance listener bound: " << applicationId;
+    return true;
+}
+
+void SingleInstanceListener::stop()
+{
+    if (!m_server) {
+        return;
+    }
+    m_server->close();
+    delete m_server;
+    m_server = nullptr;
+}
+
+bool SingleInstanceListener::isListening() const
+{
+    return m_server && m_server->isListening();
+}
+
+async::Channel<QStringList> SingleInstanceListener::messageReceived() const
+{
+    return m_messageReceived;
+}
+
+void SingleInstanceListener::onNewConnection()
+{
+    QLocalSocket* socket = m_server->nextPendingConnection();
+    if (!socket) {
+        return;
+    }
+
+    QObject::connect(socket, &QLocalSocket::disconnected, socket, &QObject::deleteLater);
+
+    auto channel = m_messageReceived;
+
+    auto handleData = [socket, channel]() mutable {
+        ipc::readFromSocket(socket, [socket, channel](const QByteArray& data) mutable {
+            ipc::Msg msg;
+            ipc::deserialize(data, msg);
+
+            if (msg.method != SINGLE_INSTANCE_ACTIVATE) {
+                LOGW() << "ignoring unexpected method: " << msg.method;
+                return;
+            }
+
+            socket->write(ipc::ACK);
+            socket->flush();
+
+            LOGI() << "received activation from second instance";
+            LOGD() << "args: " << msg.args;
+            channel.send(msg.args);
+        });
+    };
+
+    QObject::connect(socket, &QLocalSocket::readyRead, socket, handleData);
+
+    if (socket->bytesAvailable() > 0) {
+        handleData();
+    }
+}
+}

--- a/src/framework/multiwindows/singleinstance.h
+++ b/src/framework/multiwindows/singleinstance.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+#include "async/asyncable.h"
+#include "async/channel.h"
+
+class QLocalServer;
+
+namespace muse::mi {
+//! Returns true if a running instance accepted `args`; the caller should exit.
+bool activateExistingInstance(const QString& applicationId, const QStringList& args);
+
+class SingleInstanceListener : public async::Asyncable
+{
+public:
+    SingleInstanceListener();
+    ~SingleInstanceListener();
+
+    SingleInstanceListener(const SingleInstanceListener&) = delete;
+    SingleInstanceListener& operator=(const SingleInstanceListener&) = delete;
+
+    bool start(const QString& applicationId);
+    void stop();
+    bool isListening() const;
+
+    async::Channel<QStringList> messageReceived() const;
+
+private:
+    void onNewConnection();
+
+    QLocalServer* m_server = nullptr;
+    async::Channel<QStringList> m_messageReceived;
+};
+}


### PR DESCRIPTION
Prevents launching a second process, when opening a project from cloud/file explorer.

Usage example: 
```cpp
void GuiApp::initSingleInstance(const QString& applicationId)
{
    if (!m_singleInstance.start(applicationId)) {
        return;
    }

    m_singleInstance.messageReceived().onReceive(this, [this](const QStringList& args) {
        onSecondInstanceArgs(args);
    });
}

void GuiApp::onSecondInstanceArgs(const QStringList& args)
{
    // TODO: Handle args to open a project or raise a window if the project is already open 
}
```

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
