### PR TITLE
Fix editable Publish tab

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
+++ b/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
@@ -86,7 +86,7 @@ DockWindow {
                 }
 
                 onSelected: function(uri) {
-                    root.loadPage(uri, {})
+                    root.openPage(uri)
                 }
 
                 Component.onCompleted: {

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -1435,6 +1435,10 @@ void AbstractNotationPaintView::setNotation(INotationPtr notation)
 {
     m_notation = notation;
 
+    if (publishMode() && isNoteEnterMode()) {
+        notationNoteInput()->endNoteInput(true);
+    }
+
     if (m_loadCalled) {
         m_continuousPanel->setNotation(m_notation);
         m_playbackCursor->setNotation(m_notation);
@@ -1651,6 +1655,9 @@ void AbstractNotationPaintView::setPublishMode(bool arg)
     }
 
     m_publishMode = arg;
+    if (m_publishMode) {
+        setReadonly(true);
+    }
     emit publishModeChanged();
 }
 

--- a/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
@@ -72,7 +72,7 @@ void NotationViewInputController::init()
 {
     m_possibleZoomPercentages = configuration()->possibleZoomPercentageList();
 
-    if (dispatcher() && !m_readonly) {
+    if (dispatcher()) {
         dispatcher()->reg(this, "zoomin", this, &NotationViewInputController::zoomIn);
         dispatcher()->reg(this, "zoomout", this, &NotationViewInputController::zoomOut);
         dispatcher()->reg(this, "zoom-page-width", this, &NotationViewInputController::zoomToPageWidth);
@@ -81,45 +81,47 @@ void NotationViewInputController::init()
         dispatcher()->reg(this, "zoom100", [this]() { setZoom(100, findZoomFocusPoint()); });
         dispatcher()->reg(this, "zoom-x-percent", [this](const ActionData& args) { setZoom(args.arg<int>(0), findZoomFocusPoint()); });
 
-        dispatcher()->reg(this, "view-mode-page", [this]() {
-            setViewMode(ViewMode::PAGE);
-        });
+        if (!m_readonly) {
+            dispatcher()->reg(this, "view-mode-page", [this]() {
+                setViewMode(ViewMode::PAGE);
+            });
 
-        if (globalConfiguration()->devModeEnabled()) {
-            dispatcher()->reg(this, "view-mode-float", [this]() {
-                setViewMode(ViewMode::FLOAT);
+            if (globalConfiguration()->devModeEnabled()) {
+                dispatcher()->reg(this, "view-mode-float", [this]() {
+                    setViewMode(ViewMode::FLOAT);
+                });
+            }
+
+            dispatcher()->reg(this, "view-mode-continuous", [this]() {
+                setViewMode(ViewMode::LINE);
+            });
+
+            dispatcher()->reg(this, "view-mode-single", [this]() {
+                setViewMode(ViewMode::SYSTEM);
+            });
+
+            dispatcher()->reg(this, "scr-next", this, &NotationViewInputController::nextScreen);
+            dispatcher()->reg(this, "scr-prev", this, &NotationViewInputController::previousScreen);
+            dispatcher()->reg(this, "page-next", this, &NotationViewInputController::nextPage);
+            dispatcher()->reg(this, "page-prev", this, &NotationViewInputController::previousPage);
+            dispatcher()->reg(this, "page-top", this, &NotationViewInputController::startOfScore);
+            dispatcher()->reg(this, "page-end", this, &NotationViewInputController::endOfScore);
+
+            dispatcher()->reg(this, "notation-context-menu", [this]() {
+                m_view->showContextMenu(selectionType(), m_view->fromLogical(selectionElementPos()).toQPointF());
+            });
+
+            dispatcher()->reg(this, "notation-popup-menu", [this](const ActionData& args) {
+                if (EngravingItem* el = args.arg<EngravingItem*>()) {
+                    togglePopupForItemIfSupports(el);
+                }
+            });
+
+            onNotationChanged();
+            globalContext()->currentNotationChanged().onNotify(this, [this]() {
+                onNotationChanged();
             });
         }
-
-        dispatcher()->reg(this, "view-mode-continuous", [this]() {
-            setViewMode(ViewMode::LINE);
-        });
-
-        dispatcher()->reg(this, "view-mode-single", [this]() {
-            setViewMode(ViewMode::SYSTEM);
-        });
-
-        dispatcher()->reg(this, "scr-next", this, &NotationViewInputController::nextScreen);
-        dispatcher()->reg(this, "scr-prev", this, &NotationViewInputController::previousScreen);
-        dispatcher()->reg(this, "page-next", this, &NotationViewInputController::nextPage);
-        dispatcher()->reg(this, "page-prev", this, &NotationViewInputController::previousPage);
-        dispatcher()->reg(this, "page-top", this, &NotationViewInputController::startOfScore);
-        dispatcher()->reg(this, "page-end", this, &NotationViewInputController::endOfScore);
-
-        dispatcher()->reg(this, "notation-context-menu", [this]() {
-            m_view->showContextMenu(selectionType(), m_view->fromLogical(selectionElementPos()).toQPointF());
-        });
-
-        dispatcher()->reg(this, "notation-popup-menu", [this](const ActionData& args) {
-            if (EngravingItem* el = args.arg<EngravingItem*>()) {
-                togglePopupForItemIfSupports(el);
-            }
-        });
-
-        onNotationChanged();
-        globalContext()->currentNotationChanged().onNotify(this, [this]() {
-            onNotationChanged();
-        });
     }
 }
 
@@ -1111,7 +1113,7 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
     const bool isNoteEnterMode = m_view->isNoteEnterMode();
     const bool isMiddleButton  = (event->buttons() & Qt::MiddleButton);
-    const bool isDragObjectsAllowed = !(isNoteEnterMode || playbackController()->isPlaying() || isMiddleButton);
+    const bool isDragObjectsAllowed = !(readonly() || isNoteEnterMode || playbackController()->isPlaying() || isMiddleButton);
     if (isDragObjectsAllowed) {
         const EngravingItem* hitElement = hitElementContext().element;
 


### PR DESCRIPTION
Resolves: #33355

The "Publish" tab allowed editing. I have made it readonly, and ensured that note input mode is disabled when switching to the "Publish" tab.

There were also related problems due to the UI context being `UiCtxUnknown` when navigating the Dock pages. This was due to the fact that `DockWindow`>`DockToolBar`>`MainToolBar`>`onSelected` was calling `DockWindow::loadPage()` directly (skipping the `Interactive::open()` call). This caused the Interactive's `m_openingObject` to have an unset `query` (because the `query` is set within `Interactive::openFunc()`,  called by `Interactive::open()`) when used in `Interactive::onOpen()` (called from `DockWindow`>`onPageLoaded`). The `query` is what contains the URI, therefore the unset URI caused the `UiContextResolver` to be unable to resolve the `UiContext`, causing:
* Some actions that would usually not be allowed in the "Publish" tab to be enabled
* If you return to the "Score" tab from the "Publish" or "Home" page (by clicking on the tab, not re-opening the Score), you would not be able to edit the score.

I have fixed this by calling `openPage()` (a new function) during `onSelect`, instead of calling `loadPage()` directly.

Related to: [Add DockWindow::openPage](https://github.com/musescore/muse_framework/pull/32)