### PR TITLE
Fix cmake -P build.cmake run on Windows

### DIFF
--- a/build.cmake
+++ b/build.cmake
@@ -166,7 +166,7 @@ fn__set_default(INSTALL_PATH "install") # relative to BUILD_PATH
 
 # MSCORE_EXECUTABLE (path relative to INSTALL_PATH)
 if(WIN32)
-    fn__set_default(MSCORE_EXECUTABLE "bin/MuseScore5.exe")
+    fn__set_default(MSCORE_EXECUTABLE "bin/MuseScoreStudio5.exe")
 elseif(APPLE)
     fn__set_default(MSCORE_EXECUTABLE "mscore.app/Contents/MacOS/mscore")
 else()


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

`cmake -P build.cmake run` on Windows starts MuseScore5.exe instead of MuseScoreStudio5.exe.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [rmcat](https://musescore.org/en/user/6621726): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).