### PR TITLE
[audio] added fxnode

### DIFF
--- a/src/framework/audio/engine/CMakeLists.txt
+++ b/src/framework/audio/engine/CMakeLists.txt
@@ -93,6 +93,8 @@ else()
         internal/nodes/mixernode.h
         internal/nodes/eventaudionode.cpp
         internal/nodes/eventaudionode.h
+        internal/nodes/fxnode.cpp
+        internal/nodes/fxnode.h
 
         # DSP
         internal/dsp/envelopefilterconfig.h

--- a/src/framework/audio/engine/ifxprocessor.h
+++ b/src/framework/audio/engine/ifxprocessor.h
@@ -42,7 +42,7 @@ public:
     virtual bool active() const = 0;
     virtual void setActive(bool active) = 0;
 
-    virtual void setPlaying(bool playing) = 0;
+    virtual void setMode(const ProcessMode mode) = 0;
 
     virtual bool shouldProcessDuringSilence() const = 0;
 

--- a/src/framework/audio/engine/internal/audiofactory.cpp
+++ b/src/framework/audio/engine/internal/audiofactory.cpp
@@ -96,14 +96,24 @@ RetVal<ITrackAudioOutputPtr> AudioFactory::makeMixerAuxChannel(const TrackId tra
     return RetVal<ITrackAudioOutputPtr>::make_ok(channel);
 }
 
-std::vector<IFxProcessorPtr> AudioFactory::makeMasterFxList(const AudioFxChain& fxChain) const
+std::vector<FxNodePtr> AudioFactory::makeMasterFxList(const AudioFxChain& fxChain) const
 {
-    return fxResolver()->resolveMasterFxList(fxChain, audioEngine()->outputSpec());
+    std::vector<IFxProcessorPtr> fxlist = fxResolver()->resolveMasterFxList(fxChain, audioEngine()->outputSpec());
+    std::vector<FxNodePtr> result;
+    for (const auto& fx : fxlist) {
+        result.push_back(std::make_shared<FxNode>(fx));
+    }
+    return result;
 }
 
-std::vector<IFxProcessorPtr> AudioFactory::makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const
+std::vector<FxNodePtr> AudioFactory::makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const
 {
-    return fxResolver()->resolveFxList(trackId, fxChain, audioEngine()->outputSpec());
+    std::vector<IFxProcessorPtr> fxlist = fxResolver()->resolveFxList(trackId, fxChain, audioEngine()->outputSpec());
+    std::vector<FxNodePtr> result;
+    for (const auto& fx : fxlist) {
+        result.push_back(std::make_shared<FxNode>(fx));
+    }
+    return result;
 }
 
 void AudioFactory::clearAllFx()

--- a/src/framework/audio/engine/internal/audiofactory.h
+++ b/src/framework/audio/engine/internal/audiofactory.h
@@ -58,8 +58,8 @@ public:
     RetVal<ITrackAudioOutputPtr> makeMixerAuxChannel(const TrackId trackId, const AudioOutputParams& params) const override;
 
     // Make FX
-    std::vector<IFxProcessorPtr> makeMasterFxList(const AudioFxChain& fxChain) const override;
-    std::vector<IFxProcessorPtr> makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const override;
+    std::vector<FxNodePtr> makeMasterFxList(const AudioFxChain& fxChain) const override;
+    std::vector<FxNodePtr> makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const override;
     void clearAllFx() override;
 };
 }

--- a/src/framework/audio/engine/internal/contextplayer.cpp
+++ b/src/framework/audio/engine/internal/contextplayer.cpp
@@ -200,7 +200,7 @@ void ContextPlayer::stop()
     m_status.set(PlaybackStatus::Stopped);
     m_countDown = 0.;
     seek(TimePosition::zero(m_currentPosition.sampleRate()));
-    m_notYetReadyToPlayTrack.clear();
+    m_notYetReadyToPlayTracks.clear();
 }
 
 void ContextPlayer::pause()
@@ -212,7 +212,7 @@ void ContextPlayer::pause()
     }
 
     m_status.set(PlaybackStatus::Paused);
-    m_notYetReadyToPlayTrack.clear();
+    m_notYetReadyToPlayTracks.clear();
 }
 
 void ContextPlayer::resume(const secs_t delay)
