### PR TITLE
TextInputArea: emit escaped() before focus loss

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
@@ -224,9 +224,9 @@ FocusScope {
 
                 Keys.onPressed: function(event) {
                     if (event.key === Qt.Key_Escape) {
+                        root.escaped()
                         root.focus = false
                         root.textEditingFinished(valueInput.text)
-                        root.escaped()
                     }
                 }
 


### PR DESCRIPTION
Previously escaped() fired after root.focus = false, meaning any
onFocusChanged handler in a parent component would run before
onEscaped had a chance to. This made it impossible to distinguish
an Escape-triggered focus loss from a normal one without a deferred
callback workaround.

Emitting escaped() first gives consumers a synchronous opportunity
to set a cancel flag before onFocusChanged fires.

Use case: in Audacity's label text editor, onFocusChanged was unconditionally saving the edit, so pressing Escape confirmed instead of cancelling. This fix enables a clean cancel implementation without Qt.callLater workarounds.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
