### PR TITLE
String tuning follows selected chord spelling

### DIFF
--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -24,6 +24,7 @@
 
 #include "types/typesconv.h"
 #include "utils.h"
+#include "pitchspelling.h"
 
 #include "part.h"
 #include "score.h"
@@ -35,6 +36,32 @@
 
 using namespace mu;
 using namespace mu::engraving;
+
+static String tuningPitchName(const instrString& stringInfo, NoteSpellingType spelling, bool withOctave)
+{
+    if (!pitchIsValid(stringInfo.pitch)) {
+        return String();
+    }
+
+    const int tpc = pitch2tpc(stringInfo.pitch, Key::C, stringInfo.useFlat ? Prefer::FLATS : Prefer::SHARPS);
+
+    String step;
+    String accidental;
+    tpc2name(tpc, spelling, NoteCaseType::CAPITAL, step, accidental);
+
+    if (spelling == NoteSpellingType::GERMAN && tpc == TPC_B_B) {
+        accidental.clear();
+    }
+
+    String result = convertPitchStringFlatsAndSharpsToUnicode(step + accidental);
+
+    if (withOctave) {
+        const int octave = (stringInfo.pitch / PITCH_DELTA_OCTAVE) - 1;
+        result += String::number(octave);
+    }
+
+    return result;
+}
 
 // STYLE
 static const ElementStyle STRING_TUNINGS_STYLE {
@@ -161,6 +188,8 @@ String StringTunings::accessibleInfo() const
         return String();
     }
 
+    const NoteSpellingType spelling = style().styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
+
     String elementName = score() ? score()->getTextStyleUserName(TextStyleType::STRING_TUNINGS).translated()
                          : TConv::translatedUserName(TextStyleType::STRING_TUNINGS);
     String info;
