### PR TITLE
Fix RepeatList update trigger

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -2908,12 +2908,15 @@ bool Measure::setProperty(Pid propertyId, const PropertyValue& value)
         break;
     case Pid::REPEAT_END:
         setRepeatEnd(value.toBool());
+        score()->setPlaylistDirty();
         break;
     case Pid::REPEAT_START:
         setRepeatStart(value.toBool());
+        score()->setPlaylistDirty();
         break;
     case Pid::REPEAT_JUMP:
         setRepeatJump(value.toBool());
+        score()->setPlaylistDirty();
         break;
     default:
         return MeasureBase::setProperty(propertyId, value);


### PR DESCRIPTION
Resolves: #33122

Courtesies were not being immediately added when adding repeat barlines.

The cause seemed to be that the master score's RepeatList was not being properly notified of a score change when a repeat barline was added, therefore it was not being updated until something else triggered a recalculation of that system's courtesies.