### PR TITLE
[4.7.3] Fix #33561: fix hang on explode caused by a tie with startNote == endNote

### DIFF
--- a/src/engraving/playback/renderers/bendsrenderer.cpp
+++ b/src/engraving/playback/renderers/bendsrenderer.cpp
@@ -75,8 +75,13 @@ bool BendsRenderer::isMultibendPart(const Note* note)
     }
 
     const Note* currNote = note->firstTiedNote(IGNORE_UNPLAYABLE);
+    std::unordered_set<const Note*> visited;
 
     while (currNote && currNote->play()) {
+        if (!visited.insert(currNote).second) {
+            break;
+        }
+
         if (currNote->bendFor() || note->bendBack()) {
             return true;
         }
@@ -127,11 +132,16 @@ void BendsRenderer::renderMultibend(const Note* startNote, const RenderingContex
 {
     const Note* currNote = startNote;
     const GuitarBend* currBend = nullptr;
+    std::unordered_set<const Note*> visited;
 
     mpe::PlaybackEventList bendEvents;
     BendTimeFactorMap bendTimeFactorMap;
 
     while (currNote) {
+        if (!visited.insert(currNote).second) {
+            break;
+        }
+
         RenderingContext currNoteCtx = buildRenderingContext(currNote, startNoteCtx);
         if (!currNote->tieBack() || !currNote->tieBack()->playSpanner()) {
             renderNote(currNote, currNoteCtx, bendEvents);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33561

Indirectly caused by changes in this commit: https://github.com/musescore/MuseScore/commit/f66e1b7aa2c88dc27dff6591537fedb42e29788f