### PR TITLE
Fix width of selection box when restoring a measure during layout

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -294,6 +294,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
                 prevMeasureState.measureWidth = nmb->width();
                 for (Segment& seg : toMeasure(nmb)->segments()) {
                     prevMeasureState.elementPositions.emplace(&seg, seg.ldata()->pos());
+                    prevMeasureState.elementWidths.emplace(&seg, seg.width());
                     for (EngravingItem* item : seg.annotations()) {
                         if (item->isHarmony() || item->isFretDiagram()) {
                             prevMeasureState.elementPositions.emplace(item, item->ldata()->pos());
@@ -367,6 +368,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
                     MeasureLayout::layoutMeasureElements(m, ctx);
                     BeamLayout::restoreBeams(m, ctx);
                     SystemLayout::restoreOldSystemLayout(m->system(), ctx);
+
                     if (m == nm || !m->noBreak()) {
                         break;
                     }

--- a/src/engraving/rendering/score/systemlayout.h
+++ b/src/engraving/rendering/score/systemlayout.h
@@ -93,6 +93,7 @@ private:
         double measureWidth = 0.0;
         double measurePos = 0.0;
         std::map<EngravingItem*, PointF> elementPositions;
+        std::map<EngravingItem*, double> elementWidths;
         bool curHeader = false;
         bool curTrailer = false;
 
@@ -102,6 +103,7 @@ private:
             measureWidth = 0.0;
             measurePos = 0.0;
             elementPositions.clear();
+            elementWidths.clear();
         }
 
         void restoreMeasure()
@@ -110,6 +112,9 @@ private:
             measure->setWidth(measureWidth);
             for (auto pair : elementPositions) {
                 pair.first->setPos(pair.second);
+            }
+            for (auto pair : elementWidths) {
+                pair.first->setWidth(pair.second);
             }
         }
     };


### PR DESCRIPTION
Resolves: #30435

When any item in a system is modified, and only that one system is to be updated (i.e. no re-layout of the next system is needed), the first measure of the next system is added to the previous system during `SystemLayout::collectSystem()` and it is modified in `updateSpacingForLastAddedMeasure()`.

Then, when it realises that the last measure doesn't fit the target system width, the measure is removed from the system and its state restored, _however_, the width of its segments was not being restored (the width of the segments is what is used in `ScoreRangeUtilities::boundingArea()` to calculate the selection rectangle).

The problem seemed to only arise in the last system due to more prominent justification, but it was actually arising in any system. The fix was to store the width of the elements in `SystemLayout::MeasureState` and restore it when necessary.