### PR TITLE
[audio] added super mixer

### DIFF
--- a/src/framework/audio/engine/CMakeLists.txt
+++ b/src/framework/audio/engine/CMakeLists.txt
@@ -86,6 +86,12 @@ else()
         internal/transporteventsdispatcher.cpp
         internal/transporteventsdispatcher.h
 
+        # Nodes
+        internal/nodes/audionode.cpp
+        internal/nodes/audionode.h
+        internal/nodes/mixernode.cpp
+        internal/nodes/mixernode.h
+
         # DSP
         internal/dsp/envelopefilterconfig.h
         internal/dsp/compressor.cpp

--- a/src/framework/audio/engine/CMakeLists.txt
+++ b/src/framework/audio/engine/CMakeLists.txt
@@ -68,8 +68,8 @@ else()
         internal/mixer.h
         internal/mixerchannel.cpp
         internal/mixerchannel.h
-        internal/engineplayer.cpp
-        internal/engineplayer.h
+        internal/contextplayer.cpp
+        internal/contextplayer.h
         internal/samplerateconvertor.cpp
         internal/samplerateconvertor.h
         internal/track.h

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -25,7 +25,7 @@
 #include "audio/common/audioerrors.h"
 #include "audio/common/audioutils.h"
 
-#include "engineplayer.h"
+#include "contextplayer.h"
 
 #include "muse_framework_config.h"
 #ifdef MUSE_MODULE_AUDIO_EXPORT
@@ -39,7 +39,7 @@ using namespace muse::audio::engine;
 AudioContext::AudioContext(const AudioCtxId& ctxId)
     : m_ctxId(ctxId)
 {
-    m_player = std::make_shared<EnginePlayer>(this);
+    m_player = std::make_shared<ContextPlayer>(this);
     m_mixer = std::make_shared<Mixer>();
 }
 
@@ -99,10 +99,9 @@ void AudioContext::setMode(const ProcessMode mode)
     m_mixer->setMode(mode);
 }
 
-void AudioContext::setOutputSpec(const OutputSpec& outputSpec)
+void AudioContext::onOutputSpecChanged(const OutputSpec& outputSpec)
 {
     ONLY_AUDIO_ENGINE_THREAD;
-    m_outputSpec = outputSpec;
     m_mixer->setOutputSpec(outputSpec);
 
     TimePosition currentPosition = m_player->currentPosition();

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -809,8 +809,8 @@ SaveSoundTrackProgress AudioContext::saveSoundTrackProgressChanged() const
 }
 
 // Processing
-samples_t AudioContext::process(float* buffer, samples_t samplesPerChannel)
+void AudioContext::doSelfProcess(float* buffer, samples_t samplesPerChannel)
 {
     ONLY_AUDIO_PROC_THREAD;
-    return m_mixer->process(buffer, samplesPerChannel);
+    m_mixer->process(buffer, samplesPerChannel);
 }

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "iaudiocontext.h"
+#include "nodes/audionode.h"
 
 #include "global/async/asyncable.h"
 
