### PR TITLE
Fix #33520: Allow unhidden instruments in part scores

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
@@ -29,6 +29,15 @@ using namespace mu::instrumentsscene;
 using namespace mu::notation;
 using namespace muse;
 
+static bool isPartItemEnabled(const Part* part, bool partExists)
+{
+    if (!partExists) {
+        return true;
+    }
+
+    return part->isSharedPart() || !(part->sharedPart() && part->sharedPart()->enabled());
+}
+
 PartTreeItem::PartTreeItem(IMasterNotationPtr masterNotation, INotationPtr notation, QObject* parent, LayoutPanelItemType::ItemType type)
     : AbstractLayoutPanelTreeItem(type, masterNotation, notation, parent), Contextable(iocCtxForQmlObject(this))
 {
@@ -46,7 +55,7 @@ void PartTreeItem::init(const notation::Part* masterPart)
     const Part* part = notation()->parts()->part(masterPart->id());
     m_partExists = part != nullptr;
     bool visible = m_partExists && part->getProperty(Pid::VISIBLE).toBool();
-    bool enabled = m_partExists && !(part->sharedPart() && part->sharedPart()->enabled());
+    bool enabled = isPartItemEnabled(part, m_partExists);
 
     if (!m_partExists) {
         part = masterPart;
@@ -84,9 +93,7 @@ void PartTreeItem::onScoreChanged(const mu::engraving::ScoreChanges&)
 
     m_ignoreVisibilityChange = true;
     setIsVisible(m_partExists && m_part->getProperty(Pid::VISIBLE).toBool());
-    if (!m_part->isSharedPart()) {
-        setIsEnabled(!(m_part->sharedPart() && m_part->sharedPart()->enabled()));
-    }
+    setIsEnabled(isPartItemEnabled(m_part, m_partExists));
     m_ignoreVisibilityChange = false;
 }
 


### PR DESCRIPTION
Resolves: #33520

Part-score Layout panel rows for instruments that do not yet exist in the current part score were initialized disabled, so the visibility control could not create and show them until another score change refreshed the row state. This keeps nonexistent master-part rows enabled and reuses the same enabled-state rule during score-change refresh, while existing rows still respect enabled shared parts.

Validation:
- `git diff --check`
- `cmake -P /tmp/MuseScore/muse/buildscripts/ci/checkcodestyle/checkcodestyle.cmake src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal`

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)