### PR TITLE
[4.7.6] Fix compiler warnings

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2827,7 +2827,6 @@ void Score::deleteItem(EngravingItem* el)
         el = chord;
     }
     // fall through
-
     case ElementType::CHORD:
     {
         Chord* chord = toChord(el);
@@ -3147,6 +3146,7 @@ void Score::deleteItem(EngravingItem* el)
         }
     }
     break;
+
     case ElementType::REHEARSAL_MARK:
     case ElementType::TEMPO_TEXT:
     {
@@ -3180,6 +3180,7 @@ void Score::deleteItem(EngravingItem* el)
 
         break;
     }
+
     case ElementType::OTTAVA_SEGMENT:
     case ElementType::HAIRPIN_SEGMENT:
     case ElementType::TRILL_SEGMENT:
@@ -3250,10 +3251,12 @@ void Score::deleteItem(EngravingItem* el)
             undoRemoveElement(el);
         }
         break;
+
     case ElementType::PLAY_COUNT_TEXT: {
         PlayCountText* pct = toPlayCountText(el);
         pct->barline()->undoChangeProperty(Pid::PLAY_COUNT_TEXT_SETTING, AutoCustomHide::HIDE);
     } break;
+
     case ElementType::INSTRUMENT_CHANGE:
     {
         InstrumentChange* ic = static_cast<InstrumentChange*>(el);
@@ -3334,6 +3337,7 @@ void Score::deleteItem(EngravingItem* el)
         EditSystemLocks::undoRemoveSystemLock(this, systemLock);
     }
     break;
+
     case ElementType::PARENTHESIS: {
         Parenthesis* paren = toParenthesis(el);
         // Use EditChord::removeChordParentheses when parent is a chord, fall through for all others
@@ -3352,7 +3356,7 @@ void Score::deleteItem(EngravingItem* el)
             break;
         }
     }
-
+    // fall through
     default:
         undoRemoveElement(el);
         break;

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2827,7 +2827,6 @@ void Score::deleteItem(EngravingItem* el)
         el = chord;
     }
     // fall through
-
     case ElementType::CHORD:
     {
         Chord* chord = toChord(el);
@@ -3147,6 +3146,7 @@ void Score::deleteItem(EngravingItem* el)
         }
     }
     break;
+
     case ElementType::REHEARSAL_MARK:
     case ElementType::TEMPO_TEXT:
     {
@@ -3180,6 +3180,7 @@ void Score::deleteItem(EngravingItem* el)
 
         break;
     }
+
     case ElementType::OTTAVA_SEGMENT:
     case ElementType::HAIRPIN_SEGMENT:
     case ElementType::TRILL_SEGMENT:
@@ -3251,10 +3252,12 @@ void Score::deleteItem(EngravingItem* el)
             undoRemoveElement(el);
         }
         break;
+
     case ElementType::PLAY_COUNT_TEXT: {
         PlayCountText* pct = toPlayCountText(el);
         pct->barline()->undoChangeProperty(Pid::PLAY_COUNT_TEXT_SETTING, AutoCustomHide::HIDE);
     } break;
+
     case ElementType::INSTRUMENT_CHANGE:
     {
         InstrumentChange* ic = static_cast<InstrumentChange*>(el);
@@ -3335,6 +3338,7 @@ void Score::deleteItem(EngravingItem* el)
         EditSystemLocks::undoRemoveSystemLock(this, systemLock);
     }
     break;
+
     case ElementType::PARENTHESIS: {
         Parenthesis* paren = toParenthesis(el);
         // Use EditChord::removeChordParentheses when parent is a chord, fall through for all others
@@ -3353,7 +3357,7 @@ void Score::deleteItem(EngravingItem* el)
             break;
         }
     }
