### PR TITLE
Properties panel: remove unused `resetProperties` method

### DIFF
--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/emptystaves/emptystavesvisiblitysettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/emptystaves/emptystavesvisiblitysettingsmodel.h
@@ -42,7 +42,6 @@ public:
 
     void createProperties() override {}
     void loadProperties() override;
-    void resetProperties() override {}
     void requestElements() override {}
 
     bool isEmpty() const override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.cpp
@@ -127,16 +127,6 @@ void AppearanceSettingsModel::loadProperties()
     updatemeasurementUnits();
 }
 
-void AppearanceSettingsModel::resetProperties()
-{
-    m_leadingSpace->resetToDefault();
-    m_minimumDistance->resetToDefault();
-    m_measureWidth->resetToDefault();
-    m_color->resetToDefault();
-    m_arrangeOrder->resetToDefault();
-    m_offset->resetToDefault();
-}
-
 void AppearanceSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.h
@@ -60,7 +60,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* leadingSpace() const;
     PropertyItem* measureWidth() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
@@ -113,14 +113,6 @@ void GeneralSettingsModel::loadProperties()
     updateAreGeneralPropertiesAvailable();
 }
 
-void GeneralSettingsModel::resetProperties()
-{
-    m_isVisible->resetToDefault();
-    m_isAutoPlaceAllowed->resetToDefault();
-    m_isPlayable->resetToDefault();
-    m_isSmall->resetToDefault();
-}
-
 void GeneralSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.h
@@ -66,7 +66,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
     void onVisibleChanged(bool visible);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/arpeggioplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/arpeggioplaybackmodel.cpp
@@ -52,11 +52,6 @@ void ArpeggioPlaybackModel::loadProperties()
     loadPropertyItem(m_stretch, formatDoubleFunc);
 }
 
-void ArpeggioPlaybackModel::resetProperties()
-{
-    m_stretch->resetToDefault();
-}
-
 PropertyItem* ArpeggioPlaybackModel::stretch() const
 {
     return m_stretch;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/arpeggioplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/arpeggioplaybackmodel.h
@@ -42,7 +42,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_stretch = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/breathplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/breathplaybackmodel.cpp
@@ -51,11 +51,6 @@ void BreathPlaybackModel::loadProperties()
     loadPropertyItem(m_pauseTime, formatDoubleFunc);
 }
 
-void BreathPlaybackModel::resetProperties()
-{
-    m_pauseTime->resetToDefault();
-}
-
 PropertyItem* BreathPlaybackModel::pauseTime() const
 {
     return m_pauseTime;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/breathplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/breathplaybackmodel.h
@@ -44,7 +44,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_pauseTime = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/fermataplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/fermataplaybackmodel.cpp
@@ -56,11 +56,6 @@ void FermataPlaybackModel::loadProperties()
     });
 }
 
-void FermataPlaybackModel::resetProperties()
-{
-    m_timeStretch->resetToDefault();
-}
-
 PropertyItem* FermataPlaybackModel::timeStretch() const
 {
     return m_timeStretch;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/fermataplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/fermataplaybackmodel.h
@@ -44,7 +44,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_timeStretch = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/glissandoplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/glissandoplaybackmodel.cpp
@@ -54,11 +54,6 @@ void GlissandoPlaybackModel::loadProperties()
     loadPropertyItem(m_styleType);
 }
 
-void GlissandoPlaybackModel::resetProperties()
-{
-    m_styleType->resetToDefault();
-}
-
 void GlissandoPlaybackModel::updateIsHarpGliss()
 {
     bool isHarpGliss = false;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/glissandoplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/glissandoplaybackmodel.h
@@ -48,7 +48,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     void updateIsHarpGliss();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/gradualtempochangeplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/gradualtempochangeplaybackmodel.cpp
@@ -75,9 +75,3 @@ void GradualTempoChangePlaybackModel::loadProperties()
 
     loadPropertyItem(m_tempoEasingMethod);
 }
-
-void GradualTempoChangePlaybackModel::resetProperties()
-{
-    m_tempoChangeFactor->resetToDefault();
-    m_tempoEasingMethod->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/gradualtempochangeplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/gradualtempochangeplaybackmodel.h
@@ -47,7 +47,6 @@ public:
 protected:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_tempoChangeFactor = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/noteplaybackmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/noteplaybackmodel.cpp
@@ -55,12 +55,6 @@ void NotePlaybackModel::loadProperties()
     });
 }
 
-void NotePlaybackModel::resetProperties()
-{
-    m_tuning->resetToDefault();
-    m_velocity->resetToDefault();
-}
-
 PropertyItem* NotePlaybackModel::tuning() const
 {
     return m_tuning;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/noteplaybackmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/playback/internal/noteplaybackmodel.h
@@ -45,7 +45,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_tuning = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/measures/measuressettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/measures/measuressettingsmodel.h
@@ -47,7 +47,6 @@ public:
 
     void createProperties() override { }
     void loadProperties() override;
-    void resetProperties() override { }
     void requestElements() override { }
 
     bool isEmpty() const override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/modelwithvoiceandpositionoptions.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/modelwithvoiceandpositionoptions.cpp
@@ -56,14 +56,6 @@ void ModelWithVoiceAndPositionOptions::loadProperties()
     updateIsStaveCenteringAvailable();
 }
 
-void ModelWithVoiceAndPositionOptions::resetProperties()
-{
-    m_voiceBasedPosition->resetToDefault();
-    m_voiceAssignment->resetToDefault();
-    m_voice->setValue(0);
-    m_centerBetweenStaves->resetToDefault();
-}
-
 void ModelWithVoiceAndPositionOptions::onNotationChanged(const PropertyIdSet&, const StyleIdSet&)
 {
     loadProperties();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/modelwithvoiceandpositionoptions.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/modelwithvoiceandpositionoptions.h
@@ -57,7 +57,6 @@ public:
 
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const PropertyIdSet&, const StyleIdSet&) override;
 
     PropertyItem* voiceBasedPosition() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/accidentals/accidentalsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/accidentals/accidentalsettingsmodel.cpp
@@ -63,12 +63,6 @@ void AccidentalSettingsModel::loadProperties()
     updateIsStackingOrderAvailableAndEnabled();
 }
 
