### PR TITLE
Undocked panel fixes (#33232 & #33228)

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
@@ -95,9 +95,6 @@ DockPage {
     readonly property int horizontalPanelMinHeight: 100
     readonly property int horizontalPanelMaxHeight: 520
 
-    readonly property int panelMinDimension: 10
-    readonly property int panelMaxDimension: 7500 //! NOTE: Value found experimentally - see issue #27770
-
     readonly property string verticalPanelsGroup: "VERTICAL_PANELS"
     readonly property string horizontalPanelsGroup: "HORIZONTAL_PANELS"
 
@@ -259,9 +256,6 @@ DockPage {
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
 
-            minimumHeight: root.panelMinDimension
-            maximumHeight: root.panelMaxDimension
-
             groupName: root.verticalPanelsGroup
 
             dropDestinations: root.verticalPanelDropDestinations
@@ -287,9 +281,6 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-
-            minimumHeight: root.panelMinDimension
-            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
 
@@ -317,9 +308,6 @@ DockPage {
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
 
-            minimumHeight: root.panelMinDimension
-            maximumHeight: root.panelMaxDimension
-
             groupName: root.verticalPanelsGroup
 
             dropDestinations: root.verticalPanelDropDestinations
@@ -342,9 +330,6 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-
-            minimumHeight: root.panelMinDimension
-            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
 
@@ -370,9 +355,6 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-
-            minimumHeight: root.panelMinDimension
-            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
             location: Location.Right
@@ -401,9 +383,6 @@ DockPage {
             height: 368
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
-
-            minimumWidth: root.panelMinDimension
-            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 
@@ -455,9 +434,6 @@ DockPage {
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
 
-            minimumWidth: root.panelMinDimension
-            maximumWidth: root.panelMaxDimension
-
             groupName: root.horizontalPanelsGroup
 
             //! NOTE: hidden by default
@@ -488,9 +464,6 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
-
-            minimumWidth: root.panelMinDimension
-            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 
@@ -544,9 +517,6 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
-
-            minimumWidth: root.panelMinDimension
-            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 

--- a/src/appshell/qml/MuseScore/AppShell/notationpagemodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/notationpagemodel.cpp
@@ -62,6 +62,8 @@ void NotationPageModel::init()
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onNotationChanged();
+        scheduleUpdateDrumsetPanelVisibility();
+        scheduleUpdatePercussionPanelVisibility();
     });
 
     extensionsProvider()->manifestListChanged().onNotify(this, [this]() {

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
@@ -626,21 +626,6 @@ void QWidgetAdapter::move(int x, int y)
 
 void QWidgetAdapter::setSize(QSize size)
 {
-#ifdef Q_OS_MACOS
-    FloatingWindow *floatingWindow = this->floatingWindow();
-    if (!floatingWindow) {
-        return;
-    }
-
-    const auto newSize = size.expandedTo(minimumSize());
-
-    QWindow* window = floatingWindow->windowHandle();
-    if (window && window->size() != newSize) {
-        QRect windowGeo = window->geometry();
-        windowGeo.setSize(newSize);
-        window->setGeometry(windowGeo);
-    }
-#endif
     QQuickItem::setSize(QSizeF(size));
 }
 


### PR DESCRIPTION
Resolves: #33232

Partially reverts: #29896
Resolves: #33228
Reopens: #27770
Reopens: #30028

There's a potential alternate solution here (that doesn't involve a revert) where you don't allow `DockBase::resize` calls before the `DockBase` has had a chance to load its initial size (see `m_inited`). I was only able to arrive at a partial fix for the percussion panel, though - the mixer panel still had problems.

---

Something I noticed while working on this is that there's actually a separate issue for **_all horizontal panels_** (not just panels that have "resize requested" logic like the mixer and percussion panels). On close and reopening MuseScore, panels such as the piano keyboard have "pencil width" content:

<img width="1136" height="793" alt="Screenshot 2026-05-01 at 17 33 40" src="https://github.com/user-attachments/assets/51c504cb-5f12-4894-bb4c-2d95724a6ac5" />
...

This can be resolved by reverting 3918bd0d69ee9e95a3372627eed5d671399e03c6 (which is a patch we ported directly from KDDockWidgets). Unfortunately this will also reopen the "resize from corner" bug described in #30028.