### PR TITLE
Fix input by duration getting stuck when arriving at the same note

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3110,6 +3110,7 @@ void Score::padToggle(Pad p, bool toggleForSelectionOnly)
 
                     for (const NoteVal& nval : m_is.notes()) {
                         if (chord && chord->findNote(nval.pitch)) {
+                            m_is.moveToNextInputPos();
                             continue;
                         }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27640

Fixes bug which caused input by duration to stop moving forward when the newly inputted note reached a position where a note with the same pitch was already in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed note entry behavior when attempting to add a pitch that already exists in a chord. The input cursor now properly advances to the next position instead of remaining at the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->