### PR TITLE
[audio] transformed eventaudiosource to eventaudionode

### DIFF
--- a/src/framework/audio/engine/CMakeLists.txt
+++ b/src/framework/audio/engine/CMakeLists.txt
@@ -75,8 +75,6 @@ else()
         internal/track.h
         internal/abstractaudiosource.cpp
         internal/abstractaudiosource.h
-        internal/eventaudiosource.cpp
-        internal/eventaudiosource.h
         internal/sinesource.cpp
         internal/sinesource.h
         # internal/noisesource.cpp
@@ -89,8 +87,12 @@ else()
         # Nodes
         internal/nodes/audionode.cpp
         internal/nodes/audionode.h
+        internal/nodes/audiosourcenode.cpp
+        internal/nodes/audiosourcenode.h
         internal/nodes/mixernode.cpp
         internal/nodes/mixernode.h
+        internal/nodes/eventaudionode.cpp
+        internal/nodes/eventaudionode.h
 
         # DSP
         internal/dsp/envelopefilterconfig.h

--- a/src/framework/audio/engine/internal/audiocontext.cpp
+++ b/src/framework/audio/engine/internal/audiocontext.cpp
@@ -157,7 +157,9 @@ RetVal2<TrackId, AudioParams> AudioContext::addTrack(const std::string& trackNam
         return RetType::make_ret(Err::InvalidSetupData);
     }
 
-    auto onOffStreamReceived = [this](const TrackId trackId) {
+    TrackId trackId = newTrackId();
+
+    auto onOffStreamReceived = [this, trackId]() {
         std::unordered_set<TrackId> tracksToProcess = m_tracksToProcessWhenIdle;
 
         if (m_prevActiveTrackId == INVALID_TRACK_ID) {
@@ -170,10 +172,8 @@ RetVal2<TrackId, AudioParams> AudioContext::addTrack(const std::string& trackNam
         m_prevActiveTrackId = trackId;
     };
 
-    TrackId trackId = newTrackId();
-
 // Make source
-    RetVal<ITrackAudioInputPtr> source = audioFactory()->makeEventSource(trackId, playbackData, params.in, onOffStreamReceived);
+    RetVal<AudioSourceNodePtr> source = audioFactory()->makeEventSource(trackId, playbackData, params.in, onOffStreamReceived);
     if (!source.ret) {
         return RetType::make_ret(source.ret);
     }
@@ -362,7 +362,7 @@ RetVal<TrackName> AudioContext::trackName(const TrackId trackId) const
     return RetVal<TrackName>::make_ret((int)Err::InvalidTrackId, "no track");
 }
 
-ITrackAudioInputPtr AudioContext::trackSource(const TrackId trackId) const
+AudioSourceNodePtr AudioContext::trackSource(const TrackId trackId) const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     if (const Track* t = track(trackId)) {
@@ -371,10 +371,10 @@ ITrackAudioInputPtr AudioContext::trackSource(const TrackId trackId) const
     return nullptr;
 }
 
-std::vector<ITrackAudioInputPtr> AudioContext::allTracksSources() const
+std::vector<AudioSourceNodePtr> AudioContext::allTracksSources() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
-    std::vector<ITrackAudioInputPtr> result;
+    std::vector<AudioSourceNodePtr> result;
     result.reserve(m_tracks.size());
     for (const Track& t : m_tracks) {
         if (t.source) {

--- a/src/framework/audio/engine/internal/audiocontext.h
+++ b/src/framework/audio/engine/internal/audiocontext.h
@@ -128,7 +128,7 @@ private:
         TrackId id = INVALID_TRACK_ID;
         TrackType type = Undefined;
         TrackName name;
-        ITrackAudioInputPtr source = nullptr;
+        AudioSourceNodePtr source = nullptr;
         ITrackAudioOutputPtr output = nullptr;
     };
 
@@ -139,8 +139,8 @@ private:
     const Track* track(const TrackId id) const;
 
     // IGetTrackSource
-    ITrackAudioInputPtr trackSource(const TrackId trackId) const override;
-    std::vector<ITrackAudioInputPtr> allTracksSources() const override;
+    AudioSourceNodePtr trackSource(const TrackId trackId) const override;
+    std::vector<AudioSourceNodePtr> allTracksSources() const override;
     // -----
 
     void listenInputProcessing(std::function<void(const Ret&)> completed);

--- a/src/framework/audio/engine/internal/audiofactory.cpp
+++ b/src/framework/audio/engine/internal/audiofactory.cpp
@@ -26,7 +26,7 @@
 
 #include "audio/engine/internal/mixerchannel.h"
 
-#include "eventaudiosource.h"
+#include "nodes/eventaudionode.h"
 
 using namespace muse;
 using namespace muse::audio;
@@ -71,18 +71,18 @@ void AudioFactory::clearSynthSources()
     synthResolver()->clearSources();
 }
 
-RetVal<ITrackAudioInputPtr> AudioFactory::makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData,
-                                                          const AudioInputParams& params,
-                                                          const std::function<void(const TrackId)> onOffStreamReceived) const
+RetVal<AudioSourceNodePtr> AudioFactory::makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData,
+                                                         const AudioInputParams& params,
+                                                         const std::function<void()> onOffStreamReceived) const
 {
-    EventAudioSourcePtr source = std::make_shared<EventAudioSource>(trackId, playbackData, onOffStreamReceived);
+    EventAudioNodePtr source = std::make_shared<EventAudioNode>(trackId, playbackData, onOffStreamReceived);
     source->setOutputSpec(audioEngine()->outputSpec());
     source->applyInputParams(params);
-    return RetVal<ITrackAudioInputPtr>::make_ok(source);
+    return RetVal<AudioSourceNodePtr>::make_ok(source);
 }
 
 RetVal<ITrackAudioOutputPtr> AudioFactory::makeMixerChannel(const TrackId trackId, const AudioOutputParams& params,
-                                                            const ITrackAudioInputPtr& source) const
+                                                            const AudioNodePtr& source) const
 {
     auto channel = std::make_shared<MixerChannel>(trackId, audioEngine()->outputSpec(), source, nullptr);
     channel->applyOutputParams(params);

--- a/src/framework/audio/engine/internal/audiofactory.h
+++ b/src/framework/audio/engine/internal/audiofactory.h
@@ -49,13 +49,12 @@ public:
     RetVal<synth::ISynthesizerPtr> makeDefaultSynth(const TrackId trackId) const override;
     void clearSynthSources() override;
 
-    RetVal<ITrackAudioInputPtr> makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData,
-                                                const AudioInputParams& params,
-                                                const std::function<void(const TrackId)> onOffStreamReceived = nullptr) const override;
+    RetVal<AudioSourceNodePtr> makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData, const AudioInputParams& params,
+                                               const std::function<void()> onOffStreamReceived = nullptr) const override;
 
     // Make output (mixer channel)
     RetVal<ITrackAudioOutputPtr> makeMixerChannel(const TrackId trackId, const AudioOutputParams& params,
-                                                  const ITrackAudioInputPtr& source) const override;
+                                                  const AudioNodePtr& source) const override;
     RetVal<ITrackAudioOutputPtr> makeMixerAuxChannel(const TrackId trackId, const AudioOutputParams& params) const override;
 
     // Make FX

--- a/src/framework/audio/engine/internal/contextplayer.cpp
+++ b/src/framework/audio/engine/internal/contextplayer.cpp
@@ -200,7 +200,7 @@ void ContextPlayer::stop()
     m_status.set(PlaybackStatus::Stopped);
     m_countDown = 0.;
     seek(TimePosition::zero(m_currentPosition.sampleRate()));
-    m_notYetReadyToPlayTrackIdSet.clear();
+    m_notYetReadyToPlayTrack.clear();
 }
 
 void ContextPlayer::pause()
@@ -212,7 +212,7 @@ void ContextPlayer::pause()
     }
 
     m_status.set(PlaybackStatus::Paused);
-    m_notYetReadyToPlayTrackIdSet.clear();
+    m_notYetReadyToPlayTrack.clear();
 }
 
 void ContextPlayer::resume(const secs_t delay)
@@ -327,37 +327,33 @@ void ContextPlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReady
         return;
     }
 
-    std::vector<ITrackAudioInputPtr> notYetReadyToPlayTracks;
-    m_notYetReadyToPlayTrackIdSet.clear();
+    m_notYetReadyToPlayTrack.clear();
 
     for (const auto& source : m_trackSource->allTracksSources()) {
         source->prepareToPlay();
 
         if (!source->readyToPlay()) {
-            notYetReadyToPlayTracks.push_back(source);
-            m_notYetReadyToPlayTrackIdSet.insert(source->trackId());
+            m_notYetReadyToPlayTrack.insert(source);
         }
     }
 
-    if (notYetReadyToPlayTracks.empty()) {
+    if (m_notYetReadyToPlayTrack.empty()) {
         allTracksReadyCallback();
         return;
     }
 
-    for (const auto& source : notYetReadyToPlayTracks) {
-        TrackId trackId = source->trackId();
-        source->readyToPlayChanged().onNotify(this, [this, trackId, allTracksReadyCallback]() {
-            muse::remove(m_notYetReadyToPlayTrackIdSet, trackId);
+    for (const auto& source : m_notYetReadyToPlayTrack) {
+        std::weak_ptr<AudioSourceNode> weakPtr = source;
+        source->readyToPlayChanged().onNotify(this, [this, weakPtr, allTracksReadyCallback]() {
+            if (auto source = weakPtr.lock()) {
+                muse::remove(m_notYetReadyToPlayTrack, source);
 
-            if (m_notYetReadyToPlayTrackIdSet.empty()) {
-                allTracksReadyCallback();
-            }
+                if (m_notYetReadyToPlayTrack.empty()) {
+                    allTracksReadyCallback();
+                }
 
-            ITrackAudioInputPtr source = m_trackSource->trackSource(trackId);
-            IF_ASSERT_FAILED(source) {
-                return;
+                source->readyToPlayChanged().disconnect(this);
             }
-            source->readyToPlayChanged().disconnect(this);
         }, Asyncable::Mode::SetReplace);
     }
 }

--- a/src/framework/audio/engine/internal/contextplayer.h
+++ b/src/framework/audio/engine/internal/contextplayer.h
@@ -107,6 +107,6 @@ private:
     async::Channel<TimeEvent> m_timeEvent;
 
     bool m_flushSoundOnSeek = true;
-    std::set<TrackId> m_notYetReadyToPlayTrackIdSet;
+    std::set<AudioSourceNodePtr> m_notYetReadyToPlayTrack;
 };
 }

--- a/src/framework/audio/engine/internal/eventaudiosource.cpp
+++ b/src/framework/audio/engine/internal/eventaudiosource.cpp
@@ -100,23 +100,14 @@ void EventAudioSource::setOutputSpec(const OutputSpec& spec)
 unsigned int EventAudioSource::audioChannelsCount() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
-
-    if (!m_synth) {
-        return 0;
-    }
-
-    return m_synth->audioChannelsCount();
+    return m_outputSpec.audioChannelCount;
 }
 
 async::Channel<unsigned int> EventAudioSource::audioChannelsCountChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
-
-    IF_ASSERT_FAILED(m_synth) {
-        return {};
-    }
-
-    return m_synth->audioChannelsCountChanged();
+    static async::Channel<unsigned int> channel;
+    return channel;
 }
 
 samples_t EventAudioSource::process(float* buffer, samples_t samplesPerChannel)

