### PR TITLE
Fix creation of thumbnail when a score is created via 'Save selection'

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -860,7 +860,7 @@ muse::Ret NotationProject::writeProject(const muse::io::path_t& path, const writ
         return make_ret(Ret::Code::InternalError);
     }
 
-    return saveScore(path, suffix, false /*generateBackup*/, false /*createThumbnail*/, false /*isAutosave*/, ctx);
+    return saveScore(path, suffix, false /*generateBackup*/, true /*createThumbnail*/, false /*isAutosave*/, ctx);
 }
 
 Ret NotationProject::writeProject(MscWriter& msczWriter, bool createThumbnail, const write::WriteContext* ctx)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33194

Scores created via 'Save selection' did not have a preview in Home>Scores tab. They now do.