### PR TITLE
Implement mid-measure staff type changes: allow staff type changes at any tick.

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -249,7 +249,13 @@ void BarLine::calcY()
         return;
     }
 
-    Fraction tick = segment()->measure()->tick();
+    const Fraction measureTick = measure->tick();
+    Fraction tick = segment()->tick();
+    if (segment()->isEndBarLineType()) {
+        // End barline should reflect the staff type active at the end of this measure,
+        // not necessarily the one active at the measure start.
+        tick = measure->endTick() - Fraction::eps();
+    }
     const Staff* staff1 = score()->staff(staffIdx1);
     const StaffType* staffType1 = staff1->staffType(tick);
 
@@ -291,7 +297,7 @@ void BarLine::calcY()
     }
 
     // if stafftype change in next measure, check new staff positions
-    Fraction tickNext = tick + measure->ticks();
+    Fraction tickNext = measureTick + measure->ticks();
     if (staff1->isStaffTypeStartFrom(tickNext)) {
         Measure* measureNext = measure->nextMeasure();
         System* systemNext = measureNext ? measureNext->system() : nullptr;

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1064,8 +1064,8 @@ bool Chord::shouldHaveStem() const
            && durationType().hasStem()
            && !(durationType().type() == DurationType::V_HALF && staffType && staffType->isTabStaff()
                 && staffType->minimStyle() == TablatureMinimStyle::NONE)
-           && !(measure() && measure()->stemless(staffIdx()))
-           && !(staffType && staffType->isTabStaff() && staffType->stemless());
+           && !(measure() && measure()->stemless(staffIdx(), tick()))
+           && !(staffType && staffType->stemless());
 }
 
 bool Chord::shouldHaveHook() const

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -442,7 +442,7 @@ EngravingItem* ChordRest::drop(EditData& data)
 
 Beam* ChordRest::beam() const
 {
-    return !(measure() && measure()->stemless(staffIdx())) ? m_beam : nullptr;
+    return !(measure() && measure()->stemless(staffIdx(), tick())) ? m_beam : nullptr;
 }
 
 //---------------------------------------------------------
