### PR TITLE
Only update spanner map when necessary

### DIFF
--- a/src/engraving/dom/glissando.h
+++ b/src/engraving/dom/glissando.h
@@ -100,6 +100,9 @@ public:
 
     static bool pitchSteps(const Spanner* spanner, std::vector<int>& pitchOffsets);
 
+protected:
+    bool isInSpannerMap() const override { return false; }
+
 private:
 
     std::optional<bool> m_isHarpGliss = std::nullopt;

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -157,6 +157,9 @@ public:
     };
     DECLARE_LAYOUTDATA_METHODS(GuitarBend)
 
+protected:
+    bool isInSpannerMap() const override { return false; }
+
 private:
     GuitarBendType m_bendType = GuitarBendType::BEND;
     GuitarBendHold* m_holdLine = nullptr;
@@ -263,6 +266,9 @@ public:
     GuitarBend* guitarBend() const { return toGuitarBend(explicitParent()); }
 
     double lineWidth() const;
+
+protected:
+    bool isInSpannerMap() const override { return false; }
 };
 
 class GuitarBendHoldSegment final : public LineSegment

--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -150,6 +150,8 @@ public:
 protected:
     LyricsLine(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
 
+    bool isInSpannerMap() const override { return false; }
+
     Lyrics* m_nextLyrics = nullptr;
 
     void doComputeEndElement() override;
@@ -235,6 +237,7 @@ public:
 
 protected:
     void doComputeEndElement() override;
+    bool isInSpannerMap() const override { return true; }
 
 private:
     bool m_isEndMelisma = false;

--- a/src/engraving/dom/noteline.h
+++ b/src/engraving/dom/noteline.h
@@ -70,6 +70,7 @@ public:
 
 protected:
     Sid defaultPosSid() const override;
+    bool isInSpannerMap() const override { return false; }
 
 private:
     NoteLineEndPlacement m_lineEndPlacement = NoteLineEndPlacement::OFFSET_ENDS;

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -655,7 +655,7 @@ bool Spanner::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::SPANNER_TICK:
         triggerLayout();           // spanner may have moved to another system
         setTick(v.value<Fraction>());
-        if (score() && score()->spannerMap().removeSpanner(this)) {
+        if (score() && isInSpannerMap() && score()->spannerMap().removeSpanner(this)) {
             score()->addSpanner(this, /*computeStartEnd =*/ false);
         }
         break;
@@ -1386,7 +1386,7 @@ void Spanner::setTick(const Fraction& v)
 
     Score* score = this->score();
 
-    if (score) {
+    if (score && isInSpannerMap()) {
         score->spannerMap().setDirty();
     }
 }
@@ -1423,7 +1423,7 @@ void Spanner::setTicks(const Fraction& f)
 
     Score* score = this->score();
 
-    if (score) {
+    if (score && isInSpannerMap()) {
         score->spannerMap().setDirty();
     }
 }

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -276,6 +276,8 @@ protected:
     virtual void doComputeStartElement();
     virtual void doComputeEndElement();
 
+    virtual bool isInSpannerMap() const { return true; }
+
 private:
     bool canBeCrossStaff() const;
 

--- a/src/engraving/dom/spannermap.cpp
+++ b/src/engraving/dom/spannermap.cpp
@@ -46,6 +46,7 @@ SpannerMap::SpannerMap()
 
 void SpannerMap::update() const
 {
+    TRACEFUNC;
     IntervalList regularIntervals;
     IntervalList collisionFreeIntervals;
 

--- a/src/engraving/dom/tapping.h
+++ b/src/engraving/dom/tapping.h
@@ -110,6 +110,9 @@ public:
 
     Tapping* tapping() const { return toTapping(parent()); }
 
+protected:
+    bool isInSpannerMap() const override { return false; }
+
 private:
     bool m_isHalfSlurAbove = true;
 };

--- a/src/engraving/dom/tie.h
+++ b/src/engraving/dom/tie.h
@@ -143,6 +143,8 @@ public:
 protected:
     Tie(const ElementType& type, EngravingItem* parent = nullptr);
 
+    bool isInSpannerMap() const override { return false; }
+
     bool m_isInside = false;
     TiePlacement m_tiePlacement = TiePlacement::AUTO;
 


### PR DESCRIPTION
Some spanner types are not added to the score's spanner map and are instead managed by other items. We shouldn't unnecessarily update the spanner map when these type's ticks change.

Taking the Beethoven 9 score (saved in 5.0) as a benchmark, this PR speeds up opening and layout by 15s. The majority of the calls to `SpannerMap::update` were caused during layout of `LyricsLine`s.