### PR TITLE
SWITCH TO C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-cmake_minimum_required(VERSION 3.28...3.31) 
+cmake_minimum_required(VERSION 3.28) 
 
 project(MuseScore LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -48,9 +49,9 @@ set(CMAKE_MODULE_PATH
 message(STATUS "C:   ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
 message(STATUS "CXX: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")    
 
-set(CLANG_MIN_VERSION 16)
-set(GCC_MIN_VERSION 10)
-set(MSVC_MIN_VERSION 19.10)
+set(CLANG_MIN_VERSION 20)
+set(GCC_MIN_VERSION 14)
+set(MSVC_MIN_VERSION 19.40)
 
 include(GetCompilerInfo)
 


### PR DESCRIPTION
We are moving to C++20

Now these are the minimum versions of compilers: 
* Clang 20+ 
* AppleClang 20+ (XCode 26.4)
* Gcc 14+ 
* MSVC 19.40+ (Visual Studio 2022 17.10+ (toolset v143))


Some clarifications:
* In our project, we do not differentiate between Clang and AppleClang; We decided that there is just Clang.
* We now know that Xcode 26.4 provides AppleClang 21 - this is enough 
* Clang 20 - This is a limitation due to Ubuntu 24.04, where the repository has a maximum of Clang 20. 
* Gcc 14 - The saddest thing is that it's also limited to Ubuntu 24.04, with the maximum Gcc 14 in the repository.


We don't plan to use C++20 code from tomorrow... It will take some time for all dependent things to be adapted. 