-void AccidentalSettingsModel::resetProperties()
-{
-    m_bracketType->resetToDefault();
-    m_stackingOrderOffset->resetToDefault();
-}
-
 PropertyItem* AccidentalSettingsModel::bracketType() const
 {
     return m_bracketType;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/accidentals/accidentalsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/accidentals/accidentalsettingsmodel.h
@@ -46,7 +46,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* bracketType() const;
     PropertyItem* isSmall() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ambituses/ambitussettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ambituses/ambitussettingsmodel.cpp
@@ -84,20 +84,6 @@ void AmbitusSettingsModel::loadProperties()
     loadPropertyItem(m_lineThickness, formatDoubleFunc);
 }
 
-void AmbitusSettingsModel::resetProperties()
-{
-    m_noteheadGroup->resetToDefault();
-    m_noteheadType->resetToDefault();
-
-    m_direction->resetToDefault();
-    m_lineThickness->resetToDefault();
-
-    m_topTpc->resetToDefault();
-    m_bottomTpc->resetToDefault();
-    m_topPitch->resetToDefault();
-    m_bottomPitch->resetToDefault();
-}
-
 void AmbitusSettingsModel::matchRangesToStaff()
 {
     m_topTpc->resetToDefault();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ambituses/ambitussettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ambituses/ambitussettingsmodel.h
@@ -53,7 +53,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* noteheadGroup() const;
     PropertyItem* noteheadType() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/articulations/articulationsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/articulations/articulationsettingsmodel.cpp
@@ -70,11 +70,6 @@ void ArticulationSettingsModel::loadProperties()
     updateIsPlacementAvailable();
 }
 
-void ArticulationSettingsModel::resetProperties()
-{
-    m_placement->resetToDefault();
-}
-
 void ArticulationSettingsModel::updateIsPlacementAvailable()
 {
     bool available = false;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/articulations/articulationsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/articulations/articulationsettingsmodel.h
@@ -49,7 +49,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     void updateIsPlacementAvailable();
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.cpp
@@ -86,18 +86,6 @@ void BarlineSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void BarlineSettingsModel::resetProperties()
-{
-    m_type->resetToDefault();
-    m_playCount->resetToDefault();
-    m_playCountText->resetToDefault();
-    m_playCountTextSetting->resetToDefault();
-    m_isSpanToNextStaff->resetToDefault();
-    m_spanFrom->resetToDefault();
-    m_spanTo->resetToDefault();
-    m_hasToShowTips->resetToDefault();
-}
-
 void BarlineSettingsModel::onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                                              const mu::engraving::StyleIdSet&)
 {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.h
@@ -72,7 +72,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/beams/beammodesmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/beams/beammodesmodel.cpp
@@ -72,11 +72,6 @@ void BeamModesModel::loadProperties()
     });
 }
 
-void BeamModesModel::resetProperties()
-{
-    m_mode->resetToDefault();
-}
-
 PropertyItem* BeamModesModel::mode() const
 {
     return m_mode;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/beams/beammodesmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/beams/beammodesmodel.h
@@ -46,7 +46,6 @@ public slots:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_mode = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/bends/bendsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/bends/bendsettingsmodel.cpp
@@ -102,14 +102,6 @@ void BendSettingsModel::loadProperties()
     loadBendCurve();
 }
 
-void BendSettingsModel::resetProperties()
-{
-    m_bendDirection->resetToDefault();
-    m_showHoldLine->resetToDefault();
-    m_diveTabPos->resetToDefault();
-    m_dipVibratoType->resetToDefault();
-}
-
 bool BendSettingsModel::areSettingsAvailable() const
 {
     return m_elementList.count() == 1; // Bend propertiespanel doesn't support multiple selection

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/bends/bendsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/bends/bendsettingsmodel.h
@@ -58,7 +58,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* bendDirection() const;
     PropertyItem* showHoldLine() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/brackets/bracketsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/brackets/bracketsettingsmodel.cpp
@@ -79,14 +79,6 @@ void BracketSettingsModel::loadProperties()
     updateIsGroupBracket();
 }
 
-void BracketSettingsModel::resetProperties()
-{
-    m_bracketColumnPosition->resetToDefault();
-    m_bracketSpanStaves->resetToDefault();
-    m_longName->resetToDefault();
-    m_shortName->resetToDefault();
-}
-
 void BracketSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/brackets/bracketsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/brackets/bracketsettingsmodel.h
@@ -51,7 +51,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* bracketColumnPosition() const;
     PropertyItem* bracketSpanStaves() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.cpp
@@ -73,16 +73,6 @@ void ChordSymbolSettingsModel::loadProperties()
     loadPropertyItem(m_doNotStackModifiers);
 }
 
-void ChordSymbolSettingsModel::resetProperties()
-{
-    m_isLiteral->resetToDefault();
-    m_voicingType->resetToDefault();
-    m_durationType->resetToDefault();
-    m_verticalAlign->resetToDefault();
-    m_bassScale->resetToDefault();
-    m_doNotStackModifiers->resetToDefault();
-}
-
 PropertyItem* ChordSymbolSettingsModel::isLiteral() const
 {
     return m_isLiteral;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.h
@@ -49,7 +49,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* isLiteral() const;
     PropertyItem* voicingType() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/clefs/clefsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/clefs/clefsettingsmodel.cpp
@@ -56,12 +56,6 @@ void ClefSettingsModel::loadProperties()
     updatePropertiesAvailable();
 }
 
-void ClefSettingsModel::resetProperties()
-{
-    m_shouldShowCourtesy->resetToDefault();
-    m_clefToBarlinePosition->resetToDefault();
-}
-
 PropertyItem* ClefSettingsModel::shouldShowCourtesy() const
 {
     return m_shouldShowCourtesy;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/clefs/clefsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/clefs/clefsettingsmodel.h
@@ -43,7 +43,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* shouldShowCourtesy() const;
     PropertyItem* clefToBarlinePosition() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/dynamics/dynamicsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/dynamics/dynamicsettingsmodel.cpp
@@ -89,22 +89,6 @@ void DynamicsSettingsModel::loadProperties()
     updateFramePropertiesAvailability();
 }
 
