### PR TITLE
Call tuplet->setTick in MNX importer when creating Tuplet.

### DIFF
--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -503,7 +503,7 @@ void MsScWriter::doTriplet(mu::engraving::Chord* cr, StartStop triplet)
         tuplet = new mu::engraving::Tuplet(currentMeasure);
         tuplet->setTrack(0);
         tuplet->setRatio(mu::engraving::Fraction(3, 2));
-//            tuplet->setTick(tick);
+        tuplet->setTick(tick);
         currentMeasure->add(tuplet);
     } else if (triplet == StartStop::ST_STOP) {
         if (tuplet) {

--- a/src/importexport/mnx/internal/import/mnximporter.h
+++ b/src/importexport/mnx/internal/import/mnximporter.h
@@ -104,7 +104,7 @@ private:
                                       const mnx::FractionValue& startTick, const std::stack<engraving::Tuplet*>& activeTuplets,
                                       engraving::TremoloTwoChord* activeTremolo);
     engraving::Tuplet* createTuplet(const mnx::sequence::Tuplet& mnxTuplet, engraving::Measure* measure,
-                                    engraving::track_idx_t curTrackIdx);
+                                    engraving::track_idx_t curTrackIdx, const mnx::FractionValue& startTick);
     void createTremolo(const mnx::sequence::MultiNoteTremolo& mnxTremolo, engraving::Measure* measure, engraving::track_idx_t curTrackIdx,
                        const mnx::FractionValue& startTick, const mnx::FractionValue& endTick);
     void processSequencePass2(const mnx::Sequence& sequence, engraving::Measure* measure);

--- a/src/importexport/mnx/internal/import/mnximporter.h
+++ b/src/importexport/mnx/internal/import/mnximporter.h
@@ -103,8 +103,8 @@ private:
     engraving::ChordRest* importEvent(const mnx::sequence::Event& event, engraving::track_idx_t, engraving::Measure* measure,
                                       const mnx::FractionValue& startTick, const std::stack<engraving::Tuplet*>& activeTuplets,
                                       engraving::TremoloTwoChord* activeTremolo);
-    engraving::Tuplet* createTuplet(const mnx::sequence::Tuplet& mnxTuplet, engraving::Measure* measure,
-                                    engraving::track_idx_t curTrackIdx, const mnx::FractionValue& startTick);
+    engraving::Tuplet* createTuplet(const mnx::sequence::Tuplet& mnxTuplet, engraving::Measure* measure, engraving::track_idx_t curTrackIdx,
+                                    const mnx::FractionValue& startTick);
     void createTremolo(const mnx::sequence::MultiNoteTremolo& mnxTremolo, engraving::Measure* measure, engraving::track_idx_t curTrackIdx,
                        const mnx::FractionValue& startTick, const mnx::FractionValue& endTick);
     void processSequencePass2(const mnx::Sequence& sequence, engraving::Measure* measure);

--- a/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
+++ b/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
@@ -560,7 +560,8 @@ Note* MnxImporter::createNote(const mnx::sequence::Note& mnxNote, Chord* chord, 
 //   Create a MuseScore tuplet from an MNX tuplet container.
 //---------------------------------------------------------
 
-Tuplet* MnxImporter::createTuplet(const mnx::sequence::Tuplet& mnxTuplet, Measure* measure, track_idx_t curTrackIdx)
+Tuplet* MnxImporter::createTuplet(const mnx::sequence::Tuplet& mnxTuplet, Measure* measure, track_idx_t curTrackIdx,
+                                  const mnx::FractionValue& startTick)
 {
     TDuration baseLen = toMuseScoreDuration(mnxTuplet.outer().duration());
     mnx::FractionValue ratioDivisor = mnxTuplet.outer() / mnxTuplet.inner().duration();
@@ -574,6 +575,7 @@ Tuplet* MnxImporter::createTuplet(const mnx::sequence::Tuplet& mnxTuplet, Measur
     Tuplet* t = Factory::createTuplet(measure);
     t->setTrack(curTrackIdx);
     t->setParent(measure);
+    t->setTick(measure->tick() + toMuseScoreFraction(startTick));
     t->setRatio(tupletRatio);
     t->setBaseLen(baseLen);
     Fraction f = baseLen.fraction() * tupletRatio.denominator();
@@ -818,7 +820,7 @@ bool MnxImporter::importNonGraceEvents(const mnx::Sequence& sequence, Measure* m
                 activeTuplets.push(nullptr);
                 return mnx::util::SequenceWalkControl::SkipChildren;
             }
-            if (Tuplet* t = createTuplet(mnxTuplet, measure, curTrackIdx)) {
+            if (Tuplet* t = createTuplet(mnxTuplet, measure, curTrackIdx, ctx.elapsedTime)) {
                 if (!activeTuplets.empty()) {
                     DO_ASSERT(activeTuplets.top());
                     if (activeTuplets.top()) {


### PR DESCRIPTION
This PR is a continuation of #33366 and part of the resolution of #33360. It adds a call to `Tuplet::setTick` when creating a tuplet in the MNX importer.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
