### PR TITLE
Fix crashes on saving scores with parts

### DIFF
--- a/src/engraving/infrastructure/eid.cpp
+++ b/src/engraving/infrastructure/eid.cpp
@@ -182,8 +182,8 @@ EID EID::fromStdString(const std::string_view& s)
 EID EID::newUnique()
 {
     static std::random_device s_device;
-    static std::mt19937_64 s_engine(s_device());
-    static std::uniform_int_distribution<uint64_t> s_unifDist;
+    thread_local static std::mt19937_64 s_engine(s_device());
+    thread_local static std::uniform_int_distribution<uint64_t> s_unifDist;
 
     return EID(s_unifDist(s_engine), s_unifDist(s_engine));
 }

--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -37,6 +37,7 @@ EID EIDRegister::newEIDForItem(const EngravingObject* item)
 
 void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
 {
+    std::lock_guard lock(m_mutex);
     IF_ASSERT_FAILED(eid.isValid() && item) {
         return;
     }
@@ -58,6 +59,7 @@ void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
 
 void EIDRegister::removeItem(const EngravingObject* item)
 {
+    std::lock_guard lock(m_mutex);
     // NOTE: needed only when elements are removed during read (e.g. broken spanners)
 
     auto itemIter = m_itemToEid.find(const_cast<EngravingObject*>(item));
@@ -80,6 +82,7 @@ void EIDRegister::removeItem(const EngravingObject* item)
 
 EngravingObject* EIDRegister::itemFromEID(const EID& eid) const
 {
+    std::shared_lock lock(m_mutex);
     auto iter = m_eidToItem.find(eid);
     IF_ASSERT_FAILED(iter != m_eidToItem.end()) {
         return nullptr;
@@ -89,6 +92,7 @@ EngravingObject* EIDRegister::itemFromEID(const EID& eid) const
 
 EID EIDRegister::EIDFromItem(const EngravingObject* item) const
 {
+    std::shared_lock lock(m_mutex);
     auto iter = m_itemToEid.find(const_cast<EngravingObject*>(item));
     return iter == m_itemToEid.end() ? EID::invalid() : iter->second;
 }

--- a/src/engraving/infrastructure/eidregister.h
+++ b/src/engraving/infrastructure/eidregister.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <shared_mutex>
 
 #include "eid.h"
 #include "../types/types.h"
@@ -49,5 +50,7 @@ private:
     std::unordered_map<EngravingObject*, EID> m_itemToEid;
 
     uint64_t m_maxValTestMode = 0;
+
+    mutable std::shared_mutex m_mutex;
 };
 }

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -231,8 +231,10 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::Writ
 
     ctx.setCurTrack(0);
 
-    // Let's decide: write midi mapping to a file or not
-    score->masterScore()->checkMidiMapping();
+    if (score->isMaster()) {
+        // Let's decide: write midi mapping to a file or not
+        score->masterScore()->checkMidiMapping();
+    }
 
     auto shouldWritePart = [&ctx, score, staffStart, staffEnd](const Part* part) {
         if (!ctx.shouldWriteRange()) {

--- a/src/engraving/rw/write/writer.h
+++ b/src/engraving/rw/write/writer.h
@@ -32,7 +32,7 @@
 namespace mu::engraving::write {
 class Writer : public rw::IWriter
 {
-    muse::GlobalInject<muse::IApplication> application;
+    muse::GlobalThreadSafeInject<muse::IApplication> application;
 
 public:
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33516

This PR makes EIDRegister and EID::newUnique thread safe, as during saving we create and register new EIDs. 
I have also made sure `MasterScore::checkMidiMapping` is only called for the master score. There's no need to repeat this for each part.

The crashes were introduced in https://github.com/musescore/MuseScore/pull/32702