### PR TITLE
same-string transpose: negative fret support

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -4101,7 +4101,7 @@ void Note::addLineAttachPoint(PointF point, EngravingItem* line, bool start)
 
 bool Note::negativeFretUsed() const
 {
-    return configuration()->negativeFretsAllowed() && m_fret < 0;
+    return configuration()->negativeFretsAllowed() && m_fret < 0 && m_string != INVALID_STRING_INDEX;
 }
 
 int Note::stringOrLine() const

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -524,8 +524,10 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 
 void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
 {
-    int capoFret = chord->staff()->capo(chord->tick()).fretPosition;
+    const CapoParams& capo = chord->staff()->capo(chord->tick());
+    int capoFret = capo.fretPosition;
     const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
+    const int pitchOffsetWithCapo = pitchOffsetAt(chord->staff(), chord->tick());
 
     bool anyReset = false;
     for (Note* note : chord->notes()) {
@@ -535,27 +537,61 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
         if (skipDeadNotes && note->deadNote()) {
             continue;
         }
-        if (note->string() < 0 || note->fret() < 0) {
+        if (note->string() < 0) {
             anyReset = true;
             continue;
         }
         int pitch = getPitch(note->string(), note->fret() + capoFret, pitchOffset);
         int newFret = note->fret() + note->pitch() - pitch;
         if (newFret < 0) {
-            anyReset = true;
+            if (note->configuration()->negativeFretsAllowed()) {
+                note->setFret(newFret);
+            } else {
+                anyReset = true;
+            }
         } else {
             note->setFret(newFret);
         }
     }
 
-    // If any note in the chord couldn't keep its string, reset ALL notes
-    // so fretChords/convertPitch assigns the entire chord optimally.
+    // Returns true if a valid non-negative placement exists for this note.
+    // Used in the detection and reset passes below.
+    auto hasNonNegativeAlternative = [&](const Note* note) {
+        int string = 0;
+        int fret = 0;
+        return convertPitch(note->pitch(), pitchOffsetWithCapo, &string, &fret, capo);
+    };
+
+    // When negativeFretsAllowed kept a note with a negative fret, check if a
+    // valid (non-negative) fret exists on any string. If so, resetting the
+    // chord lets fretChords find a more compact arrangement.
+    if (!anyReset) {
+        for (Note* note : chord->notes()) {
+            if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
+                continue;
+            }
+            if (skipDeadNotes && note->deadNote()) {
+                continue;
+            }
+            if (note->fret() < 0 && hasNonNegativeAlternative(note)) {
+                anyReset = true;
+                break;
+            }
+        }
+    }
+
+    // Reset notes so fretChords/convertPitch assigns the chord optimally.
+    // Preserve negative-fret notes that have no valid in-range alternative —
+    // their negative fret is the only option for that pitch.
     if (anyReset) {
         for (Note* note : chord->notes()) {
             if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
                 continue;
             }
             if (skipDeadNotes && note->deadNote()) {
+                continue;
+            }
+            if (note->fret() < 0 && !hasNonNegativeAlternative(note)) {
                 continue;
             }
             note->setString(INVALID_STRING_INDEX);

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -292,6 +292,13 @@ void StringData::fretChords(Chord* chord) const
             }
         }
 
+        // Still two notes on one string: try a free string with fret <0 or >maxFrets.
+        if (note->configuration()->negativeFretsAllowed()
+            && note->displayFret() == Note::DisplayFretOption::NoHarmonic
+            && bUsed[nNewString] > 1) {
+            tryResolveStringConflictWithOutOfRangeFret(note, strings, bUsed, nNewString, nNewFret);
+        }
+
         // TODO : try to optimize used fret range, avoiding excessively open positions
 
         // if fretting did change, store as a fret change
@@ -517,6 +524,54 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 }
 
 //---------------------------------------------------------
