### PR TITLE
Fix #33272 part not exported correctly if it wasn't created

### DIFF
--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -367,7 +367,7 @@ std::optional<VideoWriter::ScoreRestoreData> VideoWriter::prepareScore(INotation
     score->style().set(engraving::Sid::staffUpperBorder, engraving::Spatium(7));
 
     score->setLayoutAll();
-    score->update();
+    score->doLayout();
 
     return result;
 }


### PR DESCRIPTION
Score::update() does a bunch more staff that shouldn't be necessary here (and skips closed parts, hence why the part wasn't being correctly updated to reflow correctly). It should be fine to just call Score::doLayout.

Resolves: #33272