--- a/src/framework/audio/engine/internal/iaudiofactory.h
+++ b/src/framework/audio/engine/internal/iaudiofactory.h
@@ -25,9 +25,10 @@
 #include "global/modularity/imoduleinterface.h"
 #include "global/types/retval.h"
 #include "mpe/events.h"
-#include "track.h"
 #include "../ifxprocessor.h"
 #include "../isynthesizer.h"
+#include "nodes/audiosourcenode.h"
+#include "track.h"
 
 namespace muse::audio::engine {
 class IAudioFactory : MODULE_GLOBAL_INTERFACE
@@ -53,13 +54,13 @@ public:
     // This method clears this registry.
     virtual void clearSynthSources() = 0;
 
-    virtual RetVal<ITrackAudioInputPtr> makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData,
-                                                        const AudioInputParams& params,
-                                                        const std::function<void(const TrackId)> onOffStreamReceived = nullptr) const = 0;
+    virtual RetVal<AudioSourceNodePtr> makeEventSource(const TrackId trackId, const mpe::PlaybackData& playbackData,
+                                                       const AudioInputParams& params,
+                                                       const std::function<void()> onOffStreamReceived = nullptr) const = 0;
 
     // Make output (mixer channel)
     virtual RetVal<ITrackAudioOutputPtr> makeMixerChannel(const TrackId trackId, const AudioOutputParams& params,
-                                                          const ITrackAudioInputPtr& source) const = 0;
+                                                          const AudioNodePtr& source) const = 0;
     virtual RetVal<ITrackAudioOutputPtr> makeMixerAuxChannel(const TrackId trackId, const AudioOutputParams& params) const = 0;
 
     // Make FX

--- a/src/framework/audio/engine/internal/igettracksource.h
+++ b/src/framework/audio/engine/internal/igettracksource.h
@@ -24,7 +24,7 @@
 
 #include "audio/common/audiotypes.h"
 
-#include "track.h"
+#include "nodes/audiosourcenode.h"
 
 namespace muse::audio::engine {
 class IGetTrackSource
@@ -32,7 +32,7 @@ class IGetTrackSource
 public:
     virtual ~IGetTrackSource() = default;
 
-    virtual ITrackAudioInputPtr trackSource(const TrackId trackId) const = 0;
-    virtual std::vector<ITrackAudioInputPtr> allTracksSources() const = 0;
+    virtual AudioSourceNodePtr trackSource(const TrackId trackId) const = 0;
+    virtual std::vector<AudioSourceNodePtr> allTracksSources() const = 0;
 };
 }

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -94,7 +94,7 @@ Ret Mixer::addChannel(ITrackAudioOutputPtr output)
             channel->setMode(ProcessMode::Idle);
         } else {
             channel->setMode(mode());
-            ITrackAudioInputPtr source = std::static_pointer_cast<ITrackAudioInput>(channel->source());
+            AudioSourceNodePtr source = std::dynamic_pointer_cast<AudioSourceNode>(channel->source());
             if (source) {
                 source->seek(playbackPosition());
             }

--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -32,7 +32,7 @@ using namespace muse::async;
 using namespace muse::audio;
 using namespace muse::audio::engine;
 
-MixerChannel::MixerChannel(const TrackId trackId, const OutputSpec& outputSpec, IAudioSourcePtr source,
+MixerChannel::MixerChannel(const TrackId trackId, const OutputSpec& outputSpec, AudioNodePtr source,
                            PlayheadPositionPtr playheadPosition)
     : m_trackId(trackId),
     m_outputSpec(outputSpec),
@@ -60,7 +60,7 @@ TrackId MixerChannel::trackId() const
     return m_trackId;
 }
 
-IAudioSourcePtr MixerChannel::source() const
+AudioNodePtr MixerChannel::source() const
 {
     return m_audioSource;
 }
@@ -189,14 +189,15 @@ unsigned int MixerChannel::audioChannelsCount() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    return m_audioSource ? m_audioSource->audioChannelsCount() : m_outputSpec.audioChannelCount;
+    return m_outputSpec.audioChannelCount;
 }
 
 async::Channel<unsigned int> MixerChannel::audioChannelsCountChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    return m_audioSource ? m_audioSource->audioChannelsCountChanged() : async::Channel<unsigned int>();