@@ -327,28 +327,28 @@ void ContextPlayer::prepareAllTracksToPlay(AllTracksReadyCallback allTracksReady
         return;
     }
 
-    m_notYetReadyToPlayTrack.clear();
+    m_notYetReadyToPlayTracks.clear();
 
     for (const auto& source : m_trackSource->allTracksSources()) {
         source->prepareToPlay();
 
         if (!source->readyToPlay()) {
-            m_notYetReadyToPlayTrack.insert(source);
+            m_notYetReadyToPlayTracks.insert(source);
         }
     }
 
-    if (m_notYetReadyToPlayTrack.empty()) {
+    if (m_notYetReadyToPlayTracks.empty()) {
         allTracksReadyCallback();
         return;
     }
 
-    for (const auto& source : m_notYetReadyToPlayTrack) {
+    for (const auto& source : m_notYetReadyToPlayTracks) {
         std::weak_ptr<AudioSourceNode> weakPtr = source;
         source->readyToPlayChanged().onNotify(this, [this, weakPtr, allTracksReadyCallback]() {
             if (auto source = weakPtr.lock()) {
-                muse::remove(m_notYetReadyToPlayTrack, source);
+                muse::remove(m_notYetReadyToPlayTracks, source);
 
-                if (m_notYetReadyToPlayTrack.empty()) {
+                if (m_notYetReadyToPlayTracks.empty()) {
                     allTracksReadyCallback();
                 }
 

--- a/src/framework/audio/engine/internal/contextplayer.h
+++ b/src/framework/audio/engine/internal/contextplayer.h
@@ -107,6 +107,6 @@ private:
     async::Channel<TimeEvent> m_timeEvent;
 
     bool m_flushSoundOnSeek = true;
-    std::set<AudioSourceNodePtr> m_notYetReadyToPlayTrack;
+    std::set<AudioSourceNodePtr> m_notYetReadyToPlayTracks;
 };
 }

--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -356,16 +356,19 @@ void EngineRpcController::init()
 
         onQuickRequest(ctxId, MsgCode::GetInputParams, [this](const Msg& msg) {
             ONLY_AUDIO_RPC_THREAD;
+
+            using RetType = RetVal<AudioInputParams>;
+
             TrackId trackId = 0;
             IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId)) {
-                return make_response_ret(msg, make_ret(Err::InvalidRpcData));
+                return make_response_ret(msg, RetType::make_ret(Err::InvalidRpcData));
             }
 
             if (auto actx = audioContext(msg.ctxId)) {
-                RetVal<AudioInputParams> ret = actx->inputParams(trackId);
+                RetType ret = actx->inputParams(trackId);
                 return make_response_ret(msg, ret);
             } else {
-                return make_response_ret(msg, RetVal<AudioInputParams>::make_ret(Err::InvalidContext));
+                return make_response_ret(msg, RetType::make_ret(Err::InvalidContext));
             }
         });
 

--- a/src/framework/audio/engine/internal/fx/equaliser.cpp
+++ b/src/framework/audio/engine/internal/fx/equaliser.cpp
@@ -44,7 +44,7 @@ void Equaliser::setActive(bool active)
     m_active = active;
 }
 
-void Equaliser::setPlaying(bool)
+void Equaliser::setMode(const ProcessMode)
 {
 }
 

--- a/src/framework/audio/engine/internal/fx/equaliser.h
+++ b/src/framework/audio/engine/internal/fx/equaliser.h
@@ -39,7 +39,7 @@ public:
     void setGain(float value);
     void setQ(float value);
 
-    void setPlaying(bool playing) override;
+    void setMode(const ProcessMode mode) override;
     bool shouldProcessDuringSilence() const override;
 
     void process(float* buffer, samples_t sampleCount, samples_t playbackPositionSamples = 0) override;

--- a/src/framework/audio/engine/internal/fx/reverb/reverbprocessor.cpp
+++ b/src/framework/audio/engine/internal/fx/reverb/reverbprocessor.cpp
@@ -333,7 +333,7 @@ void ReverbProcessor::setActive(bool active)
     m_params.active = active;
 }
 
-void ReverbProcessor::setPlaying(bool)
+void ReverbProcessor::setMode(const ProcessMode)
 {
 }
 

--- a/src/framework/audio/engine/internal/fx/reverb/reverbprocessor.h
+++ b/src/framework/audio/engine/internal/fx/reverb/reverbprocessor.h
@@ -47,7 +47,7 @@ public:
     bool active() const override;
     void setActive(bool active) override;
 
-    void setPlaying(bool playing) override;
+    void setMode(const ProcessMode mode) override;
 
     bool shouldProcessDuringSilence() const override;
 

--- a/src/framework/audio/engine/internal/iaudiofactory.h
+++ b/src/framework/audio/engine/internal/iaudiofactory.h
@@ -28,6 +28,7 @@
 #include "../ifxprocessor.h"
 #include "../isynthesizer.h"
 #include "nodes/audiosourcenode.h"
+#include "nodes/fxnode.h"
 #include "track.h"
 
 namespace muse::audio::engine {
@@ -64,8 +65,8 @@ public:
     virtual RetVal<ITrackAudioOutputPtr> makeMixerAuxChannel(const TrackId trackId, const AudioOutputParams& params) const = 0;
 
     // Make FX
-    virtual std::vector<IFxProcessorPtr> makeMasterFxList(const AudioFxChain& fxChain) const = 0;
-    virtual std::vector<IFxProcessorPtr> makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const = 0;
+    virtual std::vector<FxNodePtr> makeMasterFxList(const AudioFxChain& fxChain) const = 0;
+    virtual std::vector<FxNodePtr> makeTrackFxList(const TrackId trackId, const AudioFxChain& fxChain) const = 0;
 
     //! NOTE For internal purposes,
     // created effect instances are registered in an internal registry (see VST).

--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -170,7 +170,7 @@ void Mixer::setOutputSpec(const OutputSpec& spec)
         aux.channel->setOutputSpec(spec);
     }
 
-    for (IFxProcessorPtr& fx : m_masterFxProcessors) {
+    for (FxNodePtr& fx : m_masterFxNodes) {
         fx->setOutputSpec(spec);
     }
 }
@@ -345,8 +345,8 @@ void Mixer::setMode(const ProcessMode mode)
         }
     }
 
