### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -577,7 +577,7 @@ bool StringData::tryResolveStringConflictWithOutOfRangeFret(const Note* note, in
 //    chord's pitches are transposed, updating only the fret.
 //---------------------------------------------------------
 
-void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
+void StringData::sortChordNotesUseSameString(const Chord* chord) const
 {
     const CapoParams& capo = chord->staff()->capo(chord->tick());
     const bool skipDeadNotes = chord->configuration()->keepDeadNotesUnchangedOnTranspose();
@@ -673,7 +673,7 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
     int pitchOffset = -transp + chord->staff()->pitchOffset(chord->segment()->tick());
 
     if (useSameString) {
-        sortChordNotesUseSameString(chord, pitchOffset);
+        sortChordNotesUseSameString(chord);
     }
 
     for (Note* note : chord->notes()) {

--- a/src/engraving/dom/stringdata.h
+++ b/src/engraving/dom/stringdata.h
@@ -91,7 +91,7 @@ private:
 
     int         fret(int pitch, int string, int pitchOffset) const;
     void        sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* chord, int* count) const;
-    void        sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const;
+    void        sortChordNotesUseSameString(const Chord* chord) const;
     bool        tryResolveStringConflictWithOutOfRangeFret(const Note* note, int numStrings, std::vector<int>& bUsed, int& nNewString,
                                                            int& nNewFret) const;
 

--- a/src/framework/audio/main/internal/playback.cpp
+++ b/src/framework/audio/main/internal/playback.cpp
@@ -97,7 +97,7 @@ async::Promise<Ret> Playback::init()
                 ONLY_AUDIO_MAIN_THREAD;
                 Ret ret;
                 IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                    Ret ret = audio::make_ret(Err::InvalidRpcData);
+                    ret = audio::make_ret(Err::InvalidRpcData);
                     (void)resolve(ret);
                     return;
                 }

--- a/src/framework/global/thirdparty/kors_modularity/modularity/context.h
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/context.h
@@ -31,9 +31,9 @@ namespace kors::modularity {
 using IoCID = uint16_t;
 struct Context
 {
-    IoCID id = -1;
+    IoCID id = static_cast<IoCID>(-1);
 
-    Context(IoCID id = -1)
+    Context(IoCID id = static_cast<IoCID>(-1))
         : id(id) {}
 };
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -636,7 +636,7 @@ ControlElementPosition MeiImporter::findStart(const libmei::Element& meiElement,
         pos.chordRest = m_startIdChordRests.at(startId);
         pos.measure = pos.chordRest->measure();
         pos.tick = pos.chordRest->tick();
-        pos.track = pos.chordRest->track();
+        pos.track = static_cast<int>(pos.chordRest->track());
     } else {
         // No @startid, try a lookup based on the @tstamp. This is only for files not written via MuseScore
         const libmei::AttTimestampLog* timestampLogAtt = dynamic_cast<const libmei::AttTimestampLog*>(&meiElement);
@@ -685,7 +685,7 @@ ControlElementPosition MeiImporter::findEnd(pugi::xml_node controlNode, Spanner*
         pos.chordRest = m_endIdChordRests.at(endId);
         pos.measure = pos.chordRest->measure();
         pos.tick = pos.chordRest->tick();
-        pos.track = pos.chordRest->track();
+        pos.track = static_cast<int>(pos.chordRest->track());
     } else {
         // No @endid, try a lookup based on the @tstamp2. This is only for files not written via MuseScore
         libmei::InstTimestamp2Log timestamp2LogAtt;
@@ -727,7 +727,7 @@ ControlElementPosition MeiImporter::findEnd(pugi::xml_node controlNode, Spanner*
                             : track2voice(spanner->track());
 
         pos.tick = measure->tick() + tstampFraction;
-        pos.track = staffIdx * VOICES + layer;
+        pos.track = static_cast<int>(staffIdx * VOICES + layer);
         pos.chordRest = measure->findChordRest(pos.tick, pos.track);
     }
 

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -503,7 +503,9 @@ MixerChannelItem* MixerPanelModel::buildAuxChannelItem(aux_channel_idx_t index, 
     });
 
     AudioOutputParams outParams = audioSettings()->auxOutputParams(index);
-    if (MixerChannelItem* item = findChannelItem(trackId)) {
+    if (MixerChannelItem* existingItem = findChannelItem(trackId)) {
+        loadOutputParams(existingItem, std::move(outParams));
+    } else {
         loadOutputParams(item, std::move(outParams));
     }
 


### PR DESCRIPTION
* reg.: 'initializing': conversion from 'int' to 'kors::modularity::IoCID', signed/unsigned mismatch (C4245)
* reg.: declaration of 'ret' hides previous local declaration (C4456)
   and: declaration of 'item' hides previous local declaration (C4456)
* reg.: 'pitchOffset': unreferenced parameter (C4100)
* reg.: '=': conversion from 'size_t' to 'int', possible loss of data (C4267)