### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/editing/editstavesharing.cpp
+++ b/src/engraving/editing/editstavesharing.cpp
@@ -125,8 +125,6 @@ StaveSharingGroups EditStaveSharing::computeGroups(Score* score)
 
 void EditStaveSharing::createSharedParts(const StaveSharingGroups& groups, Score* score)
 {
-    const KeyList& keyList = score->keyList();
-
     for (const StaveSharingGroup& group : groups) {
         SharedPart* sharedPart = nullptr;
         for (Part* part : group) {


### PR DESCRIPTION
reg.: 'keyList': local variable is initialized but not referenced (C4189)