-void DynamicsSettingsModel::resetProperties()
-{
-    ModelWithVoiceAndPositionOptions::resetProperties();
-
-    m_avoidBarLines->resetToDefault();
-    m_dynamicScale->resetToDefault();
-    m_centerOnNotehead->resetToDefault();
-
-    m_frameType->resetToDefault();
-    m_frameBorderColor->resetToDefault();
-    m_frameFillColor->resetToDefault();
-    m_frameThickness->resetToDefault();
-    m_frameMargin->resetToDefault();
-    m_frameCornerRadius->resetToDefault();
-}
-
 PropertyItem* DynamicsSettingsModel::avoidBarLines() const
 {
     return m_avoidBarLines;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/dynamics/dynamicsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/dynamics/dynamicsettingsmodel.h
@@ -50,7 +50,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* avoidBarLines() const;
     PropertyItem* dynamicScale() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/expressions/expressionsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/expressions/expressionsettingsmodel.cpp
@@ -54,13 +54,6 @@ void ExpressionSettingsModel::loadProperties()
     loadPropertyItem(m_snapExpression);
 }
 
-void ExpressionSettingsModel::resetProperties()
-{
-    ModelWithVoiceAndPositionOptions::resetProperties();
-
-    m_snapExpression->resetToDefault();
-}
-
 PropertyItem* ExpressionSettingsModel::snapExpression() const
 {
     return m_snapExpression;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/expressions/expressionsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/expressions/expressionsettingsmodel.h
@@ -40,7 +40,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* snapExpression() const;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fermatas/fermatasettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fermatas/fermatasettingsmodel.cpp
@@ -50,11 +50,6 @@ void FermataSettingsModel::loadProperties()
     loadPropertyItem(m_placementType);
 }
 
-void FermataSettingsModel::resetProperties()
-{
-    m_placementType->resetToDefault();
-}
-
 PropertyItem* FermataSettingsModel::placementType() const
 {
     return m_placementType;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fermatas/fermatasettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fermatas/fermatasettingsmodel.h
@@ -39,7 +39,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* placementType() const;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordssettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordssettingsmodel.cpp
@@ -62,11 +62,6 @@ void FretFrameChordsSettingsModel::loadProperties()
     updateHasInvisibleChords();
 }
 
-void FretFrameChordsSettingsModel::resetProperties()
-{
-    m_listOrder->resetToDefault();
-}
-
 mu::engraving::FBox* FretFrameChordsSettingsModel::fretBox() const
 {
     if (m_elementList.isEmpty()) {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordssettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordssettingsmodel.h
@@ -69,7 +69,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframesettingsmodel.cpp
@@ -96,25 +96,6 @@ void FretFrameSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void FretFrameSettingsModel::resetProperties()
-{
-    m_textScale->resetToDefault();
-    m_diagramScale->resetToDefault();
-    m_columnGap->resetToDefault();
-    m_rowGap->resetToDefault();
-    m_chordsPerRow->resetToDefault();
-    m_horizontalAlignment->resetToDefault();
-    m_gapAbove->resetToDefault();
-    m_gapBelow->resetToDefault();
-    m_frameLeftMargin->resetToDefault();
-    m_frameRightMargin->resetToDefault();
-    m_frameTopMargin->resetToDefault();
-    m_frameBottomMargin->resetToDefault();
-    m_isSizeSpatiumDependent->resetToDefault();
-    m_paddingToNotationAbove->resetToDefault();
-    m_paddingToNotationBelow->resetToDefault();
-}
-
 void FretFrameSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframesettingsmodel.h
@@ -74,7 +74,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/horizontalframesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/horizontalframesettingsmodel.cpp
@@ -64,15 +64,6 @@ void HorizontalFrameSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void HorizontalFrameSettingsModel::resetProperties()
-{
-    m_frameWidth->resetToDefault();
-    m_leftGap->resetToDefault();
-    m_rightGap->resetToDefault();
-    m_shouldDisplayKeysAndBrackets->resetToDefault();
-    m_isSizeSpatiumDependent->resetToDefault();
-}
-
 void HorizontalFrameSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/horizontalframesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/horizontalframesettingsmodel.h
@@ -52,7 +52,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/textframesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/textframesettingsmodel.cpp
@@ -71,19 +71,6 @@ void TextFrameSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void TextFrameSettingsModel::resetProperties()
-{
-    m_gapAbove->resetToDefault();
-    m_gapBelow->resetToDefault();
-    m_frameLeftMargin->resetToDefault();
-    m_frameRightMargin->resetToDefault();
-    m_frameTopMargin->resetToDefault();
-    m_frameBottomMargin->resetToDefault();
-    m_isSizeSpatiumDependent->resetToDefault();
-    m_paddingToNotationAbove->resetToDefault();
-    m_paddingToNotationBelow->resetToDefault();
-}
-
 void TextFrameSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/textframesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/textframesettingsmodel.h
@@ -59,7 +59,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/verticalframesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/verticalframesettingsmodel.cpp
@@ -136,20 +136,6 @@ void VerticalFrameSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void VerticalFrameSettingsModel::resetProperties()
-{
-    m_frameHeight->resetToDefault();
-    m_gapAbove->resetToDefault();
-    m_gapBelow->resetToDefault();
-    m_frameLeftMargin->resetToDefault();
-    m_frameRightMargin->resetToDefault();
-    m_frameTopMargin->resetToDefault();
-    m_frameBottomMargin->resetToDefault();
-    m_isSizeSpatiumDependent->resetToDefault();
-    m_paddingToNotationAbove->resetToDefault();
-    m_paddingToNotationBelow->resetToDefault();
-}
-
 void VerticalFrameSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/verticalframesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/verticalframesettingsmodel.h
@@ -65,7 +65,6 @@ private:
     void onFrameHeightReset(const mu::engraving::Pid pid);
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
@@ -128,18 +128,6 @@ void FretDiagramSettingsModel::loadProperties()
     loadPropertyItem(m_verticalAlign);
 }
 
-void FretDiagramSettingsModel::resetProperties()
-{
-    m_scale->resetToDefault();
-    m_stringsCount->resetToDefault();
-    m_fretsCount->resetToDefault();
-    m_fretNumber->resetToDefault();
-    m_isNutVisible->resetToDefault();
-    m_placement->resetToDefault();
-    m_showFingerings->resetToDefault();
-    m_verticalAlign->resetToDefault();
-}
-
 PropertyItem* FretDiagramSettingsModel::scale() const
 {
     return m_scale;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/fretdiagramsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/fretdiagramsettingsmodel.h
@@ -64,7 +64,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* scale() const;
     PropertyItem* stringsCount() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/images/imagesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/images/imagesettingsmodel.cpp
@@ -93,16 +93,6 @@ void ImageSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void ImageSettingsModel::resetProperties()
-{
-    m_shouldScaleToFrameSize->resetToDefault();
-    m_height->resetToDefault();
-    m_width->resetToDefault();
-    m_isAspectRatioLocked->resetToDefault();
-    m_isSizeInSpatiums->resetToDefault();
-    m_isImageFramed->resetToDefault();
-}
-
 void ImageSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/images/imagesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/images/imagesettingsmodel.h
@@ -53,7 +53,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/instrumentname/instrumentnamesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/instrumentname/instrumentnamesettingsmodel.h
@@ -49,6 +49,5 @@ private:
 
     void createProperties() override {}
     void loadProperties() override {}
-    void resetProperties() override {}
 };
 }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/jumps/jumpsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/jumps/jumpsettingsmodel.cpp
