### PR TITLE
Fix MSVC compiler warnings related to the C++20 switch

### DIFF
--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -835,8 +835,11 @@ TEST_F(MusicXml_Tests, inferredRights) {
     musicXmlImportTestRef("testInferredRights");
 }
 TEST_F(MusicXml_Tests, inferredTechnique) {
+#if defined(__GNUC__) && __GNUC__ == 14
     GTEST_SKIP() << "Failed with gcc14";
+#else
     musicXmlImportTestRef("testInferredTechnique");
+#endif
 }
 TEST_F(MusicXml_Tests, inferredTempoText) {
     musicXmlImportTestRef("testInferredTempoText");


### PR DESCRIPTION
* reg. unreachable code (C4702)

TODO; there's a ton of warnings (some 2316) for the fdk-aac project, should probably get disabled, but I haven't (yet) found the place to do so.