@@ -35,7 +36,7 @@
 
 namespace muse::audio::engine {
 class EnginePlayer;
-class AudioContext : public IAudioContext, public IGetTrackSource, public async::Asyncable
+class AudioContext : public AudioNode, public IAudioContext, public IGetTrackSource, public async::Asyncable
 {
     GlobalInject<IAudioEngine> audioEngine;
     GlobalInject<IAudioFactory> audioFactory;
@@ -121,9 +122,6 @@ public:
     SaveSoundTrackProgress saveSoundTrackProgressChanged() const override;
     void abortSavingAllSoundTracks() override;
 
-    // Processing
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
-
 private:
 
     struct Track
@@ -148,6 +146,9 @@ private:
     bool hasPendingChunks(const TrackId id) const;
     size_t tracksBeingProcessedCount() const;
     Ret doSaveSoundTrack(io::IODevice& dstDevice, const SoundTrackFormat& format);
+
+    // Processing
+    void doSelfProcess(float* buffer, samples_t samplesPerChannel) override;
 
     AudioCtxId m_ctxId = 0;
 

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -35,7 +35,7 @@
 #include "mixer.h"
 
 namespace muse::audio::engine {
-class EnginePlayer;
+class ContextPlayer;
 class AudioContext : public AudioNode, public IAudioContext, public IGetTrackSource, public async::Asyncable
 {
     GlobalInject<IAudioEngine> audioEngine;
@@ -52,7 +52,6 @@ public:
 
     // Config
     void setMode(const ProcessMode newMode) override;
-    void setOutputSpec(const OutputSpec& outputSpec) override;
 
     // Tracks
     RetVal2<TrackId, AudioParams> addTrack(const std::string& trackName, io::IODevice* playbackData, const AudioParams& params) override;
@@ -133,6 +132,8 @@ private:
         ITrackAudioOutputPtr output = nullptr;
     };
 
+    void onOutputSpecChanged(const OutputSpec& spec) override;
+
     TrackId newTrackId() const;
     void doAddTrack(const Track& track);
     const Track* track(const TrackId id) const;
@@ -152,8 +153,7 @@ private:
 
     AudioCtxId m_ctxId = 0;
 
-    OutputSpec m_outputSpec;
-    std::shared_ptr<EnginePlayer> m_player;
+    std::shared_ptr<ContextPlayer> m_player;
     std::shared_ptr<Mixer> m_mixer;
 
     std::vector<Track> m_tracks;

--- a/src/framework/audio/engine/internal/audioengine.cpp
+++ b/src/framework/audio/engine/internal/audioengine.cpp
@@ -63,8 +63,10 @@ Ret AudioEngine::init(const OutputSpec& outputSpec)
            << ", audioChannelCount: " << outputSpec.audioChannelCount;
 
     m_outputSpec = outputSpec;
-
     m_operationType = OperationType::NoOperation;
+
+    m_mixer = std::make_shared<MixerNode>();
+    m_mixer->setOutputSpec(outputSpec);
 
     m_inited = true;
 
@@ -101,6 +103,9 @@ RetVal<std::shared_ptr<IAudioContext> > AudioEngine::addAudioContext(const Audio
     }
 
     m_contexts[ctxId] = ctx;
+
+    ctx->connect(m_mixer);
+
     return RetType::make_ok(ctx);
 }
 
@@ -117,7 +122,9 @@ void AudioEngine::destroyContext(const AudioCtxId& ctxId)
 {
     auto it = m_contexts.find(ctxId);
     if (it != m_contexts.end()) {
-        it->second->deinit();
+        auto& ctx = it->second;
+        ctx->deinit();
+        ctx->disconnect(m_mixer);
         m_contexts.erase(it);
     }
 }
@@ -140,8 +147,8 @@ void AudioEngine::setOutputSpec(const OutputSpec& outputSpec)
 
     m_outputSpec = outputSpec;
 
-    for (auto& p : m_contexts) {
-        p.second->setOutputSpec(outputSpec);
+    if (m_mixer) {
+        m_mixer->setOutputSpec(outputSpec);
     }
 
     m_outputSpecChanged.send(outputSpec);
@@ -209,23 +216,15 @@ samples_t AudioEngine::process(float* buffer, samples_t samplesPerChannel)
     }
     case OperationType::NoOperation: {
         // normal playing
-        //! TODO mix all contexts audio
-        samples_t totalProcessedSamples = 0;
-        for (auto& p : m_contexts) {
-            totalProcessedSamples = p.second->process(buffer, samplesPerChannel);
-        }
-        return totalProcessedSamples;
+        m_mixer->process(buffer, samplesPerChannel);
+        return samplesPerChannel;
     }
     case OperationType::QuickOperation: {
         // wait
         LOGD() << "wait end of quick operation";
         std::scoped_lock<std::mutex> lock(m_quickOperationWaitMutex);
-        //! TODO mix all contexts audio
-        samples_t totalProcessedSamples = 0;
-        for (auto& p : m_contexts) {
-            totalProcessedSamples = p.second->process(buffer, samplesPerChannel);
-        }
-        return totalProcessedSamples;
+        m_mixer->process(buffer, samplesPerChannel);
+        return samplesPerChannel;
     }
     case OperationType::LongOperation: {
         return fillSilent(buffer, samplesPerChannel);

--- a/src/framework/audio/engine/internal/audioengine.cpp
+++ b/src/framework/audio/engine/internal/audioengine.cpp
@@ -204,15 +204,17 @@ samples_t AudioEngine::process(float* buffer, samples_t samplesPerChannel)
         m_processing = false;
     };
 
+    fillSilent(buffer, samplesPerChannel); // clear buffer
+
     if (!m_inited) {
-        return fillSilent(buffer, samplesPerChannel);
+        return 0;
     }
 
     // check current operation
     switch (m_operationType) {
     case OperationType::Undefined: {
         UNREACHABLE;
-        return fillSilent(buffer, samplesPerChannel);
+        return 0;
     }
     case OperationType::NoOperation: {
         // normal playing
@@ -227,9 +229,9 @@ samples_t AudioEngine::process(float* buffer, samples_t samplesPerChannel)
         return samplesPerChannel;
     }
     case OperationType::LongOperation: {
-        return fillSilent(buffer, samplesPerChannel);
+        return 0;
     }
     }
 
-    return fillSilent(buffer, samplesPerChannel);
+    return 0;
 }

--- a/src/framework/audio/engine/internal/audioengine.h
+++ b/src/framework/audio/engine/internal/audioengine.h
@@ -30,6 +30,8 @@
 
 #include "global/types/ret.h"
 
+#include "nodes/mixernode.h"
+
 namespace muse::audio::engine {
 class AudioContext;
 class AudioEngine : public IAudioEngine
@@ -60,10 +62,11 @@ private:
 
     std::atomic<bool> m_inited = false;
 
-    std::map<AudioCtxId, std::shared_ptr<AudioContext> > m_contexts;
-
     OutputSpec m_outputSpec;
     async::Channel<OutputSpec> m_outputSpecChanged;
+
+    std::map<AudioCtxId, std::shared_ptr<AudioContext> > m_contexts;
+    std::shared_ptr<MixerNode> m_mixer;
 
     std::atomic<bool> m_processing = false;
     std::atomic<OperationType> m_operationType = OperationType::Undefined;

--- a/src/framework/audio/engine/internal/contextplayer.cpp
+++ b/src/framework/audio/engine/internal/contextplayer.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "engineplayer.h"
+#include "contextplayer.h"
 
 #include "audio/common/audiosanitizer.h"
 #include "audio/common/audioerrors.h"
@@ -32,7 +32,7 @@ using namespace muse::audio;
 using namespace muse::audio::engine;
 using namespace muse::async;
 
-EnginePlayer::EnginePlayer(IGetTrackSource* getTracks)
+ContextPlayer::ContextPlayer(IGetTrackSource* getTracks)
     : m_trackSource(getTracks)
 {
     m_status.set(PlaybackStatus::Stopped);
@@ -48,7 +48,7 @@ EnginePlayer::EnginePlayer(IGetTrackSource* getTracks)
     });
 }
 