-    for (IFxProcessorPtr& fx : m_masterFxProcessors) {
-        fx->setPlaying(isModePlaying(mode));
+    for (FxNodePtr& fx : m_masterFxNodes) {
+        fx->setMode(mode);
     }
 }
 
@@ -379,12 +379,13 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
         return;
     }
 
-    m_masterFxProcessors.clear();
-    m_masterFxProcessors = audioFactory()->makeMasterFxList(params.fxChain);
+    m_masterFxNodes.clear();
+    m_masterFxNodes = audioFactory()->makeMasterFxList(params.fxChain);
 
-    for (IFxProcessorPtr& fx : m_masterFxProcessors) {
+    for (FxNodePtr& fx : m_masterFxNodes) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isModePlaying(m_mode));
+        fx->setMode(m_mode);
+        fx->setPlayheadPosition(m_playhead);
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_masterParams.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
@@ -395,8 +396,8 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
 
     AudioOutputParams resultParams = params;
 
-    auto findFxProcessor = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) -> IFxProcessorPtr {
-        for (IFxProcessorPtr& fx : m_masterFxProcessors) {
+    auto findFxNode = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) -> FxNodePtr {
+        for (FxNodePtr& fx : m_masterFxNodes) {
             if (fx->params().chainOrder != params.first) {
                 continue;
             }
@@ -410,8 +411,8 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
     };
 
     for (auto it = resultParams.fxChain.begin(); it != resultParams.fxChain.end();) {
-        if (IFxProcessorPtr fx = findFxProcessor(*it)) {
-            fx->setActive(it->second.active);
+        if (FxNodePtr fx = findFxNode(*it)) {
+            fx->setBypassed(!it->second.active);
             ++it;
         } else {
             it = resultParams.fxChain.erase(it);
@@ -541,10 +542,8 @@ void Mixer::processAuxChannels(float* buffer, samples_t samplesPerChannel)
 
 void Mixer::processMasterFx(float* buffer, samples_t samplesPerChannel)
 {
-    for (IFxProcessorPtr& fxProcessor : m_masterFxProcessors) {
-        if (fxProcessor->active()) {
-            fxProcessor->process(buffer, samplesPerChannel, playbackPosition().samples());
-        }
+    for (FxNodePtr& fx : m_masterFxNodes) {
+        fx->process(buffer, samplesPerChannel);
     }
 }
 
@@ -586,7 +585,7 @@ void Mixer::completeOutput(float* buffer, samples_t samplesPerChannel)
 void Mixer::updateShouldProcessMasterFxDuringSilence()
 {
     m_shouldProcessMasterFxDuringSilence = false;
-    for (const IFxProcessorPtr& fx : m_masterFxProcessors) {
+    for (const FxNodePtr& fx : m_masterFxNodes) {
         if (fx->shouldProcessDuringSilence()) {
             m_shouldProcessMasterFxDuringSilence = true;
             return;

--- a/src/framework/audio/engine/internal/mixer.h
+++ b/src/framework/audio/engine/internal/mixer.h
@@ -27,8 +27,6 @@
 
 #include "global/modularity/ioc.h"
 #include "global/async/asyncable.h"
-#include "global/types/retval.h"
-
 #include "abstractaudiosource.h"
 
 #include "../iplayhead.h"
@@ -36,6 +34,7 @@
 
 #include "mixerchannel.h"
 #include "audiosignalnotifier.h"
+#include "nodes/fxnode.h"
 
 namespace muse {
 class TaskScheduler;
@@ -103,7 +102,7 @@ private:
 
     AudioOutputParams m_masterParams;
     async::Channel<AudioOutputParams> m_masterOutputParamsChanged;
-    std::vector<IFxProcessorPtr> m_masterFxProcessors = {};
+    std::vector<FxNodePtr> m_masterFxNodes;
 
     struct TrackData {
         TrackId trackId;

--- a/src/framework/audio/engine/internal/mixerchannel.cpp
+++ b/src/framework/audio/engine/internal/mixerchannel.cpp
@@ -88,12 +88,13 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
         return;
     }
 
-    m_fxProcessors.clear();
-    m_fxProcessors = audioFactory()->makeTrackFxList(m_trackId, requiredParams.fxChain);
+    m_fxNodes.clear();
+    m_fxNodes = audioFactory()->makeTrackFxList(m_trackId, requiredParams.fxChain);
 
-    for (IFxProcessorPtr& fx : m_fxProcessors) {
+    for (FxNodePtr& fx : m_fxNodes) {
         fx->setOutputSpec(m_outputSpec);
-        fx->setPlaying(isModePlaying(mode()));
+        fx->setMode(mode());
+        fx->setPlayheadPosition(m_playheadPosition);
 
         fx->paramsChanged().onReceive(this, [this](const AudioFxParams& fxParams) {
             m_params.fxChain.insert_or_assign(fxParams.chainOrder, fxParams);
@@ -104,14 +105,14 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
 
     AudioOutputParams resultParams = requiredParams;
 
-    auto findFxProcessor = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) -> IFxProcessor* {
-        for (IFxProcessorPtr& fx : m_fxProcessors) {
+    auto findFxNode = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) -> FxNodePtr {
+        for (FxNodePtr& fx : m_fxNodes) {
             if (fx->params().chainOrder != params.first) {
                 continue;
             }
 
             if (fx->params().resourceMeta == params.second.resourceMeta) {
-                return fx.get();
+                return fx;
             }
         }
 
@@ -119,8 +120,8 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& requiredParams)
     };
 
     for (auto it = resultParams.fxChain.begin(); it != resultParams.fxChain.end();) {
-        if (IFxProcessor* fx = findFxProcessor(*it)) {
-            fx->setActive(it->second.active);
+        if (FxNodePtr fx = findFxNode(*it)) {
+            fx->setBypassed(!it->second.active);
             ++it;
         } else {
             it = resultParams.fxChain.erase(it);
@@ -165,8 +166,8 @@ void MixerChannel::setMode(const ProcessMode mode)
         m_audioSource->setMode(mode);
     }
 
-    for (IFxProcessorPtr& fx : m_fxProcessors) {
-        fx->setPlaying(isModePlaying(mode));
+    for (FxNodePtr& fx : m_fxNodes) {
+        fx->setMode(mode);
     }
 }
 
@@ -180,7 +181,7 @@ void MixerChannel::setOutputSpec(const OutputSpec& spec)
         m_audioSource->setOutputSpec(spec);
     }
 
-    for (IFxProcessorPtr& fx : m_fxProcessors) {
+    for (FxNodePtr& fx : m_fxNodes) {
         fx->setOutputSpec(spec);
     }
 }
@@ -219,11 +220,8 @@ samples_t MixerChannel::process(float* buffer, samples_t samplesPerChannel)
         return processedSamplesCount;
     }
 
-    const samples_t pos = m_playheadPosition ? m_playheadPosition->currentPosition().samples() : 0;
-    for (IFxProcessorPtr& fx : m_fxProcessors) {
-        if (fx->active()) {
-            fx->process(buffer, samplesPerChannel, pos);
-        }
+    for (FxNodePtr& fx : m_fxNodes) {
+        fx->process(buffer, samplesPerChannel);
     }
 
     completeOutput(buffer, samplesPerChannel);
@@ -266,7 +264,7 @@ void MixerChannel::completeOutput(float* buffer, unsigned int samplesCount)
 void MixerChannel::updateShouldProcessDuringSilence()
 {
     bool shouldProcessDuringSilence = false;
-    for (const IFxProcessorPtr& fx : m_fxProcessors) {
+    for (const FxNodePtr& fx : m_fxNodes) {
         if (fx->shouldProcessDuringSilence()) {
             shouldProcessDuringSilence = true;
             break;

--- a/src/framework/audio/engine/internal/mixerchannel.h
+++ b/src/framework/audio/engine/internal/mixerchannel.h
@@ -31,6 +31,7 @@
 #include "audiosignalnotifier.h"
 #include "track.h"
 #include "../iplayhead.h"
+#include "nodes/fxnode.h"
 
 namespace muse::audio::engine {
 class MixerChannel : public ITrackAudioOutput, public async::Asyncable
@@ -83,7 +84,7 @@ private:
 
     AudioNodePtr m_audioSource = nullptr;
     PlayheadPositionPtr m_playheadPosition = nullptr;
-    std::vector<IFxProcessorPtr> m_fxProcessors = {};
+    std::vector<FxNodePtr> m_fxNodes;
 
     bool m_isSilent = true;
     bool m_shouldProcessDuringSilence = false;

--- a/src/framework/audio/engine/internal/nodes/audionode.cpp
+++ b/src/framework/audio/engine/internal/nodes/audionode.cpp
@@ -68,6 +68,45 @@ void AudioNode::onModeChanged(const ProcessMode mode)
     }
 }
 
+void AudioNode::setEnabled(bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+    m_enabled = enabled;
+    onEnabledChanged(enabled);
+}
+
+bool AudioNode::enabled() const
+{
+    return m_enabled;
+}
+
+void AudioNode::onEnabledChanged(bool enabled)
+{
+    if (m_input) {
+        m_input->setEnabled(enabled);
+    }
+}
+
+void AudioNode::setBypassed(bool bypassed)
+{
+    if (m_bypassed == bypassed) {
+        return;
+    }
+    m_bypassed = bypassed;
+    onBypassedChanged(bypassed);
+}
+
+bool AudioNode::bypassed() const
+{
+    return m_bypassed;
+}
+
+void AudioNode::onBypassedChanged(bool /*bypassed*/)
+{
+}
+
 AudioNode* AudioNode::connect(std::shared_ptr<AudioNode> other)
 {
     IF_ASSERT_FAILED(other) {
@@ -116,6 +155,10 @@ void AudioNode::doRemoveNode(std::shared_ptr<AudioNode> other)
 
 void AudioNode::process(float* buffer, samples_t samplesPerChannel)
 {
+    if (!m_enabled) {
+        return;
+    }
+
     doProcess(buffer, samplesPerChannel);
 }
 
@@ -123,6 +166,10 @@ void AudioNode::doProcess(float* buffer, samples_t samplesPerChannel)
 {
     if (m_input) {
         m_input->process(buffer, samplesPerChannel);
+    }
+
+    if (m_bypassed) {
+        return;
     }
 
     doSelfProcess(buffer, samplesPerChannel);

--- a/src/framework/audio/engine/internal/nodes/audionode.h
+++ b/src/framework/audio/engine/internal/nodes/audionode.h
@@ -38,6 +38,14 @@ public:
     void setMode(const ProcessMode mode);
     ProcessMode mode() const;
 
+    // turns off this node and all connected ones (like mute)
+    void setEnabled(bool enabled);
+    bool enabled() const;
+
+    // turns off only this node (like bypass)
+    void setBypassed(bool bypassed);
+    bool bypassed() const;
+
     AudioNode* connect(std::shared_ptr<AudioNode> other);
     AudioNode* disconnect(std::shared_ptr<AudioNode> other);
 
@@ -47,6 +55,8 @@ protected:
 
     virtual void onOutputSpecChanged(const OutputSpec& spec);
     virtual void onModeChanged(const ProcessMode mode);
+    virtual void onEnabledChanged(bool enabled);
+    virtual void onBypassedChanged(bool bypassed);
 
     virtual void doAddNode(std::shared_ptr<AudioNode> other);
     virtual void doRemoveNode(std::shared_ptr<AudioNode> other);
@@ -56,6 +66,8 @@ protected:
 
     OutputSpec m_outputSpec;
     ProcessMode m_mode = ProcessMode::Undefined;
+    bool m_enabled = true;
+    bool m_bypassed = false;
 
     std::shared_ptr<AudioNode> m_input = nullptr;
 };

--- a/src/framework/audio/engine/internal/nodes/fxnode.cpp
+++ b/src/framework/audio/engine/internal/nodes/fxnode.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "fxnode.h"
+
+using namespace muse;
+using namespace muse::audio;
+using namespace muse::audio::engine;
+
+FxNode::FxNode(IFxProcessorPtr fxProcessor, PlayheadPositionPtr playheadPosition)
+    : m_fxProcessor(fxProcessor), m_playheadPosition(playheadPosition)
+{
+}
+
+void FxNode::setPlayheadPosition(PlayheadPositionPtr playheadPosition)
+{
+    m_playheadPosition = playheadPosition;
+}
+
+void FxNode::onModeChanged(const ProcessMode mode)
+{
+    m_fxProcessor->setMode(mode);
+}
+
+const AudioFxParams& FxNode::params() const
+{
+    return m_fxProcessor->params();
+}
+
+async::Channel<audio::AudioFxParams> FxNode::paramsChanged() const
+{
+    return m_fxProcessor->paramsChanged();
+}
+
+bool FxNode::shouldProcessDuringSilence() const
+{
+    return m_fxProcessor->shouldProcessDuringSilence();
+}
+
+void FxNode::onOutputSpecChanged(const OutputSpec& spec)
+{
+    m_fxProcessor->setOutputSpec(spec);
+}
+
+void FxNode::doSelfProcess(float* buffer, samples_t samplesPerChannel)
+{
+    samples_t pos = m_playheadPosition ? m_playheadPosition->currentPosition().samples() : 0;
+    m_fxProcessor->process(buffer, samplesPerChannel, pos);
+}

--- a/src/framework/audio/engine/internal/nodes/fxnode.h
+++ b/src/framework/audio/engine/internal/nodes/fxnode.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "audionode.h"
+#include "../../ifxprocessor.h"
+#include "../../iplayhead.h"
+
+namespace muse::audio::engine {
+class FxNode : public AudioNode
+{
+public:
+
+    explicit FxNode(IFxProcessorPtr fxProcessor, PlayheadPositionPtr playheadPosition = nullptr);
+
+    void setPlayheadPosition(PlayheadPositionPtr playheadPosition);
+
+    const AudioFxParams& params() const;
+    async::Channel<audio::AudioFxParams> paramsChanged() const;
+
+    bool shouldProcessDuringSilence() const;
+
+protected:
+
+    void onModeChanged(const ProcessMode mode) override;
+    void onOutputSpecChanged(const OutputSpec& spec) override;
+
+    void doSelfProcess(float* buffer, samples_t samplesPerChannel) override;
+
+    IFxProcessorPtr m_fxProcessor;
+    PlayheadPositionPtr m_playheadPosition;
+};
+
+using FxNodePtr = std::shared_ptr<FxNode>;
+}

--- a/src/framework/audio/main/internal/playback.cpp
+++ b/src/framework/audio/main/internal/playback.cpp
@@ -164,6 +164,13 @@ IPlayerPtr Playback::player() const
     return p;
 }
 
+template<typename T>
+static void doReject(MsgCode code, T& reject, const Ret& ret)
+{
+    LOGE() << "failed rpc request: " << rpc::to_string(code) << ", err: " << ret.toString();
+    (void)reject(ret.code(), ret.text());
+}
+
 // 2. Setup tracks
 async::Promise<TrackIdList> Playback::trackIdList() const
 {
@@ -175,14 +182,13 @@ async::Promise<TrackIdList> Playback::trackIdList() const
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<TrackIdList> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetTrackIdList, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetTrackIdList, reject, ret.ret);
             }
         });
         return Promise<TrackIdList>::dummy_result();
@@ -199,8 +205,7 @@ async::Promise<RetVal<TrackName> > Playback::trackName(const TrackId trackId) co
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<TrackName> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetTrackName, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             (void)resolve(ret);
@@ -216,8 +221,8 @@ async::Promise<TrackId, AudioParams> Playback::addTrack(const TrackName& trackNa
 #ifdef MUE_CONFIGURATION_IS_APPWEB
     NOT_SUPPORTED;
     return async::make_promise<TrackId, AudioParams>([](auto /*resolve*/, auto reject) {
-        Ret ret = muse::make_ret(Ret::Code::NotSupported);
-        return reject(ret.code(), ret.text());
+        doReject(MsgCode::AddTrackWithIODevice, reject, muse::make_ret(Ret::Code::NotSupported));
+        return Promise<TrackId, AudioParams>::dummy_result();
     });
 #else
     ONLY_AUDIO_MAIN_THREAD;
@@ -231,14 +236,13 @@ async::Promise<TrackId, AudioParams> Playback::addTrack(const TrackName& trackNa
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::AddTrackWithIODevice, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val1, ret.val2);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::AddTrackWithIODevice, reject, ret.ret);
             }
         });
         return Promise<TrackId, AudioParams>::dummy_result();
@@ -265,14 +269,13 @@ async::Promise<TrackId, AudioParams> Playback::addTrack(const TrackName& trackNa
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::AddTrackWithPlaybackData, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val1, ret.val2);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::AddTrackWithPlaybackData, reject, ret.ret);
             }
         });
         return Promise<TrackId, AudioParams>::dummy_result();
@@ -290,14 +293,13 @@ async::Promise<TrackId, AudioOutputParams> Playback::addAuxTrack(const TrackName
             ONLY_AUDIO_MAIN_THREAD;
             RetVal2<TrackId, AudioOutputParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::AddAuxTrack, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val1, ret.val2);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::AddAuxTrack, reject, ret.ret);
             }
         });
         return Promise<TrackId, AudioOutputParams>::dummy_result();
@@ -338,14 +340,13 @@ async::Promise<AudioResourceMetaList> Playback::availableInputResources() const
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioResourceMetaList> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetAvailableInputResources, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetAvailableInputResources, reject, ret.ret);
             }
         });
         return Promise<AudioResourceMetaList>::dummy_result();
@@ -362,14 +363,13 @@ async::Promise<SoundPresetList> Playback::availableSoundPresets(const AudioResou
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<SoundPresetList> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetAvailableSoundPresets, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetAvailableSoundPresets, reject, ret.ret);
             }
         });
         return Promise<SoundPresetList>::dummy_result();
