### PR TITLE
Fix dynamic size

### DIFF
--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -121,6 +121,7 @@ public:
     bool isEditAllowed(EditData&) const override;
 
     bool positionRelativeToNoteheadRest() const override { return true; }
+    bool sizeIsSpatiumDependent() const override { return true; }
 
     Hairpin* leftHairpin() const { return m_leftHairpin; }
     Hairpin* rightHairpin() const { return m_rightHairpin; }

--- a/src/engraving/dom/mscore.h
+++ b/src/engraving/dom/mscore.h
@@ -70,10 +70,6 @@ static constexpr double PPI       = 72.0; // typographical points per inch
 static constexpr double DPI = 1200;
 static constexpr double DPMM = DPI / INCH;
 
-// NOTE: the SMuFL default is actually 20pt. We use 10 for historical reasons
-// and back-compatibility, but this will be multiplied x2 during layout.
-static constexpr double MUSICAL_SYMBOLS_DEFAULT_FONT_SIZE = 10.0;
-
 static constexpr double UI_ICONS_DEFAULT_FONT_SIZE = 12.0;
 
 static constexpr int MAX_STAVES = 4;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -886,7 +886,7 @@ Font TextFragment::font(const TextBase* t) const
             family = String::fromStdString(fontName);
             fontType = Font::Type::MusicSymbol;
 
-            m = MUSICAL_SYMBOLS_DEFAULT_FONT_SIZE;
+            m = StyleDef::DEFAULT_SMUFL_POINT_SIZE();
             m *= t->getProperty(Pid::MUSICAL_SYMBOLS_SCALE).toDouble();
             if (t->sizeIsSpatiumDependent()) {
                 m *= t->spatiumScaling();
@@ -896,10 +896,6 @@ Font TextFragment::font(const TextBase* t) const
                 std::string fontName2 = engravingFonts()->fontByName(t->style().styleSt(Sid::dynamicsFont).toStdString())->family();
                 family = String::fromStdString(fontName2);
             }
-
-            // We use a default font size of 10pt for historical reasons,
-            // but SMuFL standard is 20pt so multiply x2 here.
-            m *= 2;
 
             m *= t->mag();
         } else if (t->hasSymbolSize()) {

--- a/src/engraving/internal/engravingfont.cpp
+++ b/src/engraving/internal/engravingfont.cpp
@@ -88,15 +88,6 @@ double EngravingFont::textEnclosureThickness()
     return m_textEnclosureThickness;
 }
 
-double DEFAULT_SMUFL_POINT_SIZE()
-{
-    const double DEFAULT_SPATIUM = StyleDef::styleValues[static_cast<size_t>(Sid::spatium)].defaultValue.toDouble();
-    const double DEFAULT_SPATIUM_IN_POINT_UNITS = DEFAULT_SPATIUM / mu::engraving::DPI * mu::engraving::PPI;
-    const double DEFAULT_SMUFL_POINT_SIZE = 4 * DEFAULT_SPATIUM_IN_POINT_UNITS; // By Smufl spec the spatium is 1/4 of the em
-
-    return DEFAULT_SMUFL_POINT_SIZE;
-}
-
 // =============================================
 // Load
 // =============================================
@@ -118,7 +109,7 @@ void EngravingFont::ensureLoad()
     m_font.setNoFontMerging(true);
     m_font.setHinting(Font::Hinting::PreferVerticalHinting);
 
-    m_font.setPointSizeF(DEFAULT_SMUFL_POINT_SIZE());
+    m_font.setPointSizeF(StyleDef::DEFAULT_SMUFL_POINT_SIZE());
 
     for (size_t id = 0; id < m_symbols.size(); ++id) {
         Smufl::Code code = Smufl::code(static_cast<SymId>(id));
@@ -1117,7 +1108,7 @@ void EngravingFont::draw(SymId id, Painter* painter, const SizeF& mag, const Poi
     }
 
     painter->save();
-    m_font.setPointSizeF(DEFAULT_SMUFL_POINT_SIZE());
+    m_font.setPointSizeF(StyleDef::DEFAULT_SMUFL_POINT_SIZE());
     painter->scale(mag.width(), mag.height());
     painter->setFont(m_font);
     if (angle != 0) {

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -24,6 +24,7 @@
 #include <array>
 #include <vector>
 
+#include "../dom/mscore.h"
 #include "global/types/string.h"
 
 #include "../types/propertyvalue.h"
@@ -2269,5 +2270,14 @@ public:
     };
 
     static const std::array<StyleValue, size_t(Sid::STYLES)> styleValues;
+
+    static double DEFAULT_SMUFL_POINT_SIZE()
+    {
+        const double DEFAULT_SPATIUM = styleValues[static_cast<size_t>(Sid::spatium)].defaultValue.toDouble();
+        const double DEFAULT_SPATIUM_IN_POINT_UNITS = DEFAULT_SPATIUM / mu::engraving::DPI * mu::engraving::PPI;
+        const double DEFAULT_SMUFL_POINT_SIZE = 4 * DEFAULT_SPATIUM_IN_POINT_UNITS; // By Smufl spec the spatium is 1/4 of the em
+
+        return DEFAULT_SMUFL_POINT_SIZE;
+    }
 };
 }

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -138,7 +138,7 @@
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="start" line="yes" sign="yes" default-y="-70.01"/>
+          <pedal type="start" line="yes" sign="yes" default-y="-69.89"/>
           </direction-type>
         <staff>2</staff>
         </direction>


### PR DESCRIPTION
Resolves: #33482

Two separate issues:
- We were still using the legacy size of 20 pt for dynamic SMUFL symbol. The correct size is actually 19.84. But that's a less than 1% difference so it isn't really visible.
- Before https://github.com/musescore/MuseScore/commit/1b0b83b11959d1e2d6685c04e35a3cd7935d84d5, dynamics were skipping the `sizeIsSpatiumDependent` check in `TextFragment::font`, which is correct because dynamics should always scale with spatium and according to their internal percentage size. Now they are going through the check. The file in question had the option set to false for expressions, and dynamics take the expression text style, hence they were not scaling with the staff size anymore. Solution is to override the function for dynamics.