### PR TITLE
Fix #33534: saving unchecked Show stem slash state

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1050,7 +1050,7 @@ void TWrite::write(const Chord* item, XmlWriter& xml, WriteContext& ctx)
     if (item->hook() && item->hook()->isUserModified()) {
         write(item->hook(), xml, ctx);
     }
-    if (item->showStemSlash() && item->isUserModified()) {
+    if (item->showStemSlash() != item->propertyDefault(Pid::SHOW_STEM_SLASH).toBool()) {
         xml.tag("showStemSlash", item->showStemSlash());
     }
     if (item->stemSlash() && item->stemSlash()->isUserModified()) {


### PR DESCRIPTION
Resolves: #33534 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Before this change, `showStemSlash` was only written when it was true.
As a result, explicitly unchecking "Show stem slash" for an acciaccatura was not preserved after saving and reopening the score.

This change writes `showStemSlash` when it differs from its default value, so an explicit false value is saved as well.

Manual test:
1. Create an acciaccatura.
2. Uncheck Properties > Show stem slash.
3. Save the score.
4. Confirm that `<showStemSlash>0</showStemSlash>` is written to the `.mscx`.
5. Reopen the score and confirm that the stem slash remains hidden.

<img width="459" height="247" alt="スクリーンショット 2026-05-24 024411" src="https://github.com/user-attachments/assets/bff7b00c-4cea-4a9b-b794-0b7c20949c93" />
<img width="516" height="856" alt="スクリーンショット 2026-05-24 023129" src="https://github.com/user-attachments/assets/77687313-3931-41ee-a3b6-ca8cd41833f3" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