-void EnginePlayer::onStatusChanged(const PlaybackStatus status)
+void ContextPlayer::onStatusChanged(const PlaybackStatus status)
 {
     const bool active = status == PlaybackStatus::Running;
     if (active) {
@@ -63,7 +63,7 @@ void EnginePlayer::onStatusChanged(const PlaybackStatus status)
     }
 }
 
-void EnginePlayer::forward(const TimePosition& delta)
+void ContextPlayer::forward(const TimePosition& delta)
 {
     ONLY_AUDIO_PROC_THREAD;
 
@@ -82,7 +82,7 @@ void EnginePlayer::forward(const TimePosition& delta)
     m_timeChanged.send(m_currentPosition.time());
 }
 
-TimePosition EnginePlayer::proc_onTimeChanged(const TimePosition& delta)
+TimePosition ContextPlayer::proc_onTimeChanged(const TimePosition& delta)
 {
     ONLY_AUDIO_PROC_THREAD;
 
@@ -116,12 +116,12 @@ TimePosition EnginePlayer::proc_onTimeChanged(const TimePosition& delta)
     return newTime;
 }
 
-const TimePosition& EnginePlayer::currentPosition() const
+const TimePosition& ContextPlayer::currentPosition() const
 {
     return m_currentPosition;
 }
 
