### PR TITLE
Fix the noteGroups example view of the 'Create Time Signature' dialog

### DIFF
--- a/src/notationscene/widgets/exampleview.cpp
+++ b/src/notationscene/widgets/exampleview.cpp
@@ -106,6 +106,7 @@ void ExampleView::setScore(Score* s)
     ScoreLoad sl;
     m_score->doLayout();
     resetMatrix();
+    updateGeometry(); // notify the widget's layout system that the sizeHint has changed
     update();
 }
 

--- a/src/palette/widgets/masterpalette.cpp
+++ b/src/palette/widgets/masterpalette.cpp
@@ -109,6 +109,7 @@ void MasterPalette::componentComplete()
     m_timeItem = new QTreeWidgetItem();
     m_timeItem->setData(0, Qt::UserRole, stack->count());
     m_timeEditor = new TimeEditor(this);
+    m_timeEditor->classBegin();
     stack->addWidget(m_timeEditor);
     treeWidget->addTopLevelItem(m_timeItem);
 

--- a/src/palette/widgets/timedialog.cpp
+++ b/src/palette/widgets/timedialog.cpp
@@ -297,9 +297,10 @@ void TimeEditorDialog::classBegin()
     m_timeEditor = new TimeEditor(this);
     m_timeEditor->classBegin();
 
+    this->resize(m_timeEditor->size());
+
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
-    layout->setSizeConstraint(QLayout::SetFixedSize);
     layout->addWidget(m_timeEditor);
 }
 

--- a/src/palette/widgets/timedialog.cpp
+++ b/src/palette/widgets/timedialog.cpp
@@ -44,6 +44,11 @@ TimeEditor::TimeEditor(QWidget* parent)
     : QWidget(parent), muse::Contextable(muse::iocCtxForQWidget(this))
 {
     setupUi(this);
+}
+
+void TimeEditor::classBegin()
+{
+    groups->classBegin();
 
     QLayout* l = new QVBoxLayout();
     l->setContentsMargins(0, 0, 0, 0);
@@ -290,6 +295,8 @@ TimeEditorDialog::TimeEditorDialog(QWidget* parent)
 void TimeEditorDialog::classBegin()
 {
     m_timeEditor = new TimeEditor(this);
+    m_timeEditor->classBegin();
+
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSizeConstraint(QLayout::SetFixedSize);

--- a/src/palette/widgets/timedialog.h
+++ b/src/palette/widgets/timedialog.h
@@ -50,6 +50,8 @@ class TimeEditor : public QWidget, Ui::TimeDialogBase, public muse::Contextable
 public:
     TimeEditor(QWidget* parent = 0);
 
+    void classBegin();
+
     bool dirty() const;
     bool showTimePalette() const;
     void save();


### PR DESCRIPTION
Resolves: #33410

The "Create time signature" dialog (accessed through the "Time Signature" palette) was not displaying correctly the following:

* the "Beam groups" examples - due to the `TimeEditor`'s `setupUi()` function mis-calculating the `sizeHint` of the `NoteGroupsExampleView`. This was because the `sizeHint` is calculated from the score (in `ExampleView::sizeHint()`), but at this point the score was still unset (it is set later within the calls to `groups->setSig()`). The solution is to call the `ExampleView`'s `updateGeometry()` after each score update.
* the "Beam selector" icons - due to the `NoteGroups::classBegin()` function (which initialises the "Beam selector" icon `PaletteWidget`) not being called from the `TimeEditor`. This has been added.
