### PR TITLE
Page settings: relax page number offset limits

### DIFF
--- a/src/notationscene/widgets/pagesettings.ui
+++ b/src/notationscene/widgets/pagesettings.ui
@@ -502,10 +502,10 @@
           <bool>false</bool>
          </property>
          <property name="minimum">
-          <number>-99</number>
+          <number>-999999</number>
          </property>
          <property name="maximum">
-          <number>999</number>
+          <number>999999</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Allow any number from -999999 to 999999, because there is not really any reason to put any limit.

Resolves: https://github.com/musescore/MuseScore/issues/33188