### PR TITLE
[MusicXML] improve title box position

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -1459,8 +1459,8 @@ static void creditWords(XmlWriter& xml, const MStyle& s, const page_idx_t pageNr
     if (!creditType.empty()) {
         xml.tag("credit-type", creditType);
     }
-    String attr = String(u" default-x=\"%1\"").arg(x);
-    attr += String(u" default-y=\"%1\"").arg(y);
+    String attr = String(u" default-x=\"%1\"").arg(String::number(x, 2));
+    attr += String(u" default-y=\"%1\"").arg(String::number(y, 2));
     attr += u" justify=\"" + just + u"\"";
     attr += u" valign=\"" + val + u"\"";
     MScoreTextToMusicXml mttm(u"credit-words", attr, defFmt, mtf);

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
@@ -1001,7 +1001,7 @@ static void resizeTitleBox(VBox* vbox)
         score->renderer()->layoutItem(e);
     }
 
-    const int padding = vbox->sizeIsSpatiumDependent() ? vbox->style().spatium() : vbox->style().defaultSpatium();
+    const double padding = vbox->sizeIsSpatiumDependent() ? vbox->style().spatium() : vbox->style().defaultSpatium();
 
     for (EngravingItem* e : elist) {
         if (e->isText()) {

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
@@ -1001,7 +1001,7 @@ static void resizeTitleBox(VBox* vbox)
         score->renderer()->layoutItem(e);
     }
 
-    double padding = vbox->spatium();
+    const int padding = vbox->sizeIsSpatiumDependent() ? vbox->style().spatium() : vbox->style().defaultSpatium();
 
     for (EngravingItem* e : elist) {
         if (e->isText()) {

--- a/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
@@ -67,7 +67,7 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="616.9347" default-y="1511.197129" justify="center" valign="top" font-size="22">System-Distance Test</credit-words>
+    <credit-words default-x="616.93" default-y="1511.2" justify="center" valign="top" font-size="22">System-Distance Test</credit-words>
     </credit>
   <part-list>
     <score-part id="P1">


### PR DESCRIPTION
This rounds the `default-x` and `default-y` positions of the title vbox on export for greater stability on import and export.