### PR TITLE
[MusicXML] reset glissando counter

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -1008,10 +1008,7 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
 
 GlissandoHandler::GlissandoHandler()
 {
-    for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
-        m_glissNote[i] = 0;
-        m_slideNote[i] = 0;
-    }
+    reset();
 }
 
 void GlissandoHandler::reset()

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -264,6 +264,7 @@ class GlissandoHandler
 {
 public:
     GlissandoHandler();
+    void reset();
     void doGlissandoStart(Glissando* gliss, Notations& notations, XmlWriter& xml);
     void doGlissandoStop(Glissando* gliss, Notations& notations, XmlWriter& xml);
 
@@ -1006,6 +1007,14 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
 //---------------------------------------------------------
 
 GlissandoHandler::GlissandoHandler()
+{
+    for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
+        m_glissNote[i] = 0;
+        m_slideNote[i] = 0;
+    }
+}
+
+void GlissandoHandler::reset()
 {
     for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
         m_glissNote[i] = 0;
@@ -8635,6 +8644,7 @@ void ExportMusicXml::writeParts()
 
     for (size_t partIndex = 0; partIndex < parts.size(); ++partIndex) {
         const Part* part = parts.at(partIndex);
+        m_gh.reset(); // reset glissando handler state for each part
         m_tick = { 0, 1 };
         m_xml.startElementRaw(String(u"part id=\"P%1\"").arg(partIndex + 1));
 


### PR DESCRIPTION
On exporting somtimes ends of slides/glissandos are lost, polluting the internal counter for the `number`, resulting in some single sildes with the number 10 in larger works. 
This PR adds a reset method to be called for every new part, reducing the problem a bit. (The core problem is still under investigation.)