@@ -386,15 +386,14 @@ async::Promise<AudioInputParams> Playback::inputParams(const TrackId trackId) co
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioInputParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetInputParams, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetInputParams, reject, ret.ret);
             }
         });
         return Promise<AudioInputParams>::dummy_result();
@@ -432,8 +431,7 @@ muse::async::Promise<InputProcessingProgress> Playback::inputProcessingProgress(
             bool isStarted = false;
             StreamId streamId = 0;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret, isStarted, streamId)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetInputProcessingProgress, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
@@ -443,7 +441,7 @@ muse::async::Promise<InputProcessingProgress> Playback::inputProcessingProgress(
                 channel()->addReceiveStream(StreamName::InputProcessingProgressStream, streamId, prog.processedChannel);
                 (void)resolve(prog);
             } else {
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetInputProcessingProgress, reject, ret);
             }
         });
         return Promise<InputProcessingProgress>::dummy_result();
@@ -476,15 +474,14 @@ async::Promise<AudioOutputParams> Playback::outputParams(const TrackId trackId) 
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioOutputParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetOutputParams, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetOutputParams, reject, ret.ret);
             }
         });
         return Promise<AudioOutputParams>::dummy_result();
@@ -513,15 +510,14 @@ async::Promise<AudioOutputParams> Playback::masterOutputParams() const
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioOutputParams> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetMasterOutputParams, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetMasterOutputParams, reject, ret.ret);
             }
         });
         return Promise<AudioOutputParams>::dummy_result();
