### PR TITLE
[ci] added check submodules

### DIFF
--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -1,0 +1,39 @@
+name: 'Check: Submodules'
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check_muse_framework:
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_URL: https://github.com/musescore/muse_framework.git
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v6
+
+    - name: Verify muse_framework submodule URL
+      run: |
+        ACTUAL_URL=$(git config -f .gitmodules submodule.muse_framework.url)
+        echo "Expected: ${EXPECTED_URL}"
+        echo "Actual:   ${ACTUAL_URL}"
+        if [ "${ACTUAL_URL}" != "${EXPECTED_URL}" ]; then
+          echo "::error file=.gitmodules::muse_framework submodule URL must be ${EXPECTED_URL}, found ${ACTUAL_URL}. Did you accidentally leave it pointing at a fork?"
+          exit 1
+        fi
+
+    - name: Verify muse_framework commit is in upstream
+      run: |
+        SHA=$(git ls-tree HEAD muse | awk '{print $3}')
+        if [ -z "${SHA}" ]; then
+          echo "::error::Could not read muse_framework submodule SHA from index"
+          exit 1
+        fi
+        echo "Pinned commit: ${SHA}"
+        TMP=$(mktemp -d)
+        git clone --quiet --filter=tree:0 --no-checkout --single-branch --branch main "${EXPECTED_URL}" "${TMP}"
+        if ! git -C "${TMP}" merge-base --is-ancestor "${SHA}" origin/main; then
+          echo "::error::muse_framework is pinned to ${SHA}, which is not on the main branch of ${EXPECTED_URL}"
+          exit 1
+        fi


### PR DESCRIPTION
We're in the process of transitioning to a new development process...
Much will be decided as we go along this way.

What I can recommend now
The basic idea is to use your own fork of MF if you need to make changes in both repositories, or for example only in MF, but you would like to compile the application and test it.
Then you can make simultaneous changes, commit them, and simultaneously make two PRs on both projects.

There are at least two approaches to this:
1. Switch the submodule to use its own fork of the MF repository.
It's best to ask the AI ​​how to do this more easily. I'll post what the AI ​​recommended in the thread.
The advantage of this approach is that you work with a single repository and can see all changes, which can be especially convenient if you use a Git client.
The disadvantage is that you can accidentally push use your own fork to upstream; you need to monitor this. 

2. Use a clone of your forked MF repository and specify the path to it.
You can do this directly in the project tree for convenience.

* Clone your forked MF
* Rename it so that it ends with .local for example, muse.local, mf.local - this will cause this folder to be ignored by the main repository.
* Specify the path to this folder in the cmake options. MUSE_FRAMEWORK_PATH=...


The project will be built from two separate repositories. You can work with each of them using the usual workflow. Another advantage is that you don't have to change any project settings and can't accidentally push anything to upstream.
The disadvantage is that you have to manually change and track which changes are which, which active branch, and so on.