### PR TITLE
[4.7.0] Fix #33315: Crash when adding a bend going into a measure repeat

### DIFF
--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -289,7 +289,7 @@ Note* GuitarBend::createEndNote(Note* startNote, GuitarBendType bendType)
         endSegment = score->setNoteRest(endSegment, track, noteVal, duration);
         Chord* endChord = endSegment ? toChord(endSegment->element(track)) : nullptr;
         endNote = endChord ? endChord->upNote() : nullptr;
-    } else { // isChord
+    } else if (item->isChord()) {
         Chord* chord = toChord(item);
         endNote = score->addNote(chord, noteVal);
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33315