### PR TITLE
fixed #33401: Fixed random crashes 

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -337,12 +337,6 @@ if (OS_IS_WIN)
         install(FILES ${SNDFILE_DLL} DESTINATION bin)
     endif()
 
-    # Install ssl
-    install(FILES
-            ${DEPENDENCIES_LIB_DIR}/libcrypto-1_1-x64.dll
-            ${DEPENDENCIES_LIB_DIR}/libssl-1_1-x64.dll
-            DESTINATION bin)
-
     if (WIN_PORTABLE)
         # deploy the files and directory structure needed for the PortableApps.com format
         install(DIRECTORY ${PROJECT_SOURCE_DIR}/buildscripts/packaging/Windows/PortableApps/App DESTINATION ${CMAKE_INSTALL_PREFIX}/../..)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -25,6 +25,7 @@
 #include <QApplication>
 #include <QStyleHints>
 #include <QQuickWindow>
+#include <QSslSocket>
 
 #include "appfactory.h"
 #include "internal/commandlineparser.h"
@@ -158,6 +159,27 @@ int main(int argc, char** argv)
     QCoreApplication* qapp = new QApplication(argc, argv);
     CmdOptions opt;
     opt.runMode = IApplication::RunMode::GuiApp;
+#endif
+
+    QString activeSslBackend = QSslSocket::activeBackend();
+    LOGI() << QString("SSL Info: supported: %1, build: %2, runtime: %3, active backend: %4, available backends: %5")
+        .arg(QSslSocket::supportsSsl())
+        .arg(QSslSocket::sslLibraryBuildVersionString())
+        .arg(QSslSocket::sslLibraryVersionString())
+        .arg(activeSslBackend)
+        .arg(QSslSocket::availableBackends().join(", "));
+
+#ifdef Q_OS_WIN
+    // NOTE: Force schannel backend. Qt prefers OpenSSL when qopensslbackend.dll
+    //       is present, which can crash on ABI mismatch with bundled OpenSSL.
+    //       see https://github.com/musescore/MuseScore/issues/33401
+    QString schannel("schannel");
+    if (activeSslBackend != schannel) {
+        LOGI() << "Changing SSL backend to " << schannel;
+        if (!QSslSocket::setActiveBackend(schannel)) {
+            LOGE() << "Unable to change SSL backend to " << schannel;
+        }
+    }
 #endif
 
     AppFactory f;


### PR DESCRIPTION
Resolves: #33401

Qt prefers OpenSSL when qopensslbackend.dll is present, which can crash on ABI mismatch with bundled OpenSSL, The Windows installer installs only schannel, but Qt might find qopensslbackend.dll in the system.