### PR TITLE
Move layoutMeasure out of getNextMeasure

### DIFF
--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -396,6 +396,15 @@ public:
     bool canAddStringTunings(staff_idx_t staffIdx) const;
     bool canAddStaffTypeChange(staff_idx_t staffIdx) const;
 
+    struct LayoutData : public MeasureBase::LayoutData {
+    private:
+        bool m_needLayout = true;
+    public:
+        bool needLayout() const { return m_needLayout; }
+        void setNeedLayout(bool v) { m_needLayout = v; }
+    };
+    DECLARE_LAYOUTDATA_METHODS(Measure)
+
 private:
 
     friend class Factory;

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -953,39 +953,11 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
         return;
     }
 
-    if (!currentMB) {
+    if (!currentMB || !currentMB->isMeasure()) {
         return;
     }
-
-    if (!currentMB->isMeasure()) {
-        assert(currentMB->tick() == ctx.state().tick());
-
-        const LayoutBreak* layoutBreak = currentMB->sectionBreakElement();
-        if (layoutBreak && layoutBreak->startWithMeasureOne()) {
-            ctx.mutState().setMeasureNumber(0);
-        }
-
-        return;
-    }
-
-    //-----------------------------------------
-    //    process one measure
-    //-----------------------------------------
 
     Measure* measure = toMeasure(currentMB);
-
-    int measureNumber = adjustMeasureNumber(measure, ctx.state().measureNumber());
-    LAYOUT_CALL() << LAYOUT_ITEM_INFO(measure) << " measureNumber: " << measureNumber;
-
-    ctx.mutState().setMeasureNumber(measureNumber);
-
-    createMultiMeasureRestsIfNeed(measure, ctx);
-
-    currentMB = ctx.mutState().curMeasure();
-    measure = toMeasure(currentMB);
-
-    measure->moveTicks(ctx.state().tick() - measure->tick());
-    ctx.mutState().setTick(ctx.state().tick() + measure->ticks());
 
     if (ctx.conf().isLinearMode() && (measure->tick() < ctx.state().startTick() || measure->tick() > ctx.state().endTick())) {
         return;
@@ -1185,7 +1157,44 @@ void MeasureLayout::getNextMeasure(LayoutContext& ctx)
 
     moveToNextMeasure(ctx);
 
-    layoutMeasure(ctx.mutState().curMeasure(), ctx);
+    updateTicksMeasNumbersAndMMRests(ctx.mutState().curMeasure(), ctx);
+}
+
+void MeasureLayout::updateTicksMeasNumbersAndMMRests(MeasureBase* currentMB, LayoutContext& ctx)
+{
+    IF_ASSERT_FAILED(currentMB == ctx.state().curMeasure()) {
+        return;
+    }
+
+    if (!currentMB) {
+        return;
+    }
+
+    if (!currentMB->isMeasure()) {
+        assert(currentMB->tick() == ctx.state().tick());
+
+        const LayoutBreak* layoutBreak = currentMB->sectionBreakElement();
+        if (layoutBreak && layoutBreak->startWithMeasureOne()) {
+            ctx.mutState().setMeasureNumber(0);
+        }
+
+        return;
+    }
+
+    Measure* measure = toMeasure(currentMB);
+
+    int measureNumber = adjustMeasureNumber(measure, ctx.state().measureNumber());
+
+    ctx.mutState().setMeasureNumber(measureNumber);
+
+    createMultiMeasureRestsIfNeed(measure, ctx);
+
+    currentMB = ctx.mutState().curMeasure();
+    measure = toMeasure(currentMB);
+
+    measure->moveTicks(ctx.state().tick() - measure->tick());
+
+    ctx.mutState().setTick(ctx.state().tick() + measure->ticks());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -959,6 +959,10 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
 
     Measure* measure = toMeasure(currentMB);
 
+    if (!measure->ldata()->needLayout()) {
+        return;
+    }
+
     if (ctx.conf().isLinearMode() && (measure->tick() < ctx.state().startTick() || measure->tick() > ctx.state().endTick())) {
         return;
     }
@@ -966,6 +970,8 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
     if (ctx.dom().allStavesInvisible()) {
         return;
     }
+
+    measure->mutldata()->setNeedLayout(false);
 
     // Check if requested cross-staff is possible
     // This must happen before cmdUpdateNotes
@@ -1158,6 +1164,11 @@ void MeasureLayout::getNextMeasure(LayoutContext& ctx)
     moveToNextMeasure(ctx);
 
     updateTicksMeasNumbersAndMMRests(ctx.mutState().curMeasure(), ctx);
+
+    MeasureBase* mb = ctx.mutState().curMeasure();
+    if (mb && mb->isMeasure()) {
+        toMeasure(mb)->mutldata()->setNeedLayout(true);
+    }
 }
 
 void MeasureLayout::updateTicksMeasNumbersAndMMRests(MeasureBase* currentMB, LayoutContext& ctx)

--- a/src/engraving/rendering/score/measurelayout.h
+++ b/src/engraving/rendering/score/measurelayout.h
@@ -51,6 +51,9 @@ public:
     static void layout2(Measure* item, LayoutContext& ctx);
 
     static void getNextMeasure(LayoutContext& ctx);
+    static void updateTicksMeasNumbersAndMMRests(MeasureBase* currentMB, LayoutContext& ctx);
+    static void layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx);
+
     static void computePreSpacingItems(Measure* m, LayoutContext& ctx);
 
     static void layoutStaffLines(Measure* m, LayoutContext& ctx);