+    static async::Channel<unsigned int> channel;
+    return channel;
 }
 
 samples_t MixerChannel::process(float* buffer, samples_t samplesPerChannel)
@@ -207,7 +208,7 @@ samples_t MixerChannel::process(float* buffer, samples_t samplesPerChannel)
 
     if (m_audioSource) {
         if (!m_params.muted || !m_isSilent) {
-            processedSamplesCount = m_audioSource->process(buffer, samplesPerChannel);
+            m_audioSource->process(buffer, samplesPerChannel);
         }
     }
 

--- a/src/framework/audio/engine/internal/mixerchannel.h
+++ b/src/framework/audio/engine/internal/mixerchannel.h
@@ -38,14 +38,13 @@ class MixerChannel : public ITrackAudioOutput, public async::Asyncable
     GlobalInject<IAudioFactory> audioFactory;
 
 public:
-    explicit MixerChannel(const TrackId trackId, const OutputSpec& outputSpec, IAudioSourcePtr source,
-                          PlayheadPositionPtr playheadPosition);
+    explicit MixerChannel(const TrackId trackId, const OutputSpec& outputSpec, AudioNodePtr source, PlayheadPositionPtr playheadPosition);
     explicit MixerChannel(const TrackId trackId, const OutputSpec& outputSpec, PlayheadPositionPtr playheadPosition);
 
     void setPlayheadPosition(PlayheadPositionPtr playheadPosition);
 
     TrackId trackId() const;
-    IAudioSourcePtr source() const;
+    AudioNodePtr source() const;
 
     bool muted() const;
     async::Notification mutedChanged() const;
@@ -82,7 +81,7 @@ private:
     OutputSpec m_outputSpec;
     AudioOutputParams m_params;
 
-    IAudioSourcePtr m_audioSource = nullptr;
+    AudioNodePtr m_audioSource = nullptr;
     PlayheadPositionPtr m_playheadPosition = nullptr;
     std::vector<IFxProcessorPtr> m_fxProcessors = {};
 

--- a/src/framework/audio/engine/internal/nodes/audionode.cpp
+++ b/src/framework/audio/engine/internal/nodes/audionode.cpp
@@ -23,18 +23,48 @@
 
 #include "log.h"
 
+using namespace muse::audio;
 using namespace muse::audio::engine;
 
 void AudioNode::setOutputSpec(const OutputSpec& spec)
 {
+    if (m_outputSpec == spec) {
+        return;
+    }
     m_outputSpec = spec;
     onOutputSpecChanged(spec);
+}
+
+const OutputSpec& AudioNode::outputSpec() const
+{
+    return m_outputSpec;
 }
 
 void AudioNode::onOutputSpecChanged(const OutputSpec& spec)
 {
     if (m_input) {
         m_input->setOutputSpec(spec);
+    }
+}
+
+void AudioNode::setMode(const ProcessMode mode)
+{
+    if (m_mode == mode) {
+        return;
+    }
+    m_mode = mode;
+    onModeChanged(mode);
+}
+
+ProcessMode AudioNode::mode() const
+{
+    return m_mode;
+}
+
+void AudioNode::onModeChanged(const ProcessMode mode)
+{
+    if (m_input) {
+        m_input->setMode(mode);
     }
 }
 

--- a/src/framework/audio/engine/internal/nodes/audionode.h
+++ b/src/framework/audio/engine/internal/nodes/audionode.h
@@ -34,6 +34,9 @@ public:
     virtual ~AudioNode() = default;
 
     void setOutputSpec(const OutputSpec& spec);
+    const OutputSpec& outputSpec() const;
+    void setMode(const ProcessMode mode);
+    ProcessMode mode() const;
 
     AudioNode* connect(std::shared_ptr<AudioNode> other);
     AudioNode* disconnect(std::shared_ptr<AudioNode> other);
@@ -43,12 +46,19 @@ public:
 protected:
 
     virtual void onOutputSpecChanged(const OutputSpec& spec);
+    virtual void onModeChanged(const ProcessMode mode);
+
     virtual void doAddNode(std::shared_ptr<AudioNode> other);
     virtual void doRemoveNode(std::shared_ptr<AudioNode> other);
+
     virtual void doProcess(float* buffer, samples_t samplesPerChannel);
     virtual void doSelfProcess(float* buffer, samples_t samplesPerChannel) = 0;
 
     OutputSpec m_outputSpec;
+    ProcessMode m_mode = ProcessMode::Undefined;
+
     std::shared_ptr<AudioNode> m_input = nullptr;
 };
+
+using AudioNodePtr = std::shared_ptr<AudioNode>;
 }

