### PR TITLE
[ci] now the submodule check checks for strict equality

### DIFF
--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EXPECTED_URL: https://github.com/musescore/muse_framework.git
+      EXPECTED_BRANCH: main
     steps:
     - name: Clone repository
       uses: actions/checkout@v6
@@ -23,7 +24,7 @@ jobs:
           exit 1
         fi
 
-    - name: Verify muse_framework commit is in upstream
+    - name: Verify muse_framework commit matches upstream HEAD
       run: |
         SHA=$(git ls-tree HEAD muse | awk '{print $3}')
         if [ -z "${SHA}" ]; then
@@ -32,8 +33,11 @@ jobs:
         fi
         echo "Pinned commit: ${SHA}"
         TMP=$(mktemp -d)
-        git clone --quiet --filter=tree:0 --no-checkout --single-branch --branch main "${EXPECTED_URL}" "${TMP}"
-        if ! git -C "${TMP}" merge-base --is-ancestor "${SHA}" origin/main; then
-          echo "::error::muse_framework is pinned to ${SHA}, which is not on the main branch of ${EXPECTED_URL}"
+        git clone --quiet --filter=tree:0 --no-checkout --single-branch --branch "${EXPECTED_BRANCH}" "${EXPECTED_URL}" "${TMP}"
+        UPSTREAM_HEAD=$(git -C "${TMP}" rev-parse origin/${EXPECTED_BRANCH}^{commit})
+        echo "Upstream ${EXPECTED_BRANCH} HEAD: ${UPSTREAM_HEAD}"
+        if [ "${SHA}" != "${UPSTREAM_HEAD}" ]; then
+          echo "::error::muse_framework is pinned to ${SHA}, expected ${UPSTREAM_HEAD} (HEAD of ${EXPECTED_BRANCH} in ${EXPECTED_URL})"
+          echo "please ensure the submodule is up to date by running `git submodule update --init --remote ./muse`"
           exit 1
         fi


### PR DESCRIPTION
Problem: The submodule may not be updated or point to a different fork.

Typical situation:

During development, the developer replaced the submodule with his own fork and forgot to change it back. 
Some PR depends on changes in the MF. They were made and merged into the MF, but the submodule was forgotten or didn't know it needed to be updated. Although the test should have detected this. 
Some fixes have been made in the MF, but no one has updated the submodule in the MU. 


The AU guys provided us with a check to verify situation 1.
But I've now changed it to address situations 2 and 3.

The idea is that any PR will require the submodule to point to the latest commit, so the developer creating the PR will be forced to update the submodule. This is similar to the requirement to now fetch the latest upstream changes before creating a PR.