### PR TITLE
Fix part syncing when a Box item is pasted

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1827,17 +1827,7 @@ EngravingItem* Measure::drop(EditData& data)
     case ElementType::TBOX:
     case ElementType::FBOX:
     case ElementType::HBOX:
-    {
-        MeasureBase* newBox = toMeasureBase(e);
-        Measure* m = isMMRest() ? mmRestFirst() : this;
-        newBox->setTick(m->tick());
-        newBox->setNext(m);
-        newBox->setPrev(m->prev());
-        score()->undo(new InsertMeasures(newBox, newBox));
-        newBox->manageExclusionFromParts(/*exclude =*/ false);
-        return newBox;
-    }
-    break;
+        return score()->insertBox(toMeasureBase(e), this);
 
     default:
         LOGD("Measure: cannot drop %s here", e->typeName());

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1834,6 +1834,7 @@ EngravingItem* Measure::drop(EditData& data)
         newBox->setNext(m);
         newBox->setPrev(m->prev());
         score()->undo(new InsertMeasures(newBox, newBox));
+        newBox->manageExclusionFromParts(/*exclude =*/ false);
         return newBox;
     }
     break;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -938,6 +938,8 @@ public:
                                const InsertMeasureOptions& options = InsertMeasureOptions());
     MeasureBase* insertBox(ElementType type, MeasureBase* beforeMeasure = nullptr,
                            const InsertMeasureOptions& options = InsertMeasureOptions());
+    MeasureBase* insertBox(MeasureBase* box, MeasureBase* beforeMeasure = nullptr,
+                           const InsertMeasureOptions& options = InsertMeasureOptions());
 
     Audio* audio() const { return m_audio; }
     void setAudio(Audio* a) { m_audio = a; }

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -4749,9 +4749,27 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
 MeasureBase* Score::insertBox(ElementType type, MeasureBase* beforeMeasure, const InsertMeasureOptions& options)
 {
     const bool isFrame = type == ElementType::FBOX || type == ElementType::HBOX || type == ElementType::TBOX || type == ElementType::VBOX;
-
     if (!isFrame) {
         return nullptr;
+    }
+
+    return this->insertBox(toMeasureBase(Factory::createItem(type, dummy())), beforeMeasure, options);
+}
+
+MeasureBase* Score::insertBox(MeasureBase* box, MeasureBase* beforeMeasure, const InsertMeasureOptions& options)
+{
+    IF_ASSERT_FAILED(box) {
+        return nullptr;
+    }
+
+    ElementType type = box->type();
+    const bool isFrame = type == ElementType::FBOX || type == ElementType::HBOX || type == ElementType::TBOX || type == ElementType::VBOX;
+    if (!isFrame) {
+        return nullptr;
+    }
+
+    if (box->score() != this) {
+        box->setScore(this);
     }
 
     Fraction tick;
@@ -4777,27 +4795,26 @@ MeasureBase* Score::insertBox(ElementType type, MeasureBase* beforeMeasure, cons
         tick = last() ? last()->endTick() : Fraction(0, 1);
     }
 
-    MeasureBase* newMeasureBase = toMeasureBase(Factory::createItem(type, dummy()));
-    newMeasureBase->setTick(tick);
-    newMeasureBase->setNext(beforeMeasure);
-    newMeasureBase->setPrev(beforeMeasure ? beforeMeasure->prev() : last());
-    newMeasureBase->setSizeIsSpatiumDependent(!isTitleFrame);
+    box->setTick(tick);
+    box->setNext(beforeMeasure);
+    box->setPrev(beforeMeasure ? beforeMeasure->prev() : last());
+    box->setSizeIsSpatiumDependent(!isTitleFrame);
 
     if (type == ElementType::FBOX) {
-        toFBox(newMeasureBase)->init();
+        toFBox(box)->init();
     }
 
-    undo(new InsertMeasures(newMeasureBase, newMeasureBase));
+    undo(new InsertMeasures(box, box));
 
     if (options.needDeselectAll) {
         deselectAll();
     }
 
     if (options.cloneBoxToAllParts) {
-        newMeasureBase->manageExclusionFromParts(/*exclude =*/ false);
+        box->manageExclusionFromParts(/*exclude =*/ false);
     }
 
-    return newMeasureBase;
+    return box;
 }
 
 void Score::restoreInitialKeySigAndTimeSig()


### PR DESCRIPTION
Resolves: #33657

`Box` elements were not being synced across parts when pasted. The `Measure::drop()` function was missing a call to `manageExclusionFromParts()` to properly trigger this syncing. Since the relevant part of the function seemed to have the same behaviour as `Score::insertBox()`, I slightly refactored that part of the code as well as the `insertBox` function to avoid duplication.