### PR TITLE
Fix #33408: Broken "edit mode drag" of notes [4.7.3]

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4500,6 +4500,8 @@ bool NotationInteraction::handleKeyPress(QKeyEvent* event)
     m_editData.hRaster = hRaster;
     m_editData.vRaster = vRaster;
 
+    m_editData.isEditMode = isEditingElement();
+
     //: Means: an editing operation triggered by a keystroke
     startEdit(TranslatableString("undoableAction", "Keystroke edit"));
 


### PR DESCRIPTION
Resolves: #33408

This problem was introduced in 0f7cac1a5c8bf08bdfc93ab73bc0ca48d7eb5237. Since we don't set `m_editData.isEditMode` in `handleKeyPress`, we don't dispatch to `Note::dragInEditMode`. We then continue as if it were a "regular drag" which is why we get such unpredictable behaviour.

@cbjeukendrup it would be great to get your eyes on this if possible! As far as I can tell notes are the only place where we check this flag, so this should be a very safe fix.