### PR TITLE
suggest building with ninja on MacOS in README.md (required for Swift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ To compile MuseScore Studio for release, type:
 
     cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release
 
+On MacOS, append `-G Ninja` in order to use the `ninja` build tool (which you may need to install), since this
+is required to compile Swift components.
+
 If something goes wrong, append the word "clean" to the above command to delete the build subdirectory:
 
     cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release clean


### PR DESCRIPTION
On MacOS, the build instructions don't work because they default to using `make`, which does not support Swift components.  I get an error like:
```
-- Configuring macOS integration
CMake Error at /opt/homebrew/share/cmake/Modules/CMakeDetermineSwiftCompiler.cmake:52 (message):
  Swift language not supported by "Unix Makefiles" generator
Call Stack (most recent call first):
  src/macos_integration/CMakeLists.txt:31 (enable_language)


CMake Error: CMAKE_Swift_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
CMake Error at build.cmake:237 (message):
  Configure step failed with status 1.  See output above for details.
```
It seems that you need to use `ninja` to build, instead, which is enabled by appending `-G Ninja` to the `cmake` command, but this is not obvious from the error message. 

This PR updates the `README.md` file to suggest appending `-G Ninja`, at least on MacOS.

- [x] I signed the [CLA](https://musescore.org/en/cla) — user [stevengj](https://musescore.com/user/75936445)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