+//   tryResolveStringConflictWithOutOfRangeFret
+//    After in-range conflict resolution fails: assign an unused string using raw
+//    fret (may be <0 or >maxFrets). Chooses smallest distance to [0, maxFrets];
+//    ties break toward lower string index.
+//---------------------------------------------------------
+
+bool StringData::tryResolveStringConflictWithOutOfRangeFret(const Note* note, int numStrings, std::vector<int>& bUsed,
+                                                            int& nNewString, int& nNewFret) const
+{
+    int bestString = -1;
+    int bestDistance = INT32_MAX;
+    int bestRawFret = 0;
+
+    for (int s = 0; s < numStrings; s++) {
+        if (bUsed[static_cast<size_t>(s)] >= 1) {
+            continue;
+        }
+        const int openPitch = m_stringTable.at(m_stringTable.size() - s - 1).pitch;
+        const int rawFret = note->pitch() + pitchOffsetAt(note->staff(), note->tick(), s) - openPitch;   // not clamped to 0..m_frets
+        int distance;
+        if (rawFret < 0) {
+            distance = -rawFret;
+        } else if (rawFret > m_frets) {
+            distance = rawFret - m_frets;
+        } else {
+            continue;   // only out-of-range frets here; in-range tried above in fretChords
+        }
+
+        if (distance < bestDistance
+            || (distance == bestDistance && (bestString < 0 || s < bestString))) {
+            bestDistance = distance;
+            bestRawFret = rawFret;
+            bestString = s;
+        }
+    }
+
+    if (bestString < 0) {
+        return false;
+    }
+
+    bUsed[static_cast<size_t>(nNewString)]--;
+    bUsed[static_cast<size_t>(bestString)]++;
+    nNewFret = bestRawFret;
+    nNewString = bestString;
+    return true;
+}
+
+//---------------------------------------------------------
 //   sortChordNotesUseSameString
 //    Tries to keep each note on its currently assigned string when the
 //    chord's pitches are transposed, updating only the fret.
@@ -641,7 +696,12 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
         }
 
         int key = string * 100000;
