### PR TITLE
[4.7.1] Fix palette duplicates

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -39,6 +39,7 @@
 #include "engraving/dom/hammeronpulloff.h"
 #include "engraving/dom/harmony.h"
 #include "engraving/dom/hairpin.h"
+#include "engraving/dom/instrchange.h"
 #include "engraving/dom/ornament.h"
 #include "engraving/dom/pedal.h"
 #include "engraving/dom/score.h"
@@ -199,6 +200,14 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
 
     if (item->isActionIcon() && muse::contains(BOXES_ACTION_TYPES, toActionIcon(item)->actionType())) {
         cell->mag = COMPAT_FRAME_MAG;
+    }
+
+    if (item->isInstrumentChange()) {
+        InstrumentChange* newInstrumentChange = Factory::createInstrumentChange(paletteScore->dummy()->segment());
+        newInstrumentChange->setXmlText(QT_TRANSLATE_NOOP("palette", "Change instr."));
+
+        cell->element.reset(newInstrumentChange);
+        return;
     }
 }
 

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1214,6 +1214,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
 
     pedal = makeElement<Pedal>(gpaletteScore);
     pedal->setLineVisible(false);
+    pedal->setEndHookType(HookType::ROSETTE);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());
@@ -1866,6 +1867,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
 
     auto pedal = makeElement<Pedal>(gpaletteScore);
     pedal->setLineVisible(false);
+    pedal->setEndHookType(HookType::ROSETTE);
     pedal->setBeginText(pedal->propertyDefault(Pid::BEGIN_TEXT).value<String>());
     pedal->setContinueText(pedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
     pedal->setEndText(pedal->propertyDefault(Pid::END_TEXT).value<String>());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33291
Resolves: https://github.com/musescore/MuseScore/issues/33252

This PR fixes the duplicate instrument change and rosette pedal lines. We can't fix the duplicate system line and reoccurring duplicate pedal lines without introducing crashes in old versions. 