### PR TITLE
Reduce AppleClang requirement to version 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ message(STATUS "CXX: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 
 include(CheckCompilerVersion)
 check_compile_version("Clang" 20 "https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment")
-check_compile_version("AppleClang" 21 "https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment")
+check_compile_version("AppleClang" 16 "https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment")
 check_compile_version("GCC" 14 "https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment")
 check_compile_version("MSVC" 19.40 "https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment")
 


### PR DESCRIPTION
This PR reduces the required AppleClang compiler from 21 to 16.

This change is motivated by the fact that AppleClang version 21 is only available in the latest dot releases of macOS 26 (Tahoe). This is a very restrictive requirement, and it runs against the previous policy of being fairly inclusive towards community development environments. Forcing all macOS contributors to upgrade to Tahoe means forcing them to give up software that currently works, peripherals that currently work, and potentially it may force them to buy new computers even though their current computers work just fine.

AppleClang has supported the main corpus of C++20 for many years, going back to prepandemic times. But some of the more advanced features are only available in later versions (for details, see the [Apple C++ Language support page](https://developer.apple.com/xcode/cpp/).) I have chosen 16 as the cutoff for the following reasons.

- It matches the minimum target runtime OS (macOS 14.7)
- I am able to confirm that the build works on my macOS 14.7 machine.
- The only missing C++20 features in AppleClang 16 are fairly esoteric edge cases.

I would encourage the team to accept this PR unless there is an immediate plan to utilize a language or libc++ feature that is unavailable in AppleClang 16 that makes our lives substantially better. Because at it stands now, the AppleClang 21 requirement is making life substantially worse for macOS contributors without any obvious benefit.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