@@ -170,10 +199,10 @@ String StringTunings::accessibleInfo() const
     for (int i = 0; i < numOfStrings; ++i) {
         string_idx_t index = numOfStrings - i - 1;
         if (muse::contains(m_visibleStrings, index)) {
-            const instrString str = stringList[index];
-            String pitchStr = pitch2string(str.pitch, str.useFlat);
+            const instrString& stringInfo = stringList[index];
+            String pitchStr = tuningPitchName(stringInfo, spelling, true);
             if (pitchStr.empty()) {
-                LOGE() << "Invalid get pitch name for " << str.pitch;
+                LOGE() << "Invalid get pitch name for " << stringInfo.pitch;
                 continue;
             }
 
@@ -269,6 +298,8 @@ String StringTunings::generateText() const
         return u"";
     }
 
+    const NoteSpellingType spelling = style().styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
+
     auto guitarStringSymbol = [](int i) { return String(u"<sym>guitarString") + String::number(i) + u"</sym>"; };
 
     const std::vector<instrString>& stringList = stringData->stringList();
@@ -277,23 +308,14 @@ String StringTunings::generateText() const
     for (int i = 0; i < numOfStrings; ++i) {
         string_idx_t index = numOfStrings - i - 1;
         if (muse::contains(m_visibleStrings, index)) {
-            const instrString str = stringList[index];
-            String pitchStr = pitch2string(str.pitch, str.useFlat);
+            const instrString& stringInfo = stringList[index];
+            String pitchStr = tuningPitchName(stringInfo, spelling, false);
             if (pitchStr.empty()) {
-                LOGE() << "Invalid get pitch name for " << str.pitch;
+                LOGE() << "Invalid get pitch name for " << stringInfo.pitch;
                 continue;
             }
 
-            Char accidental;
-            if (pitchStr.size() > 1) {
-                Char sym(pitchStr[1]);
-                if (!sym.isDigit()) {
-                    accidental = sym;
-                }
-            }
-
-            visibleStringList.emplace_back(String(guitarStringSymbol(i + 1) + u" \u2013 "
-                                                  + String(pitchStr[0]).toUpper() + accidental) + u"  ");
+            visibleStringList.emplace_back(String(guitarStringSymbol(i + 1) + u" \u2013 " + pitchStr) + u"  ");
         }
     }
 

--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -37,13 +37,13 @@
 using namespace mu;
 using namespace mu::engraving;
 
-static String tuningPitchName(const instrString& stringInfo, NoteSpellingType spelling, bool withOctave)
+String mu::engraving::stringTuningPitchName(int pitch, bool useFlat, NoteSpellingType spelling, bool withOctave)
 {
-    if (!pitchIsValid(stringInfo.pitch)) {
+    if (!pitchIsValid(pitch)) {
         return String();
     }
 
-    const int tpc = pitch2tpc(stringInfo.pitch, Key::C, stringInfo.useFlat ? Prefer::FLATS : Prefer::SHARPS);
+    const int tpc = pitch2tpc(pitch, Key::C, useFlat ? Prefer::FLATS : Prefer::SHARPS);
 
     String step;
     String accidental;
@@ -56,7 +56,7 @@ static String tuningPitchName(const instrString& stringInfo, NoteSpellingType sp
     String result = convertPitchStringFlatsAndSharpsToUnicode(step + accidental);
 
     if (withOctave) {
-        const int octave = (stringInfo.pitch / PITCH_DELTA_OCTAVE) - 1;
+        const int octave = (pitch / PITCH_DELTA_OCTAVE) - 1;
         result += String::number(octave);
     }
 
@@ -200,7 +200,7 @@ String StringTunings::accessibleInfo() const
         string_idx_t index = numOfStrings - i - 1;
         if (muse::contains(m_visibleStrings, index)) {
             const instrString& stringInfo = stringList[index];
-            String pitchStr = tuningPitchName(stringInfo, spelling, true);
+            String pitchStr = stringTuningPitchName(stringInfo.pitch, stringInfo.useFlat, spelling, true);
             if (pitchStr.empty()) {
                 LOGE() << "Invalid get pitch name for " << stringInfo.pitch;
                 continue;
@@ -309,7 +309,7 @@ String StringTunings::generateText() const
         string_idx_t index = numOfStrings - i - 1;
         if (muse::contains(m_visibleStrings, index)) {
             const instrString& stringInfo = stringList[index];
-            String pitchStr = tuningPitchName(stringInfo, spelling, false);
+            String pitchStr = stringTuningPitchName(stringInfo.pitch, stringInfo.useFlat, spelling, false);
             if (pitchStr.empty()) {
                 LOGE() << "Invalid get pitch name for " << stringInfo.pitch;
                 continue;

--- a/src/engraving/dom/stringtunings.h
+++ b/src/engraving/dom/stringtunings.h
@@ -27,6 +27,8 @@
 #include "stringdata.h"
 
 namespace mu::engraving {
+String stringTuningPitchName(int pitch, bool useFlat, NoteSpellingType spelling, bool withOctave);
+
 class StringTunings final : public StaffTextBase
 {
     OBJECT_ALLOCATOR(engraving, StringTunings)

--- a/src/engraving/tests/CMakeLists.txt
+++ b/src/engraving/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/voiceswitching_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fretbox_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fretdiagram_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringtunings_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/engraving_xml_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/parentheses_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/automation/automation_tests.cpp

--- a/src/engraving/tests/stringtunings_tests.cpp
+++ b/src/engraving/tests/stringtunings_tests.cpp
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "engraving/compat/scoreaccess.h"
+#include "engraving/dom/factory.h"
+#include "engraving/dom/stringtunings.h"
+
+using namespace mu::engraving;
+
+namespace {
+void setChordSymbolSpelling(MasterScore* score, NoteSpellingType spelling)
+{
+    score->startCmd(TranslatableString::untranslatable("String tunings tests"));
+    score->undoChangeStyleVal(Sid::chordSymbolSpelling, spelling);
+    score->endCmd();
+}
+
+StringTunings* createStringTunings(MasterScore* score, std::vector<instrString> strings,
+                                   const std::vector<string_idx_t>& visibleStrings)
+{
+    StringTunings* stringTunings = Factory::createStringTunings(score->dummy()->segment());
+    stringTunings->setStringData(StringData(24, strings));
+    stringTunings->setVisibleStrings(visibleStrings);
+    return stringTunings;
+}
+}
+
+class Engraving_StringTuningsTests : public ::testing::Test
+{
+};
+
+TEST_F(Engraving_StringTuningsTests, GenerateTextUsesCurrentChordSymbolSpelling)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    StringTunings* stringTunings = createStringTunings(score, { instrString(50, false) }, { 0 });
+
+    setChordSymbolSpelling(score, NoteSpellingType::FRENCH);
+    stringTunings->updateText();
+    const QString frenchText = stringTunings->xmlText().toQString();
+    EXPECT_TRUE(frenchText.contains(u"Ré"));
+    EXPECT_FALSE(frenchText.contains(u"RÉ"));
+
+    setChordSymbolSpelling(score, NoteSpellingType::SOLFEGGIO);
+    stringTunings->updateText();
+    const QString solfeggioText = stringTunings->xmlText().toQString();
+    EXPECT_TRUE(solfeggioText.contains(u"Re"));
+    EXPECT_FALSE(solfeggioText.contains(u"RE"));
+
+    delete stringTunings;
+    delete score;
+}
+
+TEST_F(Engraving_StringTuningsTests, AccessibleInfoUsesLocalizedPitchNamesWithOctave)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    instrString string(51, false);
+    string.useFlat = true;
+
+    StringTunings* stringTunings = createStringTunings(score, { string }, { 0 });
+
+    setChordSymbolSpelling(score, NoteSpellingType::FRENCH);
+    const QString accessibleInfo = stringTunings->accessibleInfo().toQString();
+
+    EXPECT_TRUE(accessibleInfo.contains(u"Mi♭3"));
+    EXPECT_FALSE(accessibleInfo.contains(u"MI♭3"));
+
+    delete stringTunings;
+    delete score;
+}
+
+TEST_F(Engraving_StringTuningsTests, AccessibleInfoSkipsInvalidStringPitches)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    StringTunings* stringTunings = createStringTunings(score, { instrString(INVALID_PITCH, false), instrString(127, false) }, { 0, 1 });
+
+    setChordSymbolSpelling(score, NoteSpellingType::FRENCH);
+    const QString accessibleInfo = stringTunings->accessibleInfo().toQString();
+
+    EXPECT_TRUE(accessibleInfo.contains(u"Sol9"));
+    EXPECT_FALSE(accessibleInfo.contains(QStringLiteral("-1")));
+
+    delete stringTunings;
+    delete score;
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
+++ b/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
@@ -58,6 +58,8 @@ qt_add_qml_module(notationscene_qml
         elementpopups/staffvisibilitypopupmodel.h
         elementpopups/stringtuningssettingsmodel.cpp
         elementpopups/stringtuningssettingsmodel.h
+        elementpopups/stringtuningsutils.cpp
+        elementpopups/stringtuningsutils.h
         internal/undohistorymodel.cpp
         internal/undohistorymodel.h
         internal/undoredotoolbarmodel.cpp

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/StringTuningsPopup.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/StringTuningsPopup.qml
@@ -175,7 +175,7 @@ AbstractElementPopup {
                     navigation.panel: stringsNavPanel
                     navigation.row: index
                     navigation.column: 1
-                    navigation.accessible.name: visibleBox.navigation.accessible.name + " " + qsTrc("notation", "Value %1").arg(valueControl.currentValue)
+                    navigation.accessible.name: visibleBox.navigation.accessible.name + " " + qsTrc("notation", "Value %1").arg(valueControl.spelledNote)
 
                     RowLayout {
                         anchors.fill: parent
@@ -218,6 +218,7 @@ AbstractElementPopup {
 
                             property int currentValue: delegateItem.modelData["value"]
                             property string currentText: delegateItem.modelData["valueStr"]
+                            property string spelledNote: delegateItem.modelData["valueStr"]
                             property bool suppressNextTextCommit: false
 
                             Layout.leftMargin: 6
@@ -271,12 +272,12 @@ AbstractElementPopup {
                                 canDecrease: valueControl.currentValue > 0
 
                                 onIncreaseButtonClicked: {
-                                    valueControl.suppressNextTextCommit = true
+                                    valueControl.suppressNextTextCommit = valueInput.activeFocus
                                     stringTuningsModel.setStringPitchValue(delegateItem.index, valueControl.currentValue + 1, false)
                                 }
 
                                 onDecreaseButtonClicked: {
-                                    valueControl.suppressNextTextCommit = true
+                                    valueControl.suppressNextTextCommit = valueInput.activeFocus
                                     stringTuningsModel.setStringPitchValue(delegateItem.index, valueControl.currentValue - 1, true)
                                 }
                             }

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/StringTuningsPopup.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/StringTuningsPopup.qml
@@ -213,38 +213,71 @@ AbstractElementPopup {
                             }
                         }
 
-                        IncrementalPropertyControl {
+                        Item {
                             id: valueControl
+
+                            property int currentValue: delegateItem.modelData["value"]
+                            property string currentText: delegateItem.modelData["valueStr"]
+                            property bool suppressNextTextCommit: false
 
                             Layout.leftMargin: 6
 
                             Layout.preferredHeight: parent.height - ui.theme.borderWidth * 2
                             Layout.preferredWidth: 64
 
-                            currentValue: delegateItem.modelData["value"]
-                            currentText: delegateItem.modelData["valueStr"]
+                            TextInputField {
+                                id: valueInput
 
-                            minValue: 0
-                            maxValue: 127
+                                anchors.fill: parent
+                                anchors.rightMargin: valueAdjustControl.width
 
-                            navigation.panel: stringsNavPanel
-                            navigation.row: delegateItem.index
-                            navigation.column: 3
+                                textSidePadding: 4
 
-                            onIncrement: function() {
-                                return stringTuningsModel.increaseStringValue(currentValue)
+                                currentText: valueControl.currentText
+
+                                navigation.panel: stringsNavPanel
+                                navigation.row: delegateItem.index
+                                navigation.column: 3
+
+                                onTextEditingFinished: function(newValue) {
+                                    if (valueControl.suppressNextTextCommit) {
+                                        valueControl.suppressNextTextCommit = false
+                                        currentText = Qt.binding(function() { return delegateItem.modelData["valueStr"] })
+                                        return
+                                    }
+
+                                    if (newValue === delegateItem.modelData["valueStr"]) {
+                                        return
+                                    }
+
+                                    var ok = stringTuningsModel.setStringValue(delegateItem.index, newValue)
+                                    if (!ok) {
+                                        currentText = delegateItem.modelData["valueStr"]
+                                        currentText = Qt.binding(function() { return delegateItem.modelData["valueStr"] })
+                                    }
+                                }
                             }
 
-                            onDecrement: function() {
-                                return stringTuningsModel.decreaseStringValue(currentValue)
-                            }
+                            ValueAdjustControl {
+                                id: valueAdjustControl
 
-                            onValueEditingFinished: function(newValue) {
-                                var ok = stringTuningsModel.setStringValue(delegateItem.index, newValue)
-                                if (!ok) {
-                                    //! NOTE: reset the text entered by the user
-                                    currentText = delegateItem.modelData["valueStr"]
-                                    currentText = Qt.binding( function() { return delegateItem.modelData["valueStr"] } )
+                                anchors.top: parent.top
+                                anchors.right: parent.right
+                                anchors.bottom: parent.bottom
+
+                                radius: valueInput.background.radius - valueInput.background.border.width
+
+                                canIncrease: valueControl.currentValue < 127
+                                canDecrease: valueControl.currentValue > 0
+
+                                onIncreaseButtonClicked: {
+                                    valueControl.suppressNextTextCommit = true
+                                    stringTuningsModel.setStringPitchValue(delegateItem.index, valueControl.currentValue + 1, false)
+                                }
+
+                                onDecreaseButtonClicked: {
+                                    valueControl.suppressNextTextCommit = true
+                                    stringTuningsModel.setStringPitchValue(delegateItem.index, valueControl.currentValue - 1, true)
                                 }
                             }
                         }

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningssettingsmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningssettingsmodel.cpp
@@ -22,14 +22,30 @@
 
 #include "stringtuningssettingsmodel.h"
 
+#include "stringtuningsutils.h"
+
 #include "engraving/dom/stringtunings.h"
 #include "engraving/dom/utils.h"
+#include "engraving/style/styledef.h"
 
 #include "translation.h"
 
 using namespace mu;
 using namespace muse;
 using namespace mu::notation;
+
+namespace {
+mu::engraving::NoteSpellingType currentNoteSpelling(const mu::engraving::EngravingItem* item)
+{
+    using namespace mu::engraving;
+
+    if (!item) {
+        return NoteSpellingType::STANDARD;
+    }
+
+    return item->style().styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
+}
+}
 
 const QString customPreset()
 {
@@ -49,7 +65,7 @@ void StringTuningsSettingsModel::init()
 
     AbstractElementPopupModel::init();
 
-    IF_ASSERT_FAILED(m_item || m_item->isStringTunings()) {
+    IF_ASSERT_FAILED(m_item && m_item->isStringTunings()) {
         return;
     }
 
@@ -79,6 +95,7 @@ void StringTuningsSettingsModel::init()
 
     const std::vector<engraving::instrString>& stringList = stringData->stringList();
     const std::vector<engraving::string_idx_t>& visibleStrings = stringTunings->visibleStrings();
+    const engraving::NoteSpellingType spelling = currentNoteSpelling(m_item);
     int numOfStrings = static_cast<int>(stringList.size());
     for (int i = 0; i < numOfStrings; ++i) {
         engraving::string_idx_t instrStringIndex = numOfStrings - i - 1;
@@ -90,6 +107,7 @@ void StringTuningsSettingsModel::init()
         item->setNumber(QString::number(i + 1));
         item->setValue(string.pitch);
         item->setUseFlat(string.useFlat);
+        item->setSpelling(static_cast<int>(spelling));
         item->blockSignals(false);
 
         m_strings.push_back(item);
@@ -104,7 +122,7 @@ void StringTuningsSettingsModel::init()
 
 QString StringTuningsSettingsModel::pitchToString(int pitch)
 {
-    return engraving::pitch2string(pitch);
+    return stringTuningPitchToString(pitch, true, currentNoteSpelling(m_item));
 }
 
 void StringTuningsSettingsModel::toggleString(int stringIndex)
@@ -119,24 +137,15 @@ void StringTuningsSettingsModel::toggleString(int stringIndex)
     saveStringsVisibleState();
 }
 
-bool StringTuningsSettingsModel::setStringValue(int stringIndex, const QString& stringValue)
+bool StringTuningsSettingsModel::setStringPitchValue(int stringIndex, int value, bool useFlat)
 {
-    if (stringIndex >= m_strings.size()) {
+    if (stringIndex >= m_strings.size() || !engraving::pitchIsValid(value)) {
         return false;
     }
 
     StringTuningsItem* item = m_strings.at(stringIndex);
 
-    String _stringValue = engraving::convertPitchStringFlatsAndSharpsToUnicode(stringValue);
-    int value = engraving::string2pitch(_stringValue);
-    if (value == -1) {
-        item->valueChanged();
-        return false;
-    }
-
     item->setValue(value);
-
-    bool useFlat = _stringValue.contains(u'♭');
     item->setUseFlat(useFlat);
 
     beginMultiCommands(TranslatableString("undoableAction", "Set string tuning"));
@@ -149,14 +158,35 @@ bool StringTuningsSettingsModel::setStringValue(int stringIndex, const QString& 
     return true;
 }
 
-QString StringTuningsSettingsModel::increaseStringValue(int currentPitch)
+bool StringTuningsSettingsModel::setStringValue(int stringIndex, const QString& stringValue)
 {
-    return engraving::pitch2string(currentPitch + 1, false /* useFlats */);
-}
+    if (stringIndex >= m_strings.size()) {
+        return false;
+    }
 
-QString StringTuningsSettingsModel::decreaseStringValue(int currentPitch)
-{
-    return engraving::pitch2string(currentPitch - 1, true /* useFlats */);
+    StringTuningsItem* item = m_strings.at(stringIndex);
+
+    const engraving::NoteSpellingType spelling = currentNoteSpelling(m_item);
+
+    const String normalizedValue = engraving::convertPitchStringFlatsAndSharpsToUnicode(stringValue);
+
+    //! NOTE: Parse localized spellings first so popup-only spellings such as
+    //! GERMAN_PURE "B" map to the intended pitch class. If that fails, fall
+    //! back to the generic parser so standard ASCII spellings accepted
+    //! elsewhere in the engraving layer keep working here as well.
+    bool useFlat = false;
+    int value = stringTuningInputToPitch(normalizedValue, spelling, &useFlat);
+    if (value == engraving::INVALID_PITCH) {
+        value = engraving::string2pitch(normalizedValue);
+        useFlat = normalizedValue.contains(u'♭');
+    }
+
+    if (value == engraving::INVALID_PITCH) {
+        item->valueChanged();
+        return false;
+    }
+
+    return setStringPitchValue(stringIndex, value, useFlat);
 }
 
 QVariantList StringTuningsSettingsModel::presets(bool withCustom) const
@@ -305,6 +335,7 @@ void StringTuningsSettingsModel::updateStrings()
     QString currentPreset = this->currentPreset();
     const auto& tick = m_item->tick();
     const auto transpose  = m_item->part()->instrument(tick)->transpose().chromatic;
+    const engraving::NoteSpellingType spelling = currentNoteSpelling(m_item);
 
     m_strings.clear();
 
@@ -322,6 +353,7 @@ void StringTuningsSettingsModel::updateStrings()
                 item->setNumber(QString::number(i + 1));
                 item->setValue(valueList[valueIndex].toInt() - transpose);
                 item->setUseFlat(useFlats);
+                item->setSpelling(static_cast<int>(spelling));
                 item->blockSignals(false);
 
                 m_strings.push_back(item);
@@ -453,7 +485,7 @@ int StringTuningsItem::value() const
 
 QString StringTuningsItem::valueStr() const
 {
-    return engraving::pitch2string(m_value, m_useFlat).toUpper();
+    return stringTuningPitchToString(m_value, m_useFlat, static_cast<engraving::NoteSpellingType>(m_spelling));
 }
 
 void StringTuningsItem::setValue(int value)
@@ -478,5 +510,15 @@ void StringTuningsItem::setUseFlat(bool use)
     }
 
     m_useFlat = use;
+    emit valueChanged();
+}
+
+void StringTuningsItem::setSpelling(int spelling)
+{
+    if (m_spelling == spelling) {
+        return;
+    }
+
+    m_spelling = spelling;
     emit valueChanged();
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningssettingsmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningssettingsmodel.h
@@ -56,12 +56,10 @@ public:
 
     Q_INVOKABLE void init() override;
     Q_INVOKABLE QString pitchToString(int pitch);
+    Q_INVOKABLE bool setStringPitchValue(int stringIndex, int value, bool useFlat);
 
     Q_INVOKABLE void toggleString(int stringIndex);
     Q_INVOKABLE bool setStringValue(int stringIndex, const QString& stringValue);
-
-    Q_INVOKABLE QString increaseStringValue(int currentPitch);
-    Q_INVOKABLE QString decreaseStringValue(int currentPitch);
 
     QVariantList presets(bool withCustom = true) const;
 
@@ -122,6 +120,8 @@ public:
     bool useFlat() const;
     void setUseFlat(bool use);
 
+    void setSpelling(int spelling);
+
 signals:
     void showChanged();
     void numberChanged();
@@ -132,5 +132,6 @@ private:
     QString m_number;
     int m_value = 0;
     bool m_useFlat = false;
+    int m_spelling = 0;
 };
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "stringtuningsutils.h"
+
+#include "engraving/dom/pitchspelling.h"
+#include "engraving/dom/utils.h"
+
+using namespace mu;
+using namespace muse;
+
+namespace {
+String noteInputAccidentalsToAscii(const String& value)
+{
+    String result;
+    result.reserve(value.size());
+
+    // muse::String does not expose iterators, so walk the UTF-16 buffer by index.
+    for (size_t i = 0; i < value.size(); ++i) {
+        const Char ch = value.at(i);
+        if (ch == u'♭') {
+            result += u'b';
+        } else if (ch == u'♯') {
+            result += u'#';
+        } else if (ch != u' ') {
+            result += ch;
+        }
+    }
+
+    return result;
+}
+
+String normalizeLocalizedNoteInput(String value, mu::engraving::NoteSpellingType spelling)
+{
+    if (spelling != mu::engraving::NoteSpellingType::FRENCH) {
+        return value;
+    }
+
+    value.replace(u'é', u'e');
+    value.replace(u'É', u'E');
+    value.remove(u'\u0301');
+
+    return value;
+}
+}
+
+QString mu::notation::stringTuningPitchToString(int pitch, bool useFlats, engraving::NoteSpellingType spelling)
+{
+    using namespace mu::engraving;
+
+    if (!pitchIsValid(pitch)) {
+        return QString();
+    }
+
+    const int tpc = pitch2tpc(pitch, Key::C, useFlats ? Prefer::FLATS : Prefer::SHARPS);
+
+    String step;
+    String accidental;
+    tpc2name(tpc, spelling, NoteCaseType::CAPITAL, step, accidental);
+
+    if (spelling == NoteSpellingType::GERMAN && tpc == TPC_B_B) {
+        accidental.clear();
+    }
+
+    String name = convertPitchStringFlatsAndSharpsToUnicode(step + accidental);
+    const int octave = (pitch / PITCH_DELTA_OCTAVE) - 1;
+
+    return (name + String::number(octave)).toQString();
+}
+
+int mu::notation::stringTuningInputToPitch(const String& input, engraving::NoteSpellingType spelling, bool* useFlat)
+{
+    using namespace mu::engraving;
+
+    const String normalizedValue = normalizeLocalizedNoteInput(noteInputAccidentalsToAscii(input).trimmed(), spelling);
+    if (normalizedValue.empty()) {
+        return INVALID_PITCH;
+    }
+
+    size_t octaveDigitsStart = normalizedValue.size();
+    while (octaveDigitsStart > 0 && normalizedValue.at(octaveDigitsStart - 1).isDigit()) {
+        --octaveDigitsStart;
+    }
+
+    if (octaveDigitsStart == normalizedValue.size()) {
+        return INVALID_PITCH;
+    }
+
+    size_t octaveStart = octaveDigitsStart;
+    if (octaveStart > 0 && normalizedValue.at(octaveStart - 1) == u'-') {
+        --octaveStart;
+    }
+
+    const String octaveString = normalizedValue.mid(octaveStart);
+    const int octave = octaveString.toInt();
+    if (octave < -1 || octave > 9) {
+        return INVALID_PITCH;
+    }
+
+    const String noteName = normalizedValue.left(octaveStart);
+    if (noteName.empty()) {
+        return INVALID_PITCH;
+    }
+
+    NoteCaseType noteCase = NoteCaseType::AUTO;
+    size_t parsedLength = 0;
+    const int tpc = convertNote(noteName, spelling, noteCase, parsedLength);
+    if (!tpcIsValid(tpc) || parsedLength != noteName.size()) {
+        return INVALID_PITCH;
+    }
+
+    const int pitchClass = (tpc2pitch(tpc) + PITCH_DELTA_OCTAVE) % PITCH_DELTA_OCTAVE;
+    const int pitch = (octave + 1) * PITCH_DELTA_OCTAVE + pitchClass;
+
+    if (!pitchIsValid(pitch)) {
+        return INVALID_PITCH;
+    }
+
+    if (useFlat) {
+        *useFlat = static_cast<int>(tpc2alter(tpc)) < 0;
+    }
+
+    return pitch;
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.cpp
@@ -23,6 +23,7 @@
 #include "stringtuningsutils.h"
 
 #include "engraving/dom/pitchspelling.h"
+#include "engraving/dom/stringtunings.h"
 #include "engraving/dom/utils.h"
 
 using namespace mu;
@@ -65,26 +66,7 @@ String normalizeLocalizedNoteInput(String value, mu::engraving::NoteSpellingType
 
 QString mu::notation::stringTuningPitchToString(int pitch, bool useFlats, engraving::NoteSpellingType spelling)
 {
-    using namespace mu::engraving;
-
-    if (!pitchIsValid(pitch)) {
-        return QString();
-    }
-
-    const int tpc = pitch2tpc(pitch, Key::C, useFlats ? Prefer::FLATS : Prefer::SHARPS);
-
-    String step;
-    String accidental;
-    tpc2name(tpc, spelling, NoteCaseType::CAPITAL, step, accidental);
-
-    if (spelling == NoteSpellingType::GERMAN && tpc == TPC_B_B) {
-        accidental.clear();
-    }
-
-    String name = convertPitchStringFlatsAndSharpsToUnicode(step + accidental);
-    const int octave = (pitch / PITCH_DELTA_OCTAVE) - 1;
-
-    return (name + String::number(octave)).toQString();
+    return engraving::stringTuningPitchName(pitch, useFlats, spelling, true).toQString();
 }
 
 int mu::notation::stringTuningInputToPitch(const String& input, engraving::NoteSpellingType spelling, bool* useFlat)

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+#include "global/types/string.h"
+#include "engraving/types/types.h"
+
+namespace mu::notation {
+// Utility helpers shared by the string tunings popup model and its tests.
+// They keep note-name formatting and parsing aligned with the selected
+// chord-symbol spelling without depending on QML state.
+QString stringTuningPitchToString(int pitch, bool useFlats, engraving::NoteSpellingType spelling);
+int stringTuningInputToPitch(const muse::String& input, engraving::NoteSpellingType spelling, bool* useFlat = nullptr);
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/tests/CMakeLists.txt
+++ b/src/notationscene/qml/MuseScore/NotationScene/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(MODULE_TEST_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/notationviewinputcontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringtuningsutils_tests.cpp
 )
 
 set(MODULE_TEST_LINK

--- a/src/notationscene/qml/MuseScore/NotationScene/tests/stringtuningsutils_tests.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/tests/stringtuningsutils_tests.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "engraving/dom/pitchspelling.h"
+#include "notationscene/qml/MuseScore/NotationScene/elementpopups/stringtuningsutils.h"
+
+using namespace mu::engraving;
+using namespace mu::notation;
+
+namespace {
+struct FormatCase {
+    NoteSpellingType spelling;
+    int pitch;
+    bool useFlats;
+    QString expected;
+
+    FormatCase(NoteSpellingType spelling, int pitch, bool useFlats, QString expected)
+        : spelling(spelling), pitch(pitch), useFlats(useFlats), expected(std::move(expected)) {}
+};
+
+struct ParseCase {
+    NoteSpellingType spelling;
+    muse::String input;
+    int expectedPitch;
+    bool expectedUseFlat;
+
+    ParseCase(NoteSpellingType spelling, muse::String input, int expectedPitch, bool expectedUseFlat)
+        : spelling(spelling), input(std::move(input)), expectedPitch(expectedPitch), expectedUseFlat(expectedUseFlat) {}
+};
+}
+
+TEST(StringTuningsUtilsTests, PitchToStringUsesLocalizedSpellingMatrix)
+{
+    const std::vector<FormatCase> cases {
+        { NoteSpellingType::STANDARD, 0, false, QStringLiteral("C-1") },
+        { NoteSpellingType::STANDARD, 50, false, QStringLiteral("D3") },
+        { NoteSpellingType::GERMAN, 50, false, QStringLiteral("D3") },
+        { NoteSpellingType::GERMAN_PURE, 50, false, QStringLiteral("D3") },
+        { NoteSpellingType::SOLFEGGIO, 50, false, QStringLiteral("Re3") },
+        { NoteSpellingType::FRENCH, 50, false, QStringLiteral("Ré3") },
+        { NoteSpellingType::STANDARD, 58, true, QStringLiteral("B♭3") },
+        { NoteSpellingType::GERMAN, 58, true, QStringLiteral("B3") },
+        { NoteSpellingType::GERMAN_PURE, 58, true, QStringLiteral("B3") },
+        { NoteSpellingType::GERMAN_PURE, 54, false, QStringLiteral("Fis3") },
+        { NoteSpellingType::FRENCH, 127, false, QStringLiteral("Sol9") },
+    };
+
+    for (const FormatCase& testCase : cases) {
+        EXPECT_EQ(stringTuningPitchToString(testCase.pitch, testCase.useFlats, testCase.spelling), testCase.expected);
+    }
+
+    EXPECT_TRUE(stringTuningPitchToString(INVALID_PITCH, false, NoteSpellingType::STANDARD).isEmpty());
+}
+
+TEST(StringTuningsUtilsTests, InputToPitchParsesLocalizedPopupInputs)
+{
+    const std::vector<ParseCase> cases {
+        { NoteSpellingType::STANDARD, muse::String::fromUtf8("C-1"), 0, false },
+        { NoteSpellingType::STANDARD, muse::String::fromUtf8("E♭3"), 51, true },
+        { NoteSpellingType::STANDARD, muse::String::fromUtf8("E ♭ 3"), 51, true },
+        { NoteSpellingType::SOLFEGGIO, muse::String::fromUtf8("Sol3"), 55, false },
+        { NoteSpellingType::FRENCH, muse::String::fromUtf8("Ré3"), 50, false },
+        { NoteSpellingType::FRENCH, muse::String::fromUtf8("Re\u03013"), 50, false },
+        { NoteSpellingType::GERMAN, muse::String::fromUtf8("B3"), 58, true },
+        { NoteSpellingType::GERMAN_PURE, muse::String::fromUtf8("B3"), 58, true },
+        { NoteSpellingType::GERMAN_PURE, muse::String::fromUtf8("Fis3"), 54, false },
+        { NoteSpellingType::FRENCH, muse::String::fromUtf8("Sol9"), 127, false },
+    };
+
+    for (const ParseCase& testCase : cases) {
+        bool useFlat = false;
+        EXPECT_EQ(stringTuningInputToPitch(testCase.input, testCase.spelling, &useFlat), testCase.expectedPitch);
+        EXPECT_EQ(useFlat, testCase.expectedUseFlat);
+    }
+}
+
+TEST(StringTuningsUtilsTests, InputToPitchRejectsInvalidPopupInputs)
+{
+    EXPECT_EQ(stringTuningInputToPitch(muse::String::fromUtf8("Ré"), NoteSpellingType::FRENCH), mu::engraving::INVALID_PITCH);
+    EXPECT_EQ(stringTuningInputToPitch(muse::String::fromUtf8("B#3"), NoteSpellingType::GERMAN), mu::engraving::INVALID_PITCH);
+    EXPECT_EQ(stringTuningInputToPitch(muse::String::fromUtf8("C-2"), NoteSpellingType::STANDARD), mu::engraving::INVALID_PITCH);
+    EXPECT_EQ(stringTuningInputToPitch(muse::String::fromUtf8("C10"), NoteSpellingType::STANDARD), mu::engraving::INVALID_PITCH);
+    EXPECT_EQ(stringTuningInputToPitch(muse::String::fromUtf8(""), NoteSpellingType::STANDARD), mu::engraving::INVALID_PITCH);
+}


### PR DESCRIPTION
Resolves: #32018 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

## Summary

This pull request makes string tunings follow the note spelling system
selected for chord symbols.

Previously, string tunings could display note names differently from the
rest of the score. With this change, the rendered string tuning text,
accessible labels, and popup note values now all use the active
chord-symbol spelling.

## Behavior

String tunings now display localized note names consistently across the
score and the editing popup. This includes spelling systems such as
German, Solfeggio, and French, while preserving the expected casing and
special note-name behavior for each system.

The popup was also updated so that note values are both displayed and
parsed according to the selected spelling. Localized note input is
accepted, and the step controls continue to work with the active note
representation.

## Implementation

To support this, the popup note parsing and formatting logic was
refactored into reusable helper functions. On the engraving side,
string tuning text generation and accessibility output now derive note
names from the current chord-symbol spelling style.

## Testing

The patch adds engraving and notation scene tests covering:
- localized string tuning text
- accessibility note names
- popup note formatting
- localized popup input parsing
- invalid popup inputs

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