-void EnginePlayer::onTimeEvent(const TimeEvent event)
+void ContextPlayer::onTimeEvent(const TimeEvent event)
 {
     ONLY_AUDIO_ENGINE_THREAD;
     switch (event.type) {
@@ -139,7 +139,7 @@ void EnginePlayer::onTimeEvent(const TimeEvent event)
     }
 }
 
-async::Promise<Ret> EnginePlayer::prepareToPlay()
+async::Promise<Ret> ContextPlayer::prepareToPlay()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -152,7 +152,7 @@ async::Promise<Ret> EnginePlayer::prepareToPlay()
     });
 }
 
-void EnginePlayer::play(const secs_t delay)
+void ContextPlayer::play(const secs_t delay)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -164,7 +164,7 @@ void EnginePlayer::play(const secs_t delay)
     m_status.set(PlaybackStatus::Running);
 }
 
-void EnginePlayer::seek(const TimePosition& position, const bool flushSound)
+void ContextPlayer::seek(const TimePosition& position, const bool flushSound)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -189,7 +189,7 @@ void EnginePlayer::seek(const TimePosition& position, const bool flushSound)
     m_flushSoundOnSeek = true;
 }
 
-void EnginePlayer::stop()
+void ContextPlayer::stop()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -203,7 +203,7 @@ void EnginePlayer::stop()
     m_notYetReadyToPlayTrackIdSet.clear();
 }
 
-void EnginePlayer::pause()
+void ContextPlayer::pause()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -215,7 +215,7 @@ void EnginePlayer::pause()
     m_notYetReadyToPlayTrackIdSet.clear();
 }
 
-void EnginePlayer::resume(const secs_t delay)
+void ContextPlayer::resume(const secs_t delay)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -228,19 +228,19 @@ void EnginePlayer::resume(const secs_t delay)
     m_status.set(PlaybackStatus::Running);
 }
 
-secs_t EnginePlayer::duration() const
+secs_t ContextPlayer::duration() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_timeDuration;
 }
 
-void EnginePlayer::setDuration(const secs_t duration)
+void ContextPlayer::setDuration(const secs_t duration)
 {
     ONLY_AUDIO_ENGINE_THREAD;
     m_timeDuration = duration;
 }
 
-Ret EnginePlayer::setLoop(const secs_t from, const secs_t to)
+Ret ContextPlayer::setLoop(const secs_t from, const secs_t to)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -254,50 +254,50 @@ Ret EnginePlayer::setLoop(const secs_t from, const secs_t to)
     return Ret(Ret::Code::Ok);
 }
 
-void EnginePlayer::resetLoop()
+void ContextPlayer::resetLoop()
 {
     ONLY_AUDIO_ENGINE_THREAD;
     m_timeLoopStart = 0;
     m_timeLoopEnd = 0;
 }
 
-secs_t EnginePlayer::playbackPosition() const
+secs_t ContextPlayer::playbackPosition() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_currentPosition.time();
 }
 
-Channel<secs_t> EnginePlayer::playbackPositionChanged() const
+Channel<secs_t> ContextPlayer::playbackPositionChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_timeChanged;
 }
 
