### PR TITLE
[4.7.2] fixed #33532: File dialog has changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ set(MUE_COMPILE_MACOS_PRECOMPILED_DEPS_PATH "" CACHE PATH "Path to precompiled d
 
 option(MUSE_GENERATE_COMPILE_COMMANDS "Generate compile commands" OFF)
 option(MUSE_COMPILE_USE_UNITY "Use unity build" ON)
-option(MUSE_COMPILE_USE_COMPILER_CACHE "Try to use compiler cache: tries ccache, sccache, buildcache in that order. Use COMPILER_CACHE_PROGRAM to specify a specific compiler cache program." OFF)
+option(MUSE_COMPILE_USE_COMPILER_CACHE "Try to use compiler cache: tries ccache, sccache, buildcache in that order. Use COMPILER_CACHE_PROGRAM to specify a specific compiler cache program." ON)
 option(MUSE_COMPILE_USE_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
 
 # === System libraries ===

--- a/buildscripts/ci/linux/tools/make_appimage.sh
+++ b/buildscripts/ci/linux/tools/make_appimage.sh
@@ -122,9 +122,9 @@ linuxdeploy --appdir "${appdir}" # adds all shared library dependencies
 linuxdeploy-plugin-qt --appdir "${appdir}" # adds all Qt dependencies
 
 # The system must be used
-if [ -f ${appdir}/lib/libglib-2.0.so.0 ]; then
-  rm -f ${appdir}/lib/libglib-2.0.so.0 
-fi
+for lib in libglib-2.0.so.0 libgio-2.0.so.0 libgmodule-2.0.so.0 libgobject-2.0.so.0; do
+  rm -f "${appdir}/lib/${lib}"
+done
 
 unset QML_SOURCES_PATHS EXTRA_PLATFORM_PLUGINS
 

--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -78,6 +78,7 @@ if(CC_IS_MSVC)
     add_compile_definitions(_UNICODE UNICODE)
     add_compile_definitions(_USE_MATH_DEFINES)
     add_compile_definitions(NOMINMAX)
+    add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
     
     add_link_options("/NODEFAULTLIB:LIBCMT")
 endif()


### PR DESCRIPTION
Resolves: #33532

`linuxdeploy-plugin-qt`'s continuous artefact was rebuilt between two nightly runs (14 May → 15 May) and started bundling `libgio`, `libgmodule` and `libgobject` alongside libglib. The existing workaround only removed `libglib`, leaving a mixed glib stack.

On hosts this breaks `libqgtk3.so` with: `undefined symbol: g_task_set_static_name`
The host's libgdk-pixbuf calls this symbol from the host's libgio, but loads our older bundled libgio instead. The GTK platform theme fails to load and Qt falls back to its legacy QFileDialog.

Fix: also remove `libgio`, `libgmodule` and `libgobject` from `AppDir/usr/lib/ `after deploy, so the host's glib stack is used as a whole.