### PR TITLE
Make lyric lines accessible (#32514 & 19510) [4.7.3]

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -868,29 +868,27 @@ void ChordRest::processSiblings(std::function<void(EngravingItem*)> func)
 
 EngravingItem* ChordRest::nextArticulationOrLyric(EngravingItem* e)
 {
-    if (isChord() && e->isArticulationFamily()) {
-        Chord* c = toChord(this);
-        auto i = std::find(c->articulations().begin(), c->articulations().end(), e);
-        if (i != c->articulations().end()) {
-            if (i != c->articulations().end() - 1) {
-                return *(i + 1);
-            } else {
-                if (!m_lyrics.empty()) {
-                    return m_lyrics[0];
-                } else {
-                    return nullptr;
-                }
-            }
-        }
-    } else {
+    if (!isChord() || !e->isArticulationFamily()) {
         auto i = std::find(m_lyrics.begin(), m_lyrics.end(), e);
-        if (i != m_lyrics.end()) {
-            if (i != m_lyrics.end() - 1) {
-                return *(i + 1);
-            }
+        if (i == m_lyrics.end() || i == m_lyrics.end() - 1) {
+            return nullptr;
         }
+        return *(i + 1);
     }
-    return 0;
+
+    Chord* c = toChord(this);
+    auto i = std::find(c->articulations().begin(), c->articulations().end(), e);
+    if (i == c->articulations().end()) {
+        return nullptr;
+    }
+    if (i != c->articulations().end() - 1) {
+        return *(i + 1);
+    }
+    if (!m_lyrics.empty()) {
+        return m_lyrics[0];
+    }
+
+    return nullptr;
 }
 
 //---------------------------------------------------------
@@ -899,27 +897,27 @@ EngravingItem* ChordRest::nextArticulationOrLyric(EngravingItem* e)
 
 EngravingItem* ChordRest::prevArticulationOrLyric(EngravingItem* e)
 {
+    const std::vector<Articulation*> artics = isChord() ? toChord(this)->articulations() : std::vector<Articulation*>();
+
     auto i = std::find(m_lyrics.begin(), m_lyrics.end(), e);
     if (i != m_lyrics.end()) {
         if (i != m_lyrics.begin()) {
             return *(i - 1);
-        } else {
-            if (isChord() && !toChord(this)->articulations().empty()) {
-                return toChord(this)->articulations().back();
-            } else {
-                return nullptr;
-            }
         }
-    } else if (isChord() && e->isArticulationFamily()) {
-        Chord* c = toChord(this);
-        auto j = std::find(c->articulations().begin(), c->articulations().end(), e);
-        if (j != c->articulations().end()) {
-            if (j != c->articulations().begin()) {
-                return *(j - 1);
-            }
+        if (!artics.empty()) {
+            return artics.back();
         }
+        return nullptr;
     }
-    return 0;
+
+    if (artics.empty()) {
+        return nullptr;
+    }
+    auto j = std::find(artics.begin(), artics.end(), e);
+    if (j == artics.end() || j == artics.begin()) {
+        return nullptr;
+    }
+    return *(j - 1);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -868,7 +868,24 @@ void ChordRest::processSiblings(std::function<void(EngravingItem*)> func)
 
 EngravingItem* ChordRest::nextArticulationOrLyric(EngravingItem* e)
 {
+    if (e->isLyrics()) {
+        // The next element after Lyrics is the LyricsLine (if it exists)...
+        if (LyricsLine* line = toLyrics(e)->separator()) {
+            return line;
+        }
+    }
+    if (e->isLyricsLine()) {
+        LyricsLine* lyricsLine = toLyricsLine(e);
+        Lyrics* lyrics = lyricsLine->lyrics();
+        IF_ASSERT_FAILED(lyrics) {
+            return nullptr;
+        }
+        // We were on a LyricsLine - now we'll try to move to the next Lyrics...
+        e = lyrics;
+    }
+
     if (!isChord() || !e->isArticulationFamily()) {
+        // Move to the next Lyrics...
         auto i = std::find(m_lyrics.begin(), m_lyrics.end(), e);
         if (i == m_lyrics.end() || i == m_lyrics.end() - 1) {
             return nullptr;
@@ -876,6 +893,7 @@ EngravingItem* ChordRest::nextArticulationOrLyric(EngravingItem* e)
         return *(i + 1);
     }
 
+    // Cycle through articulations...
     Chord* c = toChord(this);
     auto i = std::find(c->articulations().begin(), c->articulations().end(), e);
     if (i == c->articulations().end()) {
@@ -899,25 +917,37 @@ EngravingItem* ChordRest::prevArticulationOrLyric(EngravingItem* e)
 {
     const std::vector<Articulation*> artics = isChord() ? toChord(this)->articulations() : std::vector<Articulation*>();
 
-    auto i = std::find(m_lyrics.begin(), m_lyrics.end(), e);
-    if (i != m_lyrics.end()) {
-        if (i != m_lyrics.begin()) {
-            return *(i - 1);
-        }
-        if (!artics.empty()) {
-            return artics.back();
-        }
-        return nullptr;
+    if (e->isLyricsLine()) {
+        // The previous element to a LyricsLine is the associated Lyrics...
+        return toLyricsLine(e)->lyrics();
     }
 
-    if (artics.empty()) {
+    auto i = std::find(m_lyrics.begin(), m_lyrics.end(), e);
+    if (i == m_lyrics.end()) {
+        // Cycle through articulations...
+        if (artics.empty()) {
+            return nullptr;
+        }
+        auto j = std::find(artics.begin(), artics.end(), e);
+        if (j == artics.end() || j == artics.begin()) {
+            return nullptr;
+        }
+        return *(j - 1);
+    }
+    if (i == m_lyrics.begin()) {
+        return !artics.empty() ? artics.back() : nullptr;
+    }
+
+    // Move to the previous Lyrics...
+    Lyrics* lyrics = *(i - 1);
+    IF_ASSERT_FAILED(lyrics) {
         return nullptr;
     }
-    auto j = std::find(artics.begin(), artics.end(), e);
-    if (j == artics.end() || j == artics.begin()) {
-        return nullptr;
+    if (lyrics->separator()) {
+        // Move to the LyricsLine of the previous Lyrics (if it exists)...
+        return lyrics->separator();
     }
-    return *(j - 1);
+    return lyrics;
 }
 
 //---------------------------------------------------------
@@ -934,7 +964,8 @@ EngravingItem* ChordRest::nextElement()
     case ElementType::ARTICULATION:
     case ElementType::ORNAMENT:
     case ElementType::TAPPING:
-    case ElementType::LYRICS: {
+    case ElementType::LYRICS:
+    case ElementType::LYRICSLINE: {
         EngravingItem* next = nextArticulationOrLyric(e);
         if (next) {
             return next;
@@ -970,7 +1001,8 @@ EngravingItem* ChordRest::prevElement()
     case ElementType::ARTICULATION:
     case ElementType::ORNAMENT:
     case ElementType::TAPPING:
-    case ElementType::LYRICS: {
+    case ElementType::LYRICS:
+    case ElementType::LYRICSLINE: {
         EngravingItem* prev = prevArticulationOrLyric(e);
         if (prev) {
             return prev;
@@ -1008,11 +1040,17 @@ EngravingItem* ChordRest::prevElement()
 
 EngravingItem* ChordRest::lastElementBeforeSegment()
 {
-    if (!m_lyrics.empty()) {
-        return m_lyrics.back();
+    if (m_lyrics.empty()) {
+        return nullptr;
     }
-
-    return nullptr;
+    Lyrics* lyrics = m_lyrics.back();
+    IF_ASSERT_FAILED(lyrics) {
+        return nullptr;
+    }
+    if (LyricsLine* lyricsLine = lyrics->separator()) {
+        return lyricsLine;
+    }
+    return lyrics;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -21,6 +21,7 @@
  */
 #include "lyricslayout.h"
 
+#include "dom/factory.h"
 #include "dom/masterscore.h"
 #include "dom/repeatlist.h"
 #include "style/styledef.h"
@@ -481,7 +482,7 @@ void LyricsLayout::createOrRemoveLyricsLine(Lyrics* item, LayoutContext& ctx)
 
     if (isEndMelisma() || item->syllabic() == LyricsSyllabic::BEGIN || item->syllabic() == LyricsSyllabic::MIDDLE) {
         if (!item->separator()) {
-            LyricsLine* separator = new LyricsLine(ctx.mutDom().dummyParent());
+            LyricsLine* separator = Factory::createLyricsLine(ctx.mutDom().dummyParent());
             separator->setTick(cr->tick());
             item->setSeparator(separator);
             ctx.mutDom().addUnmanagedSpanner(item->separator());


### PR DESCRIPTION
Resolves: #32514
Resolves: #19510

This PR includes lyric lines in the alt+direction navigation chain (ace2e5da11fd7fa789175ad9e507845af8373341) and ensures that the screen reader reads the type name out (0b6c55a613bce39144761d40955acea4ee1f27c0). The video below demos the navigation order, which is as follows when starting on a note:

1st verse lyrics -> 1st verse lyrics line -> 2nd verse lyrics -> 2nd verse lyrics line (etc.) -> next note


https://github.com/user-attachments/assets/c96f165f-91d9-4151-af57-c1ab03873df3