-        key += -(note->pitch() + pitchOffset) * 100 + *count;       // disambiguate notes of equal pitch
+        if (string == INVALID_STRING_INDEX && note->configuration()->negativeFretsAllowed()) {
+            // No string assigned yet: lower note first, then higher (transpose in one go or in steps must match).
+            key += (note->pitch() + pitchOffset) * 100 + *count;
+        } else {
+            key += -(note->pitch() + pitchOffset) * 100 + *count;   // disambiguate notes of equal pitch
+        }
         sortedNotes.insert({ key, note });
         (*count)++;
     }

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -580,7 +580,6 @@ bool StringData::tryResolveStringConflictWithOutOfRangeFret(const Note* note, in
 void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
 {
     const CapoParams& capo = chord->staff()->capo(chord->tick());
-    int capoFret = capo.fretPosition;
     const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
     const int pitchOffsetWithCapo = pitchOffsetAt(chord->staff(), chord->tick());
 
@@ -596,7 +595,7 @@ void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset
             anyReset = true;
             continue;
         }
-        int pitch = getPitch(note->string(), note->fret() + capoFret, pitchOffset);
+        int pitch = getPitch(note->string(), note->fret(), chord->staff(), chord->tick());
         int newFret = note->fret() + note->pitch() - pitch;
         if (newFret < 0) {
             if (note->configuration()->negativeFretsAllowed()) {

--- a/src/engraving/dom/stringdata.h
+++ b/src/engraving/dom/stringdata.h
@@ -92,6 +92,8 @@ private:
     int         fret(int pitch, int string, int pitchOffset) const;
     void        sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* chord, int* count) const;
     void        sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const;
+    bool        tryResolveStringConflictWithOutOfRangeFret(const Note* note, int numStrings, std::vector<int>& bUsed, int& nNewString,
+                                                           int& nNewFret) const;
 
     //      std::vector<int>  stringTable { 40, 45, 50, 55, 59, 64 };   // guitar is default
     //      int         _frets = 19;

--- a/src/engraving/tests/tab_transpose_data/high_frets.mscx
+++ b/src/engraving/tests/tab_transpose_data/high_frets.mscx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>78</pitch>
+              <tpc>20</tpc>
+              <fret>14</fret>
+              <string>0</string>
+            </Note>
+            <Note>
+              <pitch>79</pitch>
+              <tpc>15</tpc>
+              <fret>20</fret>
+              <string>1</string>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_data/low_frets.mscx
+++ b/src/engraving/tests/tab_transpose_data/low_frets.mscx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              <fret>3</fret>
+              <string>4</string>
+            </Note>
+            <Note>
+              <pitch>43</pitch>
+              <tpc>15</tpc>
+              <fret>3</fret>
+              <string>5</string>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_data/neg_fret_chord.mscx
+++ b/src/engraving/tests/tab_transpose_data/neg_fret_chord.mscx
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>40</pitch>
+              <tpc>18</tpc>
+              <fret>0</fret>
+              <string>5</string>
+            </Note>
+            <Note>
+              <pitch>54</pitch>
+              <tpc>20</tpc>
+              <fret>4</fret>
+              <string>3</string>
+            </Note>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_data/same_string.mscx
+++ b/src/engraving/tests/tab_transpose_data/same_string.mscx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              <fret>5</fret>
+              <string>3</string>
+            </Note>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_data/same_string_high.mscx
+++ b/src/engraving/tests/tab_transpose_data/same_string_high.mscx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              <fret>14</fret>
+              <string>3</string>
+            </Note>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>22</tpc>
+              <fret>13</fret>
+              <string>2</string>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_transpose_data/valid_fret_not_displaced.mscx
+++ b/src/engraving/tests/tab_transpose_data/valid_fret_not_displaced.mscx
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.70">
+  <programVersion>4.7.0</programVersion>
+  <programRevision>393f9a7</programRevision>
+  <Score>
+    <eid>FNIBW1k/HFB_ijE+rejWlIK</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2026-04-02</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="guitar-steel-tablature">
+        <family id="guitars">Guitars</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>rPYAz8wHqoI_FwQdJ+Z9GrD</eid>
+        <StaffType group="tablature">
+          <name>tab6StrCommon</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <durationFontY>0</durationFontY>
+          <fretUseTextStyle>1</fretUseTextStyle>
+          <fretTextStyle>tab_fret_number</fretTextStyle>
+          <linesThrough>0</linesThrough>
+          <minimStyle>1</minimStyle>
+          <onLines>1</onLines>
+          <showRests>1</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <showTabFingering>1</showTabFingering>
+          <useNumbers>1</useNumbers>
+          </StaffType>
+        <defaultClef>G8vb</defaultClef>
+        </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument id="guitar-steel-tablature">
+        <longName>Guitar</longName>
+        <shortName>Guit.</shortName>
+        <trackName>Acoustic Guitar (tablature)</trackName>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>84</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>83</maxPitchA>
+        <instrumentId>pluck.guitar.acoustic</instrumentId>
+        <clef>G8vb</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>20</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+          </StringData>
+        <Channel name="open">
+          <program value="25"/>
+          <synti>Fluid</synti>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          <synti>Fluid</synti>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>KkHHzOSsq/D_jgHWk8eY+/G</eid>
+        <Text>
+          <eid>zs3Oh6bLyZN_iHJUVROTMIH</eid>
+          <style>title</style>
+          <text>Negative frets</text>
+          </Text>
+        <Text>
+          <eid>amp8qyzlpiJ_G36T48FQIwG</eid>
+          <style>subtitle</style>
+          <text>after transposition</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <eid>OF4bPnJw1yM_ovGA512wZFG</eid>
+        <voice>
+          <KeySig>
+            <eid>Qgr86AWcchP_zwsB+iJvvuI</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>Opl1W4eo4fE_pC98Z8h4IjI</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <eid>qA2QyUuSXSM_5pJFC/m0cqD</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>z0dg7cVKE5J_/pqWbwE1VpP</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Chord>
+            <eid>qUUxL6h5+YC_fi/P5dKCbzL</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>eGfcgcikgMC_h67R0k2PokK</eid>
+              <pitch>40</pitch>
+              <tpc>18</tpc>
+              <fret>0</fret>
+              <string>5</string>
+              </Note>
+            <Note>
+              <eid>HDxw3LJtqFL_aIbFgYFJTNN</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>9</fret>
+              <string>3</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>MxChqKt0ClF_F4FEOcN/JeL</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>uRtfPFwytzB_562P+4GvcZM</eid>
+        <voice>
+          <Rest>
+            <eid>vZmOkZ5ImVH_rEBPzs/Rz0B</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -135,6 +135,18 @@ protected:
     ECMock* m_mock = nullptr;
 };
 
+// Helpers for same-string / negative-fret tests
+
+static const TabNote* findNoteByString(const std::vector<TabNote>& notes, int string)
+{
+    for (const auto& n : notes) {
+        if (n.string == string) {
+            return &n;
+        }
+    }
+    return nullptr;
+}
+
 static void assertDeadNotesUnchangedByTransposeImpl(MasterScore* score)
 {
     ASSERT_TRUE(score);
@@ -261,6 +273,113 @@ TEST_F(Engraving_TabTransposeTests, deadNotesTransposedWithNormalFlow)
     for (size_t i = 0; i < deadPitchesBefore.size(); ++i) {
         EXPECT_EQ(deadPitchesAfter[i], deadPitchesBefore[i] + kSemitones)
             << "dead note pitch should change with default (MuseScore) configuration";
+    }
+
+    delete score;
+}
+
+// Not tested: capo STANDARD_ONLY/TAB_ONLY transpose mode interaction with
+// hasNonNegativeAlternative. That path requires a fixture with an active capo
+// whose fret offset shifts the pitch enough to change the convertPitch result,
+// plus mock support for CapoParams.transposeMode — disproportionate complexity
+// for a GuitarPro-specific edge case.
+
+// Transpose +1: notes on strings 2 and 3 (fret 5 each) should stay on their
+// original strings with fret bumped to 6.
+TEST_F(Engraving_TabTransposeTests, preferSameStringKeepsOriginalStrings)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "same_string.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, 1);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+
+    const TabNote* str2 = findNoteByString(notes, 2);
+    const TabNote* str3 = findNoteByString(notes, 3);
+
+    ASSERT_NE(str2, nullptr) << "note should remain on string 2";
+    EXPECT_EQ(str2->fret, 6);
+    ASSERT_NE(str3, nullptr) << "note should remain on string 3";
+    EXPECT_EQ(str3->fret, 6);
+
+    delete score;
+}
+
+// Transpose -1: string 3/fret 9 → fret 8 (valid), string 5/fret 0 → fret -1.
+// The note on string 3 must NOT be displaced to another string just because
+// its chord-mate landed on a negative fret.
+TEST_F(Engraving_TabTransposeTests, validFretNotDisplacedByNegativeFretInChord)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "valid_fret_not_displaced.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, -1);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+
+    const TabNote* str3 = findNoteByString(notes, 3);
+    const TabNote* str5 = findNoteByString(notes, 5);
+
+    ASSERT_NE(str3, nullptr) << "note should remain on string 3";
+    EXPECT_EQ(str3->fret, 8);
+    ASSERT_NE(str5, nullptr) << "note should remain on string 5";
+    EXPECT_EQ(str5->fret, -1);
+
+    delete score;
+}
+
+// A note already at a negative fret must still have its fret updated on a
+// subsequent transpose; it must not be "frozen" at the old negative value.
+// Two consecutive -1 transposes: str5/fret0 → fret-1 → fret-2 (NOT stays at -1).
+TEST_F(Engraving_TabTransposeTests, negativeFretUpdatesOnFurtherTranspose)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "valid_fret_not_displaced.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, -1);
+    transposeScore(score, -1);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+
+    const TabNote* str3 = findNoteByString(notes, 3);
+    const TabNote* str5 = findNoteByString(notes, 5);
+
+    ASSERT_NE(str3, nullptr) << "note should remain on string 3";
+    EXPECT_EQ(str3->fret, 7);
+    ASSERT_NE(str5, nullptr) << "note should remain on string 5";
+    EXPECT_EQ(str5->fret, -2);
+
+    delete score;
+}
+
+// Transpose -6: both notes land on negative frets on their original strings,
+// but valid (non-negative) frets exist on lower strings. The detection pass
+// resets the chord and fretChords places both notes with non-negative frets.
+TEST_F(Engraving_TabTransposeTests, noNegativeFretWhenLowerStringAvailable)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "same_string.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, -6);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+    for (size_t i = 0; i < notes.size(); ++i) {
+        EXPECT_GE(notes[i].fret, 0)
+            << "note " << i << " got negative fret " << notes[i].fret
+            << " but lower strings are available";
     }
 
     delete score;

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -309,6 +309,37 @@ TEST_F(Engraving_TabTransposeTests, preferSameStringKeepsOriginalStrings)
     delete score;
 }
 
