### PR TITLE
Improve parenthesis layout performance

### DIFF
--- a/src/engraving/rendering/score/parenthesislayout.cpp
+++ b/src/engraving/rendering/score/parenthesislayout.cpp
@@ -313,8 +313,8 @@ void ParenthesisLayout::createPathAndShape(Parenthesis* item, Parenthesis::Layou
 
     PointF startPoint = PointF();
     double midThickness = 2 * midPointThickness;
-    int nbShapes = round(5.0 * heightInSpatium);
-    nbShapes = std::clamp(nbShapes, 20, 50);
+    int nbShapes = round(2.0 * heightInSpatium);
+    nbShapes = std::clamp(nbShapes, 3, 10);
     PointF bezier1mid = bezier1for - PointF(midPointThickness * direction, 0.0);
     PointF bezier2mid = bezier2for - PointF(midPointThickness * direction, 0.0);
     const CubicBezier b(startPoint, bezier1mid, bezier2mid, endNormalised);


### PR DESCRIPTION
This PR makes layout of parentheses quicker by reducing the number of rectangles in their shape. This cuts segment spacing time in a parenthesis-heavy test score by ~75% (10s to 2.5s)

<img width="715" height="511" alt="Screenshot 2026-05-12 at 11 40 24" src="https://github.com/user-attachments/assets/e8fcd353-2c74-43a1-b870-063cc9ae031d" />
