### PR TITLE
Fix #33486: Application of spacers in measures with chord symbols [4.7.3]

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1832,16 +1832,11 @@ std::vector<EngravingItem*> filterTargetElements(const Selection& sel, Engraving
         uniqueMeasures = toMeasureRepeat(dropElement)->numMeasures() == 1;
         break;
 
-    // Add these elements only once per staff in range selections, else once per staff per measure:
-    case ElementType::SPACER:
-    case ElementType::STAFFTYPE_CHANGE:
-        uniqueStaves = true;
-        uniqueMeasures = !sel.isRange();
-        break;
-
     // Add these elements once per measure in list selections, else once total:
     case ElementType::MARKER:
     case ElementType::JUMP:
+    case ElementType::SPACER:  //! HACK - these should be applied "per staff" in range selections (see issue #33486)
+    case ElementType::STAFFTYPE_CHANGE:  //! HACK - these should be applied "per staff" in range selections (see issue #33486)
     case ElementType::VBOX:
     case ElementType::HBOX:
     case ElementType::TBOX:
@@ -1862,10 +1857,7 @@ std::vector<EngravingItem*> filterTargetElements(const Selection& sel, Engraving
     case ElementType::ACTION_ICON: {
         const ActionIconType actionType = toActionIcon(dropElement)->actionType();
         switch (actionType) {
-        case ActionIconType::STAFF_TYPE_CHANGE:
-            uniqueStaves = true;
-            uniqueMeasures = !sel.isRange();
-            break;
+        case ActionIconType::STAFF_TYPE_CHANGE: //! HACK - these should be applied "per staff" in range selections (see issue #33486)
         case ActionIconType::VFRAME:
         case ActionIconType::HFRAME:
         case ActionIconType::TFRAME:


### PR DESCRIPTION
Resolves: #33486

The bug was introduced in ddac4c5c145d9a293355505e3ea855911cf48c08 where we introduced some "per staff" logic for spacers and staff type changes in range selections. The idea was that, for range selections spanning multiple staves, we'd apply one of these elements for each staff in the selection range.

The problem we have is as follows ([here](https://github.com/musescore/MuseScore/blob/18ff48a6cd195f94d58131530647f073ca447536/src/engraving/dom/utils.cpp#L1902-L1909) in the `uniqueStaves` conditional in `filterTargetElements`):

1. We go through each element in the range selection and check its staff
2. If we haven't seen an element at this staff before, we'll add it to our "result"

This means we actually might be skipping elements that accept a drop for our desired type if they exist in the same staff as an element we've already seen. Indeed that's what's happening here - we reach a chord symbol (which doesn't accept spacers) and return it without looking at any other elements in the staff. Since we don't have access to the `EditData` in ths method, it isn't possible to know whether a given element will accept the drop.

The first solution that came to mind was to add the _measure_ of each element we find to our result, basically [how things were before](https://github.com/musescore/MuseScore/commit/ddac4c5c145d9a293355505e3ea855911cf48c08#diff-26bd3810778f254978e70572c39acd61846cc6e935d6376e25848725b8597e3fL2545). I didn't have any luck with this approach though, since we also made some changes around track indices and applying elements in the meantime (#30990 & 81995866017f89cb13f528b6737216785e481e8c).

So it's pretty clear a deeper look is required here, and that any fix will probably go beyond anything we should attempt in a patch. My solution in this PR is simply to treat spacers and staff type changes the same as vertical boxes etc, and apply them once to the "first navigation element" in a range. This is probably a hack since we're losing the per-staff behaviour ("probably" because I'm not sure the desired interaction for spacers and ranges was ever really given a design pass).