+// same_string_high: str2/fret 13, str3/fret 14 — same-string transpose; frets may exceed maxFrets.
+TEST_F(Engraving_TabTransposeTests, sameStringPreservesNotesAboveMaxFret)
+{
+    setFrettingFlags(true, true);
+
+    struct {
+        int semitones;
+        int fret2;
+        int fret3;
+    } const cases[] = {
+        { 6, 19, 20 },
+        { 7, 20, 21 },
+        { 12, 25, 26 },
+    };
+
+    for (const auto& c : cases) {
+        MasterScore* score = ScoreRW::readScore(DATA_DIR + "same_string_high.mscx");
+        ASSERT_TRUE(score) << "semitones=" << c.semitones;
+        transposeScore(score, c.semitones);
+        auto notes = collectTabNotes(score);
+        ASSERT_EQ(notes.size(), 2u) << "semitones=" << c.semitones;
+        const TabNote* str2 = findNoteByString(notes, 2);
+        const TabNote* str3 = findNoteByString(notes, 3);
+        ASSERT_NE(str2, nullptr) << "semitones=" << c.semitones;
+        ASSERT_NE(str3, nullptr) << "semitones=" << c.semitones;
+        EXPECT_EQ(str2->fret, c.fret2);
+        EXPECT_EQ(str3->fret, c.fret3);
+        delete score;
+    }
+}
+
 // Transpose -1: string 3/fret 9 → fret 8 (valid), string 5/fret 0 → fret -1.
 // The note on string 3 must NOT be displaced to another string just because
 // its chord-mate landed on a negative fret.
