### PR TITLE
Adjust triage workflows for forks

### DIFF
--- a/.github/workflows/triage_issues.yml
+++ b/.github/workflows/triage_issues.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   add_label:
-    if: github.event.action == 'opened'
+    if: github.event.action == 'opened' && github.repository == 'musescore/MuseScore'
     runs-on: ubuntu-slim
     steps:
       - name: "Add label to issue"
@@ -20,7 +20,7 @@ jobs:
           enable-versioned-regex: 0
 
   add_to_projects:
-    if: github.event.action == 'labeled' && github.event.issue.state == 'open'
+    if: github.event.action == 'labeled' && github.event.issue.state == 'open' && github.repository == 'musescore/MuseScore'
     runs-on: ubuntu-slim
     steps:
       - name: "Engraving"
@@ -59,7 +59,7 @@ jobs:
           labeled: "needs design"
 
   assign:
-    if: (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.issue.state == 'open'
+    if: (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.issue.state == 'open' && github.repository == 'musescore/MuseScore'
     runs-on: ubuntu-slim
     steps:
       - name: "Set assignees on issue"

--- a/.github/workflows/triage_prs.yml
+++ b/.github/workflows/triage_prs.yml
@@ -22,7 +22,7 @@ jobs:
             echo "should_add=true" >> $GITHUB_OUTPUT
           fi
       - name: "Add community PR to triaging project"
-        if: steps.check_author.outputs.should_add == 'true'
+        if: steps.check_author.outputs.should_add == 'true' && github.repository == 'musescore/MuseScore'
         uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/musescore/projects/117


### PR DESCRIPTION
Prevent running triage workflows if secrets are missing, which is the case for forks.