### PR TITLE
Fix incremental builds of MuseScoreQuickLookPreviewExtension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-cmake_minimum_required(VERSION 3.28) 
+if (APPLE)
+    # Required to prevent issues with incremental builds of MuseScoreQuickLookPreviewExtension
+    # (https://github.com/musescore/MuseScore/pull/33554)
+    cmake_minimum_required(VERSION 3.31)
+else()
+    # Required to use C++20 modules in the future.
+    cmake_minimum_required(VERSION 3.28)
+endif()
 
 project(MuseScoreStudio LANGUAGES C CXX)
 

--- a/build.cmake
+++ b/build.cmake
@@ -17,7 +17,12 @@ if(NOT DEFINED CMAKE_SCRIPT_MODE_FILE)
     )
 endif()
 
-cmake_minimum_required(VERSION 3.22) # should match version in CMakeLists.txt
+# should match version requirement in CMakeLists.txt
+if (APPLE)
+    cmake_minimum_required(VERSION 3.31)
+else()
+    cmake_minimum_required(VERSION 3.28)
+endif()
 
 # CMake arguments up to '-P' (ignore these)
 set(i "1")


### PR DESCRIPTION
Without this, incremental builds (including those caused by changes to other modules, like `engraving`) would fail with the following mysterious error:

```
[build] [12/23 (0.9/s avg 0.9/s); ETA: 00:11 ( 51%)]   Linking Swift executable src/macos_integration/MuseScoreQuickLookPreviewExtension.appex/Contents/MacOS/MuseScoreQuickLookPreviewExtension
[build] FAILED: [code=1] src/macos_integration/MuseScoreQuickLookPreviewExtension.appex/Contents/MacOS/MuseScoreQuickLookPreviewExtension src/macos_integration/CMakeFiles/MuseScoreQuickLookPreviewExtension.dir/PreviewProvider.swift.o 
[build] : && /usr/bin/swiftc -j 14 -num-threads 14 -emit-executable -o src/macos_integration/MuseScoreQuickLookPreviewExtension.appex/Contents/MacOS/MuseScoreQuickLookPreviewExtension -emit-dependencies -DKORS_LOGGER_QT_SUPPORT -DKORS_PROFILER_ENABLED -DMUSE_STRING_DEBUG_HACK -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_OPENGL_LIB -DQT_QMLINTEGRATION_LIB -DQT_QML_DEBUG -DQT_QML_LIB -DQT_QUICK_LIB -DQT_WIDGETS_LIB -Onone -g -incremental -color-diagnostics -sanitize=address -application-extension -cxx-interoperability-mode=default -output-file-map src/macos_integration/CMakeFiles/MuseScoreQuickLookPreviewExtension.dir/Debug/output-file-map.json -Onone -g -incremental -I /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/macos_integration -I /Users/casper/Desktop/MuseScore/MuseScoreGB/src/macos_integration -I /Users/casper/Desktop/MuseScore/MuseScoreGB/src -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse/framework -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse/framework/global -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse/src -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse/src/framework -I /Users/casper/Desktop/MuseScore/MuseScoreGB/muse/src/framework/global -I /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/macos_integration/MuseScoreQuickLookPreviewExtension_autogen/include -I /Users/casper/Qt/6.11.1/macos/lib/QtCore.framework/Headers -F /Users/casper/Qt/6.11.1/macos/lib -I /Users/casper/Qt/6.11.1/macos/mkspecs/macx-clang -I /Users/casper/Qt/6.11.1/macos/include -I /Users/casper/Qt/6.11.1/macos/lib/QtGui.framework/Headers -I /Users/casper/Qt/6.11.1/macos/lib/QtQuick.framework/Headers -I /Users/casper/Qt/6.11.1/macos/lib/QtQml.framework/Headers -I /Users/casper/Qt/6.11.1/macos/include/QtQmlIntegration -I /Users/casper/Qt/6.11.1/macos/lib/QtNetwork.framework/Headers -I /Users/casper/Qt/6.11.1/macos/lib/QtOpenGL.framework/Headers -I /Users/casper/Qt/6.11.1/macos/lib/QtWidgets.framework/Headers src/macos_integration/CMakeFiles/MuseScoreQuickLookPreviewExtension.dir/MuseScoreQuickLookPreviewExtension_autogen/mocs_compilation.cpp.o /Users/casper/Desktop/MuseScore/MuseScoreGB/src/macos_integration/PreviewProvider.swift src/macos_integration/CMakeFiles/MuseScoreQuickLookPreviewExtension.dir/previewprovider.cpp.o -sanitize=address -Xlinker -e -Xlinker _NSExtensionMain -F /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/global  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/importexport/imagesexport  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/project  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/notation  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/src/engraving  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/draw  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/global  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/pch  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/draw/freetype/freetype-2.14.1  -L /Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/muse/framework/draw/harfbuzz  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib  -L /Users/casper/Qt/6.11.1/macos/lib   -L /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx   -L /usr/lib/swift   -L /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift -Xlinker -rpath -Xlinker /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker /Users/casper/Qt/6.11.1/macos/lib  muse/framework/global/libmuse_global.a  src/importexport/imagesexport/libiex_imagesexport.a  src/project/libproject.a  src/notation/libnotation.a  src/engraving/libengraving.a  muse/framework/draw/libmuse_draw.a  muse/framework/global/libmuse_global.a  -lz  /Users/casper/Qt/6.11.1/macos/lib/QtWidgets.framework/Versions/A/QtWidgets  muse/framework/pch/libmuse_pch.a  /Users/casper/Qt/6.11.1/macos/lib/QtQuick.framework/Versions/A/QtQuick  /Users/casper/Qt/6.11.1/macos/lib/QtOpenGL.framework/Versions/A/QtOpenGL  /Users/casper/Qt/6.11.1/macos/lib/QtQml.framework/Versions/A/QtQml  /Users/casper/Qt/6.11.1/macos/lib/QtNetwork.framework/Versions/A/QtNetwork  muse/framework/draw/freetype/freetype-2.14.1/libfreetyped.a  muse/framework/draw/harfbuzz/libharfbuzz.a  /Users/casper/Qt/6.11.1/macos/lib/QtSvg.framework/Versions/A/QtSvg  /Users/casper/Qt/6.11.1/macos/lib/QtGui.framework/Versions/A/QtGui  -framework AppKit  -framework OpenGL  -framework ImageIO  -framework Metal  /Users/casper/Qt/6.11.1/macos/lib/QtConcurrent.framework/Versions/A/QtConcurrent  /Users/casper/Qt/6.11.1/macos/lib/QtCore.framework/Versions/A/QtCore  -framework IOKit  -framework DiskArbitration  -framework UniformTypeIdentifiers  -lc++ && :
[build] error: cannotResolveTempPath(MuseScoreQuickLookPreviewExtension-1.swiftmodule)

```