### PR TITLE
fix crash on window close

### DIFF
--- a/src/framework/global/thirdparty/kors_modularity/modularity/modulesioc.h
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/modulesioc.h
@@ -66,6 +66,7 @@ struct Subscriber
     {
         if (onUnSubscribe) {
             onUnSubscribe();
+            onUnSubscribe = nullptr;
         }
     }
 };
@@ -77,6 +78,7 @@ public:
     virtual ~ModulesIoCBase()
     {
         reset();
+        m_alive.reset();
     }
 
 #ifndef IOC_CHECK_INTERFACE_TYPE
@@ -129,10 +131,7 @@ public:
             s->changed(pointer_cast<I>(p));
         });
 
-        s->onUnSubscribe = [this, key, s]() {
-            doUnsubscribe(I::modularity_interfaceInfo(), key);
-            s->onUnSubscribe = nullptr;
-        };
+        s->onUnSubscribe = makeUnSubscribeFn<I>(key);
     }
 
 #endif
@@ -256,7 +255,19 @@ protected:
         std::map<int, OnChangedInternal> onChanges;
     };
 
+    template<class I>
+    std::function<void()> makeUnSubscribeFn(int key)
+    {
+        std::weak_ptr<bool> alive = m_alive;
+        return [this, key, alive]() {
+            if (!alive.expired()) {
+                doUnsubscribe(I::modularity_interfaceInfo(), key);
+            }
+        };
+    }
+
     std::map<std::string_view, Service > m_map;
+    std::shared_ptr<bool> m_alive = std::make_shared<bool>(true);
 };
 
 class ModulesGlobalIoC : public ModulesIoCBase
@@ -319,9 +330,7 @@ public:
             s->changed(pointer_cast<I>(p));
         });
 
-        s->onUnSubscribe = [this, key]() {
-            doUnsubscribe(I::modularity_interfaceInfo(), key);
-        };
+        s->onUnSubscribe = makeUnSubscribeFn<I>(key);
     }
 };
 
@@ -385,9 +394,7 @@ public:
             s->changed(pointer_cast<I>(p));
         });
 
-        s->onUnSubscribe = [this, key]() {
-            doUnsubscribe(I::modularity_interfaceInfo(), key);
-        };
+        s->onUnSubscribe = makeUnSubscribeFn<I>(key);
     }
 };
 }


### PR DESCRIPTION
During window close, some Injects can outlive their context because their owning QObjects are torn down via deleteLater() and the actual destruction runs on a later event-loop turn.

Add a weak pointer guard that allows skipping unsubscription if the context is destroyed.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
