### PR TITLE
Fix regroup rhythms: split 8th note at 16th-note subbeat crossing a quarter beat

### DIFF
--- a/src/engraving/dom/durationtype.cpp
+++ b/src/engraving/dom/durationtype.cpp
@@ -569,9 +569,15 @@ void populateRhythmicList(std::vector<TDuration>* dList, const Fraction& l, bool
     if (startLevel == endLevel && strongestLevelCrossed == startLevel - 1) {
         needToSplit = false;
     }
-    // nor for the next simplest case of level 2 syncopation (allow sixteenth-note, eighth, eighth... to cross unstressed beats)
-    if (startLevel == endLevel && strongestLevelCrossed == startLevel - 2) {
-        // but disallow sixteenth-note, quarter, quarter...
+    // nor for the next simplest case of level 2 syncopation: a note starting and ending at the same
+    // subbeat level crossing a beat 2 levels stronger (e.g. 32nd position crossing an 8th beat).
+    // The note must be at least as long as one unit of the crossed beat level to form a valid syncopation
+    // (e.g. an 8th note or longer at a 32nd-note position crossing an 8th beat is OK; a shorter note is not).
+    // A note that is too short to form a valid syncopation must be split (e.g. an 8th note at a 16th-note
+    // position crossing a quarter-note beat must be split into two 16th notes).
+    if (startLevel == endLevel && strongestLevelCrossed == startLevel - 2
+        && l.ticks() >= nominal.subbeatTicks(strongestLevelCrossed)) {
+        // but disallow a note that is not centered between adjacent subbets of the crossed beat level
         int ticksToNext = nominal.ticksToNextSubbeat(rtickStart.ticks(), startLevel - 1);
         int ticksPastPrev = nominal.ticksPastSubbeat(rtickStart.ticks(), startLevel - 1);
         needToSplit = ticksToNext != ticksPastPrev;

--- a/src/notationscene/qml/MuseScore/NotationScene/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/tests/notationviewinputcontroller_tests.cpp
@@ -887,11 +887,6 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Range_Context_Menu_New_S
     EXPECT_CALL(*m_interaction, setHitElementContext(contextMenuOnMeasureContext))
     .WillOnce(Return());
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
-    .WillOnce(ReturnRef(contextMenuOnMeasureContext)) // for context menu
-#endif
-    ;
-
     //! [GIVEN] No note enter mode, no playing
     EXPECT_CALL(m_view, isNoteEnterMode())
     .WillRepeatedly(Return(false));


### PR DESCRIPTION
Previously, an eighth note starting at a sixteenth-note subbeat position
and crossing a quarter-beat boundary was incorrectly preserved as a single
note, instead of being split into two tied sixteenth notes.

Root cause: populateRhythmicList() had a 'level-2 syncopation' check that
suppressed splitting for notes where startLevel == endLevel and the strongest
beat crossed was 2 levels stronger (startLevel - 2). The condition
  ticksToNext != ticksPastPrev
was intended to reject non-centered notes, but this is always false for any
note at a level-L subbeat position (such notes are always exactly equidistant
from adjacent level-(L-1) subbeat positions). So the check was unconditionally
suppressing the split.

Fix: Add a length check: the note must span at least one full unit of the
crossed beat level to qualify as a valid syncopation. Specifically:
  l.ticks() >= nominal.subbeatTicks(strongestLevelCrossed)

In 4/4 time, subbeatTicks(0) = 480 ticks (a quarter note). An eighth note
is 240 ticks < 480, so it fails the check and is correctly split into two
tied sixteenth notes. A quarter note at a 16th-note position (480 >= 480)
still qualifies as a valid syncopation and is preserved. An eighth note at
a 32nd-note position crossing an eighth-beat boundary also qualifies
(240 >= subbeatTicks(1) = 240).

Also fix a compile error in notationviewinputcontroller_tests.cpp: remove a
dangling conditional block that was placed after a statement-terminating
semicolon, causing syntax errors on Qt < 6.9.

Note: The rhythmic grouping reference test files (groupSubbeats-ref.mscx,
groupConflicts-ref.mscx, groupShortenNotes-ref.mscx) need to be regenerated
by running the engraving tests with a Qt 6.8+ build environment. The EID
system assigns sequential IDs at write time, so splitting notes adds new
elements that cascade-shift all subsequent EIDs in the file.

Fixes: https://github.com/musescore/MuseScore/issues/17322

https://claude.ai/code/session_01BLLP1CS39qygdYGC5oePKZ

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
