### PR TITLE
Fix "show actions list" crash

### DIFF
--- a/src/framework/diagnostics/qml/Muse/Diagnostics/actionsviewmodel.cpp
+++ b/src/framework/diagnostics/qml/Muse/Diagnostics/actionsviewmodel.cpp
@@ -26,7 +26,7 @@ using namespace muse::actions;
 using namespace muse::ui;
 
 ActionsViewModel::ActionsViewModel(QObject* parent)
-    : QAbstractListModel(parent), muse::Contextable(muse::iocCtxForQmlObject(parent))
+    : QAbstractListModel(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
 }
 


### PR DESCRIPTION
The crash originates from the diagnostics module, so I didn't report a bug. 
`iocCtxForQmlObject` should capture `this` instead of `parent`.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