@@ -55,14 +55,6 @@ void JumpSettingsModel::loadProperties()
     loadPropertyItem(m_hasToPlayRepeats);
 }
 
-void JumpSettingsModel::resetProperties()
-{
-    m_jumpTo->resetToDefault();
-    m_playUntil->resetToDefault();
-    m_continueAt->resetToDefault();
-    m_hasToPlayRepeats->resetToDefault();
-}
-
 PropertyItem* JumpSettingsModel::jumpTo() const
 {
     return m_jumpTo;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/jumps/jumpsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/jumps/jumpsettingsmodel.h
@@ -42,7 +42,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* jumpTo() const;
     PropertyItem* playUntil() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.cpp
@@ -74,12 +74,6 @@ void KeySignatureSettingsModel::loadProperties()
     m_mode->setIsEnabled(enableMode);
 }
 
-void KeySignatureSettingsModel::resetProperties()
-{
-    m_hasToShowCourtesy->resetToDefault();
-    m_mode->resetToDefault();
-}
-
 PropertyItem* KeySignatureSettingsModel::hasToShowCourtesy() const
 {
     return m_hasToShowCourtesy;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.h
@@ -40,7 +40,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* hasToShowCourtesy() const;
     PropertyItem* mode() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/chordbracketsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/chordbracketsettingsmodel.cpp
@@ -54,12 +54,6 @@ void ChordBracketSettingsModel::loadProperties()
     updateIsBracket();
 }
 
-void ChordBracketSettingsModel::resetProperties()
-{
-    m_bracketRightSide->resetToDefault();
-    m_hookPos->resetToDefault();
-}
-
 void ChordBracketSettingsModel::updateIsBracket()
 {
     bool isBracket = true;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/chordbracketsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/chordbracketsettingsmodel.h
@@ -53,7 +53,6 @@ signals:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_bracketRightSide = nullptr;
     PropertyItem* m_hookPos = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/glissandosettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/glissandosettingsmodel.cpp
@@ -125,18 +125,6 @@ void GlissandoSettingsModel::loadProperties()
     onUpdateGlissPropertiesAvailability();
 }
 
-void GlissandoSettingsModel::resetProperties()
-{
-    m_lineType->resetToDefault();
-    m_showText->resetToDefault();
-    m_text->resetToDefault();
-
-    m_thickness->resetToDefault();
-    m_lineStyle->resetToDefault();
-    m_dashLineLength->resetToDefault();
-    m_dashGapLength->resetToDefault();
-}
-
 void GlissandoSettingsModel::onUpdateGlissPropertiesAvailability()
 {
     bool isStraightLine = m_lineType->value().value<mu::engraving::GlissandoType>() == mu::engraving::GlissandoType::STRAIGHT;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/glissandosettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/glissandosettingsmodel.h
@@ -60,7 +60,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onUpdateGlissPropertiesAvailability();
 
     PropertyItem* m_lineType = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/gradualtempochangesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/gradualtempochangesettingsmodel.cpp
@@ -56,14 +56,6 @@ void GradualTempoChangeSettingsModel::loadProperties()
     loadPropertyItem(m_snapAfter);
 }
 
-void GradualTempoChangeSettingsModel::resetProperties()
-{
-    TextLineSettingsModel::resetProperties();
-
-    m_snapBefore->resetToDefault();
-    m_snapAfter->resetToDefault();
-}
-
 PropertyItem* GradualTempoChangeSettingsModel::snapBefore() const
 {
     return m_snapBefore;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/gradualtempochangesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/gradualtempochangesettingsmodel.h
@@ -45,7 +45,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_snapBefore = nullptr;
     PropertyItem* m_snapAfter = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinlinesettingsmodel.cpp
@@ -81,14 +81,6 @@ void HairpinLineSettingsModel::loadProperties()
     loadPropertyItem(m_snapAfter);
 }
 
