### PR TITLE
A cleaner fix for #33312

### DIFF
--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -1139,10 +1139,10 @@ int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseType& no
 
 int clampEnharmonic(int tpc, bool useDoubleSharpsFlats)
 {
-    while (tpc > (useDoubleSharpsFlats ? Tpc::TPC_MAX : Tpc::TPC_F_SS)) {
+    while (tpc > (useDoubleSharpsFlats ? Tpc::TPC_MAX : Tpc::TPC_B_S)) {
         tpc -= TPC_DELTA_ENHARMONIC;
     }
-    while (tpc < (useDoubleSharpsFlats ? Tpc::TPC_MIN : Tpc::TPC_B_BB)) {
+    while (tpc < (useDoubleSharpsFlats ? Tpc::TPC_MIN : Tpc::TPC_F_B)) {
         tpc += TPC_DELTA_ENHARMONIC;
     }
     return tpc;

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -511,27 +511,19 @@ void Transpose::transposeChord(Chord* c, const Fraction& tick)
 
 Interval Transpose::keydiff2Interval(Key oKey, Key nKey, TransposeDirection dir)
 {
-    static int stepTable[STEP_DELTA_OCTAVE] = {
-        // C  G  D  A  E  B F
-        0, 4, 1, 5, 2, 6, 3,
-    };
+    int diatonic = tpc2step(key2Tpc(nKey)) - tpc2step(key2Tpc(oKey));
+    int chromatic = ((int(nKey) - int(oKey)) + (diatonic * TPC_DELTA_ENHARMONIC)) / TPC_DELTA_SEMITONE;
 
-    int cofSteps = (nKey > oKey) ? int(nKey) - int(oKey) : int(nKey) - int(oKey) + PITCH_DELTA_OCTAVE; // circle of fifth steps
-    int diatonic = stepTable[(int(nKey) + 7) % 7] - stepTable[(int(oKey) + 7) % 7];
-    if (diatonic < 0) {
-        diatonic += STEP_DELTA_OCTAVE;
-    }
-    diatonic %= STEP_DELTA_OCTAVE;
-    int chromatic = (cofSteps * 7) % PITCH_DELTA_OCTAVE;
-
-    if ((dir == TransposeDirection::CLOSEST) && (chromatic > 6)) {
-        dir = TransposeDirection::DOWN;
+    if ((dir == TransposeDirection::CLOSEST && chromatic > 6)
+        || (dir == TransposeDirection::DOWN && chromatic > 0)) {
+        diatonic -= 7;
+        chromatic -= 12;
+    } else if ((dir == TransposeDirection::CLOSEST && chromatic < -6)
+               || (dir == TransposeDirection::UP && chromatic < 0)) {
+        diatonic += 7;
+        chromatic += 12;
     }
 
-    if (dir == TransposeDirection::DOWN) {
-        chromatic = chromatic == 0 ? 0 : chromatic - 12;
-        diatonic  = diatonic == 0 ? 0 : diatonic - 7;
-    }
     return Interval(diatonic, chromatic);
 }
 


### PR DESCRIPTION
Resolves: #33312
Resolves: #33487

The current `keydiff2Interval` algorithm produces partially erratic results that were not yet visible under the old TPC transposition system.

Take for example a transposition from 7 flats into 5 sharps (`oKey = -7, nKey = +5`):
- `cofSteps = 12`
- `diatonic= 6`
- `chromatic = 0`

We end up with an interval that seeks to move a note up 6 steps diatonically, but none chromatically. There is no musical term I'm aware of for such an interval: The relationship between C4 and Cbbbbbbbbbbbb5.
As such, the new TPC transposition algorithm is thrown out of balance, however its predessor, the ugly for loop, catches it through a range of modulo calculations. The solution is to stop calculating nonsensical intervals between keys, but instead keep the new TPC transposition algorithm and correct the `keydiff2interval` method.

Thanks @miiizen for catching some faulty logic in `clampEnharmonic`, the other cause of the linked issue adressed in a separate commit of this PR.