@@ -557,14 +553,13 @@ async::Promise<AudioResourceMetaList> Playback::availableOutputResources() const
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<AudioResourceMetaList> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetAvailableOutputResources, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
             if (ret.ret) {
                 (void)resolve(ret.val);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetAvailableOutputResources, reject, ret.ret);
             }
         });
         return Promise<AudioResourceMetaList>::dummy_result();
@@ -581,8 +576,7 @@ async::Promise<AudioSignalChanges> Playback::signalChanges(const TrackId trackId
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<StreamId> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetSignalChanges, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
@@ -591,7 +585,7 @@ async::Promise<AudioSignalChanges> Playback::signalChanges(const TrackId trackId
                 channel()->addReceiveStream(StreamName::AudioSignalStream, ret.val, ch);
                 (void)resolve(ch);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetSignalChanges, reject, ret.ret);
             }
         });
         return Promise<AudioSignalChanges>::dummy_result();
@@ -608,8 +602,7 @@ async::Promise<AudioSignalChanges> Playback::masterSignalChanges() const
             ONLY_AUDIO_MAIN_THREAD;
             RetVal<StreamId> ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::GetMasterSignalChanges, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
@@ -618,7 +611,7 @@ async::Promise<AudioSignalChanges> Playback::masterSignalChanges() const
                 channel()->addReceiveStream(StreamName::AudioMasterSignalStream, ret.val, ch);
                 (void)resolve(ch);
             } else {
-                (void)reject(ret.ret.code(), ret.ret.text());
+                doReject(MsgCode::GetMasterSignalChanges, reject, ret.ret);
             }
         });
         return Promise<AudioSignalChanges>::dummy_result();
