### PR TITLE
[4.7.0] Fix #33288: Crash closing main score tab via context menu

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
@@ -125,7 +125,7 @@ Rectangle {
                 }
 
                 onHandleContextMenuItem: function(itemId) {
-                    notationSwitchModel.handleContextMenuItem(index, itemId)
+                    Qt.callLater(notationSwitchModel.handleContextMenuItem, index, itemId)
                 }
             }
         }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33288

Caused by: https://github.com/musescore/MuseScore/pull/33211