--- a/src/framework/audio/engine/internal/nodes/audiosourcenode.h
+++ b/src/framework/audio/engine/internal/nodes/audiosourcenode.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "audionode.h"
+
+#include "global/async/notification.h"
+#include "global/async/channel.h"
+#include "audio/common/audiotypes.h"
+#include "audio/common/timeposition.h"
+
+namespace muse::audio::engine {
+//! NOTE Abstract Base Audio Source Node
+class AudioSourceNode : public AudioNode
+{
+public:
+
+    virtual void seek(const TimePosition& position, const bool flushSound = true) = 0;
+    virtual void flush() = 0;
+
+    virtual const AudioInputParams& inputParams() const = 0;
+    virtual void applyInputParams(const AudioInputParams& requiredParams) = 0;
+    virtual async::Channel<AudioInputParams> inputParamsChanged() const = 0;
+
+    virtual void prepareToPlay() = 0;
+    virtual bool readyToPlay() const = 0;
+    virtual async::Notification readyToPlayChanged() const = 0;
+
+    virtual bool hasPendingChunks() const = 0;
+    virtual void processInput() = 0;
+    virtual InputProcessingProgress inputProcessingProgress() const = 0;
+
+    virtual void clearCache() = 0;
+};
+
+using AudioSourceNodePtr = std::shared_ptr<AudioSourceNode>;
+}

--- a/src/framework/audio/engine/internal/nodes/eventaudionode.cpp
+++ b/src/framework/audio/engine/internal/nodes/eventaudionode.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "eventaudiosource.h"
+#include "eventaudionode.h"
 
 #include "audio/common/audiosanitizer.h"
 
@@ -32,41 +32,31 @@ using namespace muse::audio::engine;
 using namespace muse::audio::synth;
 using namespace muse::mpe;
 
-EventAudioSource::EventAudioSource(const TrackId trackId,
-                                   const mpe::PlaybackData& playbackData,
-                                   OnOffStreamEventsReceived onOffStreamReceived)
+EventAudioNode::EventAudioNode(TrackId trackId, const mpe::PlaybackData& playbackData,
+                               OnOffStreamEventsReceived onOffStreamReceived)
     : m_trackId(trackId), m_playbackData(playbackData)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
     if (onOffStreamReceived) {
-        m_playbackData.offStream.onReceive(this, [onOffStreamReceived, trackId](const PlaybackEventsMap&,
-                                                                                const DynamicLevelLayers&,
-                                                                                bool) {
-            onOffStreamReceived(trackId);
+        m_playbackData.offStream.onReceive(this, [onOffStreamReceived](const PlaybackEventsMap&,
+                                                                       const DynamicLevelLayers&,
+                                                                       bool) {
+            onOffStreamReceived();
         });
     }
 }
 
-EventAudioSource::~EventAudioSource()
+EventAudioNode::~EventAudioNode()
 {
     m_playbackData.offStream.disconnect(this);
 }
 
-TrackId EventAudioSource::trackId() const
-{
-    return m_trackId;
-}
-
-void EventAudioSource::setMode(const ProcessMode mode)
+void EventAudioNode::onModeChanged(const ProcessMode mode)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
-    IF_ASSERT_FAILED(m_synth) {
-        return;
-    }
-
-    if (m_synth->mode() == mode) {
+    if (!m_synth) {
         return;
     }
 
@@ -74,22 +64,9 @@ void EventAudioSource::setMode(const ProcessMode mode)
     m_synth->flushSound();
 }
 
-ProcessMode EventAudioSource::mode() const
+void EventAudioNode::onOutputSpecChanged(const OutputSpec& spec)
 {
     ONLY_AUDIO_ENGINE_THREAD;
-
-    if (!m_synth) {
-        return ProcessMode::Undefined;
-    }
-
-    return m_synth->mode();
-}
-
-void EventAudioSource::setOutputSpec(const OutputSpec& spec)
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-    m_outputSpec = spec;
-
     if (!m_synth) {
         return;
     }
@@ -97,31 +74,17 @@ void EventAudioSource::setOutputSpec(const OutputSpec& spec)
     m_synth->setOutputSpec(spec);
 }
 
-unsigned int EventAudioSource::audioChannelsCount() const
+void EventAudioNode::doSelfProcess(float* buffer, samples_t samplesPerChannel)
 {
-    ONLY_AUDIO_ENGINE_THREAD;
-    return m_outputSpec.audioChannelCount;
-}
-
-async::Channel<unsigned int> EventAudioSource::audioChannelsCountChanged() const
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-    static async::Channel<unsigned int> channel;
-    return channel;
-}
-
-samples_t EventAudioSource::process(float* buffer, samples_t samplesPerChannel)
-{
-    ONLY_AUDIO_ENGINE_THREAD;
-
+    ONLY_AUDIO_PROC_THREAD;
     if (!m_synth) {
-        return 0;
+        return;
     }
 
-    return m_synth->process(buffer, samplesPerChannel);
+    m_synth->process(buffer, samplesPerChannel);
 }
 
-void EventAudioSource::seek(const TimePosition& position, const bool flushSound)
+void EventAudioNode::seek(const TimePosition& position, const bool flushSound)
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -140,7 +103,7 @@ void EventAudioSource::seek(const TimePosition& position, const bool flushSound)
     }
 }
 
-void EventAudioSource::flush()
+void EventAudioNode::flush()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -151,12 +114,12 @@ void EventAudioSource::flush()
     m_synth->flushSound();
 }
 
-const AudioInputParams& EventAudioSource::inputParams() const
+const AudioInputParams& EventAudioNode::inputParams() const
 {
     return m_params;
 }
 
