### PR TITLE
Fix #33553: Allow Style System page to resize vertically

### DIFF
--- a/src/notationscene/widgets/editstyle.ui
+++ b/src/notationscene/widgets/editstyle.ui
@@ -3844,6 +3844,24 @@
       <widget class="QWidget" name="PageSystem">
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
+         <widget class="QScrollArea" name="scrollArea_system">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollArea_system_contents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>660</width>
+             <height>806</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_system">
+        <item>
          <widget class="QGroupBox" name="groupBox_systemBrackets">
           <property name="title">
            <string>System brackets</string>
@@ -4804,6 +4822,10 @@
         </item>
        </layout>
       </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
       <widget class="QWidget" name="PageInstrumentNames">
        <layout class="QVBoxLayout" name="verticalLayout_55">
         <property name="spacing">
@@ -13655,6 +13677,7 @@ followed by dashes</string>
   <tabstop>evenFooterL</tabstop>
   <tabstop>evenFooterC</tabstop>
   <tabstop>evenFooterR</tabstop>
+  <tabstop>scrollArea_system</tabstop>
   <tabstop>bracketWidth</tabstop>
   <tabstop>resetBracketThickness</tabstop>
   <tabstop>akkoladeWidth</tabstop>


### PR DESCRIPTION
Resolves: #33553

The System page in Format > Style used a plain page widget, so its full size hint became the dialog minimum height. This wraps the page contents in a frameless scroll area, matching other tall Style pages, so the dialog can resize vertically while all controls stay reachable.

Validation:
- `xmllint --noout src/notationscene/widgets/editstyle.ui`
- `git diff --check`

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)