@@ -635,15 +628,14 @@ async::Promise<bool> Playback::saveSoundTrack(const SoundTrackFormat& format, io
             ONLY_AUDIO_MAIN_THREAD;
             Ret ret;
             IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                Ret ret = audio::make_ret(Err::InvalidRpcData);
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::SaveSoundTrack, reject, audio::make_ret(Err::InvalidRpcData));
                 return;
             }
 
             if (ret) {
                 (void)resolve(true);
             } else {
-                (void)reject(ret.code(), ret.text());
+                doReject(MsgCode::SaveSoundTrack, reject, ret);
             }
         });
         return Promise<bool>::dummy_result();

--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -100,9 +100,9 @@ void VstFxProcessor::setActive(bool active)
     m_params.active = active;
 }
 
-void VstFxProcessor::setPlaying(bool playing)
+void VstFxProcessor::setMode(const muse::audio::ProcessMode mode)
 {
-    m_vstAudioClient->setIsPlaying(playing);
+    m_vstAudioClient->setIsPlaying(muse::audio::isModePlaying(mode));
 }
 
 bool VstFxProcessor::shouldProcessDuringSilence() const

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -49,7 +49,7 @@ public:
     bool active() const override;
     void setActive(bool active) override;
 
-    void setPlaying(bool playing) override;
+    void setMode(const muse::audio::ProcessMode mode) override;
 
     bool shouldProcessDuringSilence() const override;
 


### PR DESCRIPTION


A FxNode has been added.
It's a wrapper around the fx processor.
(It's similar to a EventAudioNode, like a wrapper around a synthesizer.)

It can work with a node chain, but for now everything is the same; essentially, nothing has changed.

Also added to the AudioNode base class:
* enabled - turns off this node and all connected ones (like mute)
* bypassed - turns off only this node (like bypass) 