### PR TITLE
Remove .md (MuseData) file association on macOS

### DIFF
--- a/buildscripts/packaging/macOS/Info.plist.in
+++ b/buildscripts/packaging/macOS/Info.plist.in
@@ -205,6 +205,12 @@
 			<key>LSTypeIsPackage</key>
 			<false/>
 		</dict>
+		<!--
+			THIRD-PARTY FORMATS
+
+			Removed MuseData (.md) files to avoid conflicts with Markdown.
+			See https://github.com/musescore/MuseScore/issues/25330
+		-->
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>Uncompressed MusicXML File</string>
@@ -400,20 +406,6 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>MGU</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>Alternate</string>
-			<key>LSTypeIsPackage</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>MuseData File</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>md</string>
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>


### PR DESCRIPTION
## What

Removes the `MuseData File` document-type declaration from the macOS `Info.plist`, which currently claims the `.md` extension.

## Why

In 2026 `.md` is, with the warmest respect to MuseData, Markdown. Apple ships no system UTI for Markdown, so whichever installed app declares `.md` wins Finder's "Kind" column and Spotlight's `kind:` filter. MuseScore's declaration sensibly sets `LSHandlerRank = Alternate` — but "Alternate from a present app" still outranks "nothing from no one," so on every Mac with MuseScore installed:

- Every `.md` file is labelled **"MuseData File"** in Finder's Kind column.
- `kind:text` Spotlight searches silently exclude `.md` files.
- Setting "Always Open With → TextEdit/Obsidian/etc." via Get Info fixes the double-click default but doesn't touch the Kind label, which sends users on a rather diverting tour of the Launch Services database before they discover this.

It's reported on the MuseScore forum going back to 2019:

- https://musescore.org/en/node/304962
- https://musescore.org/en/node/304972

…and surfaces regularly on the Obsidian forum, MacPowerUsers, MacRumors, etc. As best I can tell it has never been filed on GitHub, which may explain the long quiet — sending it up the right pipe now.

## Impact on MuseData users

The MuseData importer is untouched. Removing the Launch Services declaration only means MuseScore is no longer offered as a handler for double-clicked `.md` files; anyone with actual MuseData files can still open them via **File → Open…** or by dragging onto the MuseScore icon. Given how rare MuseData files are in 2026, the trade — a minor extra step for the handful of MuseData users vs. silent Spotlight/Finder breakage for effectively every macOS user with Markdown files — looks lopsided in the right direction.

## Test plan

- Build the macOS package from this branch.
- `mdls some-markdown-file.md | grep kMDItemKind` → "Plain Text" (or "Markdown Document" if the user has another app providing that UTI), no longer "MuseData File".
- `mdfind 'kind:text'` includes `.md` files again.
- **File → Open…** on a `.md` MuseData fixture still works.
- Dragging a `.md` MuseData fixture onto the MuseScore icon still works.

## Out of scope

- No source-code changes.
- No icon, translation, or documentation changes.
- Windows and Linux packaging files are not touched in this PR; happy to follow up separately if the same pattern exists there and reviewers think it's worth doing.