### PR TITLE
Scan for FFmpeg providers on Windows & macOS [4.7]

### DIFF
--- a/src/framework/global/io/internal/filesystem.cpp
+++ b/src/framework/global/io/internal/filesystem.cpp
@@ -285,6 +285,9 @@ RetVal<io::paths_t> FileSystem::scanFiles(const io::path_t& rootDir, const std::
     case ScanMode::FilesInCurrentDir:
         filters |= QDir::Files;
         break;
+    case ScanMode::FoldersInCurrentDir:
+        filters |= QDir::Dirs;
+        break;
     case ScanMode::FilesAndFoldersInCurrentDir:
         filters |= QDir::Files | QDir::Dirs;
         break;

--- a/src/framework/global/io/ioenums.h
+++ b/src/framework/global/io/ioenums.h
@@ -36,6 +36,7 @@ enum class OpenMode {
 
 enum class ScanMode {
     FilesInCurrentDir,
+    FoldersInCurrentDir,
     FilesAndFoldersInCurrentDir,
     FilesInCurrentDirAndSubdirs
 };

--- a/src/framework/media/internal/ffmpegutils.cpp
+++ b/src/framework/media/internal/ffmpegutils.cpp
@@ -25,6 +25,10 @@
 #include "io/fileinfo.h"
 #include "io/path.h"
 
+#if defined(Q_OS_WIN)
+#include <QSettings>
+#endif
+
 using namespace muse::media;
 using namespace muse;
 
@@ -32,15 +36,37 @@ namespace muse::media {
 io::paths_t defaultSearchPaths()
 {
     io::paths_t paths;
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_WIN)
+    QSettings settings(
+        "HKEY_LOCAL_MACHINE\\Software\\FFmpeg\\Providers",
+        QSettings::NativeFormat
+        );
+
+    for (const QString& child : settings.childGroups()) {
+        settings.beginGroup(child);
+        QVariant value = settings.value("InstallPath");
+        if (value.isValid()) {
+            QString path = value.toString();
+            if (!path.isEmpty()) {
+                paths.push_back(path.replace('\\', '/') + "/bin");
+            }
+        }
+        settings.endGroup(); // Back to parent group.
+    }
+#elif defined(Q_OS_MAC)
+    RetVal<io::paths_t> providers = io::Dir::scanFiles("/Library/Application Support/FFmpeg/Providers", { "*" },
+                                                       io::ScanMode::FoldersInCurrentDir);
+    if (providers.ret) {
+        for (const io::path_t& dir : providers.val) {
+            paths.push_back(dir + "/lib");
+        }
+    }
     paths.push_back("/opt/homebrew/lib");
     paths.push_back("/usr/local/lib");
-#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#else
     paths.push_back("/usr/lib/x86_64-linux-gnu");
     paths.push_back("/usr/lib64");
     paths.push_back("/usr/lib");
-#elif defined(Q_OS_WIN)
-    // Windows: rely on PATH or user-specified path
 #endif
     return paths;
 }


### PR DESCRIPTION
Look for FFmpeg installations under:

* **Windows:** Registry keys `HKEY_LOCAL_MACHINE\Software\FFmpeg\Providers\*`.
    * The `InstallPath` value gives the location selected by the user during installation of FFmpeg.
    * Default location: `C:\Program Files\FFmpeg\Providers\PROVIDER-ID` (append `\bin` to find DLLs).
* **macOS:** Directories `/Library/Application Support/FFmpeg/Providers/*` (append `/lib` to find DYLIBs).
    * On macOS FFmpeg's location is fixed and cannot be changed by the user.

It's expected that each FFmpeg provider will choose a unique ID such as `com.example.ffmpeg8.1`, and use that ID as the name of their installation's folder and registry key under `FFmpeg/Providers`.

Unchanged in this PR, we also check some default paths used by distributions and package managers:

* **macOS:**
    * `/opt/homebrew/lib` (Homebrew on Apple Silicon).
    * `/usr/local/lib` (Homebrew on Intel; or self-compiled FFmpeg).
* **Linux and others:** 
    * `/usr/lib/x86_64-linux-gnu`
    * `/usr/lib64`
    * `/usr/lib`

Also unchanged in this PR, when we find an FFmpeg version, we check whether we are actually able to link against it (e.g. based on the library version and included components). If not, we ignore it and try the next detected FFmpeg version. Once we find a version that works, we store its path in Preferences and use it on all subsequent launches.