-void EventAudioSource::applyInputParams(const AudioInputParams& requiredParams)
+void EventAudioNode::applyInputParams(const AudioInputParams& requiredParams)
 {
     IF_ASSERT_FAILED(m_outputSpec.isValid()) {
         return;
@@ -200,12 +163,12 @@ void EventAudioSource::applyInputParams(const AudioInputParams& requiredParams)
     m_paramsChanges.send(m_params);
 }
 
-async::Channel<AudioInputParams> EventAudioSource::inputParamsChanged() const
+async::Channel<AudioInputParams> EventAudioNode::inputParamsChanged() const
 {
     return m_paramsChanges;
 }
 
-void EventAudioSource::prepareToPlay()
+void EventAudioNode::prepareToPlay()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -216,7 +179,7 @@ void EventAudioSource::prepareToPlay()
     m_synth->prepareToPlay();
 }
 
-bool EventAudioSource::readyToPlay() const
+bool EventAudioNode::readyToPlay() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -227,7 +190,7 @@ bool EventAudioSource::readyToPlay() const
     return m_synth->readyToPlay();
 }
 
-async::Notification EventAudioSource::readyToPlayChanged() const
+async::Notification EventAudioNode::readyToPlayChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -238,7 +201,7 @@ async::Notification EventAudioSource::readyToPlayChanged() const
     return m_synth->readyToPlayChanged();
 }
 
-bool EventAudioSource::hasPendingChunks() const
+bool EventAudioNode::hasPendingChunks() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -249,7 +212,7 @@ bool EventAudioSource::hasPendingChunks() const
     return m_synth->hasPendingChunks();
 }
 
-void EventAudioSource::processInput()
+void EventAudioNode::processInput()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -260,7 +223,7 @@ void EventAudioSource::processInput()
     m_synth->processInput();
 }
 
-InputProcessingProgress EventAudioSource::inputProcessingProgress() const
+InputProcessingProgress EventAudioNode::inputProcessingProgress() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -271,7 +234,7 @@ InputProcessingProgress EventAudioSource::inputProcessingProgress() const
     return m_synth->inputProcessingProgress();
 }
 
-void EventAudioSource::clearCache()
+void EventAudioNode::clearCache()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 
@@ -282,7 +245,7 @@ void EventAudioSource::clearCache()
     m_synth->clearCache();
 }
 
-EventAudioSource::SynthCtx EventAudioSource::currentSynthCtx() const
+EventAudioNode::SynthCtx EventAudioNode::currentSynthCtx() const
 {
     if (!m_synth) {
         return SynthCtx();
@@ -291,13 +254,13 @@ EventAudioSource::SynthCtx EventAudioSource::currentSynthCtx() const
     return { m_synth->mode(), m_synth->playbackPosition() };
 }
 
-void EventAudioSource::restoreSynthCtx(const SynthCtx& ctx)
+void EventAudioNode::restoreSynthCtx(const SynthCtx& ctx)
 {
     m_synth->setPlaybackPosition(ctx.playbackPosition);
     m_synth->setMode(ctx.mode);
 }
 
-void EventAudioSource::setupSource()
+void EventAudioNode::setupSource()
 {
     ONLY_AUDIO_ENGINE_THREAD;
 

--- a/src/framework/audio/engine/internal/nodes/eventaudionode.h
+++ b/src/framework/audio/engine/internal/nodes/eventaudionode.h
@@ -22,34 +22,26 @@
 
 #pragma once
 
+#include "audiosourcenode.h"
+
 #include "global/async/asyncable.h"
 #include "global/modularity/ioc.h"
 #include "mpe/events.h"
 
 #include "audio/common/audiotypes.h"
-#include "iaudiofactory.h"
-#include "track.h"
+#include "../iaudiofactory.h"
 
 namespace muse::audio::engine {
-class EventAudioSource : public ITrackAudioInput, public async::Asyncable
+class EventAudioNode : public AudioSourceNode, public async::Asyncable
 {
     GlobalInject<IAudioFactory> audioFactory;
 
 public:
-    using OnOffStreamEventsReceived = std::function<void (const TrackId)>;
+    using OnOffStreamEventsReceived = std::function<void ()>;
 
-    explicit EventAudioSource(const TrackId trackId, const mpe::PlaybackData& playbackData, OnOffStreamEventsReceived onOffStreamReceived);
+    explicit EventAudioNode(TrackId trackId, const mpe::PlaybackData& playbackData, OnOffStreamEventsReceived onOffStreamReceived);
 
-    ~EventAudioSource() override;
-
-    TrackId trackId() const override;
-
-    void setMode(const ProcessMode mode) override;
-    ProcessMode mode() const override;
-    void setOutputSpec(const OutputSpec& spec) override;
-    unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    ~EventAudioNode() override;
 
     void seek(const TimePosition& position, const bool flushSound = true) override;
     void flush() override;
@@ -76,6 +68,11 @@ private:
         bool isValid() const { return mode != ProcessMode::Undefined; }
     };
 
+    void onModeChanged(const ProcessMode mode) override;
+    void onOutputSpecChanged(const OutputSpec& spec) override;
+
+    void doSelfProcess(float* buffer, samples_t samplesPerChannel) override;
+
     void setupSource();
     SynthCtx currentSynthCtx() const;
     void restoreSynthCtx(const SynthCtx& ctx);
@@ -85,8 +82,7 @@ private:
     synth::ISynthesizerPtr m_synth = nullptr;
     AudioInputParams m_params;
     async::Channel<AudioInputParams> m_paramsChanges;
-    OutputSpec m_outputSpec;
 };
 
-using EventAudioSourcePtr = std::shared_ptr<EventAudioSource>;
+using EventAudioNodePtr = std::shared_ptr<EventAudioNode>;
 }

--- a/src/framework/audio/engine/internal/nodes/mixernode.cpp
+++ b/src/framework/audio/engine/internal/nodes/mixernode.cpp
@@ -33,6 +33,13 @@ void MixerNode::onOutputSpecChanged(const OutputSpec& spec)
     }
 }
 
