### PR TITLE
Refactor slur/tie mask computation to only check for items that are on a staff covered by the spanner

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -4134,4 +4134,10 @@ bool Note::transpose(Interval interval, bool useDoubleSharpsFlats)
     EditNote::undoChangePitch(score(), this, npitch, ntpc1, ntpc2);
     return true;
 }
+
+staff_idx_t Note::vStaffIdx() const
+{
+    const Chord* c = chord();
+    return c ? c->vStaffIdx() : EngravingItem::vStaffIdx();
+}
 }

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -167,6 +167,8 @@ public:
     void scanElements(std::function<void(EngravingItem*)> func) override;
     void setTrack(track_idx_t val) override;
 
+    staff_idx_t vStaffIdx() const override;
+
     int playTicks() const;
     Fraction playTicksFraction() const;
 

--- a/src/engraving/rendering/score/masklayout.cpp
+++ b/src/engraving/rendering/score/masklayout.cpp
@@ -31,6 +31,7 @@
 #include "dom/measurenumber.h"
 #include "dom/note.h"
 #include "dom/parenthesis.h"
+#include "dom/score.h"
 #include "dom/segment.h"
 #include "dom/staff.h"
 #include "dom/stafflines.h"
@@ -371,17 +372,25 @@ void MaskLayout::computeSlurTieMasks(SlurTieSegment* slurTieSegment)
     TRACEFUNC;
 
     Spanner* spanner = slurTieSegment->spanner();
-    std::vector<const EngravingItem*> itemsToMaskOver;
     const Segment* startSeg = spanner->startSegment();
     const Segment* endSeg = spanner->endSegment();
+    const EngravingItem* startElement = spanner->startElement();
+    const EngravingItem* endElement = spanner->endElement();
+    staff_idx_t startStaffIdx = startElement ? startElement->vStaffIdx() : 0;
+    staff_idx_t endStaffIdx = endElement ? endElement->vStaffIdx() : spanner->score()->nstaves() - 1;
+    if (startStaffIdx > endStaffIdx) {
+        std::swap(startStaffIdx, endStaffIdx);
+    }
+
+    std::vector<const EngravingItem*> itemsToMaskOver;
     for (const Segment* seg = startSeg; seg && seg != endSeg; seg = seg->next1()) {
         if (!seg->enabled()
             || !seg->isType(SegmentType::KeySigType | SegmentType::TimeSigType | SegmentType::ClefType)
             || seg->system() != slurTieSegment->system()) {
             continue;
         }
-        for (const EngravingItem* item : seg->elist()) {
-            if (item) {
+        for (staff_idx_t staffIdx = startStaffIdx; staffIdx <= endStaffIdx; ++staffIdx) {
+            if (EngravingItem* item = seg->element(staffIdx * VOICES)) { // Key/Time/Clef-type segments never have elements in any voice other than 0
                 itemsToMaskOver.push_back(item);
             }
         }

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2157,7 +2157,7 @@ void SlurTieLayout::forceHorizontal(Tie* tie, SlurTiePos& sPos)
 
     if (startNote && endNote
         && startNote->line() == endNote->line()
-        && startNote->chord()->vStaffIdx() == endNote->chord()->vStaffIdx()) {
+        && startNote->vStaffIdx() == endNote->vStaffIdx()) {
         double y1 = sPos.p1.y();
         double y2 = sPos.p2.y();
         double outerY = tie->up() ? std::min(y1, y2) : std::max(y1, y2);


### PR DESCRIPTION
Follow up on https://github.com/musescore/MuseScore/pull/33024 (see https://github.com/musescore/MuseScore/pull/33024#discussion_r3323178680).

Avoid checking for mask collisions agains all items unnecessarily, by using the `vStaffIdx()` of the spanner's start and end note/chord to only check for items within those bounds.

I added a `Note::vStaffIdx()` overload which simply calls the same function on the note's chord.