### PR TITLE
Fix 'Save selection' bug due to stale pointers in EID register

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3515,6 +3515,8 @@ static void writeTimeSig(Score* score, const Fraction& tick, XmlWriter& xml, Wri
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(tsf);
     TWrite::write(ts, xml, ctx);
+    ts->masterScore()->eidRegister()->removeItem(ts);
+    delete ts;
 }
 
 //---------------------------------------------------------
@@ -3696,6 +3698,7 @@ void TWrite::writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t strack
                     KeySig* ks = Factory::createKeySig(score->dummy()->segment());
                     ks->setKey(ck, tk);
                     TWrite::write(ks, xml, ctx);
+                    ks->masterScore()->eidRegister()->removeItem(ks);
                     delete ks;
                     keySigWritten = true;
                 }


### PR DESCRIPTION
### The issue

When opening a score saved via "Save selection",  for scores containing multiple staves, there was often an assert crash (in Debug build only) due to a duplicate `KeySig` EID across multiple `Staff` sections in the XML file.


https://github.com/user-attachments/assets/b8d55ea9-0e68-4387-81ff-7698ff51119f



### The cause

When saving a score selection, when the selection does not contain the Key signatures (see the example video), a dummy `KeySig` is inserted into the new score for each staff. The `TWrite::writeSegments` function was deleting the dummy `KeySigs` after writing them to the XML, but the pointer to them remained in the `EIDRegister`. This was in itself a bug but not the direct cause of the duplicate EID failed assert.

The duplicate EID seemed to be due to `Factory::createKeySig` reusing the memory address of an old `KeySig` too soon to allocate a new dummy `KeySig`, therefore causing the `TWrite::writeItemEid` function to successfully find a suitable existing EID for the new dummy `KeySig` in the `EIDRegister` (when it shouldn't have) and re-using it in the XML. This is why the problem appeared somewhat arbitrarily.

### The solution
* Ensure that the dummy `KeySig`s and `TimeSig`s are removed from the `EIDRegister` after writing them to the XML (the issue did not arise in the case of `TimeSig`s because they were not being deleted, but they were still unnecessarily accumulated into the `EIDRegister`).
* Ensure that both the dummy `KeySig`s and `TimeSig`s are deleted after writing to the XML, as they are no longer needed.