@@ -381,6 +412,100 @@ TEST_F(Engraving_TabTransposeTests, noNegativeFretWhenLowerStringAvailable)
             << "note " << i << " got negative fret " << notes[i].fret
             << " but lower strings are available";
     }
+
+    delete score;
+}
+
+// low_frets: two notes on str4/str5; after -7 both get the same negative fret on their original strings
+// (pitch 41 @ 45-4, pitch 36 @ 40-4). They must stay on different strings — no accidental merge onto one string.
+TEST_F(Engraving_TabTransposeTests, chordNotesOnDifferentStringsWithNegativeFrets)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "low_frets.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, -7);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+    const TabNote* n4 = findNoteByString(notes, 4);
+    const TabNote* n5 = findNoteByString(notes, 5);
+    ASSERT_NE(n4, nullptr);
+    ASSERT_NE(n5, nullptr);
+    EXPECT_EQ(n4->fret, -4);
+    EXPECT_EQ(n5->fret, -4);
+
+    delete score;
+}
+
+// neg_fret_chord: path-independent assignment for -7 vs direct -8 (same strings, frets differ by one semitone step).
+TEST_F(Engraving_TabTransposeTests, negFretChordAssignmentIsPathIndependent)
+{
+    setFrettingFlags(true, true);
+
+    {
+        MasterScore* score = ScoreRW::readScore(DATA_DIR + "neg_fret_chord.mscx");
+        ASSERT_TRUE(score);
+        transposeScore(score, -7);
+
+        auto notes = collectTabNotes(score);
+        ASSERT_EQ(notes.size(), 3u);
+
+        const TabNote* n5 = findNoteByString(notes, 5);
+        const TabNote* n4 = findNoteByString(notes, 4);
+        const TabNote* n3 = findNoteByString(notes, 3);
+        ASSERT_NE(n5, nullptr) << "no note on string 5 at -7";
+        ASSERT_NE(n4, nullptr) << "no note on string 4 at -7";
+        ASSERT_NE(n3, nullptr) << "no note on string 3 at -7";
+        EXPECT_EQ(n5->fret, -7);
+        EXPECT_EQ(n4->fret,  2);
+        EXPECT_EQ(n3->fret,  0);
+
+        delete score;
+    }
+
+    {
+        MasterScore* score = ScoreRW::readScore(DATA_DIR + "neg_fret_chord.mscx");
+        ASSERT_TRUE(score);
+        transposeScore(score, -8);
+
+        auto notes = collectTabNotes(score);
+        ASSERT_EQ(notes.size(), 3u);
+
+        const TabNote* n5 = findNoteByString(notes, 5);
+        const TabNote* n4 = findNoteByString(notes, 4);
+        const TabNote* n3 = findNoteByString(notes, 3);
+        ASSERT_NE(n5, nullptr) << "no note on string 5 at -8";
+        ASSERT_NE(n4, nullptr) << "no note on string 4 at -8";
+        ASSERT_NE(n3, nullptr) << "no note on string 3 at -8";
+        EXPECT_EQ(n5->fret, -8);
+        EXPECT_EQ(n4->fret,  1);
+        EXPECT_EQ(n3->fret, -1);
+
+        delete score;
+    }
+}
+
+// high_frets: same-string +9; second fret can exceed maxFrets without changing strings.
+TEST_F(Engraving_TabTransposeTests, sameStringTransposeKeepsStringsWithFretAboveMax)
+{
+    setFrettingFlags(true, true);
+
+    MasterScore* score = ScoreRW::readScore(DATA_DIR + "high_frets.mscx");
+    ASSERT_TRUE(score);
+
+    transposeScore(score, 9);
+
+    auto notes = collectTabNotes(score);
+    ASSERT_EQ(notes.size(), 2u);
+
+    const TabNote* n0 = findNoteByString(notes, 0);
+    const TabNote* n1 = findNoteByString(notes, 1);
+    ASSERT_NE(n0, nullptr) << "note should remain on string 0";
+    ASSERT_NE(n1, nullptr) << "note should remain on string 1";
+    EXPECT_EQ(n0->fret, 23);
+    EXPECT_EQ(n1->fret, 29);
 
     delete score;
 }


### PR DESCRIPTION
from coderabbit (I agree):

This change enhances tablature transposition logic to improve negative fret handling and same-string preference. The Note::negativeFretUsed() method now checks if negative frets are allowed and the note has a valid string assignment before reporting negative fret usage. The sortChordNotesUseSameString() function is updated to avoid forced chord resets solely due to negative frets, while still preserving alternative non-negative placements when available. Two new test data files and four new test cases provide coverage for same-string preference, negative fret behavior across transpositions, and displacement scenarios.