### PR TITLE
Fix undocked panels crash and ensure they respect their size constraints (#27770 & #30028) [4.7.3]

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
@@ -95,6 +95,9 @@ DockPage {
     readonly property int horizontalPanelMinHeight: 100
     readonly property int horizontalPanelMaxHeight: 520
 
+    readonly property int panelMinDimension: 10
+    readonly property int panelMaxDimension: 7500 //! NOTE: Value found experimentally - see issue #27770
+
     readonly property string verticalPanelsGroup: "VERTICAL_PANELS"
     readonly property string horizontalPanelsGroup: "HORIZONTAL_PANELS"
 
@@ -256,6 +259,9 @@ DockPage {
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
 
+            minimumHeight: root.panelMinDimension
+            maximumHeight: root.panelMaxDimension
+
             groupName: root.verticalPanelsGroup
 
             dropDestinations: root.verticalPanelDropDestinations
@@ -281,6 +287,9 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+
+            minimumHeight: root.panelMinDimension
+            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
 
@@ -308,6 +317,9 @@ DockPage {
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
 
+            minimumHeight: root.panelMinDimension
+            maximumHeight: root.panelMaxDimension
+
             groupName: root.verticalPanelsGroup
 
             dropDestinations: root.verticalPanelDropDestinations
@@ -330,6 +342,9 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+
+            minimumHeight: root.panelMinDimension
+            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
 
@@ -355,6 +370,9 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+
+            minimumHeight: root.panelMinDimension
+            maximumHeight: root.panelMaxDimension
 
             groupName: root.verticalPanelsGroup
             location: Location.Right
@@ -383,6 +401,9 @@ DockPage {
             height: 368
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+
+            minimumWidth: root.panelMinDimension
+            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 
@@ -434,6 +455,9 @@ DockPage {
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
 
+            minimumWidth: root.panelMinDimension
+            maximumWidth: root.panelMaxDimension
+
             groupName: root.horizontalPanelsGroup
 
             //! NOTE: hidden by default
@@ -464,6 +488,9 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+
+            minimumWidth: root.panelMinDimension
+            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 
@@ -517,6 +544,9 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+
+            minimumWidth: root.panelMinDimension
+            maximumWidth: root.panelMaxDimension
 
             groupName: root.horizontalPanelsGroup
 

--- a/src/framework/dockwindow/qml/Muse/Dock/DockPanel.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockPanel.qml
@@ -34,6 +34,6 @@ DockPanelView {
     Loader {
         id: contentLoader
 
-        active: root.visible
+        active: root.visible && root.inited
     }
 }

--- a/src/framework/dockwindow/qml/Muse/Dock/dockpageview.cpp
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockpageview.cpp
@@ -74,6 +74,7 @@ void DockPageView::deinit()
     TRACEFUNC;
 
     for (DockBase* dock : allDocks()) {
+        dock->deinit();
         dock->disconnect(this);
     }
 }

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
@@ -626,7 +626,21 @@ void QWidgetAdapter::move(int x, int y)
 
 void QWidgetAdapter::setSize(QSize size)
 {
-    QQuickItem::setSize(QSizeF(size));
+    QSize newSize = size;
+#ifdef Q_OS_MACOS
+    FloatingWindow *floatingWindow = this->floatingWindow();
+    if (floatingWindow) {
+        newSize = size.expandedTo(minimumSize());
+
+        QWindow* window = floatingWindow->windowHandle();
+        if (window && window->size() != newSize) {
+            QRect windowGeo = window->geometry();
+            windowGeo.setSize(newSize);
+            window->setGeometry(windowGeo);
+        }
+    }
+#endif
+    QQuickItem::setSize(QSizeF(newSize));
 }
 
 void QWidgetAdapter::setParent(QQuickItem *p)


### PR DESCRIPTION
Resolves: #27770
Resolves: #30028

As a quick fix for #33228 we went for a revert in c832d1a694f44a40474307b637df115429a90fb7 which re-opened the two issues above. This PR re-introduces the reverted code and addresses the root of the issue. The fix is a two-parter:

- Part of the problem in [#33228](https://github.com/musescore/MuseScore/issues/33228) was due to the fact that we [weren't calling setSize with newSize](https://github.com/musescore/MuseScore/pull/29896/changes/3918bd0d69ee9e95a3372627eed5d671399e03c6#diff-4e6b4602509b738a3aef4685de87c1317dd8d985199477de154211f865bed3c8R627-R643). Instead we called it with the "un-expanded" `size` parameter. This is now corrected.
- The above fix does ensure that the window sizes are recalled correctly, but there's an additional problem where the window _content_ sizing remains "pencil thin" (shown below). This appears to be down to the fact that the [contentLoader](https://github.com/mathesoncalum/MuseScore/blob/f716c6486f9f13fa8b3f843c015dc79169315958/src/framework/dockwindow/qml/Muse/Dock/DockPanel.qml#L35) is activating as soon as the panel is set to visible - which is before `DockWindow::loadPageContent` has had a chance to place the panel into its floating window. The fix for this can be found in f716c6486f9f13fa8b3f843c015dc79169315958 where we only activate the loader once the dock has been inited, and we make sure to de-init our docks when de-initing the page.
<img width="1136" height="793" alt="Screenshot 2026-05-01 at 17 33 40" src="https://github.com/user-attachments/assets/51c504cb-5f12-4894-bb4c-2d95724a6ac5" />