### PR TITLE
fixed #32871: Focus goes to Home tab instead of playback after pressing Space when restore session

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -25,6 +25,8 @@
 #include <QPainter>
 #include <QMimeData>
 
+#include "async/async.h"
+
 #include "actions/actiontypes.h"
 #include "engraving/dom/shadownote.h"
 #include "log.h"
@@ -354,7 +356,10 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
         });
     }
 
-    forceFocusIn();
+    async::Async::call(this, [this](){
+        forceFocusIn();
+    });
+
     scheduleRedraw();
 
     emit horizontalScrollChanged();


### PR DESCRIPTION
Resolves: #32871

The program opens, focusing on the Top toolbar. A restore dialog opens, and we save the focus from the Top toolbar button to restore it. Clicking OK takes us to the score page and activates navigation on the score. The dialog closes, restoring focus to the Top toolbar. The solution is to defer focus to the score page after closing the dialog and restoring focus to the Top toolbar.