-PlaybackStatus EnginePlayer::playbackStatus() const
+PlaybackStatus ContextPlayer::playbackStatus() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_status.val;
 }
 
-Channel<PlaybackStatus> EnginePlayer::playbackStatusChanged() const
+Channel<PlaybackStatus> ContextPlayer::playbackStatusChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_status.ch;
 }
 
-bool EnginePlayer::isActive() const
+bool ContextPlayer::isActive() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_isActive.val;
 }
 
-Channel<bool> EnginePlayer::isActiveChanged() const
+Channel<bool> ContextPlayer::isActiveChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_isActive.ch;
 }
 
-void EnginePlayer::seekAllTracks(const TimePosition& position)
+void ContextPlayer::seekAllTracks(const TimePosition& position)
 {
     IF_ASSERT_FAILED(m_trackSource) {
         return;
@@ -308,7 +308,7 @@ void EnginePlayer::seekAllTracks(const TimePosition& position)
     }
 }
 
-void EnginePlayer::flushAllTracks()
+void ContextPlayer::flushAllTracks()
 {
     IF_ASSERT_FAILED(m_trackSource) {
         return;
@@ -319,7 +319,7 @@ void EnginePlayer::flushAllTracks()
     }
 }
 
-void EnginePlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReadyCallback)
+void ContextPlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReadyCallback)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 

--- a/src/framework/audio/engine/internal/contextplayer.h
+++ b/src/framework/audio/engine/internal/contextplayer.h
@@ -32,10 +32,10 @@
 #include "igettracksource.h"
 
 namespace muse::audio::engine {
-class EnginePlayer : public IEnginePlayer, public IPlayhead, public async::Asyncable
+class ContextPlayer : public IEnginePlayer, public IPlayhead, public async::Asyncable
 {
 public:
-    explicit EnginePlayer(IGetTrackSource* getTracks);
+    explicit ContextPlayer(IGetTrackSource* getTracks);
 
     async::Promise<Ret> prepareToPlay() override;
 

--- a/src/framework/audio/engine/internal/iaudiocontext.h
+++ b/src/framework/audio/engine/internal/iaudiocontext.h
@@ -40,7 +40,6 @@ public:
 
     // Config
     virtual void setMode(const ProcessMode newMode) = 0;
-    virtual void setOutputSpec(const OutputSpec& outputSpec) = 0;
 
     // Tracks
     virtual RetVal2<TrackId, AudioParams> addTrack(const TrackName& trackName, io::IODevice* playbackData, const AudioParams& params) = 0;

--- a/src/framework/audio/engine/internal/iaudiocontext.h
+++ b/src/framework/audio/engine/internal/iaudiocontext.h
@@ -109,8 +109,5 @@ public:
     virtual async::Promise<Ret> saveSoundTrack(io::IODevice& dstDevice, const SoundTrackFormat& format) = 0;
     virtual SaveSoundTrackProgress saveSoundTrackProgressChanged() const = 0;
     virtual void abortSavingAllSoundTracks() = 0;
-
-    // Processing
-    virtual samples_t process(float* buffer, samples_t samplesPerChannel) = 0;
 };
 }

--- a/src/framework/audio/engine/internal/nodes/audionode.cpp
+++ b/src/framework/audio/engine/internal/nodes/audionode.cpp
@@ -70,8 +70,17 @@ void AudioNode::doAddNode(std::shared_ptr<AudioNode> other)
     m_input = other;
 }
 
-void AudioNode::doRemoveNode(std::shared_ptr<AudioNode>)
+void AudioNode::doRemoveNode(std::shared_ptr<AudioNode> other)
 {
+    IF_ASSERT_FAILED(other) {
+        return;
+    }
+
+    IF_ASSERT_FAILED(m_input == other) {
+        LOGE() << "not connected to this node";
+        return;
+    }
+
     m_input = nullptr;
 }
 

