### PR TITLE
[4.7.1] CI. Crash dumps fail check

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -229,6 +229,7 @@ jobs:
                    -DSENTRY_ORG=sentry \
                    -DSENTRY_AUTH_TOKEN=${{ secrets.SENTRY_MUSE_AUTH_TOKEN }} \
                    -DSENTRY_PROJECT=${SENTRY_PROJECT} \
+                   -DSTAGE=${BUILD_MODE} \
                    -P buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
     - name: Publish to OSUOSL
       if: env.DO_PUBLISH == 'true'

--- a/.github/workflows/build_linux_arm32.yml
+++ b/.github/workflows/build_linux_arm32.yml
@@ -167,6 +167,7 @@ jobs:
                    -DSENTRY_ORG=sentry \
                    -DSENTRY_AUTH_TOKEN=${{ secrets.SENTRY_MUSE_AUTH_TOKEN }} \
                    -DSENTRY_PROJECT=${SENTRY_PROJECT} \
+                   -DSTAGE=${BUILD_MODE} \
                    -P buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
     - name: Publish to OSUOSL
       if: env.DO_PUBLISH == 'true'

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -221,6 +221,7 @@ jobs:
               -DSENTRY_ORG=sentry \
               -DSENTRY_AUTH_TOKEN=${{ secrets.SENTRY_MUSE_AUTH_TOKEN }} \
               -DSENTRY_PROJECT=${SENTRY_PROJECT} \
+              -DSTAGE=${BUILD_MODE} \
               -P buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
     - name: Publish to OSUOSL
       if: env.DO_PUBLISH == 'true'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -212,6 +212,7 @@ jobs:
               -DSENTRY_ORG=sentry \
               -DSENTRY_AUTH_TOKEN=${{ secrets.SENTRY_MUSE_AUTH_TOKEN }} \
               -DSENTRY_PROJECT=${SENTRY_PROJECT} \
+              -DSTAGE=${BUILD_MODE} \
               -P buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
     - name: Publish to OSUOSL
       if: env.DO_PUBLISH == 'true'

--- a/buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
+++ b/buildscripts/ci/crashdumps/ci_generate_and_upload.cmake
@@ -27,12 +27,14 @@ set(SENTRY_URL "" CACHE STRING "Sentry URL")
 set(SENTRY_AUTH_TOKEN "" CACHE STRING "Sentry Auth Token")
 set(SENTRY_ORG "" CACHE STRING "Sentry Organization")
 set(SENTRY_PROJECT "" CACHE STRING "Sentry Project")
+set(STAGE "" CACHE STRING "Build stage (e.g. stable, testing, nightly, devel)")
 
 set(CONFIG
     -DSENTRY_URL=${SENTRY_URL}
     -DSENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
     -DSENTRY_ORG=${SENTRY_ORG}
     -DSENTRY_PROJECT=${SENTRY_PROJECT}
+    -DSTAGE=${STAGE}
 )
 
 execute_process(

--- a/buildscripts/ci/crashdumps/ci_sentry_dumpsyms_upload.cmake
+++ b/buildscripts/ci/crashdumps/ci_sentry_dumpsyms_upload.cmake
@@ -10,6 +10,7 @@ set(SENTRY_URL "" CACHE STRING "Sentry URL")
 set(SENTRY_AUTH_TOKEN "" CACHE STRING "Sentry Auth Token")
 set(SENTRY_ORG "" CACHE STRING "Sentry Organization")
 set(SENTRY_PROJECT "" CACHE STRING "Sentry Project")
+set(STAGE "" CACHE STRING "Build stage (e.g. stable, testing, nightly, devel)")
 
 # Check
 if(NOT SYMBOLS_PATH)
@@ -34,6 +35,7 @@ message(STATUS "SENTRY_URL: ${SENTRY_URL}")
 message(STATUS "SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN}")
 message(STATUS "SENTRY_ORG: ${SENTRY_ORG}")
 message(STATUS "SENTRY_PROJECT: ${SENTRY_PROJECT}")
+message(STATUS "STAGE: ${STAGE}")
 
 # Upload symbols
 set(ENV{SENTRY_URL} ${SENTRY_URL})
@@ -46,25 +48,30 @@ if(WIN32)
 
     file(MAKE_DIRECTORY ${INSTALL_PATH})
     file(DOWNLOAD ${SENTRY_DOWNLOAD_Windows_x86_64} ${SENTRY_CLI})
-
-    execute_process(
-        COMMAND ${SENTRY_CLI} upload-dif -o ${SENTRY_ORG} -p ${SENTRY_PROJECT} ${SYMBOLS_PATH}
-        RESULT_VARIABLE result
-    )
 else()
     set(SENTRY_CLI_INSTALL_SCRIPT "sentry-cli.sh")
     file(DOWNLOAD ${SENTRY_DOWNLOAD_SCRIPT} ${SENTRY_CLI_INSTALL_SCRIPT})
     execute_process(COMMAND bash ${SENTRY_CLI_INSTALL_SCRIPT})
 
     set(SENTRY_CLI "sentry-cli")
-    execute_process(
-        COMMAND ${SENTRY_CLI} upload-dif -o ${SENTRY_ORG} -p ${SENTRY_PROJECT} ${SYMBOLS_PATH}
-        RESULT_VARIABLE result
-    )
 endif()
 
-if(result EQUAL 0)
-    message(STATUS "Success symbols uploaded")
-else()
+execute_process(
+    COMMAND ${SENTRY_CLI} upload-dif -o ${SENTRY_ORG} -p ${SENTRY_PROJECT} ${SYMBOLS_PATH}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE output
+    ECHO_OUTPUT_VARIABLE
+    ECHO_ERROR_VARIABLE
+)
+
+if(NOT result EQUAL 0)
     message(FATAL_ERROR "Failed symbols uploaded, code: ${result}")
 endif()
+
+# sentry-cli exits 0 even when nothing was uploaded — detect that explicitly
+if(STAGE STREQUAL "stable" AND output MATCHES "No debug information files found")
+    message(FATAL_ERROR "Failed symbols uploaded: no debug information files found in ${SYMBOLS_PATH}")
+endif()
+
+message(STATUS "Success symbols uploaded")


### PR DESCRIPTION
In the previous [deployment](https://github.com/musescore/MuseScore/actions/runs/25802171304/job/75795689029#step:16:47), we didn't upload debug symbols to sentry. It's unclear why we couldn't, but now the upload works without any changes. To prevent such cases from being missed, I added a check for debug symbols files in stable mode. If they aren't found, the build is marked as failed.