### PR TITLE
Fix file name of exported parts

### DIFF
--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -48,7 +48,7 @@ std::vector<INotationWriter::UnitType> ExportProjectScenario::supportedUnitTypes
 }
 
 RetVal<muse::io::path_t> ExportProjectScenario::askExportPath(const INotationPtrList& notations, const ExportType& exportType,
-                                                              INotationWriter::UnitType unitType, muse::io::path_t defaultPath) const
+                                                              INotationWriter::UnitType unitType, muse::io::path_t defaultDirPath) const
 {
     INotationProjectPtr project = context()->currentProject();
 
@@ -84,8 +84,12 @@ RetVal<muse::io::path_t> ExportProjectScenario::askExportPath(const INotationPtr
         }
     }
 
-    if (defaultPath == "") {
+    muse::io::path_t defaultPath;
+    if (defaultDirPath == "") {
         defaultPath = configuration()->defaultSavingFilePath(project, filenameAddition, exportType.suffixes.front().toStdString());
+    } else {
+        defaultPath = defaultDirPath.appendingComponent(io::filename(project->path(), false) + filenameAddition)
+                      .appendingSuffix(exportType.suffixes.front().toStdString());
     }
 
     RetVal<muse::io::path_t> exportPath;

--- a/src/project/internal/exportprojectscenario.h
+++ b/src/project/internal/exportprojectscenario.h
@@ -56,7 +56,7 @@ public:
 
     muse::RetVal<muse::io::path_t> askExportPath(const notation::INotationPtrList& notations, const ExportType& exportType,
                                                  INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,
-                                                 muse::io::path_t defaultPath = "") const override;
+                                                 muse::io::path_t defaultDirPath = "") const override;
 
     bool exportScores(notation::INotationPtrList notations, const muse::io::path_t destinationPath,
                       INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -154,7 +154,7 @@ void ExportDialogModel::init()
         selectExportTypeById(info.id);
     }
 
-    m_exportPath = info.exportPath;
+    m_exportDirPath = info.exportDirPath;
     setUnitType(info.unitType);
 
     beginResetModel();
@@ -416,28 +416,15 @@ bool ExportDialogModel::exportScores()
         return false;
     }
 
-    INotationProjectPtr project = context()->currentProject();
-    muse::io::path_t filename = io::filename(project->path());
-    // TODO: only restore filename if exactly the same notations are selected and the same unit type.
-    // These settings may namely cause extra things to be added to the name, but these extra things
-    // are not applicable to other values of these settings.
-    //if (project && project->path() == exportProjectScenario()->exportInfo().projectPath) {
-    //    filename = io::filename(m_exportPath);
-    //}
-    muse::io::path_t defaultPath;
-    if (m_exportPath != "" && filename != "") {
-        defaultPath = io::absoluteDirpath(m_exportPath)
-                      .appendingComponent(io::filename(filename, false))
-                      .appendingSuffix(m_selectedExportType.suffixes[0]);
-    }
+    std::shared_ptr<IExportProjectScenario> scenario = exportProjectScenario();
 
     RetVal<muse::io::path_t> exportPath
-        = exportProjectScenario()->askExportPath(notations, m_selectedExportType, m_selectedUnitType, defaultPath);
+        = scenario->askExportPath(notations, m_selectedExportType, m_selectedUnitType, m_exportDirPath);
     if (!exportPath.ret) {
         return false;
     }
 
-    m_exportPath = exportPath.val;
+    m_exportDirPath = io::absoluteDirpath(exportPath.val);
 
     struct Params {
         INotationPtrList notations;
@@ -451,10 +438,8 @@ bool ExportDialogModel::exportScores()
     //! Therefore, we save everything we need in variables
     //! and pass them to the lambda.
     //! We can't access the dialog class member in the lambda body.
-    Params params{ notations, m_exportPath, m_selectedUnitType,
+    Params params{ notations, exportPath.val, m_selectedUnitType,
                    shouldDestinationFolderBeOpenedOnExport() };
-
-    std::shared_ptr<IExportProjectScenario> scenario = exportProjectScenario();
 
     //! NOTE We can't use Async here
     // because the async::processMessages is called deep within the functions,
@@ -891,7 +876,7 @@ void ExportDialogModel::updateExportInfo()
 {
     ExportInfo info;
     info.id = m_selectedExportType.id;
-    info.exportPath = m_exportPath;
+    info.exportDirPath = m_exportDirPath;
     info.unitType = m_selectedUnitType;
 
     for (const QModelIndex& index : m_selectionModel->selectedIndexes()) {

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
@@ -306,7 +306,7 @@ private:
 
     ExportTypeList m_exportTypeList {};
     ExportType m_selectedExportType = ExportType();
-    muse::io::path_t m_exportPath;
+    muse::io::path_t m_exportDirPath;
     project::INotationWriter::UnitType m_selectedUnitType = project::INotationWriter::UnitType::PER_PART;
 };
 }

--- a/src/project/types/projecttypes.h
+++ b/src/project/types/projecttypes.h
@@ -126,7 +126,7 @@ struct CloudAudioInfo {
 
 struct ExportInfo {
     QString id;
-    muse::io::path_t exportPath;
+    muse::io::path_t exportDirPath;
     INotationWriter::UnitType unitType;
     std::vector<notation::INotationWeakPtr> notations;
 };


### PR DESCRIPTION
Resolves: #21161

When exporting score parts, the resulting filename was expected to have appended some description of the file's contents (e.g. the part name for individual part files, or `-Parts`/`-Score_and_parts` for multipart files).

However, this was only the case the first time an export was made, and later exports contained only the filename.

This was due to a default path being saved in the `ExportDialogModel` in order to "remember" the last export directory. This default path contained the full path, including the filename, of the first export made since opening the MSS program, and it caused subsequent exports to use the exact same default without appending the extra filename parts.

The fix is to store the path to the default save directory, instead of the full path to the last saved file. This way, only the directory is reused, while the filename is re-calculated each time an export is made.