--- a/src/framework/audio/engine/internal/nodes/audionode.cpp
+++ b/src/framework/audio/engine/internal/nodes/audionode.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "audionode.h"
+
+#include "log.h"
+
+using namespace muse::audio::engine;
+
+void AudioNode::setOutputSpec(const OutputSpec& spec)
+{
+    m_outputSpec = spec;
+    onOutputSpecChanged(spec);
+}
+
+void AudioNode::onOutputSpecChanged(const OutputSpec& spec)
+{
+    if (m_input) {
+        m_input->setOutputSpec(spec);
+    }
+}
+
+AudioNode* AudioNode::connect(std::shared_ptr<AudioNode> other)
+{
+    IF_ASSERT_FAILED(other) {
+        return this;
+    }
+    other->doAddNode(shared_from_this());
+    return this;
+}
+
+AudioNode* AudioNode::disconnect(std::shared_ptr<AudioNode> other)
+{
+    IF_ASSERT_FAILED(other) {
+        return this;
+    }
+    other->doRemoveNode(shared_from_this());
+    return this;
+}
+
+void AudioNode::doAddNode(std::shared_ptr<AudioNode> other)
+{
+    IF_ASSERT_FAILED(other) {
+        return;
+    }
+
+    IF_ASSERT_FAILED(m_input) {
+        LOGE() << "already connected to another node";
+        return;
+    }
+
+    m_input = other;
+}
+
+void AudioNode::doRemoveNode(std::shared_ptr<AudioNode>)
+{
+    m_input = nullptr;
+}
+
+void AudioNode::process(float* buffer, samples_t samplesPerChannel)
+{
+    doProcess(buffer, samplesPerChannel);
+}
+
+void AudioNode::doProcess(float* buffer, samples_t samplesPerChannel)
+{
+    if (m_input) {
+        m_input->process(buffer, samplesPerChannel);
+    }
+
+    doSelfProcess(buffer, samplesPerChannel);
+}

--- a/src/framework/audio/engine/internal/nodes/audionode.h
+++ b/src/framework/audio/engine/internal/nodes/audionode.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "audio/common/audiotypes.h"
+
+namespace muse::audio::engine {
+//! NOTE Abstract Base Audio Node
+class AudioNode : public std::enable_shared_from_this<AudioNode>
+{
+public:
+    virtual ~AudioNode() = default;
+
+    void setOutputSpec(const OutputSpec& spec);
+
+    AudioNode* connect(std::shared_ptr<AudioNode> other);
+    AudioNode* disconnect(std::shared_ptr<AudioNode> other);
+
+    void process(float* buffer, samples_t samplesPerChannel);
+
+protected:
+
+    virtual void onOutputSpecChanged(const OutputSpec& spec);
+    virtual void doAddNode(std::shared_ptr<AudioNode> other);
+    virtual void doRemoveNode(std::shared_ptr<AudioNode> other);
+    virtual void doProcess(float* buffer, samples_t samplesPerChannel);
+    virtual void doSelfProcess(float* buffer, samples_t samplesPerChannel) = 0;
+
+    OutputSpec m_outputSpec;
+    std::shared_ptr<AudioNode> m_input = nullptr;
+};
+}

