### PR TITLE
[4.7.0] Fix #32000: Some Style Dropdown menus colors a bit dark on Windows

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ComboBoxDropdown.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ComboBoxDropdown.qml
@@ -138,6 +138,24 @@ ComboBox {
             }
         }
 
+        popup: Popup {
+            width: comboDropdown.width
+            height: Math.min(contentItem.implicitHeight, comboDropdown.Window.height)
+
+            padding: 0
+
+            background: Rectangle {
+                color: ui.theme.popupBackgroundColor
+            }
+
+            contentItem: StyledListView {
+                implicitHeight: contentHeight
+
+                model: comboDropdown.delegateModel
+                currentIndex: comboDropdown.highlightedIndex
+            }
+        }
+
         Component.onCompleted: function() {
             if (!styleItem) {
                 return;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/32000