### PR TITLE
Fix #33166: Layout as harmony rather than text in editing

### DIFF
--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -708,8 +708,8 @@ void Harmony::startEdit(EditData& ed)
         rightParen()->mutldata()->reset();
     }
 
-    // layout as text, without position reset
-    renderer()->layoutText1(this, true);
+    // layout as harmony, without position reset
+    renderer()->layoutText1(this);
     triggerLayout();
 
     TextBase::startEdit(ed);
@@ -749,8 +749,8 @@ bool Harmony::edit(EditData& ed)
 
     bool rv = TextBase::edit(ed);
 
-    // layout as text, without position reset
-    renderer()->layoutText1(this, true);
+    // layout as harmony, without position reset
+    renderer()->layoutText1(this);
     triggerLayout();
 
     // check spelling

--- a/src/engraving/tests/chordsymbol_tests.cpp
+++ b/src/engraving/tests/chordsymbol_tests.cpp
@@ -33,12 +33,15 @@
 #include "engraving/dom/part.h"
 #include "engraving/dom/score.h"
 #include "engraving/dom/segment.h"
+#include "engraving/editing/editdata.h"
 #include "engraving/editing/transpose.h"
 
 #include "utils/scorerw.h"
 #include "utils/scorecomp.h"
 
 using namespace mu::engraving;
+
+static constexpr double POSITION_ERROR = 1e-6;
 
 static const String CHORDSYMBOL_DATA_DIR("chordsymbol_data/");
 
@@ -138,6 +141,43 @@ TEST_F(Engraving_ChordSymbolTests, testAddLink)
     score->undoAddElement(harmony);
     score->doLayout();
     test_post(score, u"add-link");
+}
+
+TEST_F(Engraving_ChordSymbolTests, harmonyEditKeepsDisplayPosition)
+{
+    MasterScore* score = test_pre(u"add-link");
+    ASSERT_TRUE(score);
+
+    Segment* seg = score->firstSegment(SegmentType::ChordRest);
+    ASSERT_TRUE(seg);
+    ChordRest* cr = seg->cr(0);
+    ASSERT_TRUE(cr);
+
+    Harmony* harmony = new Harmony(cr->segment());
+    harmony->setHarmony(u"C");
+    harmony->setTrack(cr->track());
+    harmony->setParent(cr->segment());
+    score->undoAddElement(harmony);
+    score->doLayout();
+
+    const double x = harmony->canvasPos().x();
+    const double y = harmony->canvasPos().y();
+
+    EditData ed;
+    harmony->startEdit(ed);
+
+    EXPECT_NEAR(harmony->canvasPos().x(), x, POSITION_ERROR);
+    EXPECT_NEAR(harmony->canvasPos().y(), y, POSITION_ERROR);
+
+    ed.s = String(u"7");
+    harmony->cursor()->moveCursorToEnd();
+    harmony->edit(ed);
+
+    EXPECT_NEAR(harmony->canvasPos().x(), x, POSITION_ERROR);
+    EXPECT_NEAR(harmony->canvasPos().y(), y, POSITION_ERROR);
+
+    harmony->endEdit(ed);
+    delete score;
 }
 
 TEST_F(Engraving_ChordSymbolTests, testAddPart)


### PR DESCRIPTION
After https://github.com/musescore/MuseScore/pull/32770, it seems that laying out harmony as text is no longer appropriate; change it to be laid out as harmony.

Resolves: #33166 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