--- a/src/framework/audio/engine/internal/nodes/mixernode.cpp
+++ b/src/framework/audio/engine/internal/nodes/mixernode.cpp
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mixernode.h"
+
+using namespace muse::audio::engine;
+
+void MixerNode::onOutputSpecChanged(const OutputSpec& spec)
+{
+    const size_t bufferSize = m_outputSpec.samplesPerChannel * m_outputSpec.audioChannelCount;
+    m_buffer.resize(bufferSize);
+
+    for (auto& input : m_inputs) {
+        input->setOutputSpec(spec);
+    }
+}
+
+void MixerNode::doAddNode(std::shared_ptr<AudioNode> other)
+{
+    m_inputs.emplace_back(other);
+}
+
+void MixerNode::doRemoveNode(std::shared_ptr<AudioNode> other)
+{
+    muse::remove(m_inputs, other);
+}
+
+void MixerNode::doProcess(float* buffer, samples_t samplesPerChannel)
+{
+    const audioch_t audioChannelCount = m_outputSpec.audioChannelCount;
+    const size_t outBufferSize = m_outputSpec.samplesPerChannel * audioChannelCount;
+    for (auto& input : m_inputs) {
+        // prepare input buffer
+        if (m_buffer.size() < outBufferSize) {
+            m_buffer.resize(outBufferSize);
+        }
+        std::fill(m_buffer.begin(), m_buffer.begin() + outBufferSize, 0.0f);
+
+        // process input
+        input->process(m_buffer.data(), samplesPerChannel);
+
+        // mix input into output
+        for (samples_t s = 0; s < samplesPerChannel; ++s) {
+            size_t samplePos = s * audioChannelCount;
+            for (audioch_t audioChNum = 0; audioChNum < audioChannelCount; ++audioChNum) {
+                size_t idx = samplePos + audioChNum;
+                buffer[idx] += m_buffer[idx];
+            }
+        }
+    }
+}
+
+void MixerNode::doSelfProcess(float*, samples_t)
+{
+    // noop
+}

--- a/src/framework/audio/engine/internal/nodes/mixernode.cpp
+++ b/src/framework/audio/engine/internal/nodes/mixernode.cpp
@@ -46,12 +46,15 @@ void MixerNode::doRemoveNode(std::shared_ptr<AudioNode> other)
 void MixerNode::doProcess(float* buffer, samples_t samplesPerChannel)
 {
     const audioch_t audioChannelCount = m_outputSpec.audioChannelCount;
-    const size_t outBufferSize = m_outputSpec.samplesPerChannel * audioChannelCount;
+    const size_t outBufferSize = samplesPerChannel * audioChannelCount;
+
     for (auto& input : m_inputs) {
         // prepare input buffer
         if (m_buffer.size() < outBufferSize) {
             m_buffer.resize(outBufferSize);
         }
+
+        // clear previous data
         std::fill(m_buffer.begin(), m_buffer.begin() + outBufferSize, 0.0f);
 
         // process input

--- a/src/framework/audio/engine/internal/nodes/mixernode.h
+++ b/src/framework/audio/engine/internal/nodes/mixernode.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include "audionode.h"
+
+namespace muse::audio::engine {
+class MixerNode : public AudioNode
+{
+protected:
+    void onOutputSpecChanged(const OutputSpec& spec) override;
+    void doAddNode(std::shared_ptr<AudioNode> other) override;
+    void doRemoveNode(std::shared_ptr<AudioNode> other) override;
+    void doProcess(float* buffer, samples_t samplesPerChannel) override;
+    void doSelfProcess(float* buffer, samples_t samplesPerChannel) override;
+
+    std::vector<std::shared_ptr<AudioNode> > m_inputs;
+    std::vector<float> m_buffer;
+};
+}


### PR DESCRIPTION
We are thinking of transferring the structure of our audio engine into a node graph.
Inspiration comes from the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) 

In this PR:
* Added a base abstract class Audio Node - by default, a single 1 to 1 connection is implemented, unlike the Web Audio API, where there is a multi-connection and each node can be a mixer. 
* A specialized Mixer Node has been added, many other nodes can connect to it.
* This Mixer is used in the Audio Engine to mix audio from Audio Contexts.
* Audio Contexts are now also Audio Nodes

```
Driver - [AudioEngine] SuperMixer - Audio Context 1
                                  \ Audio Context N: graph of nodes (de facto)
```

This is just the very beginning of the transformation of the structure, step by step...

Now, in single-process mode, we can open multiple windows and start audio playback in each one independently.

Also renamed EnginePlayer to ContexPlayer 