### PR TITLE
[4.7.0] Fix #32742: deinit VST view while NSView still exists

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -175,9 +175,7 @@ void VstView::deinit()
 
     if (m_view) {
         m_view->setFrame(nullptr);
-#ifndef Q_OS_MAC
         m_view->removed();
-#endif
         m_view = nullptr;
         m_plugViewHandle = nullptr;
         m_rootHandle = nullptr;

--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -163,6 +163,10 @@ void VstView::init()
         qApp->installNativeEventFilter(this);
     }
 #endif
+
+#ifdef Q_OS_MAC
+    window()->installEventFilter(this);
+#endif
 }
 
 void VstView::deinit()
@@ -173,13 +177,12 @@ void VstView::deinit()
 
     m_screenMetricsTimer.stop();
 
-    if (m_view) {
-        m_view->setFrame(nullptr);
-        m_view->removed();
-        m_view = nullptr;
-        m_plugViewHandle = nullptr;
-        m_rootHandle = nullptr;
+    deinitPluginView();
 
+    m_plugViewHandle = nullptr;
+    m_rootHandle = nullptr;
+
+    if (m_vstWindow) {
         m_vstWindow->hide();
         delete m_vstWindow;
         m_vstWindow = nullptr;
@@ -195,6 +198,15 @@ void VstView::deinit()
     if (m_instance) {
         m_instance->refreshConfig();
         m_instance = nullptr;
+    }
+}
+
+void VstView::deinitPluginView()
+{
+    if (m_view) {
+        m_view->setFrame(nullptr);
+        m_view->removed();
+        m_view = nullptr;
     }
 }
 
@@ -242,6 +254,15 @@ Steinberg::tresult VstView::resizeView(Steinberg::IPlugView* view, Steinberg::Vi
     m_resizeViewCalled = false;
 
     return Steinberg::kResultTrue;
+}
+
+bool VstView::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::Close) {
+        deinitPluginView();
+    }
+
+    return QQuickItem::eventFilter(watched, event);
 }
 
 bool VstView::nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result)

--- a/src/framework/vst/qml/Muse/Vst/vstview.h
+++ b/src/framework/vst/qml/Muse/Vst/vstview.h
@@ -85,6 +85,9 @@ signals:
     void minimumWidthChanged();
 
 private:
+    void deinitPluginView();
+
+    bool eventFilter(QObject* watched, QEvent* event) override;
     bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override;
 
     struct ScreenMetrics {

--- a/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
+++ b/src/framework/vst/widgets/vstviewdialog_qwidget.cpp
@@ -64,9 +64,7 @@ void VstViewDialog::deinit()
 {
     if (m_view) {
         m_view->setFrame(nullptr);
-#ifndef Q_OS_MAC
         m_view->removed();
-#endif
         m_view = nullptr;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33019
Resolves: https://github.com/musescore/MuseScore/issues/32742
Reverts: https://github.com/musescore/MuseScore/pull/32745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VST plugin view cleanup and deinitialization handling to prevent resource leaks.
  * Fixed event handling on macOS to ensure proper plugin view cleanup when closing.
  
* **Refactor**
  * Refactored plugin view cleanup logic for better maintainability and consistent behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->