### PR TITLE
Fix instrument family and template category selection

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -124,7 +124,6 @@ Rectangle {
                 instrumentsModel.currentGroupIndex = newIndex
 
                 if (instrumentsView.searching) {
-                    instrumentsModel.saveCurrentGroup()
                     instrumentsView.clearSearch()
                 }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentlistmodel.cpp
@@ -235,18 +235,20 @@ void InstrumentListModel::loadGroups()
     m_groups = acceptedGroups;
     emit groupsChanged();
 
-    bool currentGroupInNewGenre = false;
-    for (const InstrumentGroup* group : m_groups) {
-        if (group->id == m_currentGroupId) {
-            currentGroupInNewGenre = true;
-            break;
+    if (m_currentGroupId != NONE_GROUP_ID) {
+        bool currentGroupInNewGenre = false;
+        for (const InstrumentGroup* group : m_groups) {
+            if (group->id == m_currentGroupId) {
+                currentGroupInNewGenre = true;
+                break;
+            }
         }
-    }
-    if (!currentGroupInNewGenre && !isSearching()) {
-        setCurrentGroupIndex(0);
-    }
+        if (!currentGroupInNewGenre && !isSearching()) {
+            setCurrentGroupIndex(0);
+        }
 
-    emit currentGroupIndexChanged();
+        emit currentGroupIndexChanged();
+    }
 }
 
 void InstrumentListModel::loadInstruments()
@@ -396,11 +398,6 @@ QStringList InstrumentListModel::selectedInstrumentIdList() const
     return QStringList(result.begin(), result.end());
 }
 
-void InstrumentListModel::saveCurrentGroup()
-{
-    m_saveCurrentGroup = true;
-}
-
 void InstrumentListModel::setSearchText(const QString& text)
 {
     if (m_searchText == text) {
@@ -468,7 +465,7 @@ void InstrumentListModel::updateStateBySearch()
 
     //! The current group may not be present in the saved genre,
     //! so let's keep ALL_INSTRUMENTS_GENRE_ID as the current genre
-    if (m_saveCurrentGroup && !searching) {
+    if (!searching && m_currentGroupId != NONE_GROUP_ID && m_savedGroupId != m_currentGroupId) {
         m_savedGenreId.clear();
     }
 
@@ -486,15 +483,16 @@ void InstrumentListModel::updateStateBySearch()
         loadInstruments();
     }
 
-    if (searching && m_savedGroupId.isEmpty()) {
+    bool groupSaved = !m_savedGroupId.isEmpty();
+    if (searching && !groupSaved) {
         m_savedGroupId = m_currentGroupId;
         setCurrentGroup(NONE_GROUP_ID);
-    } else if (!searching) {
-        setCurrentGroup(m_savedGroupId);
-        m_savedGroupId = "";
+    } else if (!searching && groupSaved) {
+        if (m_currentGroupId == NONE_GROUP_ID) {
+            setCurrentGroup(m_savedGroupId);
+        }
+        m_savedGroupId.clear();
     }
-
-    m_saveCurrentGroup = false;
 }
 
 bool InstrumentListModel::isInstrumentAccepted(const InstrumentTemplate& instrument, bool compareWithCurrentGroup) const

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentlistmodel.h
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentlistmodel.h
@@ -69,7 +69,6 @@ public:
 
     Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId);
 
-    Q_INVOKABLE void saveCurrentGroup();
     Q_INVOKABLE void setSearchText(const QString& text);
 
     Q_INVOKABLE void selectInstrument(int instrumentIndex);
@@ -144,6 +143,5 @@ private:
     notation::InstrumentGroupList m_groups;
 
     bool m_instrumentsLoadingAllowed = false;
-    bool m_saveCurrentGroup = false;
 };
 }

--- a/src/project/qml/MuseScore/Project/internal/NewScore/templatesmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/templatesmodel.cpp
@@ -139,16 +139,17 @@ void TemplatesModel::setVisibleCategories(const QStringList& titles)
         return;
     }
 
-    QString currentCategory = titles.value(0);
-    if (m_saveCurrentCategory) {
-        m_saveCurrentCategory = false;
-        currentCategory = m_currentCategory;
-    }
-
     m_visibleCategoriesTitles = titles;
     emit categoriesChanged();
 
-    setCurrentCategory(currentCategory);
+    if (m_saveCurrentCategory) {
+        m_saveCurrentCategory = false;
+        // when the visibleCategoriesTitles are updated, the UI currentCategoryIndex needs to be updated,
+        // even if we want the currentCategory to remain the same. So we need to force an emit:
+        emit currentCategoryChanged();
+    } else {
+        setCurrentCategory(titles.value(0));
+    }
 }
 
 void TemplatesModel::setCurrentCategory(const QString& category)


### PR DESCRIPTION
Resolves: #23588

Fixes two problems in the `New Score` dialog:

### 1. Choose instruments

When selecting an instrument family in the `New Score`>`Choose Instruments` window, while the search bar had some text in it, the family would not be correctly assigned. The reason was that the newly updated family was overwritten when the search bar was cleared, and substituted with the family that was previously saved when the user began typing in the search bar.

I couldn't simply move the family update to _after_ clearing the search bar (in the `ChooseInstrumentsPage.qml` > `FamilyView` > `onGroupSelected`), because during the search bar clearing, the list of visible families is updated, therefore the numeric index passed to`InstrumentListModel::setCurrentGroupIndex()` would no longer translate to the correct group. Therefore, I have added some checks in `InstrumentListModel` and changed some logic to ensure the problem no longer happens.

### 2. Create from template

When selecting a template category while the search bar still has some content, the category was correctly updated in the `TemplatesModel`, but the UI item was not selected.

I'm pretty sure this had something to do with the `categoriesTitles` being updated in `TemplatesModel::setVisibleCategories()` _after_ the current category was already selected (during search bar clearing), so the selection was being cleared. I just added an `emit currentCategoryChanged()` after the update, so the current category will always be correctly selected in the UI.