### PR TITLE
Fix Navigator scaling when directly opening Score tab

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.cpp
@@ -68,7 +68,13 @@ void NotationNavigator::load()
 
     AbstractNotationPaintView::load();
 
-    rescale();
+    rescaleIfVisible();
+}
+
+void NotationNavigator::onLoadNotation(INotationPtr notation)
+{
+    AbstractNotationPaintView::onLoadNotation(notation);
+    rescaleIfVisible();
 }
 
 bool NotationNavigator::isVerticalOrientation() const
@@ -86,7 +92,7 @@ const PageList& NotationNavigator::pages() const
     return notation()->elements()->pages();
 }
 
-void NotationNavigator::rescale()
+void NotationNavigator::rescaleIfVisible()
 {
     TRACEFUNC;
 
@@ -236,9 +242,7 @@ void NotationNavigator::initOrientation()
 void NotationNavigator::initVisible()
 {
     connect(this, &NotationNavigator::visibleChanged, [this]() {
-        if (isVisible()) {
-            rescale();
-        }
+        rescaleIfVisible();
     });
 }
 
@@ -266,11 +270,7 @@ void NotationNavigator::paint(QPainter* painter)
 
 void NotationNavigator::onViewSizeChanged()
 {
-    if (!isVisible()) {
-        return;
-    }
-
-    rescale();
+    rescaleIfVisible();
 }
 
 void NotationNavigator::paintPageNumbers(QPainter* painter)

--- a/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.h
@@ -80,12 +80,14 @@ signals:
     void orientationChanged();
 
 private:
+    void onLoadNotation(INotationPtr notation) override;
+
     void initOrientation();
     void initVisible();
 
     ViewMode notationViewMode() const;
 
-    void rescale();
+    void rescaleIfVisible();
 
     void paint(QPainter* painter) override;
     void onViewSizeChanged() override;


### PR DESCRIPTION
(rather than first opening the Home tab and then switching to the Score tab)

In this situation, the `rescale` calls in `load`/`initVisible`/`onViewSizeChanged` all fail to do the job, because the score is not loaded yet. Add another one upon loading notation.

En passant, let’s rename `rescale` to `rescaleIfVisible`, and remove some unnecessary visibility checks outside that method.

Resolves: https://github.com/musescore/MuseScore/issues/33459