-
+    // fall through
     default:
         undoRemoveElement(el);
         break;

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1742,10 +1742,10 @@ void TDraw::draw(const TextFragment& textFragment, const TextBase* item, muse::d
 {
 #ifndef Q_OS_MACOS
     drawTextWorkaround(textFragment, item, painter);
-    return;
-#endif
+#else
     painter->setFont(textFragment.font(item));
     painter->drawText(textFragment.pos, textFragment.text);
+#endif
 }
 
 void TDraw::drawTextWorkaround(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -440,7 +440,7 @@ struct Event {
 
         switch (messageType()) {
         case MessageType::ChannelVoice10: return m_data[0] & 0x7F;
-        case MessageType::ChannelVoice20: return scaleDown(m_data[1] >> 16, 16, 7);
+        case MessageType::ChannelVoice20: return static_cast<uint8_t>(scaleDown(m_data[1] >> 16, 16, 7));
         default: assert(false);
         }
         return 0;
@@ -471,7 +471,7 @@ struct Event {
         assertOpcode({ Opcode::NoteOn, Opcode::NoteOff });
 
         switch (messageType()) {
-        case MessageType::ChannelVoice10: return scaleUp(m_data[0] & 0x7F, 7, 16);
+        case MessageType::ChannelVoice10: return static_cast<uint16_t>(scaleUp(m_data[0] & 0x7F, 7, 16));
         case MessageType::ChannelVoice20: return static_cast<uint16_t>(m_data[1] >> 16);
         default: assert(false);
         }
@@ -592,9 +592,11 @@ struct Event {
     {
         uint32_t val = data();
         if (messageType() == MessageType::ChannelVoice20) {
-            return scaleDown(val, 32, 7);
+            val = scaleDown(val, 32, 7);
+        } else if (messageType() == MessageType::ChannelVoice10 && opcode() == Opcode::PitchBend) {
+            val = scaleDown(val, 14, 7);
         }
-        return val;
+        return val & 0x7F;
     }
 
     uint32_t data14() const
@@ -836,7 +838,7 @@ struct Event {
             //D2.3
             case Opcode::AssignableController:
             case Opcode::RegisteredController: {
-                std::vector<std::pair<uint8_t, uint8_t> > controlChanges = {
+                std::vector<std::pair<uint8_t, uint32_t> > controlChanges = {
                     { (opcode() == Opcode::RegisteredController ? 101 : 99), bank() },
                     { (opcode() == Opcode::RegisteredController ? 100 : 98), index() },
                     { 6,  data() >> 25 }, // first 7 bits

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -60,7 +60,7 @@ class UIDRegister;
 struct ControlElementPosition {
     engraving::Measure* measure = nullptr;
     engraving::Fraction tick;
-    int track = 0;
+    engraving::track_idx_t track = 0;
     engraving::ChordRest* chordRest = nullptr;
 };
 

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -2957,9 +2957,9 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
         delete inferredFingering;
     }
 
-    for (auto& harmony : delayedHarmony) {
-        HarmonyDesc harmonyDesc = harmony.second;
-        Fraction tick = Fraction::fromTicks(harmony.first);
+    for (auto& delHarmony : delayedHarmony) {
+        HarmonyDesc harmonyDesc = delHarmony.second;
+        Fraction tick = Fraction::fromTicks(delHarmony.first);
         if (FretDiagram* fd = harmonyDesc.m_fretDiagram) {
             fd->setTrack(harmonyDesc.m_track);
             Segment* s = measure->getSegment(SegmentType::ChordRest, tick);

--- a/src/musesounds/internal/musesamplercheckupdateservice.cpp
+++ b/src/musesounds/internal/musesamplercheckupdateservice.cpp
@@ -98,7 +98,7 @@ Promise<RetVal<bool> > MuseSamplerCheckUpdateService::checkForUpdate()
             return resolve(RetVal<bool>::make_ret(progress.ret));
         }
 
-        progress.val.finished().onReceive(this, [this, receivedData, localVersion, resolve](const ProgressResult& res) {
+        progress.val.finished().onReceive(this, [receivedData, localVersion, resolve](const ProgressResult& res) {
             RetVal<bool> result = RetVal<bool>::make_ok(false);
 
             if (res.ret) {


### PR DESCRIPTION
* reg. (MSVC):
   * 'return': conversion from 'uint32_t' to 'uint8_t', possible loss of data (C4244)
   * 'return': conversion from 'uint32_t' to 'uint16_t', possible loss of data (C4244)
   * 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data (C4244)
    Went into master (now main) via #32771, commit 4, on April 7.

* and reg. (MSVC):
    * '=': conversion from 'size_t' to 'int', possible loss of data (C4267)
    See also #33748, merged into main meanwhile

* and reg. (MSVC):
    * unreachable code (C4702)
    Apparently (currently) in 4.7 only

* and reg. (gcc):
    * this statement may fall through [-Wimplicit-fallthrough=] (see also #34221, where this turned into a bug, due to lacking the fallthough)


* and reg. (CLANG);
    * reg.: lambda capture 'this' is not used [-Wunused-lambda-capture] (see also #34221)

* and reg. (MSVC):
    * declaration of 'harmony' hides previous local declaration (C4456) (now also in main, see #34889)