### PR TITLE
Fix #31997: Mixer not loading when switching pages [4.7.0]

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -578,6 +578,10 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
 
     loadPageContent(newPage);
     restorePageState(newPage);
+
+    // Calls such as clearRegistry lead to deferred deletes of docks. Ensure these
+    // have been fully processed before attempting to re-init (see issue #31997)
+    qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete);
     initDocks(newPage);
 
     newPage->setParams(params);


### PR DESCRIPTION
Resolves: #31997

As mentioned in the code comment - calls such as `clearRegistry` lead to deferred deletes of docks. The new call to `sendPostedEvents` ensures that these have been fully processed before attempting to re-init.