### PR TITLE
Fix #33293: Crash when loading palettes from older MSS version [4.7.0]

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -398,7 +398,8 @@ void PaletteCompat::addNewLineItems(Palette& linesPalette, Score* paletteScore)
     }
 
     if (!containsChordBrackets) {
-        addChordBrackets(linesPalette, paletteScore, 27);
+        int defaultPosition = std::min(27, linesPalette.cellsCount());
+        addChordBrackets(linesPalette, paletteScore, defaultPosition);
     }
 }
 


### PR DESCRIPTION
Resolves: #33293