-void HairpinLineSettingsModel::resetProperties()
-{
-    TextLineSettingsModel::resetProperties();
-
-    m_snapBefore->resetToDefault();
-    m_snapAfter->resetToDefault();
-}
-
 void HairpinLineSettingsModel::requestElements()
 {
     m_elementList = m_repository->findElementsByType(mu::engraving::ElementType::HAIRPIN, [this](const mu::engraving::EngravingItem* element) -> bool {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinlinesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinlinesettingsmodel.h
@@ -51,7 +51,6 @@ public:
 protected:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
     void requestElements() override;
 
 private:

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinsettingsmodel.cpp
@@ -84,15 +84,6 @@ void HairpinSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void HairpinSettingsModel::resetProperties()
-{
-    HairpinLineSettingsModel::resetProperties();
-
-    m_isNienteCircleVisible->resetToDefault();
-    m_height->resetToDefault();
-    m_continuousHeight->resetToDefault();
-}
-
 void HairpinSettingsModel::requestElements()
 {
     m_elementList = m_repository->findElementsByType(mu::engraving::ElementType::HAIRPIN, [](const mu::engraving::EngravingItem* element) -> bool {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/hairpinsettingsmodel.h
@@ -48,7 +48,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
     void requestElements() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/lyricslinesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/lyricslinesettingsmodel.cpp
@@ -71,9 +71,3 @@ void LyricsLineSettingsModel::loadProperties()
     loadPropertyItem(m_thickness);
     loadPropertyItem(m_verse);
 }
-
-void LyricsLineSettingsModel::resetProperties()
-{
-    m_thickness->resetToDefault();
-    m_verse->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/lyricslinesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/lyricslinesettingsmodel.h
@@ -52,7 +52,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_thickness = nullptr;
     PropertyItem* m_verse = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/ottavasettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/ottavasettingsmodel.cpp
@@ -109,11 +109,3 @@ void OttavaSettingsModel::loadProperties()
     loadPropertyItem(m_showNumbersOnly);
     updateStartAndEndHookTypes();
 }
-
-void OttavaSettingsModel::resetProperties()
-{
-    TextLineSettingsModel::resetProperties();
-
-    m_ottavaType->resetToDefault();
-    m_showNumbersOnly->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/ottavasettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/ottavasettingsmodel.h
@@ -49,7 +49,6 @@ protected:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_ottavaType = nullptr;
     PropertyItem* m_showNumbersOnly = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/slurandtiesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/slurandtiesettingsmodel.cpp
@@ -143,14 +143,6 @@ void SlurAndTieSettingsModel::loadProperties()
     updateisLineStyleAvailable();
 }
 
-void SlurAndTieSettingsModel::resetProperties()
-{
-    m_lineStyle->resetToDefault();
-    m_direction->resetToDefault();
-    m_tiePlacement->resetToDefault();
-    m_minLength->resetToDefault();
-}
-
 void SlurAndTieSettingsModel::updateIsTiePlacementAvailable()
 {
     bool available = false;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/slurandtiesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/slurandtiesettingsmodel.h
@@ -74,7 +74,6 @@ signals:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     void updateIsTiePlacementAvailable();
     void updateIsMinLengthAvailable();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/textlinesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/textlinesettingsmodel.cpp
@@ -135,42 +135,6 @@ void TextLineSettingsModel::loadProperties()
     updateStartAndEndHookTypes();
 }
 
-void TextLineSettingsModel::resetProperties()
-{
-    ModelWithVoiceAndPositionOptions::resetProperties();
-
-    QList<PropertyItem*> allProperties {
-        m_isLineVisible,
-        m_allowDiagonal,
-        m_lineStyle,
-        m_thickness,
-        m_dashLineLength,
-        m_dashGapLength,
-        m_startHookType,
-        m_endHookType,
-        m_startHookHeight,
-        m_endHookHeight,
-        m_startLineArrowHeight,
-        m_startLineArrowWidth,
-        m_endLineArrowHeight,
-        m_endLineArrowWidth,
-        m_gapBetweenTextAndLine,
-        m_placement,
-        m_beginningText,
-        m_beginningTextOffset,
-        m_continuousText,
-        m_continuousTextOffset,
-        m_endText,
-        m_endTextOffset
-    };
-
-    for (PropertyItem* property : allProperties) {
-        if (property) {
-            property->resetToDefault();
-        }
-    }
-}
-
 PropertyItem* TextLineSettingsModel::isLineVisible() const
 {
     return m_isLineVisible;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/textlinesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/textlinesettingsmodel.h
@@ -157,7 +157,6 @@ protected:
 
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/vibratosettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/vibratosettingsmodel.cpp
@@ -82,9 +82,3 @@ void VibratoSettingsModel::loadProperties()
     loadPropertyItem(m_lineType);
     loadPropertyItem(m_placement);
 }
-
-void VibratoSettingsModel::resetProperties()
-{
-    m_lineType->resetToDefault();
-    m_placement->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/vibratosettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/vibratosettingsmodel.h
@@ -46,7 +46,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_lineType = nullptr;
     PropertyItem* m_placement = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/voltasettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/voltasettingsmodel.cpp
@@ -77,10 +77,3 @@ void VoltaSettingsModel::loadProperties()
     loadPropertyItem(m_repeatCount);
     updateStartAndEndHookTypes();
 }
-
-void VoltaSettingsModel::resetProperties()
-{
-    TextLineSettingsModel::resetProperties();
-
-    m_repeatCount->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/voltasettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/voltasettingsmodel.h
@@ -45,7 +45,6 @@ protected:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_repeatCount = nullptr;
 };

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lyrics/lyricssettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lyrics/lyricssettingsmodel.cpp
@@ -51,12 +51,6 @@ void LyricsSettingsModel::loadProperties()
     loadPropertyItem(m_avoidBarlines);
 }
 
-void LyricsSettingsModel::resetProperties()
-{
-    m_verse->resetToDefault();
-    m_avoidBarlines->resetToDefault();
-}
-
 PropertyItem* LyricsSettingsModel::verse() const
 {
     return m_verse;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lyrics/lyricssettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lyrics/lyricssettingsmodel.h
@@ -40,7 +40,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* verse() const;
     PropertyItem* avoidBarlines() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/markers/markersettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/markers/markersettingsmodel.cpp
@@ -56,14 +56,6 @@ void MarkerSettingsModel::loadProperties()
     loadPropertyItem(m_centerOnSymbol);
 }
 
-void MarkerSettingsModel::resetProperties()
-{
-    m_type->resetToDefault();
-    m_label->resetToDefault();
-    m_position->resetToDefault();
-    m_centerOnSymbol->resetToDefault();
-}
-
 PropertyItem* MarkerSettingsModel::type() const
 {
     return m_type;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/markers/markersettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/markers/markersettingsmodel.h
@@ -43,7 +43,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* type() const;
     PropertyItem* label() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/measurerepeats/measurerepeatsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/measurerepeats/measurerepeatsettingsmodel.cpp
@@ -50,11 +50,6 @@ void MeasureRepeatSettingsModel::loadProperties()
     loadPropertyItem(m_numberPosition);
 }
 
-void MeasureRepeatSettingsModel::resetProperties()
-{
-    m_numberPosition->resetToDefault();
-}
-
 PropertyItem* MeasureRepeatSettingsModel::numberPosition() const
 {
     return m_numberPosition;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/measurerepeats/measurerepeatsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/measurerepeats/measurerepeatsettingsmodel.h
@@ -40,7 +40,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* numberPosition() const;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.cpp
@@ -62,12 +62,6 @@ void MMRestSettingsModel::loadProperties()
     updateNumberOptionsEnabled();
 }
 
-void MMRestSettingsModel::resetProperties()
-{
-    m_isNumberVisible->resetToDefault();
-    m_numberPosition->resetToDefault();
-}
-
 PropertyItem* MMRestSettingsModel::isNumberVisible() const
 {
     return m_isNumberVisible;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.h
@@ -42,7 +42,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* isNumberVisible() const;
     PropertyItem* numberPosition() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/beams/beamsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/beams/beamsettingsmodel.cpp
@@ -157,23 +157,6 @@ void BeamSettingsModel::loadBeamHeightProperties()
     m_cachedBeamHeights.second = m_beamHeightRight->value().toDouble();
 }
 
-void BeamSettingsModel::resetProperties()
-{
-    m_featheringHeightLeft->resetToDefault();
-    m_featheringHeightRight->resetToDefault();
-    m_beamHeightLeft->resetToDefault();
-    m_beamHeightRight->resetToDefault();
-    m_forceHorizontal->resetToDefault();
-    m_customPositioned->resetToDefault();
-    m_stemDirection->resetToDefault();
-    m_crossStaffMove->resetToDefault();
-
-    m_cachedBeamHeights = PairF();
-
-    setFeatheringMode(BeamTypes::FeatheringMode::FEATHERING_NONE);
-    setIsBeamHeightLocked(false);
-}
-
 PropertyItem* BeamSettingsModel::forceHorizontal()
 {
     return m_forceHorizontal;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/beams/beamsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/beams/beamsettingsmodel.h
@@ -97,7 +97,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/chords/chordsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/chords/chordsettingsmodel.cpp
@@ -61,13 +61,6 @@ void ChordSettingsModel::loadProperties()
     updateShowStemSlashEnabled();
 }
 
-void ChordSettingsModel::resetProperties()
-{
-    m_isStemless->resetToDefault();
-    m_showStemSlash->resetToDefault();
-    updateShowStemSlashEnabled();
-}
-
 PropertyItem* ChordSettingsModel::isStemless() const
 {
     return m_isStemless;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/chords/chordsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/chords/chordsettingsmodel.h
@@ -61,7 +61,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     void updateShowStemSlashVisible();
     void updateShowStemSlashEnabled();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/hooks/hooksettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/hooks/hooksettingsmodel.cpp
@@ -50,11 +50,6 @@ void HookSettingsModel::loadProperties()
     updatemeasurementUnits();
 }
 
-void HookSettingsModel::resetProperties()
-{
-    m_offset->resetToDefault();
-}
-
 void HookSettingsModel::onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet, const mu::engraving::StyleIdSet&)
 {
     if (muse::contains(changedPropertyIdSet, mu::engraving::Pid::DURATION)

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/hooks/hooksettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/hooks/hooksettingsmodel.h
@@ -43,7 +43,6 @@ protected:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/noteheads/noteheadsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/noteheads/noteheadsettingsmodel.cpp
@@ -121,19 +121,6 @@ void NoteheadSettingsModel::loadProperties()
     updatemeasurementUnits();
 }
 
-void NoteheadSettingsModel::resetProperties()
-{
-    m_isHeadHidden->resetToDefault();
-    m_isHeadSmall->resetToDefault();
-    m_hasHeadParentheses->resetToDefault();
-    m_headDirection->resetToDefault();
-    m_headGroup->resetToDefault();
-    m_headType->resetToDefault();
-    m_headSystem->resetToDefault();
-    m_dotPosition->resetToDefault();
-    m_offset->resetToDefault();
-}
-
 void NoteheadSettingsModel::onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet, const mu::engraving::StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/noteheads/noteheadsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/noteheads/noteheadsettingsmodel.h
@@ -69,7 +69,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/stems/stemsettingsmodel.cpp
@@ -70,14 +70,6 @@ void StemSettingsModel::loadProperties()
     emit useStraightNoteFlagsChanged();
 }
 
-void StemSettingsModel::resetProperties()
-{
-    m_thickness->resetToDefault();
-    m_length->resetToDefault();
-    m_stemDirection->resetToDefault();
-    m_offset->resetToDefault();
-}
-
 PropertyItem* StemSettingsModel::thickness() const
 {
     return m_thickness;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/stems/stemsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/stems/stemsettingsmodel.h
@@ -60,7 +60,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ornaments/ornamentsettingsmodel.cpp
@@ -149,18 +149,6 @@ void OrnamentSettingsModel::loadProperties()
     updateIsIntervalBelowAvailable();
 }
 
-void OrnamentSettingsModel::resetProperties()
-{
-    m_placement->resetToDefault();
-    m_intervalAbove->resetToDefault();
-    m_intervalBelow->resetToDefault();
-    m_intervalStep->resetToDefault();
-    m_intervalType->resetToDefault();
-    m_showAccidental->resetToDefault();
-    m_showCueNote->resetToDefault();
-    m_startOnUpperNote->resetToDefault();
-}
-
 PropertyItem* OrnamentSettingsModel::placement() const
 {
     return m_placement;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ornaments/ornamentsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/ornaments/ornamentsettingsmodel.h
@@ -56,7 +56,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* placement() const;
     PropertyItem* intervalAbove() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/playcounttext/playcounttextsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/playcounttext/playcounttextsettingsmodel.cpp
@@ -57,12 +57,6 @@ void PlayCountTextSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void PlayCountTextSettingsModel::resetProperties()
-{
-    m_playCountText->resetToDefault();
-    m_playCountTextSetting->resetToDefault();
-}
-
 void PlayCountTextSettingsModel::onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                                                    const mu::engraving::StyleIdSet&)
 {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/playcounttext/playcounttextsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/playcounttext/playcounttextsettingsmodel.h
@@ -45,7 +45,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/beams/restbeamsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/beams/restbeamsettingsmodel.h
@@ -44,7 +44,6 @@ private:
     void createProperties() override {}
     void requestElements() override;
     void loadProperties() override {}
-    void resetProperties() override {}
 
     void onCurrentNotationChanged() override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/restsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/restsettingsmodel.cpp
@@ -51,9 +51,4 @@ void RestSettingsModel::loadProperties()
 {
     loadPropertyItem(m_alignWithOtherRests);
 }
-
-void RestSettingsModel::resetProperties()
-{
-    m_alignWithOtherRests->resetToDefault();
-}
 } // namespace mu::propertiespanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/restsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/rests/restsettingsmodel.h
@@ -44,7 +44,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
 private:
     PropertyItem* m_alignWithOtherRests = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -59,15 +59,6 @@ void SectionBreakSettingsModel::loadProperties()
     loadPropertyItem(m_showCourtesySignatures);
 }
 
-void SectionBreakSettingsModel::resetProperties()
-{
-    m_shouldStartWithLongInstrNames->resetToDefault();
-    m_shouldResetBarNums->resetToDefault();
-    m_pauseDuration->resetToDefault();
-    m_firstSystemIndent->resetToDefault();
-    m_showCourtesySignatures->resetToDefault();
-}
-
 PropertyItem* SectionBreakSettingsModel::shouldStartWithLongInstrNames() const
 {
     return m_shouldStartWithLongInstrNames;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/sectionbreaks/sectionbreaksettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/sectionbreaks/sectionbreaksettingsmodel.h
@@ -44,7 +44,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* shouldStartWithLongInstrNames() const;
     PropertyItem* shouldResetBarNums() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/spacers/spacersettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/spacers/spacersettingsmodel.cpp
@@ -52,11 +52,6 @@ void SpacerSettingsModel::loadProperties()
     loadPropertyItem(m_spacerHeight, formatDoubleFunc);
 }
 
-void SpacerSettingsModel::resetProperties()
-{
-    m_spacerHeight->resetToDefault();
-}
-
 void SpacerSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     if (muse::contains(changedPropertyIdSet, Pid::SPACE)) {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/spacers/spacersettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/spacers/spacersettingsmodel.h
@@ -40,7 +40,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* spacerHeight() const;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stafftype/stafftypesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stafftype/stafftypesettingsmodel.cpp
@@ -94,30 +94,6 @@ void StaffTypeSettingsModel::loadProperties()
     loadPropertyItem(m_staffShortName);
 }
 
-void StaffTypeSettingsModel::resetProperties()
-{
-    m_isSmall->resetToDefault();
-    m_verticalOffset->resetToDefault();
-    m_scale->resetToDefault();
-
-    m_lineCount->resetToDefault();
-    m_lineDistance->resetToDefault();
-    m_stepOffset->resetToDefault();
-    m_isInvisible->resetToDefault();
-    m_color->resetToDefault();
-
-    m_noteheadSchemeType->resetToDefault();
-    m_isStemless->resetToDefault();
-    m_shouldShowBarlines->resetToDefault();
-    m_shouldShowLedgerLines->resetToDefault();
-    m_shouldGenerateClefs->resetToDefault();
-    m_shouldGenerateTimeSignatures->resetToDefault();
-    m_shouldGenerateKeySignatures->resetToDefault();
-
-    m_staffLongName->resetToDefault();
-    m_staffShortName->resetToDefault();
-}
-
 PropertyItem* StaffTypeSettingsModel::isSmall() const
 {
     return m_isSmall;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stafftype/stafftypesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stafftype/stafftypesettingsmodel.h
@@ -59,7 +59,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* isSmall() const;
     PropertyItem* verticalOffset() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stringtunings/stringtuningssettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stringtunings/stringtuningssettingsmodel.h
@@ -40,7 +40,6 @@ public:
 private:
     void createProperties() override { }
     void loadProperties() override { }
-    void resetProperties() override { }
     void requestElements() override { }
 
     bool isEmpty() const override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/symbols/symbolsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/symbols/symbolsettingsmodel.cpp
@@ -68,14 +68,6 @@ void SymbolSettingsModel::loadProperties()
     loadPropertyItem(m_symAngle);
 }
 
-void SymbolSettingsModel::resetProperties()
-{
-    m_sym->resetToDefault();
-    m_scoreFont->resetToDefault();
-    m_symbolSize->resetToDefault();
-    m_symAngle->resetToDefault();
-}
-
 PropertyItem* SymbolSettingsModel::sym() const
 {
     return m_sym;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/symbols/symbolsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/symbols/symbolsettingsmodel.h
@@ -48,7 +48,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* sym() const;
     PropertyItem* scoreFont() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tempos/temposettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tempos/temposettingsmodel.cpp
@@ -79,12 +79,6 @@ void TempoSettingsModel::loadProperties()
     loadPropertyItem(m_tempo, formatDoubleFunc);
 }
 
-void TempoSettingsModel::resetProperties()
-{
-    m_isFollowText->resetToDefault();
-    m_tempo->resetToDefault();
-}
-
 PropertyItem* TempoSettingsModel::isFollowText() const
 {
     return m_isFollowText;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tempos/temposettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tempos/temposettingsmodel.h
@@ -42,7 +42,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* isFollowText() const;
     PropertyItem* tempo() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/timesignatures/timesignaturesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/timesignatures/timesignaturesettingsmodel.cpp
@@ -100,13 +100,6 @@ void TimeSignatureSettingsModel::loadProperties()
     m_verticalScale->setIsEnabled(!m_isGenerated);
 }
 
-void TimeSignatureSettingsModel::resetProperties()
-{
-    m_horizontalScale->resetToDefault();
-    m_verticalScale->resetToDefault();
-    m_shouldShowCourtesy->resetToDefault();
-}
-
 void TimeSignatureSettingsModel::showTimeSignatureProperties()
 {
     dispatcher()->dispatch("time-signature-properties");

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/timesignatures/timesignaturesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/timesignatures/timesignaturesettingsmodel.h
@@ -45,7 +45,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* horizontalScale() const;
     PropertyItem* verticalScale() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolobars/tremolobarsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolobars/tremolobarsettingsmodel.cpp
@@ -73,14 +73,6 @@ void TremoloBarSettingsModel::loadProperties()
     loadPropertyItem(m_scale, formatDoubleFunc);
 }
 
-void TremoloBarSettingsModel::resetProperties()
-{
-    m_type->resetToDefault();
-    m_curve->resetToDefault();
-    m_lineThickness->resetToDefault();
-    m_scale->resetToDefault();
-}
-
 PropertyItem* TremoloBarSettingsModel::type() const
 {
     return m_type;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolobars/tremolobarsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolobars/tremolobarsettingsmodel.h
@@ -45,7 +45,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* type() const;
     PropertyItem* curve() const;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolos/tremolosettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolos/tremolosettingsmodel.cpp
@@ -74,12 +74,6 @@ void TremoloSettingsModel::loadProperties()
     loadProperties(PropertyIdSet { Pid::TREMOLO_STYLE, Pid::STEM_DIRECTION });
 }
 
-void TremoloSettingsModel::resetProperties()
-{
-    m_style->resetToDefault();
-    m_direction->resetToDefault();
-}
-
 void TremoloSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
 {
     loadProperties(changedPropertyIdSet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolos/tremolosettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tremolos/tremolosettingsmodel.h
@@ -41,7 +41,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tuplets/tupletsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tuplets/tupletsettingsmodel.cpp
@@ -100,11 +100,3 @@ void TupletSettingsModel::loadProperties()
     loadPropertyItem(m_bracketType);
     loadPropertyItem(m_lineThickness, formatDoubleFunc);
 }
-
-void TupletSettingsModel::resetProperties()
-{
-    m_directionType->resetToDefault();
-    m_numberType->resetToDefault();
-    m_bracketType->resetToDefault();
-    m_lineThickness->resetToDefault();
-}

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tuplets/tupletsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/tuplets/tupletsettingsmodel.h
@@ -51,7 +51,6 @@ public:
 private:
     void createProperties() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     PropertyItem* m_directionType = nullptr;
     PropertyItem* m_numberType = nullptr;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/parts/partssettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/parts/partssettingsmodel.cpp
@@ -89,13 +89,6 @@ void PartsSettingsModel::loadProperties()
     loadPropertyItem(m_excludeFromOtherParts, m_elementsForExcludeOption);
 }
 
-void PartsSettingsModel::resetProperties()
-{
-    m_positionLinkedToMaster->resetToDefault();
-    m_appearanceLinkedToMaster->resetToDefault();
-    m_textLinkedToMaster->resetToDefault();
-}
-
 void PartsSettingsModel::onNotationChanged(const PropertyIdSet&, const StyleIdSet&)
 {
     loadProperties();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/parts/partssettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/parts/partssettingsmodel.h
@@ -65,7 +65,6 @@ private:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
     void onNotationChanged(const mu::engraving::PropertyIdSet&, const mu::engraving::StyleIdSet&) override;
     void onCurrentNotationChanged() override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.cpp
@@ -239,11 +239,6 @@ void PropertiesPanelAbstractModel::updatemeasurementUnits()
     }
 }
 
-void PropertiesPanelAbstractModel::requestResetToDefaults()
-{
-    resetProperties();
-}
-
 QString PropertiesPanelAbstractModel::title() const
 {
     return m_title;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.h
@@ -165,8 +165,6 @@ public:
 
     void init();
 
-    Q_INVOKABLE virtual void requestResetToDefaults();
-
     QString title() const;
     int icon() const;
     PropertiesPanelSectionType sectionType() const;
@@ -181,7 +179,6 @@ public:
 
     virtual void createProperties() = 0;
     virtual void loadProperties() = 0;
-    virtual void resetProperties() = 0;
 
     virtual void requestElements();
 
@@ -208,7 +205,6 @@ public slots:
 signals:
     void titleChanged();
 
-    void modelReseted();
     void isEmptyChanged();
 
     void requestReloadPropertyItems();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractproxymodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractproxymodel.cpp
@@ -84,13 +84,6 @@ void PropertiesPanelAbstractProxyModel::requestElements()
     }
 }
 