+void MixerNode::onModeChanged(const ProcessMode mode)
+{
+    for (auto& input : m_inputs) {
+        input->setMode(mode);
+    }
+}
+
 void MixerNode::doAddNode(std::shared_ptr<AudioNode> other)
 {
     m_inputs.emplace_back(other);

--- a/src/framework/audio/engine/internal/nodes/mixernode.h
+++ b/src/framework/audio/engine/internal/nodes/mixernode.h
@@ -32,8 +32,11 @@ class MixerNode : public AudioNode
 {
 protected:
     void onOutputSpecChanged(const OutputSpec& spec) override;
+    void onModeChanged(const ProcessMode mode) override;
+
     void doAddNode(std::shared_ptr<AudioNode> other) override;
     void doRemoveNode(std::shared_ptr<AudioNode> other) override;
+
     void doProcess(float* buffer, samples_t samplesPerChannel) override;
     void doSelfProcess(float* buffer, samples_t samplesPerChannel) override;
 

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -402,11 +402,6 @@ void FluidSynth::setPlaybackPosition(const TimePosition& position)
     }
 }
 
-unsigned int FluidSynth::audioChannelsCount() const
-{
-    return FLUID_AUDIO_CHANNELS_COUNT;
-}
-
 samples_t FluidSynth::process(float* buffer, samples_t samplesPerChannel)
 {
     IF_ASSERT_FAILED(samplesPerChannel > 0) {
@@ -466,11 +461,6 @@ bool FluidSynth::processSequence(const FluidSequencer::EventSequence& sequence, 
                                          buffer, 1, FLUID_AUDIO_CHANNELS_COUNT);
 
     return result == FLUID_OK;
-}
-
-async::Channel<unsigned int> FluidSynth::audioChannelsCountChanged() const
-{
-    return m_streamsCountChanged;
 }
 
 void FluidSynth::toggleExpressionController()

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -61,9 +61,7 @@ public:
     TimePosition playbackPosition() const override;
     void setPlaybackPosition(const TimePosition& position) override;
 
-    unsigned int audioChannelsCount() const override;
     samples_t process(float* buffer, samples_t samplesPerChannel) override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
     void setMode(const ProcessMode mode) override;
     void setOutputSpec(const OutputSpec& spec) override;
@@ -115,8 +113,6 @@ private:
 
     std::shared_ptr<Fluid> m_fluid;
     std::shared_ptr<midi::IMidiOutPort> m_midiOutPort;
-
-    async::Channel<unsigned int> m_streamsCountChanged;
 
     FluidSequencer m_sequencer;
     std::set<io::path_t> m_sfontPaths;

--- a/src/framework/audio/engine/internal/track.h
+++ b/src/framework/audio/engine/internal/track.h
@@ -30,6 +30,7 @@
 #include "audio/common/audiotypes.h"
 #include "audio/common/timeposition.h"
 
+#include "nodes/audionode.h"
 #include "../iaudiosource.h"
 
 namespace muse::audio::engine {
@@ -37,31 +38,6 @@ enum TrackType {
     Undefined = -1,
     Event_track,
     Sound_track
-};
-
-class ITrackAudioInput : public IAudioSource
-{
-public:
-    virtual ~ITrackAudioInput() = default;
-
-    virtual TrackId trackId() const = 0;
-
-    virtual void seek(const TimePosition& position, const bool flushSound = true) = 0;
-    virtual void flush() = 0;
-
-    virtual const AudioInputParams& inputParams() const = 0;
-    virtual void applyInputParams(const AudioInputParams& requiredParams) = 0;
-    virtual async::Channel<AudioInputParams> inputParamsChanged() const = 0;
-
-    virtual void prepareToPlay() = 0;
-    virtual bool readyToPlay() const = 0;
-    virtual async::Notification readyToPlayChanged() const = 0;
-
-    virtual bool hasPendingChunks() const = 0;
-    virtual void processInput() = 0;
-    virtual InputProcessingProgress inputProcessingProgress() const = 0;
-
-    virtual void clearCache() = 0;
 };
 
 class ITrackAudioOutput : public IAudioSource
@@ -76,6 +52,5 @@ public:
     virtual AudioSignalChanges audioSignalChanges() const = 0;
 };
 
-using ITrackAudioInputPtr = std::shared_ptr<ITrackAudioInput>;
 using ITrackAudioOutputPtr = std::shared_ptr<ITrackAudioOutput>;
 }

--- a/src/framework/audio/engine/isynthesizer.h
+++ b/src/framework/audio/engine/isynthesizer.h
@@ -22,14 +22,16 @@
 
 #pragma once
 
