### PR TITLE
Workflow changes to allow workflow reuse in the framework repo

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -47,6 +47,26 @@ on:
         default: ""
         type: string
         required: false
+      app_repo:
+        description: 'owner/repo to source MuseScore from (default: this repo)'
+        type: string
+        required: false
+        default: ''
+      app_ref:
+        description: 'MuseScore ref to check out (default: ref of triggering event)'
+        type: string
+        required: false
+        default: ''
+      framework_repo:
+        description: 'owner/repo to source muse_framework from (default: pinned submodule)'
+        type: string
+        required: false
+        default: ''
+      framework_ref:
+        description: 'Ref to check out into the muse_framework submodule (default: pinned SHA)'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
@@ -56,13 +76,13 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_x64') || contains(inputs.platforms, 'linux_arm64')
+    if: inputs.platforms == '' || contains(inputs.platforms, 'linux_x64') || contains(inputs.platforms, 'linux_arm64')
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         platform: ${{
-          (github.event_name != 'workflow_dispatch'
+          (inputs.platforms == ''
            || (contains(inputs.platforms, 'linux_x64') && contains(inputs.platforms, 'linux_arm64')))
           && fromJson('["linux_x64","linux_arm64"]')
           || (contains(inputs.platforms, 'linux_x64') && fromJson('["linux_x64"]')
@@ -86,7 +106,19 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v6
       with:
+        repository: ${{ inputs.app_repo || github.repository }}
+        ref: ${{ inputs.app_ref || github.ref }}
         submodules: recursive
+
+    - name: Override muse_framework
+      if: inputs.framework_ref != '' && inputs.framework_repo != ''
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.framework_repo }}
+        ref: ${{ inputs.framework_ref }}
+        path: muse
+        submodules: recursive
+
     - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -38,6 +38,26 @@ on:
         default: ""
         type: string
         required: false
+      app_repo:
+        description: 'owner/repo to source MuseScore from (default: this repo)'
+        type: string
+        required: false
+        default: ''
+      app_ref:
+        description: 'MuseScore ref to check out (default: ref of triggering event)'
+        type: string
+        required: false
+        default: ''
+      framework_repo:
+        description: 'owner/repo to source muse_framework from (default: pinned submodule)'
+        type: string
+        required: false
+        default: ''
+      framework_ref:
+        description: 'Ref to check out into the muse_framework submodule (default: pinned SHA)'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
@@ -55,7 +75,19 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v6
       with:
+        repository: ${{ inputs.app_repo || github.repository }}
+        ref: ${{ inputs.app_ref || github.ref }}
         submodules: recursive
+
+    - name: Override muse_framework
+      if: inputs.framework_ref != '' && inputs.framework_repo != ''
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.framework_repo }}
+        ref: ${{ inputs.framework_ref }}
+        path: muse
+        submodules: recursive
+
     - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -47,6 +47,26 @@ on:
         default: ""
         type: string
         required: false
+      app_repo:
+        description: 'owner/repo to source MuseScore from (default: this repo)'
+        type: string
+        required: false
+        default: ''
+      app_ref:
+        description: 'MuseScore ref to check out (default: ref of triggering event)'
+        type: string
+        required: false
+        default: ''
+      framework_repo:
+        description: 'owner/repo to source muse_framework from (default: pinned submodule)'
+        type: string
+        required: false
+        default: ''
+      framework_ref:
+        description: 'Ref to check out into the muse_framework submodule (default: pinned SHA)'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   # If run via workflow_call, ${{ github.workflow }} is the root workflow's name (e.g. 'Deploy'),
@@ -56,13 +76,25 @@ concurrency:
 
 jobs:
   windows_x64:
-    if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_x64')
+    if: inputs.platforms == '' || contains(inputs.platforms, 'windows_x64')
     runs-on: windows-2025
     steps:
     - name: Clone repository
       uses: actions/checkout@v6
       with:
+        repository: ${{ inputs.app_repo || github.repository }}
+        ref: ${{ inputs.app_ref || github.ref }}
         submodules: recursive
+
+    - name: Override muse_framework
+      if: inputs.framework_ref != '' && inputs.framework_repo != ''
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.framework_repo }}
+        ref: ${{ inputs.framework_ref }}
+        path: muse
+        submodules: recursive
+
     - name: Configure workflow
       shell: bash
       env:
@@ -245,9 +277,10 @@ jobs:
 
 
   windows_portable:
-    # Disable on pull_request
+    # Disable on pull_request and on framework PR builds
     if: |
       github.event_name != 'pull_request' &&
+      inputs.framework_ref == '' &&
       (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_portable'))
     runs-on: windows-2025
     steps:


### PR DESCRIPTION
Workflow changes to allow workflow reuse in the framework repo: https://github.com/musescore/MuseFramework/pull/8

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