@@ -1030,7 +1030,7 @@ EngravingItem* ChordRest::nextSegmentElement()
 void ChordRest::scanElements(std::function<void(EngravingItem*)> func)
 {
     if (m_beam && (m_beam->elements().front() == this)
-        && !measure()->stemless(staffIdx())) {
+        && !measure()->stemless(staffIdx(), tick())) {
         m_beam->scanElements(func);
     }
     for (Lyrics* l : m_lyrics) {

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -514,12 +514,12 @@ AccidentalVal Measure::findAccidental(Segment* s, staff_idx_t staffIdx, int line
 
 //---------------------------------------------------------
 //   tick2pos
-///    return x position for tick relative to System
+///    return x position for absolute tick, relative to Measure origin
 //---------------------------------------------------------
 
 double Measure::tick2pos(Fraction tck) const
 {
-    tck -= ticks();
+    tck -= tick();   // convert absolute tick to relative (offset from measure start)
     if (isMMRest()) {
         Segment* s = first(SegmentType::ChordRest);
         double x1   = s->x();
@@ -536,7 +536,7 @@ double Measure::tick2pos(Fraction tck) const
         x2    = s->x();
         tick2 = s->rtick();
         if (tck == tick2) {
-            return x2 + pos().x();
+            return x2;
         }
         if (tck <= tick2) {
             break;
@@ -551,7 +551,7 @@ double Measure::tick2pos(Fraction tck) const
     double dx = x2 - x1;
     Fraction dt   = tick2 - tick1;
     x1      += dt.isZero() ? 0.0 : (dx * (tck.ticks() - tick1.ticks()) / dt.ticks());
-    return x1 + pos().x();
+    return x1;
 }
 
 //---------------------------------------------------------
@@ -906,26 +906,27 @@ void Measure::add(EngravingItem* e)
     case ElementType::STAFFTYPE_CHANGE:
     {
         StaffTypeChange* staffTypeChange = toStaffTypeChange(e);
+        const Fraction staffTypeTick = staffTypeChange->tick();
         const StaffType* templateStaffType = staffTypeChange->staffType();
 
         Staff* staff = staffTypeChange->staff();
 
-        // This will need to point to the stafftype element within the stafftypelist for the staff
+        // This will need to point to the stafftype element within the stafftype list for the staff
         StaffType* newStaffType = nullptr;
 
         if (templateStaffType) {
             // executed on read, undo/redo, clone
             // setStaffType adds a copy to stafftypelist and returns a pointer to that element within stafftypelist
-            newStaffType = staff->setStaffType(tick(), *templateStaffType);
+            newStaffType = staff->setStaffType(staffTypeTick, *templateStaffType);
         } else {
             // executed on add from palette
             // staffType returns a pointer to the current stafftype element in the list
             // setStaffType will make a copy and return a pointer to that element within list
-            templateStaffType = staff->staffType(tick());
-            newStaffType = staff->setStaffType(tick(), *templateStaffType);
+            templateStaffType = staff->staffType(staffTypeTick);
+            newStaffType = staff->setStaffType(staffTypeTick, *templateStaffType);
         }
 
-        staff->staffTypeListChanged(tick());
+        staff->staffTypeListChanged(staffTypeTick);
         staffTypeChange->setStaffType(newStaffType, false);
 
         MeasureBase::add(e);
@@ -1028,11 +1029,12 @@ void Measure::remove(EngravingItem* e)
         StaffTypeChange* stc = toStaffTypeChange(e);
         Staff* staff = stc->staff();
         if (staff) {
+            const Fraction staffTypeTick = stc->tick();
             // st currently points to an list element that is about to be removed
             // make a copy now to use on undo/redo
             StaffType* st = new StaffType(*stc->staffType());
-            if (!tick().isZero()) {
-                staff->removeStaffType(tick());
+            if (!staffTypeTick.isZero()) {
+                staff->removeStaffType(staffTypeTick);
             }
             stc->setStaffType(st, true);
         }
@@ -1106,6 +1108,11 @@ void Measure::moveTicks(const Fraction& diff)
                     }
                 }
             }
+        }
+    }
+    for (EngravingItem* element : m_el) {
+        if (element && element->isStaffTypeChange()) {
+            toStaffTypeChange(element)->moveTicks(diff);
         }
     }
     tuplets.clear();
@@ -1440,6 +1447,12 @@ bool Measure::acceptDrop(EditData& data) const
     case ElementType::CLEF:
     case ElementType::STAFFTYPE_CHANGE:
         // Always drop to single staff
+        if (e->isStaffTypeChange()) {
+            const Fraction tick = StaffTypeChange::insertionTick(this, data.pos);
+            if (!canAddStaffTypeChange(staffIdx, tick)) {
+                return false;
+            }
+        }
         if (viewer) {
             viewer->setDropRectangle(staffRect);
         }
@@ -1472,7 +1485,7 @@ bool Measure::acceptDrop(EditData& data) const
             return true;
         }
         case ActionIconType::STAFF_TYPE_CHANGE:
-            if (!canAddStaffTypeChange(staffIdx)) {
+            if (!canAddStaffTypeChange(staffIdx, StaffTypeChange::insertionTick(this, data.pos))) {
                 return false;
             }
             if (viewer) {
@@ -1798,12 +1811,14 @@ EngravingItem* Measure::drop(EditData& data)
             score()->insertMeasure(ElementType::MEASURE, this);
             break;
         case ActionIconType::STAFF_TYPE_CHANGE: {
-            if (!canAddStaffTypeChange(staffIdx)) {
+            const Fraction tick = StaffTypeChange::insertionTick(this, data.pos);
+            if (!canAddStaffTypeChange(staffIdx, tick)) {
                 return nullptr;
             }
             EngravingItem* stc = Factory::createStaffTypeChange(this);
             stc->setParent(this);
             stc->setTrack(trackZeroVoice(data.track));
+            toStaffTypeChange(stc)->setTickFromDropPosition(this, data.pos);
             score()->undoAddElement(stc);
             break;
         }
@@ -1817,8 +1832,15 @@ EngravingItem* Measure::drop(EditData& data)
 
     case ElementType::STAFFTYPE_CHANGE:
     {
+        const Fraction tick = StaffTypeChange::insertionTick(this, data.pos);
+        if (!canAddStaffTypeChange(staffIdx, tick)) {
+            delete e;
+            return nullptr;
+        }
+
         e->setParent(this);
         e->setTrack(trackZeroVoice(data.track));
+        toStaffTypeChange(e)->setTickFromDropPosition(this, data.pos);
         score()->undoAddElement(e);
     }
     break;
@@ -2045,12 +2067,17 @@ bool Measure::visible(staff_idx_t staffIdx) const
 
 bool Measure::stemless(staff_idx_t staffIdx) const
 {
+    return stemless(staffIdx, tick());
+}
+
+bool Measure::stemless(staff_idx_t staffIdx, const Fraction& atTick) const
+{
     const Staff* staff = score()->staff(staffIdx);
     if (!staff) {
         return false;
     }
 
-    return staff->stemless(tick()) || m_mstaves[staffIdx]->stemless() || staff->staffType(tick())->stemless();
+    return staff->stemless(atTick) || m_mstaves[staffIdx]->stemless() || staff->staffType(atTick)->stemless();
 }
 
 //---------------------------------------------------------
@@ -3657,10 +3684,19 @@ bool Measure::canAddStringTunings(staff_idx_t staffIdx) const
     return !alreadyHasStringTunings;
 }
 
-bool Measure::canAddStaffTypeChange(staff_idx_t staffIdx) const
+bool Measure::canAddStaffTypeChange(staff_idx_t staffIdx, const Fraction& tick) const
 {
     if (isMMRest()) {
         return false;
+    }
+
+    return staffTypeChangeAt(staffIdx, tick) == nullptr;
+}
+
+const StaffTypeChange* Measure::staffTypeChangeAt(staff_idx_t staffIdx, const Fraction& tick) const
+{
+    if (el().empty()) {
+        return nullptr;
     }
 
     for (const EngravingObject* child : el()) {
@@ -3669,13 +3705,131 @@ bool Measure::canAddStaffTypeChange(staff_idx_t staffIdx) const
         }
 
         const StaffTypeChange* stc = toStaffTypeChange(child);
-        if (stc->staffIdx() == staffIdx) {
-            // Staff already has a StaffTypeChange at this measure...
-            return false;
+        if (stc->staffIdx() == staffIdx && stc->tick() == tick) {
+            return stc;
         }
     }
 
+    return nullptr;
+}
+
+std::vector<Fraction> Measure::midMeasureStaffTypeChangeTicks(staff_idx_t staffIdx) const
+{
+    if (el().empty()) {
+        return {};
+    }
+
+    const Fraction measureStart = tick();
+    const Fraction measureEnd = endTick();
+
+    std::vector<Fraction> ticks;
+    ticks.reserve(el().size());
+    for (const EngravingObject* child : el()) {
+        if (!child || !child->isStaffTypeChange()) {
+            continue;
+        }
+
+        const StaffTypeChange* stc = toStaffTypeChange(child);
+        if (stc->staffIdx() != staffIdx) {
+            continue;
+        }
+
+        const Fraction stcTick = stc->tick();
+        if (stcTick <= measureStart || stcTick >= measureEnd) {
+            continue;
+        }
+
+        ticks.push_back(stcTick);
+    }
+
+    if (ticks.size() > 1) {
+        std::sort(ticks.begin(), ticks.end());
+        ticks.erase(std::unique(ticks.begin(), ticks.end()), ticks.end());
+    }
+    return ticks;
+}
+
+const StaffTypeChange* Measure::firstMidMeasureStaffTypeChange(staff_idx_t staffIdx) const
+{
+    if (el().empty()) {
+        return nullptr;
+    }
+
+    const Fraction measureStart = tick();
+    const Fraction measureEnd = endTick();
+
+    const StaffTypeChange* firstStc = nullptr;
+    Fraction firstTick = Fraction(0, 1);
+
+    for (const EngravingObject* child : el()) {
+        if (!child || !child->isStaffTypeChange()) {
+            continue;
+        }
+
+        const StaffTypeChange* stc = toStaffTypeChange(child);
+        if (stc->staffIdx() != staffIdx) {
+            continue;
+        }
+
+        const Fraction stcTick = stc->tick();
+        if (stcTick <= measureStart || stcTick >= measureEnd) {
+            continue;
+        }
+
+        if (!firstStc || stcTick < firstTick) {
+            firstTick = stcTick;
+            firstStc = stc;
+        }
+    }
+
+    return firstStc;
+}
+
+bool Measure::isStaffTypeTransitionMeasure(staff_idx_t staffIdx, Fraction* transitionTick) const
+{
+    const StaffTypeChange* stc = firstMidMeasureStaffTypeChange(staffIdx);
+    if (!stc) {
+        return false;
+    }
+
+    if (transitionTick) {
+        *transitionTick = stc->tick();
+    }
     return true;
+}
+
+bool Measure::isPostStaffTypeTransitionTick(staff_idx_t staffIdx, const Fraction& itemTick) const
+{
+    if (itemTick <= tick()) {
+        return false;
+    }
+
+    Fraction transitionTick;
+    if (!isStaffTypeTransitionMeasure(staffIdx, &transitionTick)) {
+        return false;
+    }
+
+    return itemTick >= transitionTick;
+}
+
+double Measure::computeStaffTypeTransitionOffset(staff_idx_t staffIdx, const Fraction& itemTick, double spatium) const
+{
+    if (!isPostStaffTypeTransitionTick(staffIdx, itemTick)) {
+        return 0.0;
+    }
+
+    const Staff* staff = score()->staff(staffIdx);
+    if (!staff) {
+        return 0.0;
+    }
+
+    const StaffType* activeType = staff->staffType(itemTick);
+    const StaffType* measureStartType = staff->staffType(tick());
+    if (!activeType || !measureStartType) {
+        return 0.0;
+    }
+
+    return (activeType->yoffset().val() - measureStartType->yoffset().val()) * spatium;
 }
 
 Fraction Measure::maxTicks() const

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -63,6 +63,7 @@ class Part;
 class Score;
 class Spacer;
 class Staff;
+class StaffTypeChange;
 class System;
 class TieMap;
 
@@ -315,6 +316,7 @@ public:
     bool isCutawayClef(staff_idx_t staffIdx) const;
     bool isFullMeasureRest() const;
     bool visible(staff_idx_t staffIdx) const;
+    bool stemless(staff_idx_t staffIdx, const Fraction& tick) const;
     bool stemless(staff_idx_t staffIdx) const;
     bool isFinalMeasureOfSection() const;
     LayoutBreak* sectionBreakElement(bool includeNextFrames = true) const;
@@ -398,7 +400,13 @@ public:
     void respaceSegments();
 
     bool canAddStringTunings(staff_idx_t staffIdx) const;
-    bool canAddStaffTypeChange(staff_idx_t staffIdx) const;
+    bool canAddStaffTypeChange(staff_idx_t staffIdx, const Fraction& tick) const;
+    const StaffTypeChange* staffTypeChangeAt(staff_idx_t staffIdx, const Fraction& tick) const;
+    std::vector<Fraction> midMeasureStaffTypeChangeTicks(staff_idx_t staffIdx) const;
+    const StaffTypeChange* firstMidMeasureStaffTypeChange(staff_idx_t staffIdx) const;
+    bool isStaffTypeTransitionMeasure(staff_idx_t staffIdx, Fraction* transitionTick = nullptr) const;
+    bool isPostStaffTypeTransitionTick(staff_idx_t staffIdx, const Fraction& itemTick) const;
+    double computeStaffTypeTransitionOffset(staff_idx_t staffIdx, const Fraction& itemTick, double spatium) const;
 
     struct LayoutData : public MeasureBase::LayoutData {
     private:

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1290,9 +1290,16 @@ const StaffType* Staff::staffTypeForElement(const EngravingItem* e) const
         // if one staff type spans for the entire staff, optimize by omitting a call to `tick()`
         return &m_staffTypeList.staffType({ 0, 1 });
     }
-    // Handle items at the last tick of measures as StaffTypeList::staffType rounds up
+
+    Fraction tick = e->tick();
+
+    // Handle items at the last tick of a measure as StaffTypeList::staffType rounds up
+    // to a change that may belong to the next measure.
     const Measure* measure = e->findMeasure();
-    const Fraction tick = measure ? measure->tick() : e->tick();
+    if (measure && tick == measure->endTick()) {
+        tick -= Fraction::eps();
+    }
+
     return &m_staffTypeList.staffType(tick);
 }
 

--- a/src/engraving/dom/stafflines.cpp
+++ b/src/engraving/dom/stafflines.cpp
@@ -60,8 +60,22 @@ StaffLines::StaffLines(Measure* parent)
 
 PointF StaffLines::pagePos() const
 {
-    System* system = measure()->system();
-    return PointF(measure()->x() + system->x(), system->staff(staffIdx())->y() + system->y());
+    const Measure* m = measure();
+    System* system = m->system();
+    if (!system) {
+        return EngravingItem::pagePos();
+    }
+
+    PointF pagePos(m->x() + system->x(),
+                   system->staff(staffIdx())->y() + system->y());
+
+    // Keep historical behavior for non-transition measures. Transition measures
+    // encode the pre-section y offset in ldata->pos().
+    if (m->isStaffTypeTransitionMeasure(staffIdx())) {
+        pagePos += ldata()->pos();
+    }
+
+    return pagePos;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/stafflines.h
+++ b/src/engraving/dom/stafflines.h
@@ -23,6 +23,7 @@
 #ifndef MU_ENGRAVING_STAFFLINES_H
 #define MU_ENGRAVING_STAFFLINES_H
 
+#include <utility>
 #include <vector>
 
 #include "engravingitem.h"
@@ -40,6 +41,11 @@ class StaffLines final : public EngravingItem
     DECLARE_CLASSOF(ElementType::STAFF_LINES)
 
 public:
+    struct ColoredLine {
+        LineF line;
+        Color color;
+        double width = 0.0;
+    };
 
     StaffLines* clone() const override { return new StaffLines(*this); }
 
@@ -47,7 +53,14 @@ public:
     PointF canvasPos() const override;    ///< position in page coordinates
 
     const std::vector<LineF>& lines() const { return m_lines; }
-    void setLines(const std::vector<LineF>& l) { m_lines = l; }
+    void setLines(std::vector<LineF> l)
+    {
+        m_lines = std::move(l);
+        m_coloredLines.clear();
+    }
+
+    const std::vector<ColoredLine>& coloredLines() const { return m_coloredLines; }
+    void setColoredLines(std::vector<ColoredLine> lines) { m_coloredLines = std::move(lines); }
 
     Measure* measure() const { return (Measure*)explicitParent(); }
     double y1() const;
@@ -66,6 +79,7 @@ private:
 
     double m_lw = 0.0;
     std::vector<LineF> m_lines;
+    std::vector<ColoredLine> m_coloredLines;
 };
 }
 

--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -37,9 +37,54 @@ namespace mu::engraving {
 //   StaffTypeChange
 //---------------------------------------------------------
 
+namespace {
+Fraction tickFromDropX(const Measure* measure, const PointF& dropPos)
+{
+    IF_ASSERT_FAILED(measure) {
+        return Fraction(0, 1);
+    }
+
+    const Fraction startTick = measure->tick();
+    const Fraction endTick = measure->endTick();
+    if (endTick <= startTick) {
+        return startTick;
+    }
+
+    const Fraction oneTick = Fraction::fromTicks(1);
+    const Fraction lastTickInMeasure = endTick - oneTick;
+    const double x = dropPos.x() - measure->canvasPos().x();
+
+    if (x <= measure->tick2pos(startTick)) {
+        return startTick;
+    }
+    if (x >= measure->tick2pos(lastTickInMeasure)) {
+        return lastTickInMeasure;
+    }
+
+    Fraction lo = startTick;
+    Fraction hi = lastTickInMeasure;
+
+    // Bisection in Fraction space preserves non-integer rhythmic subdivisions.
+    for (int i = 0; i < 64 && (hi - lo) > oneTick; ++i) {
+        const Fraction mid = (lo + hi) / 2;
+        const double midX = measure->tick2pos(mid);
+        if (midX <= x) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    const double x0 = measure->tick2pos(lo);
+    const double x1 = measure->tick2pos(hi);
+    return ((x1 - x) < (x - x0)) ? hi : lo;
+}
+}
+
 StaffTypeChange::StaffTypeChange(MeasureBase* parent)
     : EngravingItem(ElementType::STAFFTYPE_CHANGE, parent)
 {
+    setTickFromMeasure(toMeasure(parent));
     m_lw = spatium() * 0.3;
 }
 
@@ -47,6 +92,7 @@ StaffTypeChange::StaffTypeChange(const StaffTypeChange& lb)
     : EngravingItem(lb)
 {
     m_lw = lb.m_lw;
+    m_tick = lb.m_tick;
     m_ownsStaffType = lb.m_ownsStaffType;
     if (lb.m_ownsStaffType && lb.m_staffType) {
         m_staffType = new StaffType(*lb.m_staffType);
@@ -72,6 +118,78 @@ void StaffTypeChange::setStaffType(StaffType* st, bool owned)
     m_ownsStaffType = owned && (st != nullptr);
 }
 
+// Keep staff type and tick aligned when both are updated.
+void StaffTypeChange::setStaffTypeAndTick(StaffType* st, bool owned, const Fraction& tick)
+{
+    setTick(tick);
+    setStaffType(st, owned);
+}
+
+void StaffTypeChange::setTick(const Fraction& tick)
+{
+    assert(!tick.negative());
+
+    if (tick == m_tick) {
+        return;
+    }
+
+    const Fraction oldTick = m_tick;
+    Staff* st = staff();
+    if (st && m_staffType && st->staffType(oldTick) == m_staffType) {
+        st->moveStaffType(oldTick, tick);
+    }
+
+    m_tick = tick;
+}
+
+void StaffTypeChange::setTickFromMeasure(const Measure* measure)
+{
+    // Resolve the base tick from the measure provided by the caller.
+    // Constructors and split/join operations use the same measure-start fallback.
+    // This keeps recreated items on the same base tick as the shared helper.
+    setTick(insertionTick(measure));
+}
+
+void StaffTypeChange::setTickFromDropPosition(const Measure* measure, const PointF& dropPos)
+{
+    setTick(insertionTick(measure, dropPos));
+}
+
+Fraction StaffTypeChange::insertionTick(const Measure* measure)
+{
+    return measure ? measure->tick() : Fraction(0, 1);
+}
+
+// Map drop x-position to the nearest tick in the measure.
+Fraction StaffTypeChange::insertionTick(const Measure* measure, const PointF& dropPos)
+{
+    if (!measure) {
+        return insertionTick(measure);
+    }
+
+    return tickFromDropX(measure, dropPos);
+}
+
+void StaffTypeChange::moveTicks(const Fraction& diff)
+{
+    if (diff.numerator() == 0) {
+        return;
+    }
+
+    setTick(m_tick + diff);
+}
+
+bool StaffTypeChange::isAtMeasureStart() const
+{
+    const Measure* currentMeasure = measure();
+    return currentMeasure ? m_tick == currentMeasure->tick() : m_tick.isZero();
+}
+
+Fraction StaffTypeChange::rtick() const
+{
+    return measure() ? m_tick - measure()->tick() : m_tick;
+}
+
 //---------------------------------------------------------
 //   spatiumChanged
 //---------------------------------------------------------
@@ -88,6 +206,8 @@ void StaffTypeChange::spatiumChanged(double, double)
 PropertyValue StaffTypeChange::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::TICK:
+        return m_tick;
     case Pid::STEP_OFFSET:
         return m_staffType->stepOffset();
     case Pid::STAFF_LINES:
@@ -134,6 +254,9 @@ PropertyValue StaffTypeChange::getProperty(Pid propertyId) const
 bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
+    case Pid::TICK:
+        setTick(v.value<Fraction>());
+        break;
     case Pid::STEP_OFFSET:
         m_staffType->setStepOffset(v.toInt());
         break;
@@ -205,7 +328,7 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     }
 
     if (explicitParent()) {
-        staff()->staffTypeListChanged(measure()->tick());
+        staff()->staffTypeListChanged(m_tick);
     }
     return true;
 }
@@ -217,6 +340,8 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
 PropertyValue StaffTypeChange::propertyDefault(Pid id) const
 {
     switch (id) {
+    case Pid::TICK:
+        return insertionTick(measure());
     case Pid::STEP_OFFSET:
         return 0;
     case Pid::STAFF_LINES:

--- a/src/engraving/dom/stafftypechange.h
+++ b/src/engraving/dom/stafftypechange.h
@@ -26,6 +26,7 @@
 #include "engravingitem.h"
 
 namespace mu::engraving {
+class Measure;
 class StaffType;
 
 //---------------------------------------------------------
@@ -42,8 +43,19 @@ public:
 
     StaffTypeChange* clone() const override { return new StaffTypeChange(*this); }
 
+    static Fraction insertionTick(const Measure* measure);
+    static Fraction insertionTick(const Measure* measure, const PointF& dropPos);
+
+    Fraction tick() const override { return m_tick; }
+    Fraction rtick() const override;
+
     const StaffType* staffType() const { return m_staffType; }
     void setStaffType(StaffType* st, bool owned);
+    void setStaffTypeAndTick(StaffType* st, bool owned, const Fraction& tick);
+    void setTickFromMeasure(const Measure* measure);
+    void setTickFromDropPosition(const Measure* measure, const PointF& dropPos);
+    void moveTicks(const Fraction& diff);
+    bool isAtMeasureStart() const;
 
     double lw() const { return m_lw; }
 
@@ -55,6 +67,8 @@ public:
 
 private:
 
+    void setTick(const Fraction& tick);
+
     friend class Factory;
     StaffTypeChange(MeasureBase* parent = 0);
     StaffTypeChange(const StaffTypeChange&);
@@ -64,6 +78,7 @@ private:
     StaffType* m_staffType = nullptr;
     bool m_ownsStaffType = false;
     double m_lw = 0.0;
+    Fraction m_tick = Fraction(0, 1);
 };
 } // namespace mu::engraving
 

--- a/src/engraving/editing/editmeasures.cpp
+++ b/src/engraving/editing/editmeasures.cpp
@@ -153,9 +153,9 @@ void InsertRemoveMeasures::insertMeasures()
                 staff->moveStaffType(tick, tickNew);
 
                 for (EngravingItem* el : measure->el()) {
-                    if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES) {
+                    if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES && el->tick() == tickNew) {
                         StaffTypeChange* stc = toStaffTypeChange(el);
-                        stc->setStaffType(staff->staffType(tickNew), false);
+                        stc->setStaffTypeAndTick(staff->staffType(tickNew), false, tickNew);
                         stIcon = true;
                         break;
                     }
@@ -272,9 +272,9 @@ void InsertRemoveMeasures::removeMeasures()
                 staff->moveStaffType(tick, newTick);
 
                 for (EngravingItem* el : measure->el()) {
-                    if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES) {
+                    if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES && el->tick() == tick) {
                         StaffTypeChange* stc = toStaffTypeChange(el);
-                        stc->setStaffType(staff->staffType(newTick), false);
+                        stc->setStaffTypeAndTick(staff->staffType(newTick), false, newTick);
                         stIcon = true;
                         break;
                     }

--- a/src/engraving/editing/splitjoinmeasure.cpp
+++ b/src/engraving/editing/splitjoinmeasure.cpp
@@ -39,6 +39,52 @@
 
 using namespace mu::engraving;
 
+namespace {
+std::vector<std::vector<Fraction> > collectStaffTypeChangeTicksInRange(const MasterScore* score,
+                                                                       const Fraction& rangeStart,
+                                                                       const Fraction& rangeEnd)
+{
+    std::vector<std::vector<Fraction> > result;
+    if (!score || rangeEnd <= rangeStart) {
+        return result;
+    }
+
+    result.resize(score->nstaves());
+
+    const int startTick = rangeStart.ticks();
+    const int endTick = rangeEnd.ticks();
+    for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
+        const Staff* staff = score->staves().at(staffIdx);
+        std::vector<Fraction>& ticks = result[staffIdx];
+
+        if (staff->isStaffTypeStartFrom(rangeStart)) {
+            ticks.push_back(rangeStart);
+        }
+
+        for (int tick = staff->staffTypeRange(Fraction::fromTicks(startTick + 1)).second;
+             tick != -1 && tick < endTick;
+             tick = staff->staffTypeRange(Fraction::fromTicks(tick + 1)).second) {
+            ticks.push_back(Fraction::fromTicks(tick));
+        }
+    }
+
+    return result;
+}
+
+void reinsertStaffTypeChange(MasterScore* score, Measure* measure, size_t staffIdx, const Fraction& tick)
+{
+    if (!score || !measure || !measure->canAddStaffTypeChange(staffIdx, tick)) {
+        return;
+    }
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setParent(measure);
+    stc->setTrack(staffIdx * VOICES);
+    stc->setProperty(Pid::TICK, PropertyValue(tick));
+    score->addElement(stc);
+}
+}
+
 //---------------------------------------------------------
 //   splitMeasure
 //---------------------------------------------------------
@@ -70,6 +116,8 @@ void SplitJoinMeasure::splitMeasure(MasterScore* masterScore, const Fraction& ti
 
     Fraction stick = measure->tick();
     Fraction etick = measure->endTick();
+    const std::vector<std::vector<Fraction> > staffTypeChangeTicks
+        = collectStaffTypeChangeTicksInRange(masterScore, stick, etick);
 
     std::vector<std::tuple<Spanner*, Fraction, Fraction> > spanners;
     for (auto i : masterScore->spanner()) {
@@ -172,12 +220,9 @@ void SplitJoinMeasure::splitMeasure(MasterScore* masterScore, const Fraction& ti
     }
 
     for (size_t staffIdx = 0; staffIdx < masterScore->nstaves(); ++staffIdx) {
-        Staff* staff = masterScore->staves().at(staffIdx);
-        if (staff->isStaffTypeStartFrom(stick)) {
-            StaffTypeChange* stc = Factory::createStaffTypeChange(m1);
-            stc->setParent(m1);
-            stc->setTrack(staffIdx * VOICES);
-            masterScore->addElement(stc);
+        for (const Fraction& stcTick : staffTypeChangeTicks[staffIdx]) {
+            Measure* destination = (stcTick < m2->tick()) ? m1 : m2;
+            reinsertStaffTypeChange(masterScore, destination, staffIdx, stcTick);
         }
     }
 }
@@ -221,6 +266,8 @@ void SplitJoinMeasure::joinMeasures(MasterScore* masterScore, const Fraction& ti
 
     Fraction startTick = m1->tick();
     Fraction endTick = m2->endTick();
+    const std::vector<std::vector<Fraction> > staffTypeChangeTicks
+        = collectStaffTypeChangeTicksInRange(masterScore, startTick, endTick);
 
     auto spanners = masterScore->spannerMap().findContained(startTick.ticks(), endTick.ticks());
     for (auto i : spanners) {
@@ -266,12 +313,8 @@ void SplitJoinMeasure::joinMeasures(MasterScore* masterScore, const Fraction& ti
     }
 
     for (size_t staffIdx = 0; staffIdx < masterScore->nstaves(); ++staffIdx) {
-        Staff* staff = masterScore->staves().at(staffIdx);
-        if (staff->isStaffTypeStartFrom(tick1)) {
-            StaffTypeChange* stc = engraving::Factory::createStaffTypeChange(joinedMeasure);
-            stc->setParent(joinedMeasure);
-            stc->setTrack(staffIdx * VOICES);
-            masterScore->addElement(stc);
+        for (const Fraction& stcTick : staffTypeChangeTicks[staffIdx]) {
+            reinsertStaffTypeChange(masterScore, joinedMeasure, staffIdx, stcTick);
         }
     }
 

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cfloat>
+#include <utility>
 
 #include "chordlayout.h"
 
@@ -1293,6 +1294,7 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
     double lineDistance = 1;
     bool staffVisible  = true;
     int stepOffset = 0;                         // for staff type changes with a step offset
+    double staffYOffset = 0.0;                  // transition-only y-offset delta
 
     Segment* segment = item->segment();
 
@@ -1301,10 +1303,15 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
         staff_idx_t idx = item->staffIdx() + item->staffMove();
         track         = staff2track(idx);
         const Staff* st     = ctx.dom().staff(idx);
+        const Measure* measure = segment->measure();
         lineBelow     = (st->lines(tick) - 1) * 2;
         lineDistance  = st->lineDistance(tick);
         staffVisible  = !st->isLinesInvisible(tick);
-        stepOffset = st->staffType(tick)->stepOffset();
+        const StaffType* currentType = st->staffType(tick);
+        stepOffset = currentType->stepOffset();
+        if (measure && measure->isPostStaffTypeTransitionTick(idx, tick)) {
+            staffYOffset = measure->computeStaffTypeTransitionOffset(idx, tick, item->spatium());
+        }
     }
 
     // need ledger lines?
@@ -1331,7 +1338,8 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
     // NOTE: notes are sorted from bottom to top (line no. decreasing)
     // notes are scanned twice from outside (bottom or top) toward the staff
     // each pass stops at the first note without ledger lines
-    int n = static_cast<int>(item->notes().size());
+    const std::vector<Note*>& notes = item->notes();
+    int n = static_cast<int>(notes.size());
 
     for (const bool topToBottom : { false, true }) {
         const int from = topToBottom ? n - 1 : 0;
@@ -1344,7 +1352,7 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
         int maxLine = lineBelow;
 
         for (int i = from; i < n && i >= 0; i += delta) {
-            const Note* note = item->notes().at(i);
+            const Note* note = notes[i];
             int l = note->line() + stepOffset;
 
             // if 1st pass and note not below staff or 2nd pass and note not above staff
@@ -1372,8 +1380,10 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
 
             // ledger lines need the leftmost point of the notehead with a respect of bbox
             const double x = note->pos().x() + note->bboxXShift();
-            if (x - extraLen * note->mag() < minX) {
-                minX = x - extraLen * note->mag();
+            const double noteMag = note->mag();
+            const double noteExtent = extraLen * noteMag;
+            if (x - noteExtent < minX) {
+                minX = x - noteExtent;
                 // increase width of all lines between this one and the staff
                 for (auto& d : vecLines) {
                     if (!d.accidental && ((l < 0 && d.line >= l) || (l > 0 && d.line <= l))) {
@@ -1382,8 +1392,8 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
                 }
             }
             // same for left side
-            if (x + hw + extraLen * note->mag() > maxX) {
-                maxX = x + hw + extraLen * note->mag();
+            if (x + hw + noteExtent > maxX) {
+                maxX = x + hw + noteExtent;
                 for (auto& d : vecLines) {
                     if ((l < 0 && d.line >= l) || (l > 0 && d.line <= l)) {
                         d.maxX = maxX;
@@ -1419,7 +1429,10 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
             }
         }
         if (minLine < 0 || maxLine > lineBelow) {
-            ledgerLineData.insert(ledgerLineData.end(), vecLines.begin(), vecLines.end());
+            ledgerLineData.reserve(ledgerLineData.size() + vecLines.size());
+            for (LedgerLineData& lineData : vecLines) {
+                ledgerLineData.push_back(std::move(lineData));
+            }
         }
     }
 
@@ -1427,13 +1440,13 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
     double stepDistance = lineDistance * 0.5;
     item->resizeLedgerLinesTo(ledgerLineData.size());
     for (size_t i = 0; i < ledgerLineData.size(); ++i) {
-        LedgerLineData lld = ledgerLineData[i];
+        const LedgerLineData& lld = ledgerLineData[i];
         LedgerLine* h = item->ledgerLines()[i];
         h->setParent(item);
         h->setTrack(track);
         h->setVisible(lld.visible && staffVisible);
         h->setLen(lld.maxX - lld.minX);
-        h->setPos(lld.minX, lld.line * _spatium * stepDistance);
+        h->setPos(lld.minX, lld.line * _spatium * stepDistance + staffYOffset);
     }
 
     for (LedgerLine* ll : item->ledgerLines()) {
@@ -2691,6 +2704,11 @@ void ChordLayout::layoutChords3(const std::vector<Chord*>& chords,
     double sp           = staff->spatium(tick);
     double stepDistance = sp * staff->lineDistance(tick) * .5;
     int stepOffset     = staff->staffType(tick)->stepOffset();
+    double staffYOffset = 0.0;
+    const Measure* measure = notes.front()->chord()->measure();
+    if (measure && measure->isPostStaffTypeTransitionTick(staff->idx(), tick)) {
+        staffYOffset = measure->computeStaffTypeTransitionOffset(staff->idx(), tick, sp);
+    }
 
     double upDotPosX    = 0.0;
     double downDotPosX  = 0.0;
@@ -2792,7 +2810,7 @@ void ChordLayout::layoutChords3(const std::vector<Chord*>& chords,
                 noteX = chord->noteHeadWidth() - note->headBodyWidth();
             }
 
-            double ny = (note->line() + stepOffset) * stepDistance;
+            double ny = (note->line() + stepOffset) * stepDistance + staffYOffset;
             if (note->ldata()->pos().y() != ny) {
                 note->mutldata()->setPosY(ny);
                 if (stem) {

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -127,10 +127,16 @@ void RestLayout::layoutRest(const Rest* item, Rest::LayoutData* ldata, const Lay
     int voiceOffset = computeVoiceOffset(item, ldata); // Measured in 1sp steps
     int wholeRestOffset = computeWholeOrBreveRestOffset(item, voiceOffset, lines);
     int finalLine = naturalLine + voiceOffset + wholeRestOffset;
+    double transitionYOffset = 0.0;
+
+    const Measure* measure = item->measure();
+    if (measure && measure->isPostStaffTypeTransitionTick(item->staffIdx(), item->tick())) {
+        transitionYOffset = measure->computeStaffTypeTransitionOffset(item->staffIdx(), item->tick(), spatium);
+    }
 
     ldata->sym = item->getSymbol(item->durationType().type(), finalLine + userLine, lines);
 
-    ldata->setPosY(finalLine * lineDist * spatium);
+    ldata->setPosY(finalLine * lineDist * spatium + transitionYOffset);
     if (!item->shouldNotBeDrawn()) {
         fillShape(item, ldata, ctx.conf());
     }
@@ -499,6 +505,13 @@ InterruptionPoints RestLayout::computeInterruptionPoints(const Measure* measure,
 
     track_idx_t sTrack = staffIdx * VOICES;
     track_idx_t eTrack = sTrack + VOICES;
+
+    for (const Fraction& transitionTick : measure->midMeasureStaffTypeChangeTicks(staffIdx)) {
+        const Fraction transitionRTick = transitionTick - measure->tick();
+        for (voice_idx_t voice = 0; voice < VOICES; ++voice) {
+            interruptionPointSets[voice].insert(transitionRTick);
+        }
+    }
 
     // Compute all-voices interruptions
     for (const Segment* segment = measure->first(SegmentType::ChordRest); segment; segment = segment->next(SegmentType::ChordRest)) {

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1665,7 +1665,12 @@ void SystemLayout::createSkylines(const ElementsToLayout& elementsToLayout, Layo
 
                         // add element to skyline
                         if (e->addToSkyline()) {
-                            const PointF offset = e->staffOffset();
+                            PointF offset = e->staffOffset();
+
+                            if (e->isChord() && m->isPostStaffTypeTransitionTick(staffIdx, e->tick())) {
+                                offset.ry() -= m->computeStaffTypeTransitionOffset(staffIdx, e->tick(), e->spatium());
+                            }
+
                             Shape shape = e->shape();
                             // add grace notes to skyline
                             if (e->isChord()) {

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2373,8 +2373,8 @@ void TDraw::draw(const Note* item, Painter* painter, const PaintOptions& opt)
         painter->setFont(f);
 
         const double startPosX = ldata->bbox().x();
-        const double yOffset = tab->fretFontYOffset();
-        painter->drawText(PointF(startPosX, yOffset * item->magS()), item->fretString());
+        const double fretYOffset = tab->fretFontYOffset();
+        painter->drawText(PointF(startPosX, fretYOffset * item->magS()), item->fretString());
     }
     // NOT tablature
     else {
@@ -2731,8 +2731,18 @@ void TDraw::draw(const StaffLines* item, Painter* painter, const PaintOptions& o
 
     setMask(item, painter);
 
-    painter->setPen(Pen(item->curColor(opt), item->lw(), PenStyle::SolidLine, PenCapStyle::FlatCap));
-    painter->drawLines(item->lines());
+    const std::vector<StaffLines::ColoredLine>& coloredLines = item->coloredLines();
+    if (!coloredLines.empty()) {
+        for (const StaffLines::ColoredLine& coloredLine : coloredLines) {
+            const double lineWidth = coloredLine.width > 0.0 ? coloredLine.width : item->lw();
+            painter->setPen(Pen(item->curColor(item->visible(), coloredLine.color, opt),
+                                lineWidth, PenStyle::SolidLine, PenCapStyle::FlatCap));
+            painter->drawLine(coloredLine.line);
+        }
+    } else {
+        painter->setPen(Pen(item->curColor(opt), item->lw(), PenStyle::SolidLine, PenCapStyle::FlatCap));
+        painter->drawLines(item->lines());
+    }
 
     painter->restore();
 }

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cfloat>
+#include <utility>
 
 #include "tlayout.h"
 
@@ -5087,41 +5088,174 @@ void TLayout::layoutStaffLines(StaffLines* item, LayoutContext& ctx)
     layoutForWidth(item, item->measure()->width(), ctx);
 }
 
+struct StaffLinesTransitionLayoutContext {
+    const Staff* staff = nullptr;
+    const Measure* measure = nullptr;
+    const std::vector<Fraction>* transitionTicks = nullptr;
+    StaffLines* item = nullptr;
+    StaffLines::LayoutData* ldata = nullptr;
+    double width = 0.0;
+    double staffLineWidthStyle = 0.0;
+    double spatium = 0.0;
+    std::vector<LineF>* lines = nullptr;
+    std::vector<StaffLines::ColoredLine>* coloredLines = nullptr;
+};
+
+static void layoutTransitionMeasureStaffLines(const StaffLinesTransitionLayoutContext& ctx)
+{
+    const Staff* staff = ctx.staff;
+    const Measure* measure = ctx.measure;
+    const std::vector<Fraction>& transitionTicks = *ctx.transitionTicks;
+    StaffLines* item = ctx.item;
+    StaffLines::LayoutData* ldata = ctx.ldata;
+    const double width = ctx.width;
+    const double staffLineWidthStyle = ctx.staffLineWidthStyle;
+    const double spatium = ctx.spatium;
+    std::vector<LineF>& lines = *ctx.lines;
+    std::vector<StaffLines::ColoredLine>& coloredLines = *ctx.coloredLines;
+
+    const Fraction measureStartTick = measure->tick();
+    const StaffType* preSt = staff->staffType(measureStartTick);
+    const double preSpatium = staff->spatium(measureStartTick);
+    const double preDist = preSpatium * preSt->lineDistance().val();
+    const int preLines = preSt->lines();
+    const double preYOffset = preSt->yoffset().val() * preSpatium;
+
+    const size_t estimatedSections = transitionTicks.size() + 1;
+    const size_t estimatedLineSegments = static_cast<size_t>(std::max(preLines, 0)) * estimatedSections;
+    lines.reserve(estimatedLineSegments);
+    coloredLines.reserve(estimatedLineSegments);
+
+    // Transition measures can mix invisible and visible sections.
+    // Keep the item visible and encode invisibility per section.
+    item->setVisible(true);
+    item->setLw(staffLineWidthStyle * spatium);
+    ldata->setPosY(preYOffset);
+    double minY = -item->lw() * 0.5;
+    double maxY = (preLines - 1) * preDist + item->lw() * 0.5;
+
+    auto appendSection = [&](const Fraction& sectionTick, double startX, double endX) {
+        if (endX <= startX) {
+            return;
+        }
+
+        const StaffType* st = staff->staffType(sectionTick);
+        const double sectionSpatium = staff->spatium(sectionTick);
+        const double sectionLw = staffLineWidthStyle * sectionSpatium;
+        const double yOffset = st->yoffset().val() * sectionSpatium;
+        const double lineDistance = sectionSpatium * st->lineDistance().val();
+        const double deltaYOffset = yOffset - preYOffset;
+        const int sectionLines = st->lines();
+        const bool sectionInvisible = staff->isLinesInvisible(sectionTick);
+        const Color sectionColor = sectionInvisible
+                                   ? item->configuration()->invisibleColor()
+                                   : staff->color(sectionTick);
+
+        for (int line = 0; line < sectionLines; ++line) {
+            const double y = deltaYOffset + line * lineDistance;
+            const LineF lineSegment(startX, y, endX, y);
+            lines.push_back(lineSegment);
+            coloredLines.push_back({ lineSegment, sectionColor, sectionLw });
+            minY = std::min(minY, y - sectionLw * 0.5);
+            maxY = std::max(maxY, y + sectionLw * 0.5);
+        }
+    };
+
+    double startX = 0.0;
+    Fraction sectionTick = measureStartTick;
+    for (const Fraction& transitionTick : transitionTicks) {
+        const double endX = std::clamp(measure->tick2pos(transitionTick), 0.0, width);
+        appendSection(sectionTick, startX, endX);
+        startX = endX;
+        sectionTick = transitionTick;
+    }
+    appendSection(sectionTick, startX, width);
+    ldata->setBbox(0.0, minY, width, maxY - minY);
+}
+
 void TLayout::layoutForWidth(StaffLines* item, double w, LayoutContext& ctx)
 {
     LAYOUT_CALL_ITEM(item);
     StaffLines::LayoutData* ldata = item->mutldata();
     const Staff* s = item->staff();
     double _spatium = item->spatium();
-    double dist     = _spatium;
     item->setPos(PointF(0.0, 0.0));
-    int _lines;
-    if (s) {
-        ldata->setMag(s->staffMag(item->measure()->tick()));
-        item->setVisible(!s->isLinesInvisible(item->measure()->tick()));
-        item->setColor(s->color(item->measure()->tick()));
-        const StaffType* st = s->staffType(item->measure()->tick());
-        dist *= st->lineDistance().val();
-        _lines = st->lines();
-        ldata->setPosY(st->yoffset().val() * _spatium);
-//            if (_lines == 1)
-//                  rypos() = 2 * _spatium;
-    } else {
-        _lines = 5;
-        item->setColor(item->configuration()->defaultColor());
-    }
-    item->setLw(ctx.conf().styleS(Sid::staffLineWidth).val() * _spatium);
-    double x1 = item->pos().x();
-    double x2 = x1 + w;
-    double y  = item->pos().y();
-    ldata->setBbox(x1, -item->lw() * .5 + y, w, (_lines - 1) * dist + item->lw());
 
     std::vector<LineF> ll;
-    for (int i = 0; i < _lines; ++i) {
-        ll.push_back(LineF(x1, y, x2, y));
-        y += dist;
+    std::vector<StaffLines::ColoredLine> coloredLines;
+    const double staffLineWidthStyle = ctx.conf().styleS(Sid::staffLineWidth).val();
+
+    if (s) {
+        const Measure* measure = item->measure();
+        const Fraction measureStartTick = measure->tick();
+        const std::vector<Fraction> transitionTicks = measure->midMeasureStaffTypeChangeTicks(item->staffIdx());
+
+        ldata->setMag(s->staffMag(measureStartTick));
+        item->setColor(s->color(measureStartTick));
+
+        const bool isTransitionMeasure = !transitionTicks.empty();
+
+        if (!isTransitionMeasure) {
+            // Original single-staff-type-per-measure path.
+            item->setVisible(!s->isLinesInvisible(measureStartTick));
+            const StaffType* st = s->staffType(measureStartTick);
+            const double dist = _spatium * st->lineDistance().val();
+            const int lines = st->lines();
+            ldata->setPosY(st->yoffset().val() * _spatium);
+
+            ll.reserve(static_cast<size_t>(std::max(lines, 0)));
+            coloredLines.reserve(static_cast<size_t>(std::max(lines, 0)));
+
+            item->setLw(staffLineWidthStyle * _spatium);
+            const PointF itemPos = item->pos();
+            const double startX = itemPos.x();
+            const double endX = startX + w;
+            double y = itemPos.y();
+            ldata->setBbox(startX, -item->lw() * .5 + y, w, (lines - 1) * dist + item->lw());
+
+            for (int i = 0; i < lines; ++i) {
+                const LineF lineSegment(startX, y, endX, y);
+                ll.push_back(lineSegment);
+                coloredLines.push_back({ lineSegment, item->color(), item->lw() });
+                y += dist;
+            }
+        } else {
+            // Transition measure path: split only at/after transition tick.
+            // Keep layout-space semantics consistent with the original path:
+            // yoffset lives in item posY, while bbox remains in local staff-line coordinates.
+            const StaffLinesTransitionLayoutContext transitionCtx {
+                s,
+                measure,
+                &transitionTicks,
+                item,
+                ldata,
+                w,
+                staffLineWidthStyle,
+                _spatium,
+                &ll,
+                &coloredLines,
+            };
+            layoutTransitionMeasureStaffLines(transitionCtx);
+        }
+    } else {
+        const int lines = 5;
+        item->setColor(item->configuration()->defaultColor());
+        item->setLw(staffLineWidthStyle * _spatium);
+        ldata->setBbox(0.0, -item->lw() * .5, w, (lines - 1) * _spatium + item->lw());
+
+        ll.reserve(static_cast<size_t>(lines));
+        coloredLines.reserve(static_cast<size_t>(lines));
+
+        for (int i = 0; i < lines; ++i) {
+            const double y = _spatium * i;
+            const LineF lineSegment(0.0, y, w, y);
+            ll.push_back(lineSegment);
+            coloredLines.push_back({ lineSegment, item->color(), item->lw() });
+        }
     }
-    item->setLines(ll);
+
+    item->setLines(std::move(ll));
+    item->setColoredLines(std::move(coloredLines));
 }
 
 void TLayout::layoutStaffState(const StaffState* item, StaffState::LayoutData* ldata)
@@ -5214,8 +5348,12 @@ void TLayout::layoutStaffTypeChange(const StaffTypeChange* item, StaffTypeChange
     double spatium = conf.spatium();
     ldata->setBbox(RectF(-item->lw() * .5, -item->lw() * .5, spatium * 2.5 + item->lw(), spatium * 2.5 + item->lw()));
     if (item->measure()) {
+        double x = spatium * .8;
+        if (!item->isAtMeasureStart()) {
+            x = item->measure()->tick2pos(item->tick());
+        }
         double y = -1.5 * spatium - ldata->bbox().height() + item->measure()->system()->staff(item->staffIdx())->y();
-        ldata->setPos(spatium * .8, y);
+        ldata->setPos(x, y);
     } else {
         ldata->setPos(0.0, 0.0);
     }

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2246,8 +2246,18 @@ void SingleDraw::draw(const Spacer* item, Painter* painter, const PaintOptions&)
 void SingleDraw::draw(const StaffLines* item, Painter* painter, const PaintOptions& opt)
 {
     TRACE_DRAW_ITEM;
-    painter->setPen(Pen(item->curColor(opt), item->lw(), PenStyle::SolidLine, PenCapStyle::FlatCap));
-    painter->drawLines(item->lines());
+    const std::vector<StaffLines::ColoredLine>& coloredLines = item->coloredLines();
+    if (!coloredLines.empty()) {
+        for (const StaffLines::ColoredLine& coloredLine : coloredLines) {
+            const double lineWidth = coloredLine.width > 0.0 ? coloredLine.width : item->lw();
+            painter->setPen(Pen(item->curColor(item->visible(), coloredLine.color, opt),
+                                lineWidth, PenStyle::SolidLine, PenCapStyle::FlatCap));
+            painter->drawLine(coloredLine.line);
+        }
+    } else {
+        painter->setPen(Pen(item->curColor(opt), item->lw(), PenStyle::SolidLine, PenCapStyle::FlatCap));
+        painter->drawLines(item->lines());
+    }
 }
 
 void SingleDraw::draw(const StaffState* item, Painter* painter, const PaintOptions&)

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3784,6 +3784,8 @@ void TRead::read(StaffTypeChange* c, XmlReader& e, ReadContext& ctx)
             TRead::read(st, e, ctx);
             // Measure::add() will replace this with a pointer to a copy in the staff
             c->setStaffType(st, true);
+        } else if (tag == "tick") {
+            c->setProperty(Pid::TICK, PropertyValue(e.readFraction()));
         } else if (!readItemProperties(c, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -3903,6 +3903,8 @@ void TRead::read(StaffTypeChange* c, XmlReader& e, ReadContext& ctx)
             TRead::read(st, e, ctx);
             // Measure::add() will replace this with a pointer to a copy in the staff
             c->setStaffType(st, true);
+        } else if (tag == "tick") {
+            c->setProperty(Pid::TICK, PropertyValue(e.readFraction()));
         } else if (!readItemProperties(c, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -4027,6 +4027,8 @@ void TRead::read(StaffTypeChange* c, XmlReader& e, ReadContext& ctx)
             TRead::read(st, e, ctx);
             // Measure::add() will replace this with a pointer to a copy in the staff
             c->setStaffType(st, true);
+        } else if (tag == "tick") {
+            c->setProperty(Pid::TICK, PropertyValue(e.readFraction()));
         } else if (!readItemProperties(c, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read500/tread.cpp
+++ b/src/engraving/rw/read500/tread.cpp
@@ -4051,6 +4051,8 @@ void TRead::read(StaffTypeChange* c, XmlReader& e, ReadContext& ctx)
             TRead::read(st, e, ctx);
             // Measure::add() will replace this with a pointer to a copy in the staff
             c->setStaffType(st, true);
+        } else if (tag == "tick") {
+            c->setProperty(Pid::TICK, PropertyValue(e.readFraction()));
         } else if (!readItemProperties(c, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3132,6 +3132,9 @@ void TWrite::write(const StaffTypeChange* item, XmlWriter& xml, WriteContext& ct
     if (item->staffType()) {
         write(item->staffType(), xml, ctx);
     }
+    if (item->tick() != item->propertyDefault(Pid::TICK).value<Fraction>()) {
+        xml.tagFraction("tick", item->tick());
+    }
     writeItemProperties(item, xml, ctx);
     xml.endElement();
 }

--- a/src/engraving/tests/CMakeLists.txt
+++ b/src/engraving/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/split_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/splitstaff_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/staffmove_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stafftypechange_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/stavesharing_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/system_locks_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/system_dividers_tests.cpp

--- a/src/engraving/tests/stafftypechange_tests.cpp
+++ b/src/engraving/tests/stafftypechange_tests.cpp
@@ -1,0 +1,1108 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+
+#include "engraving/compat/scoreaccess.h"
+#include "engraving/dom/barline.h"
+#include "engraving/dom/chordrest.h"
+#include "engraving/dom/clef.h"
+#include "engraving/dom/factory.h"
+#include "engraving/dom/keysig.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/measure.h"
+#include "engraving/dom/mscore.h"
+#include "engraving/dom/segment.h"
+#include "engraving/dom/staff.h"
+#include "engraving/dom/stafftype.h"
+#include "engraving/dom/stafftypechange.h"
+
+#include "utils/scorerw.h"
+
+using namespace mu::engraving;
+
+static const String MEASURE_DATA_DIR(u"measure_data/");
+
+class Engraving_StaffTypeChangeTests : public ::testing::Test
+{
+};
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_insertionTick_returnsMeasureTick
+ * @details This test verifies StaffTypeChange::insertionTick(measure) for a real
+ *          score measure. Expected behavior: it returns the absolute start tick of
+ *          that measure (default insertion position).
+ */
+TEST_F(Engraving_StaffTypeChangeTests, insertionTick_returnsMeasureTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    EXPECT_EQ(StaffTypeChange::insertionTick(measure), measure->tick());
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_isAtMeasureStart_true
+ * @details This test verifies isAtMeasureStart() when the StaffTypeChange tick is
+ *          set to the owning measure start tick. Expected behavior: it reports
+ *          true.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, isAtMeasureStart_true)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setProperty(Pid::TICK, PropertyValue(measure->tick()));
+
+    EXPECT_TRUE(stc->isAtMeasureStart());
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_isAtMeasureStart_false
+ * @details This test verifies isAtMeasureStart() for a mid-measure placement
+ *          (beat 2). Expected behavior: it reports false.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, isAtMeasureStart_false)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    // beat 2 of the measure: one quarter note after the measure's start tick
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setProperty(Pid::TICK, PropertyValue(measure->tick() + Fraction(1, 4)));
+
+    EXPECT_FALSE(stc->isAtMeasureStart());
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_rtick_midMeasure
+ * @details This test verifies relative tick computation via rtick() for a
+ *          mid-measure StaffTypeChange. Expected behavior: rtick() equals
+ *          stc->tick() - measure->tick().
+ */
+TEST_F(Engraving_StaffTypeChangeTests, rtick_midMeasure)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction offset(1, 4); // one quarter note into the measure
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setProperty(Pid::TICK, PropertyValue(measure->tick() + offset));
+
+    EXPECT_EQ(stc->rtick(), offset);
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_saveReadScore_preservesMidMeasureTick
+ * @details This test verifies full score serialization/deserialization for a
+ *          mid-measure StaffTypeChange. Expected behavior: after save/read
+ *          roundtrip, the element exists at the same absolute tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, saveReadScore_preservesMidMeasureTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction tick = measure->tick() + Fraction(1, 4);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(0);
+    stc->setProperty(Pid::TICK, PropertyValue(tick));
+    measure->add(stc);
+
+    // Round-trip through XML to validate persisted tick semantics.
+    const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::filesystem::path roundtripPathStd
+        = std::filesystem::temp_directory_path()
+          / ("stafftypechange-roundtrip-" + std::to_string(uniqueId) + ".mscx");
+    const String roundtripPath = String::fromStdString(roundtripPathStd.string());
+    ASSERT_TRUE(ScoreRW::saveScore(score, roundtripPath));
+
+    MasterScore* restoredScore = ScoreRW::readScore(roundtripPath, true);
+    ASSERT_TRUE(restoredScore);
+
+    Measure* restoredMeasure = restoredScore->firstMeasure();
+    ASSERT_TRUE(restoredMeasure);
+
+    const StaffTypeChange* restored = restoredMeasure->staffTypeChangeAt(0, tick);
+    ASSERT_TRUE(restored);
+
+    EXPECT_EQ(restored->tick(), tick);
+
+    delete restoredScore;
+    delete score;
+
+    // Clean up temp file
+    std::filesystem::remove(roundtripPathStd);
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_getSetProperty_tick
+ * @details This test verifies the Pid::TICK property accessors on
+ *          StaffTypeChange. Expected behavior: setProperty(Pid::TICK, value)
+ *          and getProperty(Pid::TICK) round-trip exactly.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, getSetProperty_tick)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    ASSERT_TRUE(score);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(score->dummy()->measure());
+
+    const Fraction tick(3, 8);
+    stc->setProperty(Pid::TICK, PropertyValue(tick));
+
+    EXPECT_EQ(stc->getProperty(Pid::TICK).value<Fraction>(), tick);
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_propertyDefaultTick_matchesMeasureStart
+ * @details This test verifies the default value for Pid::TICK in a
+ *          measure-owned StaffTypeChange. Expected behavior:
+ *          propertyDefault(Pid::TICK) equals the owning measure start tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, propertyDefaultTick_matchesMeasureStart)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+
+    EXPECT_EQ(stc->propertyDefault(Pid::TICK).value<Fraction>(), measure->tick());
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_propertySetTick_updatesTickSemantics
+ * @details This test verifies semantic consistency after setting Pid::TICK
+ *          through setProperty at a mid-measure value. Expected behavior:
+ *          tick() updates, rtick() matches relative offset, and
+ *          isAtMeasureStart() becomes false.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, propertySetTick_updatesTickSemantics)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    const Fraction midMeasureTick = measure->tick() + Fraction(3, 8);
+
+    // Drive state via property API (not direct setter) to cover undo/property path.
+    ASSERT_TRUE(stc->setProperty(Pid::TICK, PropertyValue(midMeasureTick)));
+
+    EXPECT_EQ(stc->tick(), midMeasureTick);
+    EXPECT_EQ(stc->rtick(), Fraction(3, 8));
+    EXPECT_FALSE(stc->isAtMeasureStart());
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_unsupportedProperty_isRejectedOrUnchanged
+ * @details This test verifies behavior when setting an unrelated property
+ *          (Pid::PITCH) on StaffTypeChange. Expected behavior: tick state is
+ *          unchanged regardless of whether setProperty rejects or accepts.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, unsupportedProperty_isRejectedOrUnchanged)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    const Fraction originalTick = stc->tick();
+
+    stc->setProperty(Pid::PITCH, PropertyValue(60));
+    EXPECT_EQ(stc->tick(), originalTick);
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_canAddStaffTypeChange_rejectsDuplicateTick
+ * @details This test verifies duplicate guarding in
+ *          Measure::canAddStaffTypeChange for the same staff and tick.
+ *          Expected behavior: after adding one StaffTypeChange at that tick,
+ *          the same query returns false.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, canAddStaffTypeChange_rejectsDuplicateTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const Fraction tick = measure->tick() + Fraction(1, 4);
+
+    // Baseline: first insertion at this tick should be permitted.
+    ASSERT_TRUE(measure->canAddStaffTypeChange(staffIdx, tick));
+
+    // Add an STC directly into the measure's element list.
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(staffIdx * VOICES);
+    stc->setProperty(Pid::TICK, PropertyValue(tick));
+    measure->add(stc);
+
+    EXPECT_FALSE(measure->canAddStaffTypeChange(staffIdx, tick));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_canAddStaffTypeChange_allowsDifferentTick
+ * @details This test verifies that duplicate checks are tick-specific.
+ *          Expected behavior: a second StaffTypeChange at a different tick on
+ *          the same staff is still allowed.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, canAddStaffTypeChange_allowsDifferentTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const Fraction tick1 = measure->tick() + Fraction(1, 4);
+    const Fraction tick2 = measure->tick() + Fraction(2, 4);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(staffIdx * VOICES);
+    stc->setProperty(Pid::TICK, PropertyValue(tick1));
+    measure->add(stc);
+
+    // Duplicate checks must be local to a single absolute tick.
+    EXPECT_TRUE(measure->canAddStaffTypeChange(staffIdx, tick2));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_staffTypeChangeAt_exactTick
+ * @details This test verifies Measure::staffTypeChangeAt lookup behavior.
+ *          Expected behavior: exact tick query returns the inserted element,
+ *          while non-matching ticks return nullptr.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, staffTypeChangeAt_exactTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const Fraction tick = measure->tick() + Fraction(1, 2);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(staffIdx * VOICES);
+    stc->setProperty(Pid::TICK, PropertyValue(tick));
+    measure->add(stc);
+
+    EXPECT_EQ(measure->staffTypeChangeAt(staffIdx, tick), stc);
+    EXPECT_EQ(measure->staffTypeChangeAt(staffIdx, tick + Fraction(1, 4)), nullptr);
+    EXPECT_EQ(measure->staffTypeChangeAt(staffIdx, measure->tick()), nullptr);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_moveTicks_propagatesShift
+ * @details This test verifies tick shifting through StaffTypeChange::moveTicks.
+ *          Expected behavior: stored tick is incremented by exactly diff.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, moveTicks_propagatesShift)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction initial = measure->tick() + Fraction(1, 4);
+    const Fraction diff(1, 4);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setProperty(Pid::TICK, PropertyValue(initial));
+
+    stc->moveTicks(diff);
+
+    EXPECT_EQ(stc->tick(), initial + diff);
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_endMeasureUsesStaffTypeActiveAtEnd
+ * @details This test verifies the effective staff type near measure end after a
+ *          mid-measure StaffTypeChange is inserted. Expected behavior: querying
+ *          through the end-barline element path resolves to the new staff type,
+ *          while querying at measure start resolves to the original staff type;
+ *          specifically, end-barline resolution must match the staff type active
+ *          at the last tick in the measure.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, endMeasureUsesStaffTypeActiveAtEnd)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    Staff* staff = score->staff(0);
+    ASSERT_TRUE(staff);
+
+    const StaffType* originalStaffType = staff->staffType(measure->tick());
+    ASSERT_TRUE(originalStaffType);
+    const int originalLines = originalStaffType->lines();
+
+    const Fraction changeTick = measure->tick() + Fraction(1, 2);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    StaffType* modified = new StaffType(*originalStaffType);
+    const int changedLines = originalLines == 1 ? 2 : 1;
+    modified->setLines(changedLines);
+
+    stc->setTrack(0);
+    stc->setProperty(Pid::TICK, PropertyValue(changeTick));
+    stc->setStaffType(modified, true);
+    measure->add(stc);
+
+    Segment* endBarSegment = measure->findSegment(SegmentType::EndBarLine, measure->endTick());
+    ASSERT_TRUE(endBarSegment);
+
+    BarLine* endBarline = toBarLine(endBarSegment->element(0));
+    ASSERT_TRUE(endBarline);
+
+    const Fraction lastTickInMeasure = Fraction::fromTicks(measure->endTick().ticks() - 1);
+    const int expectedEndLines = staff->staffType(lastTickInMeasure)->lines();
+
+    // End-barline resolution should reflect the staff type active at final in-measure tick.
+    EXPECT_EQ(staff->staffType(measure->tick())->lines(), originalLines);
+    EXPECT_EQ(staff->staffType(changeTick)->lines(), changedLines);
+    EXPECT_EQ(staff->staffTypeForElement(endBarline)->lines(), expectedEndLines);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_insertionTick_dropPosMapsToExpectedTick
+ * @details This test verifies x-position to tick mapping used for mid-measure
+ *          drop placement. Expected behavior: a drop at tick2pos(expectedTick)
+ *          resolves to the nearest tick (within one tick of expectedTick);
+ *          positions left/right of measure bounds clamp to startTick and
+ *          lastTickInMeasure respectively.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, insertionTick_dropPosMapsToExpectedTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    score->doLayout();
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction expectedTick = measure->tick() + Fraction(1, 2);
+
+    // Exact coordinate at expectedTick should map to the same (or nearest) tick.
+    const PointF exactDrop(
+        measure->canvasPos().x() + measure->tick2pos(expectedTick),
+        measure->canvasPos().y());
+    const int expectedTicks = expectedTick.ticks();
+    const int mappedTicks = StaffTypeChange::insertionTick(measure, exactDrop).ticks();
+    EXPECT_LE(std::abs(mappedTicks - expectedTicks), 1);
+
+    const PointF leftDrop(measure->canvasPos().x() - 100.0, measure->canvasPos().y());
+
+    // Drops left of the measure should clamp to measure start.
+    EXPECT_EQ(StaffTypeChange::insertionTick(measure, leftDrop), measure->tick());
+
+    const int lastTickInMeasure = measure->endTick().ticks() - 1;
+    const PointF rightDrop(
+        measure->canvasPos().x() + measure->tick2pos(Fraction::fromTicks(lastTickInMeasure)) + 100.0,
+        measure->canvasPos().y());
+
+    // Drops right of the measure should clamp to the last in-measure tick.
+    EXPECT_EQ(StaffTypeChange::insertionTick(measure, rightDrop), Fraction::fromTicks(lastTickInMeasure));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_twoSTCs_differentTicks_bothAccepted
+ * @details This test verifies coexistence of multiple StaffTypeChange elements
+ *          on one staff at different ticks. Expected behavior: both insertion
+ *          checks pass for distinct ticks, and both are retrievable by
+ *          staffTypeChangeAt.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, twoSTCs_differentTicks_bothAccepted)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const Fraction tick1 = measure->tick() + Fraction(1, 4);
+    const Fraction tick2 = measure->tick() + Fraction(3, 4);
+
+    ASSERT_TRUE(measure->canAddStaffTypeChange(staffIdx, tick1));
+    ASSERT_TRUE(measure->canAddStaffTypeChange(staffIdx, tick2));
+
+    StaffTypeChange* stc1 = Factory::createStaffTypeChange(measure);
+    stc1->setTrack(staffIdx * VOICES);
+    stc1->setProperty(Pid::TICK, PropertyValue(tick1));
+    measure->add(stc1);
+
+    // Adding the first STC must not block the second tick.
+    EXPECT_TRUE(measure->canAddStaffTypeChange(staffIdx, tick2));
+
+    StaffTypeChange* stc2 = Factory::createStaffTypeChange(measure);
+    stc2->setTrack(staffIdx * VOICES);
+    stc2->setProperty(Pid::TICK, PropertyValue(tick2));
+    measure->add(stc2);
+
+    EXPECT_NE(measure->staffTypeChangeAt(staffIdx, tick1), nullptr);
+    EXPECT_NE(measure->staffTypeChangeAt(staffIdx, tick2), nullptr);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_transitionMeasureReportsMidMeasureTick
+ * @details Verifies branch selection metadata for a start measure containing a
+ *          mid-measure StaffTypeChange. Expected behavior: the measure is
+ *          reported as a transition measure and transitionTick matches the
+ *          inserted StaffTypeChange tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, transitionMeasureReportsMidMeasureTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ASSERT_TRUE(m1);
+    Measure* m2 = m1->nextMeasure();
+    ASSERT_TRUE(m2);
+
+    Staff* staff = score->staff(0);
+    ASSERT_TRUE(staff);
+
+    const Fraction changeTick = m1->tick() + Fraction(1, 4);
+    const StaffType* original = staff->staffType(m1->tick());
+    ASSERT_TRUE(original);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(m1);
+    StaffType* modified = new StaffType(*original);
+    modified->setStepOffset(original->stepOffset() + 2);
+
+    stc->setTrack(0);
+    stc->setProperty(Pid::TICK, PropertyValue(changeTick));
+    stc->setStaffType(modified, true);
+    m1->add(stc);
+
+    Fraction transitionTick;
+
+    // Transition metadata should report the earliest in-measure STC tick.
+    EXPECT_TRUE(m1->isStaffTypeTransitionMeasure(0, &transitionTick));
+    EXPECT_EQ(transitionTick, changeTick);
+
+    // Only the start measure with a mid-measure STC should be marked transition.
+    EXPECT_FALSE(m2->isStaffTypeTransitionMeasure(0));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_followingMeasureUsesChangedTypeWithoutTransitionFlag
+ * @details Verifies the post-transition branch contract. Expected behavior:
+ *          following measures are not transition measures, but the changed
+ *          staff type is active for their elements from measure start.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, followingMeasureUsesChangedTypeWithoutTransitionFlag)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ASSERT_TRUE(m1);
+    Measure* m2 = m1->nextMeasure();
+    ASSERT_TRUE(m2);
+
+    Staff* staff = score->staff(0);
+    ASSERT_TRUE(staff);
+
+    const Fraction changeTick = m1->tick() + Fraction(1, 4);
+    const StaffType* original = staff->staffType(m1->tick());
+    ASSERT_TRUE(original);
+
+    const int changedStepOffset = original->stepOffset() + 3;
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(m1);
+    StaffType* modified = new StaffType(*original);
+    modified->setStepOffset(changedStepOffset);
+
+    stc->setTrack(0);
+    stc->setProperty(Pid::TICK, PropertyValue(changeTick));
+    stc->setStaffType(modified, true);
+    m1->add(stc);
+
+    score->doLayout();
+
+    EXPECT_TRUE(m1->isStaffTypeTransitionMeasure(0));
+    EXPECT_FALSE(m2->isStaffTypeTransitionMeasure(0));
+
+    const StaffType* m2StartType = staff->staffType(m2->tick());
+    ASSERT_TRUE(m2StartType);
+    EXPECT_EQ(m2StartType->stepOffset(), changedStepOffset);
+
+    ChordRest* m2CR = score->findCR(m2->tick(), 0);
+    ASSERT_TRUE(m2CR);
+
+    const StaffType* m2ElementType = staff->staffTypeForElement(m2CR);
+    ASSERT_TRUE(m2ElementType);
+    EXPECT_EQ(m2ElementType->stepOffset(), changedStepOffset);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_midMeasureTicks_excludeStartAndEnd
+ * @details Verifies that transition tick collection only reports strict
+ *          mid-measure StaffTypeChange ticks. Expected behavior: measure start
+ *          and measure end ticks are excluded.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, midMeasureTicks_excludeStartAndEnd)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction startTick = measure->tick();
+    const Fraction midTick = measure->tick() + Fraction(1, 4);
+    const Fraction endTick = measure->endTick();
+
+    StaffTypeChange* startStc = Factory::createStaffTypeChange(measure);
+    startStc->setTrack(0);
+    startStc->setProperty(Pid::TICK, PropertyValue(startTick));
+    measure->add(startStc);
+
+    StaffTypeChange* midStc = Factory::createStaffTypeChange(measure);
+    midStc->setTrack(0);
+    midStc->setProperty(Pid::TICK, PropertyValue(midTick));
+    measure->add(midStc);
+
+    StaffTypeChange* endStc = Factory::createStaffTypeChange(measure);
+    endStc->setTrack(0);
+    endStc->setProperty(Pid::TICK, PropertyValue(endTick));
+    measure->add(endStc);
+
+    const std::vector<Fraction> ticks = measure->midMeasureStaffTypeChangeTicks(0);
+    const std::vector<Fraction> expected { midTick };
+    EXPECT_EQ(ticks, expected);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_midMeasureTicks_reportsEarliest
+ * @details Verifies current transition tick collection behavior when multiple
+ *          mid-measure StaffTypeChange elements are inserted.
+ *          Expected behavior: all mid-measure ticks are reported in order,
+ *          while transition metadata still resolves to the earliest tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, midMeasureTicks_reportsEarliest)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction tick1 = measure->tick() + Fraction(1, 4);
+    const Fraction tick2 = measure->tick() + Fraction(3, 8);
+
+    StaffTypeChange* stc1 = Factory::createStaffTypeChange(measure);
+    stc1->setTrack(0);
+    stc1->setProperty(Pid::TICK, PropertyValue(tick1));
+    measure->add(stc1);
+
+    StaffTypeChange* stc2 = Factory::createStaffTypeChange(measure);
+    stc2->setTrack(0);
+    stc2->setProperty(Pid::TICK, PropertyValue(tick2));
+    measure->add(stc2);
+
+    const std::vector<Fraction> ticks = measure->midMeasureStaffTypeChangeTicks(0);
+    const std::vector<Fraction> expected { tick1, tick2 };
+    EXPECT_EQ(ticks, expected);
+
+    Fraction transitionTick;
+    EXPECT_TRUE(measure->isStaffTypeTransitionMeasure(0, &transitionTick));
+    EXPECT_EQ(transitionTick, tick1);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_isPostTransitionTick_boundary
+ * @details Verifies boundary behavior around the first transition tick.
+ *          Expected behavior: false before, true at and after transition tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, isPostTransitionTick_boundary)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction transitionTick = measure->tick() + Fraction(1, 4);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(0);
+    stc->setProperty(Pid::TICK, PropertyValue(transitionTick));
+    measure->add(stc);
+
+    EXPECT_FALSE(measure->isPostStaffTypeTransitionTick(0, transitionTick - Fraction(1, 16)));
+    EXPECT_TRUE(measure->isPostStaffTypeTransitionTick(0, transitionTick));
+    EXPECT_TRUE(measure->isPostStaffTypeTransitionTick(0, transitionTick + Fraction(1, 16)));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_isPostTransitionTick_falseWithoutTransition
+ * @details Verifies behavior when a measure has no mid-measure transition.
+ *          Expected behavior: query is always false.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, isPostTransitionTick_falseWithoutTransition)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    EXPECT_FALSE(measure->isPostStaffTypeTransitionTick(0, measure->tick()));
+    EXPECT_FALSE(measure->isPostStaffTypeTransitionTick(0, measure->tick() + Fraction(1, 2)));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_transitionTick_usesFirstMidMeasureChange
+ * @details Verifies transition tick selection with multiple mid-measure changes.
+ *          Expected behavior: first transition tick is reported.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, transitionTick_usesFirstMidMeasureChange)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction tick1 = measure->tick() + Fraction(1, 4);
+    const Fraction tick2 = measure->tick() + Fraction(3, 4);
+
+    StaffTypeChange* stc2 = Factory::createStaffTypeChange(measure);
+    stc2->setTrack(0);
+    stc2->setProperty(Pid::TICK, PropertyValue(tick2));
+    measure->add(stc2);
+
+    StaffTypeChange* stc1 = Factory::createStaffTypeChange(measure);
+    stc1->setTrack(0);
+    stc1->setProperty(Pid::TICK, PropertyValue(tick1));
+    measure->add(stc1);
+
+    Fraction transitionTick;
+    EXPECT_TRUE(measure->isStaffTypeTransitionMeasure(0, &transitionTick));
+    EXPECT_EQ(transitionTick, tick1);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_roundTrip_preservesFirstTransitionTick
+ * @details Verifies save/read roundtrip preserves transition semantics for
+ *          measures with multiple inserted mid-measure StaffTypeChange values.
+ *          Expected behavior: transition metadata remains valid and reports
+ *          the first transition tick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, roundTrip_preservesFirstTransitionTick)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction tick1 = measure->tick() + Fraction(1, 4);
+    const Fraction tick2 = measure->tick() + Fraction(3, 4);
+
+    StaffTypeChange* stc1 = Factory::createStaffTypeChange(measure);
+    stc1->setTrack(0);
+    stc1->setProperty(Pid::TICK, PropertyValue(tick1));
+    measure->add(stc1);
+
+    StaffTypeChange* stc2 = Factory::createStaffTypeChange(measure);
+    stc2->setTrack(0);
+    stc2->setProperty(Pid::TICK, PropertyValue(tick2));
+    measure->add(stc2);
+
+    // Persist and reload to ensure transition ordering survives serialization.
+    const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::filesystem::path roundtripPathStd
+        = std::filesystem::temp_directory_path()
+          / ("stafftypechange-roundtrip-multi-" + std::to_string(uniqueId) + ".mscx");
+    const String roundtripPath = String::fromStdString(roundtripPathStd.string());
+    ASSERT_TRUE(ScoreRW::saveScore(score, roundtripPath));
+
+    MasterScore* restoredScore = ScoreRW::readScore(roundtripPath, true);
+    ASSERT_TRUE(restoredScore);
+
+    Measure* restoredMeasure = restoredScore->firstMeasure();
+    ASSERT_TRUE(restoredMeasure);
+
+    Fraction transitionTick;
+    EXPECT_TRUE(restoredMeasure->isStaffTypeTransitionMeasure(0, &transitionTick));
+    EXPECT_EQ(transitionTick, tick1);
+
+    delete restoredScore;
+    delete score;
+
+    // Clean up temp file
+    std::filesystem::remove(roundtripPathStd);
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_insertionTick_atEndTick_isRejected
+ * @details Verifies that an STC placed at the measure's end tick is excluded
+ *          from the mid-measure tick collection. Expected behavior:
+ *          midMeasureStaffTypeChangeTicks does not include endTick.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, insertionTick_atEndTick_isRejected)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction endTick = measure->endTick();
+    const staff_idx_t staffIdx = 0;
+
+    // A StaffTypeChange placed at the end tick is not a valid mid-measure tick.
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(staffIdx * VOICES);
+    stc->setProperty(Pid::TICK, PropertyValue(endTick));
+    measure->add(stc);
+
+    const std::vector<Fraction> midTicks = measure->midMeasureStaffTypeChangeTicks(staffIdx);
+    const auto it = std::find(midTicks.begin(), midTicks.end(), endTick);
+    EXPECT_EQ(it, midTicks.end());
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_canAddStaffTypeChange_sameTick_differentStaff_isAllowed
+ * @details Verifies that duplicate guarding is per-staff. Expected behavior:
+ *          adding an STC on staff 0 at a given tick does not block the same
+ *          tick on staff 1.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, canAddStaffTypeChange_sameTick_differentStaff_isAllowed)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+    ASSERT_GT(score->nstaves(), 1);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction tick = measure->tick() + Fraction(1, 4);
+
+    StaffTypeChange* stc0 = Factory::createStaffTypeChange(measure);
+    stc0->setTrack(0);
+    stc0->setProperty(Pid::TICK, PropertyValue(tick));
+    measure->add(stc0);
+
+    // Same tick, same staff — must be blocked.
+    EXPECT_FALSE(measure->canAddStaffTypeChange(0, tick));
+
+    // Same tick, different staff — allowed.
+    EXPECT_TRUE(measure->canAddStaffTypeChange(1, tick));
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_insertionTick_nullMeasure_returnsFractionZero
+ * @details Verifies that insertionTick(nullptr) is robust and does not crash.
+ *          Expected behavior: returns Fraction(0, 1).
+ */
+TEST_F(Engraving_StaffTypeChangeTests, insertionTick_nullMeasure_returnsFractionZero)
+{
+    const Fraction result = StaffTypeChange::insertionTick(nullptr);
+    EXPECT_EQ(result, Fraction(0, 1));
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_insertionTick_nullMeasureWithPos_returnsFractionZero
+ * @details Verifies that insertionTick(nullptr, pos) is robust and does not crash.
+ *          Expected behavior: returns Fraction(0, 1).
+ */
+TEST_F(Engraving_StaffTypeChangeTests, insertionTick_nullMeasureWithPos_returnsFractionZero)
+{
+    const Fraction result = StaffTypeChange::insertionTick(nullptr, PointF(100.0, 0.0));
+    EXPECT_EQ(result, Fraction(0, 1));
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_moveTicks_zeroDiff_isNoOp
+ * @details Verifies that moveTicks with Fraction(0, 1) leaves the stored tick
+ *          unchanged. Expected behavior: tick is identical before and after.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, moveTicks_zeroDiff_isNoOp)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const Fraction initial = measure->tick() + Fraction(1, 4);
+
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setProperty(Pid::TICK, PropertyValue(initial));
+
+    stc->moveTicks(Fraction(0, 1));
+
+    EXPECT_EQ(stc->tick(), initial);
+
+    delete stc;
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_multipleSTCs_sameTick_deduplicatedInMidMeasureTicks
+ * @details Verifies behavior when multiple StaffTypeChange elements are forced
+ *          to the same staff/tick by direct insertion into the measure. This
+ *          documents the defensive behavior expected when callers bypass
+ *          canAddStaffTypeChange(). Expected behavior: exact tick lookup still
+ *          resolves, and midMeasureStaffTypeChangeTicks reports that tick once
+ *          (deduplicated for transition calculations).
+ */
+TEST_F(Engraving_StaffTypeChangeTests, multipleSTCs_sameTick_deduplicatedInMidMeasureTicks)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const Fraction sharedTick = measure->tick() + Fraction(1, 4);
+
+    // Intentionally bypass duplicate guard to validate downstream robustness.
+    StaffTypeChange* stc1 = Factory::createStaffTypeChange(measure);
+    stc1->setTrack(staffIdx * VOICES);
+    stc1->setProperty(Pid::TICK, PropertyValue(sharedTick));
+    measure->add(stc1);
+
+    StaffTypeChange* stc2 = Factory::createStaffTypeChange(measure);
+    stc2->setTrack(staffIdx * VOICES);
+    stc2->setProperty(Pid::TICK, PropertyValue(sharedTick));
+    measure->add(stc2);
+
+    // Exact lookup remains valid even when duplicates exist at the same tick.
+    EXPECT_NE(measure->staffTypeChangeAt(staffIdx, sharedTick), nullptr);
+
+    // Transition tick collection must expose a stable deduplicated view.
+    const std::vector<Fraction> ticks = measure->midMeasureStaffTypeChangeTicks(staffIdx);
+    const std::vector<Fraction> expected { sharedTick };
+    EXPECT_EQ(ticks, expected);
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_staffTypeChange_coexistsWithClefAndKeySig
+ * @details Verifies StaffTypeChange behavior in a measure containing other
+ *          measure elements. Expected behavior: adding clef and key signature
+ *          elements at measure start does not affect StaffTypeChange lookup or
+ *          duplicate guarding at a mid-measure tick. This protects against
+ *          regressions where segment-level element additions interfere with
+ *          measure-level StaffTypeChange bookkeeping.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, staffTypeChange_coexistsWithClefAndKeySig)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const track_idx_t track = staffIdx * VOICES;
+    const Fraction startTick = measure->tick();
+    const Fraction stcTick = startTick + Fraction(1, 4);
+
+    // Add representative segment-based elements at measure start.
+    Segment* clefSeg = measure->undoGetSegment(SegmentType::Clef, startTick);
+    ASSERT_TRUE(clefSeg);
+    Clef* clef = Factory::createClef(score->dummy()->segment());
+    clef->setTrack(track);
+    clefSeg->add(clef);
+
+    Segment* keySigSeg = measure->undoGetSegment(SegmentType::KeySig, startTick);
+    ASSERT_TRUE(keySigSeg);
+    KeySig* keySig = Factory::createKeySig(score->dummy()->segment());
+    keySig->setTrack(track);
+    keySig->setKey(Key::C);
+    keySigSeg->add(keySig);
+
+    // Add a mid-measure staff type change on the same staff/track.
+    StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+    stc->setTrack(track);
+    stc->setProperty(Pid::TICK, PropertyValue(stcTick));
+    measure->add(stc);
+
+    // STC APIs should behave as if other measure elements were absent.
+    EXPECT_NE(measure->staffTypeChangeAt(staffIdx, stcTick), nullptr);
+    EXPECT_FALSE(measure->canAddStaffTypeChange(staffIdx, stcTick));
+
+    // Sanity check that the companion elements are really present.
+    ASSERT_TRUE(clefSeg->element(track));
+    EXPECT_TRUE(clefSeg->element(track)->isClef());
+    ASSERT_TRUE(keySigSeg->element(track));
+    EXPECT_TRUE(keySigSeg->element(track)->isKeySig());
+
+    delete score;
+}
+
+/**
+ * @brief Engraving_StaffTypeChangeTests_largeCountQueries_completeWithinBudget
+ * @details Stress/performance sanity test for measures with many mid-measure
+ *          StaffTypeChange elements. Expected behavior: query APIs return
+ *          expected results and complete within a conservative time budget.
+ *          This is intended as a regression tripwire for algorithmic slowdowns,
+ *          not as a microbenchmark.
+ */
+TEST_F(Engraving_StaffTypeChangeTests, largeCountQueries_completeWithinBudget)
+{
+    MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
+    ASSERT_TRUE(score);
+
+    Measure* measure = score->firstMeasure();
+    ASSERT_TRUE(measure);
+
+    const staff_idx_t staffIdx = 0;
+    const track_idx_t track = staffIdx * VOICES;
+    const int startTick = measure->tick().ticks();
+    const int endTick = measure->endTick().ticks();
+    const int availableMidTicks = std::max(0, endTick - startTick - 1);
+    ASSERT_GT(availableMidTicks, 0);
+
+    // Keep count bounded for stable execution on developer machines and CI.
+    const int insertedCount = std::min(availableMidTicks, 512);
+    for (int i = 0; i < insertedCount; ++i) {
+        StaffTypeChange* stc = Factory::createStaffTypeChange(measure);
+        stc->setTrack(track);
+        stc->setProperty(Pid::TICK, PropertyValue(Fraction::fromTicks(startTick + 1 + i)));
+        measure->add(stc);
+    }
+
+    // Exercise hot query paths repeatedly to detect major complexity regressions.
+    const Fraction probeTick = Fraction::fromTicks(startTick + 1 + insertedCount / 2);
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < 200; ++i) {
+        const std::vector<Fraction> ticks = measure->midMeasureStaffTypeChangeTicks(staffIdx);
+        EXPECT_EQ(static_cast<int>(ticks.size()), insertedCount);
+        EXPECT_NE(measure->staffTypeChangeAt(staffIdx, probeTick), nullptr);
+    }
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    // Optional perf guard: keep wall-clock assertions out of default CI/unit runs.
+    if (std::getenv("MUSE_PERF_TESTS") != nullptr) {
+        EXPECT_LT(elapsedMs, 5000);
+    }
+
+    delete score;
+}

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -490,10 +490,33 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
         segment = shadowNoteActualSegment;
     }
 
-    Fraction tick = segment->tick();
-    qreal mag = staff->staffMag(tick);
+    const Fraction inputTick = segment->tick();
+    Fraction previewTick = inputTick;
 
-    const mu::engraving::Instrument* instr = staff->part()->instrument(tick);
+    // Keep original input-tick behavior, but choose preview style by hovered
+    // x-region inside a transition measure.
+    if (position.segment) {
+        const Measure* hoveredMeasure = position.segment->measure();
+        if (hoveredMeasure) {
+            const std::vector<Fraction> transitionTicks
+                =hoveredMeasure->midMeasureStaffTypeChangeTicks(position.staffIdx);
+            if (!transitionTicks.empty()) {
+                const Fraction hoverTick = StaffTypeChange::insertionTick(hoveredMeasure, position.pos);
+                previewTick = hoveredMeasure->tick();
+                for (const Fraction& transitionTick : transitionTicks) {
+                    if (transitionTick <= hoverTick) {
+                        previewTick = transitionTick;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    qreal mag = staff->staffMag(previewTick);
+
+    const mu::engraving::Instrument* instr = staff->part()->instrument(inputTick);
 
     mu::engraving::NoteHeadGroup noteheadGroup = mu::engraving::NoteHeadGroup::HEAD_NORMAL;
     mu::engraving::NoteHeadType noteHead = params.duration.headType();
@@ -529,7 +552,7 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
 
     shadowNote.setVisible(true);
     shadowNote.mutldata()->setMag(mag);
-    shadowNote.setTick(tick);
+    shadowNote.setTick(previewTick);
     shadowNote.setStaffIdx(position.staffIdx);
     shadowNote.setVoice(voice);
     shadowNote.setLineIndex(line);
@@ -547,7 +570,7 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
         Score* s = score()->paletteScore() ? score()->paletteScore() : score();
         mu::engraving::Rest* rest = mu::engraving::Factory::createRest(s->dummy()->segment(), params.duration.type());
         rest->setTicks(params.duration.fraction());
-        symNotehead = rest->getSymbol(params.duration.type(), 0, staff->lines(position.segment->tick()));
+        symNotehead = rest->getSymbol(params.duration.type(), 0, staff->lines(previewTick));
         shadowNote.setState(symNotehead, params.duration, true, params.position.beyondScore);
         delete rest;
     } else {
@@ -563,7 +586,7 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
 
     // if upscaled, note appears by default a distance away from the segment start,
     // as described in ChordLayout::centreChords
-    if (mag > 1.0) {
+    if (mag > 1.0 && previewTick == inputTick) {
         qreal xOffset = (mag - 1.0) * 0.5 * shadowNote.symWidth(symNotehead);
         if (shadowNote.computeUp()) {
             position.pos.rx() += xOffset;
@@ -606,7 +629,17 @@ RectF NotationInteraction::shadowNoteRect() const
     }
 
     penWidth *= note->mag();
-    rect.adjust(-penWidth, -penWidth, penWidth, penWidth);
+
+    // Add extra vertical repaint margin to avoid staff-line artifacts while
+    // dragging note preview in ledger-line zones.
+    double lineDistanceFactor = 1.0;
+    double lineCount = 5.0;
+    if (const StaffType* st = note->staffType()) {
+        lineDistanceFactor = std::max(1.0, st->lineDistance().val());
+        lineCount = std::max(4.0, static_cast<double>(st->lines()));
+    }
+    const double extraY = note->spatium() * note->mag() * lineDistanceFactor * (lineCount + 4.0);
+    rect.adjust(-penWidth, -penWidth - extraY, penWidth, penWidth + extraY);
 
     return rect;
 }
@@ -3229,8 +3262,11 @@ bool NotationInteraction::prepareDropMeasureAnchorElement(const PointF& pos)
         return false;
     }
 
-    mu::engraving::staff_idx_t staffIdx;
-    mu::engraving::MeasureBase* mb = score()->pos2measure(pos, &staffIdx, 0, nullptr, 0);
+    mu::engraving::staff_idx_t staffIdx = muse::nidx;
+    mu::engraving::MeasureBase* mb = score()->pos2measure(pos, &staffIdx, 0, nullptr, nullptr);
+    const bool isStaffTypeChange = dropElem->isStaffTypeChange()
+                                   || (dropElem->isActionIcon()
+                                       && toActionIcon(dropElem)->actionType() == ActionIconType::STAFF_TYPE_CHANGE);
 
     //! NOTE: Should match Measure::acceptDrop
     switch (dropElem->type()) {
@@ -3259,7 +3295,7 @@ bool NotationInteraction::prepareDropMeasureAnchorElement(const PointF& pos)
     }
 
     // Apart from STAFF_TYPE_CHANGE, measure anchored action icons are applied to all staves
-    if (dropElem->isActionIcon() && toActionIcon(dropElem)->actionType() != ActionIconType::STAFF_TYPE_CHANGE) {
+    if (dropElem->isActionIcon() && !isStaffTypeChange) {
         staffIdx = 0;
     }
 
@@ -3270,11 +3306,36 @@ bool NotationInteraction::prepareDropMeasureAnchorElement(const PointF& pos)
 
         RectF measureRect = targetMeasure->staffPageBoundingRect(staffIdx);
         measureRect.adjust(page->x(), page->y(), page->x(), page->y());
-        edd.ed.pos = measureRect.center();
+
+        PointF dropPoint = measureRect.center();
+        if (isStaffTypeChange) {
+            // Keep the exact drag position in canvas coordinates for tick mapping.
+            dropPoint = pos;
+        }
+
+        edd.ed.pos = dropPoint;
 
         const bool dropAccepted = targetMeasure->acceptDrop(edd.ed);
         if (dropAccepted) {
-            setAnchorLines({ LineF(pos, measureRect.topLeft()) });
+            LineF anchorLine;
+            if (isStaffTypeChange) {
+                const Fraction measureStartTick = targetMeasure->tick();
+                const Fraction tick = StaffTypeChange::insertionTick(targetMeasure, dropPoint);
+                if (tick == measureStartTick) {
+                    // Preserve legacy left-edge cue: STC at measure start anchors to top-left.
+                    anchorLine = LineF(pos, measureRect.topLeft());
+                } else {
+                    const double measureLeftX = targetMeasure->canvasPos().x();
+                    const double snappedX = measureLeftX + targetMeasure->tick2pos(tick);
+                    anchorLine = LineF(PointF(snappedX, measureRect.top()), PointF(snappedX, measureRect.bottom()));
+                }
+            } else {
+                anchorLine = LineF(pos, dropPoint);
+            }
+
+            setAnchorLines({ anchorLine });
+        } else {
+            setDropTarget(nullptr, true);
         }
 
         return dropAccepted;


### PR DESCRIPTION
Resolves: #28310

This implementation enables mid-measure staff type changes by allowing StaffTypeChange to be placed at any tick inside a measure, instead of only at measure start. The new behavior makes it possible that a mid-measure change only affects notation from that insertion point onward, while notation before that point keeps the previous staff type. To implement this, StaffTypeChange and Measure were updated to use tick-aware insertion and drop handling, including validation to prevent duplicate StaffTypeChange elements at the same staff and tick. The add, remove, acceptDrop, and drop paths were adjusted so this behavior remains consistent with undo/redo. Read and write handling was also updated so mid-measure StaffTypeChange ticks are preserved across save/load. Finally, layout, rendering, and interaction logic were aligned with the new tick semantics so transitions inside a single measure are displayed and edited correctly. StaffTypeChange tests were added for insertion tick mapping, persistence, duplicate prevention, and transition behavior.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [raquelmrviana](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).