-#include "iaudiosource.h"
+#include <string>
 
+#include "global/async/channel.h"
 #include "global/async/notification.h"
 
+#include "audio/common/audiotypes.h"
 #include "audio/common/timeposition.h"
 
 namespace muse::audio::synth {
-class ISynthesizer : public engine::IAudioSource
+class ISynthesizer
 {
 public:
     virtual ~ISynthesizer() = default;
@@ -37,6 +39,11 @@ public:
     virtual std::string name() const = 0;
     virtual AudioSourceType type() const = 0;
     virtual bool isValid() const = 0;
+
+    virtual void setMode(const ProcessMode mode) = 0;
+    virtual ProcessMode mode() const = 0;
+
+    virtual void setOutputSpec(const OutputSpec& spec) = 0;
 
     virtual void setup(const mpe::PlaybackData& playbackData) = 0;
     virtual const mpe::PlaybackData& playbackData() const = 0;
@@ -58,6 +65,8 @@ public:
     virtual InputProcessingProgress inputProcessingProgress() const = 0;
 
     virtual void clearCache() = 0;
+
+    virtual samples_t process(float* buffer, samples_t samplesPerChannel) = 0;
 };
 
 using ISynthesizerPtr = std::shared_ptr<ISynthesizer>;

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -141,16 +141,6 @@ void MuseSamplerWrapper::setOutputSpec(const audio::OutputSpec& spec)
     setMode(m_mode);
 }
 
-unsigned int MuseSamplerWrapper::audioChannelsCount() const
-{
-    return AUDIO_CHANNELS_COUNT;
-}
-
-async::Channel<unsigned int> MuseSamplerWrapper::audioChannelsCountChanged() const
-{
-    return m_audioChannelsCountChanged;
-}
-
 samples_t MuseSamplerWrapper::process(float* buffer, samples_t samplesPerChannel)
 {
     if (!m_samplerLib || !m_sampler) {

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -43,8 +43,6 @@ public:
 
     void setMode(const muse::audio::ProcessMode mode) override;
     void setOutputSpec(const audio::OutputSpec& spec) override;
-    unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
     muse::audio::samples_t process(float* buffer, muse::audio::samples_t samplesPerChannel) override;
 
     std::string name() const override;
@@ -98,8 +96,6 @@ private:
             *this = RenderingInfo();
         }
     };
-
-    async::Channel<unsigned int> m_audioChannelsCountChanged;
 
     MuseSamplerLibHandlerPtr m_samplerLib = nullptr;
     ms_MuseSampler m_sampler = nullptr;

--- a/src/framework/stubs/audio/synthesizerstub.cpp
+++ b/src/framework/stubs/audio/synthesizerstub.cpp
@@ -34,16 +34,6 @@ void SynthesizerStub::setOutputSpec(const OutputSpec&)
 {
 }
 
-unsigned int SynthesizerStub::audioChannelsCount() const
-{
-    return 2;
-}
-
-async::Channel<unsigned int> SynthesizerStub::audioChannelsCountChanged() const
-{
-    return async::Channel<unsigned int>();
-}
-
 samples_t SynthesizerStub::process(float*, samples_t)
 {
     return 0;

--- a/src/framework/stubs/audio/synthesizerstub.h
+++ b/src/framework/stubs/audio/synthesizerstub.h
@@ -32,10 +32,6 @@ public:
 
     void setOutputSpec(const OutputSpec& spec) override;
 
-    unsigned int audioChannelsCount() const override;
-
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
-
     samples_t process(float* buffer, samples_t samplesPerChannel) override;
 
     std::string name() const override;

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -196,16 +196,6 @@ void VstSynthesiser::setOutputSpec(const audio::OutputSpec& spec)
     }
 }
 
-unsigned int VstSynthesiser::audioChannelsCount() const
-{
-    return m_outputSpec.audioChannelCount;
-}
-
-async::Channel<unsigned int> VstSynthesiser::audioChannelsCountChanged() const
-{
-    return m_streamsCountChanged;
-}
-
 samples_t VstSynthesiser::process(float* buffer, samples_t samplesPerChannel)
 {
     if (!buffer) {

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -62,10 +62,7 @@ public:
     muse::audio::TimePosition playbackPosition() const override;
     void setPlaybackPosition(const muse::audio::TimePosition& position) override;
 
-    // IAudioSource
     void setOutputSpec(const audio::OutputSpec& spec) override;
-    unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
     muse::audio::samples_t process(float* buffer, muse::audio::samples_t samplesPerChannel) override;
 
 private:
@@ -77,7 +74,6 @@ private:
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 
     audio::OutputSpec m_outputSpec;
-    async::Channel<unsigned int> m_streamsCountChanged;
 
     VstSequencer m_sequencer;
 


### PR DESCRIPTION


* Now ISynthesizer is not AudioSource, it's just ISynthesizer 
* Now there is no concept of ITrackAudioInput (or ITrackAudioSource), there is only AudioSourceNode, it may belong to a track, it may not (in theory) 
* Now MixerChannel accepts just an AudioNode, in theory it could be a source, or something else, for example an Effect (and there could be a source behind it in the chain)
* EventAudioSource is now an AudioNode and can be used in a chain, in an audio graph (in the future)