### PR TITLE
Fix playback from timeline elements

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/timelineview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/timelineview.cpp
@@ -35,7 +35,7 @@ namespace mu::notation {
 class TimelineAdapter : public QSplitter, public muse::uicomponents::IDisplayableWidget
 {
 public:
-    TimelineAdapter()
+    TimelineAdapter(const muse::modularity::ContextPtr& iocCtx)
         : QSplitter(nullptr)
     {
         setFocusPolicy(Qt::NoFocus);
@@ -43,7 +43,7 @@ public:
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         setObjectName("TimelineAdapter");
 
-        m_msTimeline = new Timeline(this);
+        m_msTimeline = new Timeline(this, iocCtx);
     }
 
     void updateView()
@@ -141,7 +141,7 @@ void TimelineView::componentComplete()
 {
     WidgetView::componentComplete();
 
-    auto timeline = std::make_shared<TimelineAdapter>();
+    auto timeline = std::make_shared<TimelineAdapter>(iocContext());
 
     auto updateView = [this, timeline]() {
         update();

--- a/src/notationscene/widgets/timeline.cpp
+++ b/src/notationscene/widgets/timeline.cpp
@@ -706,8 +706,8 @@ QString TRowLabels::cursorIsOn()
 //   Timeline
 //---------------------------------------------------------
 
-Timeline::Timeline(QSplitter* splitter)
-    : QGraphicsView(splitter), muse::Contextable(muse::iocCtxForQWidget(this))
+Timeline::Timeline(QSplitter* splitter, const muse::modularity::ContextPtr& iocCtx)
+    : QGraphicsView(splitter), muse::Contextable(iocCtx)
 {
     TRACEFUNC;
 
@@ -2310,6 +2310,27 @@ void Timeline::mousePressEvent(QMouseEvent* event)
     } else {
         interaction()->clearSelection();
     }
+
+    this->seekSelection();
+}
+
+void Timeline::seekSelection()
+{
+    const INotationSelectionPtr selection = interaction()->selection();
+    const std::vector<EngravingItem*>& elements = selection->elements();
+    if (elements.empty()) {
+        return;
+    }
+
+    EngravingItem* elementToSeek = elements.front();
+    for (EngravingItem* element : elements) {
+        if (element->tick() > elementToSeek->tick()) {
+            continue;
+        }
+        elementToSeek = element;
+    }
+
+    playbackController()->seekElement(elementToSeek);
 }
 
 //---------------------------------------------------------

--- a/src/notationscene/widgets/timeline.h
+++ b/src/notationscene/widgets/timeline.h
@@ -30,6 +30,7 @@
 #include "notation/inotation.h"
 #include "async/asyncable.h"
 #include "actions/iactionsdispatcher.h"
+#include "playback/iplaybackcontroller.h"
 
 #include <vector>
 #include <QGraphicsView>
@@ -112,6 +113,7 @@ class Timeline : public QGraphicsView, public muse::Contextable, public muse::as
 
     muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher = { this };
+    muse::ContextInject<playback::IPlaybackController> playbackController = { this };
 
 public:
     enum class ItemType {
@@ -121,7 +123,7 @@ public:
     };
     Q_ENUM(ItemType)
 
-    Timeline(QSplitter* splitter);
+    Timeline(QSplitter* splitter, const muse::modularity::ContextPtr& iocCtx);
 
     bool handleEvent(QEvent* event);
 
@@ -268,6 +270,8 @@ private:
     engraving::Staff* numToStaff(int staff);
     void toggleShow(int staff);
     QString cursorIsOn(const QPoint& cursorPos);
+
+    void seekSelection();
 };
 }
 


### PR DESCRIPTION
Resolves: #32613

Using timeline navigation, it was not possible to play from the elements or cells selected in the timeline. After the fix, when a timeline element is clicked, the playback position is now properly updated.
