### PR TITLE
use unicode × instead of ascii x for repeat counts

### DIFF
--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -1723,6 +1723,8 @@ enum class RepeatPlayCountPreset {
     N_X          = int(mu::engraving::RepeatPlayCountPreset::N_X),
     PLAY_N_TIMES = int(mu::engraving::RepeatPlayCountPreset::PLAY_N_TIMES),
     N_REPEATS    = int(mu::engraving::RepeatPlayCountPreset::N_REPEATS),
+    EX_N          = int(mu::engraving::RepeatPlayCountPreset::EX_N),
+    N_EX          = int(mu::engraving::RepeatPlayCountPreset::N_EX),
 };
 Q_ENUM_NS(RepeatPlayCountPreset);
 

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -821,7 +821,9 @@ enum RepeatPlayCountPreset : unsigned char {
     X_N,
     N_X,
     PLAY_N_TIMES,
-    N_REPEATS
+    N_REPEATS,
+    EX_N,
+    N_EX
 };
 
 //-------------------------------------------------------------------

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -953,10 +953,12 @@ ParenthesesMode TConv::fromXml(const AsciiStringView& str, ParenthesesMode def)
 }
 
 static const std::vector<Item<RepeatPlayCountPreset> > REPEAT_COUNT_PRESET = {
-    { RepeatPlayCountPreset::X_N, "xn",                         muse::TranslatableString("engraving", "x%1") },
-    { RepeatPlayCountPreset::N_X, "nx",                         muse::TranslatableString("engraving", "%1x") },
+    { RepeatPlayCountPreset::X_N, "xn",                         muse::TranslatableString("engraving", "×%1") },
+    { RepeatPlayCountPreset::N_X, "nx",                         muse::TranslatableString("engraving", "%1×") },
     { RepeatPlayCountPreset::PLAY_N_TIMES, "playntimes",        muse::TranslatableString("engraving", "Play %1 times") },
     { RepeatPlayCountPreset::N_REPEATS, "nrepeats",             muse::TranslatableString("engraving", "%1 repeats") },
+    { RepeatPlayCountPreset::EX_N, "exn",                       muse::TranslatableString("engraving", "x%1") },
+    { RepeatPlayCountPreset::N_EX, "nex",                       muse::TranslatableString("engraving", "%1x") },
 };
 
 const muse::TranslatableString& TConv::userName(RepeatPlayCountPreset v)

--- a/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
@@ -104,7 +104,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>N_N</eid>
             <style>repeat_play_count</style>
-            <text>3x</text>
+            <text>3×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
@@ -104,7 +104,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>N_N</eid>
             <style>repeat_play_count</style>
-            <text>3x</text>
+            <text>3×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
@@ -149,7 +149,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>U_U</eid>
             <style>repeat_play_count</style>
-            <text>3x</text>
+            <text>3×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
@@ -149,7 +149,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>U_U</eid>
             <style>repeat_play_count</style>
-            <text>3x</text>
+            <text>3×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/importexport/tabledit/tests/data/reading_list_11.mscx
+++ b/src/importexport/tabledit/tests/data/reading_list_11.mscx
@@ -116,7 +116,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>M_M</eid>
             <style>repeat_play_count</style>
-            <text>3x</text>
+            <text>3×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/importexport/tabledit/tests/data/reading_list_12.mscx
+++ b/src/importexport/tabledit/tests/data/reading_list_12.mscx
@@ -172,7 +172,7 @@
             <playCountCustomText></playCountCustomText>
             <eid>P_P</eid>
             <style>repeat_play_count</style>
-            <text>4x</text>
+            <text>4×</text>
             </PlayCountText>
           </voice>
         </Measure>

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/RepeatPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/RepeatPage.qml
@@ -160,7 +160,7 @@ Rectangle {
                 }
 
                 CheckBox {
-                    text: qsTrc("notation/editstyle/repeatplaycount", "Show for single repeats (e.g. “x2”)")
+                    text: qsTrc("notation/editstyle/repeatplaycount", "Show for single repeats (e.g. “×2”)")
                     checked: repeatPlayCountTextModel.repeatPlayCountShowSingleRepeats.value === true
                     onClicked: repeatPlayCountTextModel.repeatPlayCountShowSingleRepeats.value = !repeatPlayCountTextModel.repeatPlayCountShowSingleRepeats.value
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/repeatplaycounttextmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/repeatplaycounttextmodel.cpp
@@ -42,10 +42,10 @@ QVariantList RepeatPlayCountTextModel::textPresetOptions() const
 {
     QVariantList options {
         QVariantMap{
-            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "x3") },
+            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "×3") },
             { "value", mu::engraving::RepeatPlayCountPreset::X_N } },
         QVariantMap{
-            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "3x") },
+            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "3×") },
             { "value", mu::engraving::RepeatPlayCountPreset::N_X } },
         QVariantMap{
             { "text", muse::qtrc("notation/editstyle/repeatplaycount", "Play 3 times") },
@@ -53,6 +53,12 @@ QVariantList RepeatPlayCountTextModel::textPresetOptions() const
         QVariantMap{
             { "text", muse::qtrc("notation/editstyle/repeatplaycount", "3 repeats") },
             { "value", mu::engraving::RepeatPlayCountPreset::N_REPEATS } },
+        QVariantMap{
+            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "x3") },
+            { "value", mu::engraving::RepeatPlayCountPreset::EX_N } },
+        QVariantMap{
+            { "text", muse::qtrc("notation/editstyle/repeatplaycount", "3x") },
+            { "value", mu::engraving::RepeatPlayCountPreset::N_EX } },
     };
 
     return options;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/28815#discussion_r3321240072

#28815 by @miiizen added the option to indicate repeat counts like "x3" or "3x" for repeat marks that use a count ≠ 2.  However, the use of the ASCII letter "x" to represent "times", while common in informal writing (because it is easy to type), is usually considered poor typography — one should generally use the the Unicode multiplication symbol `×` ([U+00D7](https://www.compart.com/en/unicode/U+00D7)) instead, e.g. "×3" or "3×").

(Note that the `×` symbol U+00D7 has been part of Unicode since version 1.1 in 1993, and in fact dates back to [Latin-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) from the 1980s, and seems to be widely supported by fonts — as far as I can determine, it is present in every modern general-purpose font for Western languages.  e.g. see [this incomplete list](https://www.fileformat.info/info/unicode/char/00d7/fontsupport.htm).  Besides, doesn't the text rendering support the [fallback fonts](https://en.wikipedia.org/wiki/Fallback_font) provided by every modern OS?  Encoding support for × is literally older than that of curly quotes ala #17550, since curly quotes weren't included in Latin-1.)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla) — user [stevengj](https://musescore.com/user/75936445)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually