### PR TITLE
suggest cloning with submodules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ See [Code Structure on Wiki](https://github.com/musescore/MuseScore/wiki/CodeStr
 
 If using git to download repo of entire code history, type:
 
-    git clone https://github.com/musescore/MuseScore.git
+    git clone  --recurse-submodules https://github.com/musescore/MuseScore.git
     cd MuseScore
+
+(The `--recurse-submodules` ensures that the [`muse_framework`](https://github.com/musescore/muse_framework) git submodule is checked out into the `muse/` subdirectory.)
 
 Otherwise, you can just download the latest source release tarball from the [Releases page](https://github.com/musescore/MuseScore/releases), and then from your download directory type:
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/33517#issuecomment-4553961115

This updates the `README.md` to suggest using `git clone  --recurse-submodules` in order to clone the `MuseScore` repository, which is now necessary in order to clone a buildable repository because `muse_framework` has become a submodule (#33302).

(Otherwise, following the build instructions leads to errors about missing `cmake` files, as commented here: https://github.com/musescore/MuseScore/pull/33517#issuecomment-4553961115)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla) — user [stevengj](https://musescore.com/user/75936445)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