-void PropertiesPanelAbstractProxyModel::requestResetToDefaults()
-{
-    for (PropertiesPanelAbstractModel* model : modelList()) {
-        model->requestResetToDefaults();
-    }
-}
-
 bool PropertiesPanelAbstractProxyModel::isEmpty() const
 {
     for (const PropertiesPanelAbstractModel* model : modelList()) {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractproxymodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractproxymodel.h
@@ -58,10 +58,8 @@ public:
 
     void createProperties() override {}
     void loadProperties() override {}
-    void resetProperties() override {}
 
     void requestElements() override;
-    void requestResetToDefaults() override;
     bool isEmpty() const override;
 
     void updateModels(const ElementKeySet& newElementKeySet);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoreappearancesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoreappearancesettingsmodel.h
@@ -67,7 +67,6 @@ signals:
 private:
     void createProperties() override { }
     void requestElements() override { }
-    void resetProperties() override { }
     void loadProperties() override {}
 
     void onCurrentNotationChanged() override;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.cpp
@@ -67,14 +67,6 @@ void ScoreDisplaySettingsModel::loadProperties()
     updateAll();
 }
 
-void ScoreDisplaySettingsModel::resetProperties()
-{
-    setShouldShowInvisible(false);
-    setShouldShowFormatting(false);
-    setShouldShowFrames(false);
-    setShouldShowPageMargins(false);
-}
-
 ScoreConfig ScoreDisplaySettingsModel::scoreConfig() const
 {
     if (!currentNotation()) {

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.h
@@ -46,7 +46,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     bool isEmpty() const override;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.cpp
@@ -263,28 +263,6 @@ void TextSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
     updateRightPositionText();
 }
 
-void TextSettingsModel::resetProperties()
-{
-    m_fontFamily->resetToDefault();
-    m_fontStyle->resetToDefault();
-    m_fontSize->resetToDefault();
-    m_textLineSpacing->resetToDefault();
-    m_isSizeSpatiumDependent->resetToDefault();
-    m_symbolSize->resetToDefault();
-    m_symbolScale->resetToDefault();
-
-    m_frameType->resetToDefault();
-    m_frameBorderColor->resetToDefault();
-    m_frameFillColor->resetToDefault();
-    m_frameThickness->resetToDefault();
-    m_frameMargin->resetToDefault();
-    m_frameCornerRadius->resetToDefault();
-
-    m_textType->resetToDefault();
-    m_textPlacement->resetToDefault();
-    m_textScriptAlignment->resetToDefault();
-}
-
 void TextSettingsModel::onNotationChanged(const PropertyIdSet& changedProperyIds, const StyleIdSet& changedStyleIds)
 {
     loadProperties(changedProperyIds);

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.h
@@ -89,7 +89,6 @@ public:
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
-    void resetProperties() override;
 
     void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
                            const mu::engraving::StyleIdSet& changedStyleIdSet) override;


### PR DESCRIPTION
It was unused and, as I seem to recall, also not always well maintained, so it seems better to remove it.