### PR TITLE
Fix crash when closing score after deleting frame that occupies system

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1563,28 +1563,37 @@ void Score::removeElement(EngravingItem* element)
         ) {
         MeasureBase* mb = toMeasureBase(element);
         measures()->remove(mb);
-        System* system = mb->system();
 
+        System* system = mb->system();
         if (!system) {
-            // vertical boxes are not shown in continuous view so no system
 #ifndef NDEBUG
-            bool noSystemMode = lineMode() && element->isVBoxBase();
-#endif
+            // vertical boxes are not shown in continuous view so no system
+            const bool noSystemMode = lineMode() && element->isVBoxBase();
             assert(noSystemMode || !isOpen());
+#endif
             return;
         }
 
-        Page* page = system->page();
-        if (element->isBox() && system->measures().size() == 1) {
-            auto i = std::find(page->systems().begin(), page->systems().end(), system);
-            page->systems().erase(i);
-            mb->resetExplicitParent();
-            if (page->systems().empty()) {
+        system->removeMeasure(mb);
+
+        // See also InsertRemoveMeasures::removeMeasures()
+        if (element->isBox() && system->measures().empty()) {
+            Page* page = system->page();
+            if (page) {
+                muse::remove(page->systems(), system);
+            }
+
+            muse::remove(m_systems, system);
+            deleteLater(system);
+
+            if (page && page->systems().empty()) {
                 // Remove this page, since it is now empty.
                 // This involves renumbering and repositioning all subsequent pages.
                 PointF pos = page->pos();
                 auto ii = std::find(pages().begin(), pages().end(), page);
                 pages().erase(ii);
+                deleteLater(page);
+
                 while (ii != pages().end()) {
                     page = *ii;
                     page->setPageNumber(page->pageNumber() - 1);
@@ -1595,7 +1604,6 @@ void Score::removeElement(EngravingItem* element)
                 }
             }
         }
-//            setLayout(mb->tick());
         return;
     }
 

--- a/src/engraving/editing/editmeasures.cpp
+++ b/src/engraving/editing/editmeasures.cpp
@@ -339,10 +339,16 @@ void InsertRemoveMeasures::removeMeasures()
             if (page) {
                 // erase system from page
                 muse::remove(page->systems(), s);
-                // erase system from score
-                muse::remove(score->systems(), s);
-                // finally delete system
-                score->deleteLater(s);
+            }
+            // erase system from score
+            muse::remove(score->systems(), s);
+            // finally delete system
+            score->deleteLater(s);
+
+            if (page && page->systems().empty()) {
+                // if page is empty, delete it as well
+                muse::remove(score->pages(), page);
+                score->deleteLater(page);
             }
         }
     }


### PR DESCRIPTION
The deleted frame would still be referenced by the System that contained it, and that System would be deleted from its Page’s list of systems, but not from the Score’s list of systems. Lucky enough, that seems not to cause crashes normally (as far as I know), but upon closing the score, it does cause a crash: the deleted frame is destroyed by the UndoStack (correctly so), but when the frame's System is destroyed as part of the Score destruction, the deleted frame is referenced again.

Solution: properly remove the System’s reference to the frame, and also properly remove the System and its Page when they become empty. This brings the code in line with `InsertRemoveMeasures::removeMeasures()`.

Resolves: https://github.com/musescore/MuseScore/issues/33518