### PR TITLE
Fix #22708: Preview in customize kit dialog should ignore input events [4.7.1]

### DIFF
--- a/src/palette/widgets/customizekitdialog.cpp
+++ b/src/palette/widgets/customizekitdialog.cpp
@@ -159,6 +159,7 @@ CustomizeKitDialog::CustomizeKitDialog(QWidget* parent)
     drumNote->setGridSize(70, 80);
     drumNote->setDrawGrid(false);
     drumNote->setReadOnly(true);
+    drumNote->setIgnoreInputEvents(true);
 
     QTreeWidgetItem* itemToSelect = loadPitchesList();
 

--- a/src/palette/widgets/palettewidget.cpp
+++ b/src/palette/widgets/palettewidget.cpp
@@ -431,6 +431,16 @@ void PaletteWidget::setUseDoubleClickForApplyingElements(bool val)
     m_useDoubleClickForApplyingElements = val;
 }
 
+bool PaletteWidget::ignoreInputEvents() const
+{
+    return m_ignoreInputEvents;
+}
+
+void PaletteWidget::setIgnoreInputEvents(bool val)
+{
+    m_ignoreInputEvents = val;
+}
+
 void PaletteWidget::applyCurrentElementToScore()
 {
     applyElementAtIndex(m_currentIdx);
@@ -653,6 +663,10 @@ QSize PaletteWidget::sizeHint() const
 bool PaletteWidget::event(QEvent* ev)
 {
     if (!m_palette) {
+        return false;
+    }
+
+    if (m_ignoreInputEvents && ev->isInputEvent()) {
         return false;
     }
 

--- a/src/palette/widgets/palettewidget.h
+++ b/src/palette/widgets/palettewidget.h
@@ -142,6 +142,8 @@ public:
     void setApplyingElementsDisabled(bool val);
     bool useDoubleClickForApplyingElements() const;
     void setUseDoubleClickForApplyingElements(bool val);
+    bool ignoreInputEvents() const;
+    void setIgnoreInputEvents(bool val);
 
     void applyCurrentElementToScore();
 
@@ -223,6 +225,7 @@ private:
     bool m_isReadOnly = false;
     bool m_isApplyingElementsDisabled = false;
     bool m_useDoubleClickForApplyingElements = false;
+    bool m_ignoreInputEvents = false;
     bool m_showContextMenu = true;
 
     int m_currentIdx = -1;


### PR DESCRIPTION
Resolves: #22708
Resolves: #33331

This component already has quite a few similar flags to the one I've added, but none of them quite serve the purpose I was hoping for. For example:
- `isReadOnly` refers to the ability to delete/customize the properties of a cell
- `isApplyingElementsDisabled` will prevent the element from being applied to the score on click, but still allows for other interactions with the cell such as clicking/dragging

For this reason, I've introduced an `ignoreInputEvents` flag which will ensure the cell serves solely a visual purpose.