@@ -94,7 +97,7 @@ private:
     static void layoutPartialWidth(StaffLines* lines, LayoutContext& ctx, double w, double wPartial, bool alignLeft);
 
     static void moveToNextMeasure(LayoutContext& ctx);
-    static void layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx);
+
     static void checkStaffMoveValidity(Measure* measure, const LayoutContext& ctx);
 
     static void createMultiMeasureRestsIfNeed(Measure* firstMeasure, LayoutContext& ctx);

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -300,9 +300,11 @@ void ScoreHorizontalViewLayout::collectLinearSystem(LayoutContext& ctx)
         if (ctx.state().curMeasure()->isVBoxBase()) {
             ctx.mutState().curMeasure()->resetExplicitParent();
             MeasureLayout::getNextMeasure(ctx);
+            MeasureLayout::layoutMeasure(ctx.mutState().curMeasure(), ctx);
             continue;
         }
         system->appendMeasure(ctx.mutState().curMeasure());
+        MeasureLayout::layoutMeasure(ctx.mutState().curMeasure(), ctx);
         bool createHeader = ctx.state().prevMeasure() && ctx.state().prevMeasure()->isHBox()
                             && toHBox(ctx.state().prevMeasure())->createSystemHeader();
         if (ctx.state().curMeasure()->isMeasure()) {

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -154,6 +154,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
     while (ctx.state().curMeasure()) {      // collect measure for system
         oldSystem = ctx.mutState().curMeasure()->system();
         system->appendMeasure(ctx.mutState().curMeasure());
+        MeasureLayout::layoutMeasure(ctx.mutState().curMeasure(), ctx);
 
         if (ctx.state().curMeasure()->isMeasure()) {
             Measure* m = toMeasure(ctx.mutState().curMeasure());
@@ -200,6 +201,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
         } else {
             // vbox:
             MeasureLayout::getNextMeasure(ctx);
+            MeasureLayout::layoutMeasure(ctx.mutState().curMeasure(), ctx);
             SystemLayout::layout2(system, ctx);         // compute staff distances
             return system;
         }


### PR DESCRIPTION
It has always been weird that `MeasureLayout::getNextMeasure` also performs all the measure layout operations. `getNextMeasure` should only do operations connected to advancing the layout to the next measure, such as updating the ticks, updating measure numbers, updating mmRests. Everything else should be done outside of it. 

Above all, the fundamental advantage of this small refactor is that I can now call `layoutMeasure` **after** `system->appendMeasure()`, which means measure layout can be aware of what system the measure is in (which it couldn't before).