### PR TITLE
Fix #33354: Note input jumping backwards on double/halve duration [4.7.3]

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2007,7 +2007,7 @@ EngravingItem* Note::drop(EditData& data)
         NoteVal nval;
         nval.pitch = n->pitch();
         nval.headGroup = n->headGroup();
-        ChordRest* cr = nullptr;
+        const ChordRest* cr = nullptr;
         if (data.modifiers & ShiftModifier) {
             // add note to chord
             score()->addNote(ch, nval);

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -215,7 +215,7 @@ EngravingItem* Rest::drop(EditData& data)
         if (!d.isZero()) {
             Segment* seg = score()->setNoteRest(segment(), track(), nval, d, dir);
             if (seg) {
-                ChordRest* cr = toChordRest(seg->element(track()));
+                const ChordRest* cr = toChordRest(seg->element(track()));
                 if (cr) {
                     score()->nextInputPos(cr, false);
                 }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -836,7 +836,7 @@ public:
     double utick2utime(int tick) const;
     int utime2utick(double utime) const;
 
-    void nextInputPos(ChordRest* cr, bool);
+    void nextInputPos(const ChordRest* cr, bool);
     void cmdMirrorNoteHead();
 
     virtual size_t npages() const { return m_pages.size(); }

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -3383,7 +3383,7 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
             }
         }
         if (m_is.noteEntryMode()) {
-            ChordRest* cr = crs.size() == 1 ? crs.front() : nullptr;
+            const ChordRest* cr = crs.size() == 1 ? crs.front() : nullptr;
             IF_ASSERT_FAILED(cr) {
                 // (At time of writing) it shouldn't be possible to have more than
                 // one CR selected during note entry...

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -3382,6 +3382,16 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
                 select(toEngravingItem(n), SelectType::ADD);
             }
         }
+        if (m_is.noteEntryMode()) {
+            ChordRest* cr = crs.size() == 1 ? crs.front() : nullptr;
+            IF_ASSERT_FAILED(cr) {
+                // (At time of writing) it shouldn't be possible to have more than
+                // one CR selected during note entry...
+                return;
+            }
+            m_is.setDuration(cr->durationType());
+            nextInputPos(cr, false);
+        }
     }
 }
 

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -4668,7 +4668,7 @@ void Score::cmdDeleteTuplet(Tuplet* tuplet, bool replaceWithRest)
 //   nextInputPos
 //---------------------------------------------------------
 
-void Score::nextInputPos(ChordRest* cr, bool doSelect)
+void Score::nextInputPos(const ChordRest* cr, bool doSelect)
 {
     ChordRest* ncr = nextChordRest(cr);
     if ((!ncr) && (m_is.track() % VOICES)) {


### PR DESCRIPTION
Resolves: #33354

Introduced with #24385 - before these changes we used to [explicitly move the input state forward](https://github.com/musescore/MuseScore/pull/24385/changes#diff-29783252c775a56b96da85ab98e063829cce22ee173790849e56cc9376547e53L3343-L3344) at the end of the method in question. I've scanned through the conversation/code there and can't see any justification for this, so I guess this was simply an oversight.

We can't quite reintroduce the logic like-for-like since, before the aforementioned changes, only one `ChordRest` would ever be considered in the double/halve method. Now that this method instead works with multiple `crs`, we need to determine this ourselves. This is fairly straightforward since, as noted in my code comment, only one CR should ever be selected during note input.