### PR TITLE
Fix crash on closing second window

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -33,7 +33,6 @@
 #include "async/async.h"
 #include "audio/common/soundfonttypes.h"
 
-#include "defer.h"
 #include "translation.h"
 #include "log.h"
 
@@ -226,11 +225,9 @@ bool ApplicationActionController::quit(bool isAllInstances, const muse::io::path
     }
 
     m_quiting = true;
-    DEFER {
-        m_quiting = false;
-    };
 
     if (!projectFilesController()->closeOpenedProject(false)) {
+        m_quiting = false;
         return false;
     }
 
@@ -246,6 +243,8 @@ bool ApplicationActionController::quit(bool isAllInstances, const muse::io::path
         multiwindowsProvider()->notifyAboutWindowWasQuited();
     }
 
+    //! NOTE the following destroys the IoC context and `this` with it,
+    //! so don't access `this` after this point!
     if (isAllInstances) {
         multiwindowsProvider()->quitForAll();
     } else {

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -49,11 +49,15 @@ constexpr int CURRENT_URI_CHANGED_TIMEOUT = 500; // msec
 
 void UiContextResolver::init()
 {
+    m_currentUriChangedTimer.setSingleShot(true);
+    m_currentUriChangedTimer.setInterval(CURRENT_URI_CHANGED_TIMEOUT);
+    QObject::connect(&m_currentUriChangedTimer, &QTimer::timeout, [this]() {
+        updateCurrentUiContext();
+    });
+
     interactive()->currentUri().ch.onReceive(this, [this](const Uri&) {
         //! NOTE Let the page/dialog open and show itself first
-        QTimer::singleShot(CURRENT_URI_CHANGED_TIMEOUT, [this]() {
-            updateCurrentUiContext();
-        });
+        m_currentUriChangedTimer.start();
     });
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {

--- a/src/context/internal/uicontextresolver.h
+++ b/src/context/internal/uicontextresolver.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#include <QTimer>
+
 #include "../iuicontextresolver.h"
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
@@ -55,5 +57,8 @@ private:
 
     muse::ui::UiContext m_currentUiContext;
     muse::async::Notification m_currentUiContextChanged;
+
+    //! NOTE Owned by this resolver, so that a pending timeout is cancelled when the resolver is destroyed
+    QTimer m_currentUriChangedTimer;
 };
 }


### PR DESCRIPTION
Caused by accessing `ApplicationActionController::m_quitting` after calling `multiwindowsProvider()->quitWindow(iocContext());`, which destroys the IoC context, and the `ApplicationActionController` with it.