### PR TITLE
Make Revision in Score properties and About box a clickable URL to the corresponding commit

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/AboutDialog.qml
+++ b/src/appshell/qml/MuseScore/AppShell/AboutDialog.qml
@@ -106,6 +106,15 @@ StyledDialogView {
                     }
                 }
             }
+            StyledTextLabel {
+                Layout.fillWidth: true
+
+                text: qsTrc("appshell/about", "Build date: %1")
+                      .arg(aboutModel.museScoreBuildDateTime())
+
+                wrapMode: Text.WordWrap
+                maximumLineCount: 2
+            }
 
             StyledTextLabel {
                 Layout.fillWidth: true

--- a/src/appshell/qml/MuseScore/AppShell/AboutDialog.qml
+++ b/src/appshell/qml/MuseScore/AppShell/AboutDialog.qml
@@ -83,7 +83,7 @@ StyledDialogView {
 
                 StyledTextLabel {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    text: qsTrc("appshell/about", "Version:") + " " + aboutModel.museScoreVersion()
+                    text: qsTrc("appshell/about", "Version: %1").arg(aboutModel.museScoreVersion())
                     font: ui.theme.bodyBoldFont
                 }
 
@@ -93,7 +93,7 @@ StyledDialogView {
 
                     StyledTextLabel {
                         anchors.verticalCenter: parent.verticalCenter
-                        text: qsTrc("appshell/about", "Revision:") + " " + aboutModel.museScoreRevision()
+                        text: qsTrc("appshell/about", "Revision: %1").arg(aboutModel.museScoreRevisionLink())
                     }
 
                     FlatButton {

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
@@ -30,6 +30,9 @@
 
 using namespace mu::appshell;
 
+//! NOTE: Should match value in projectpropertiesmodel.cpp
+static const QString GITHUB_REVISION_URL("https://github.com/musescore/MuseScore/commit/");
+
 AboutModel::AboutModel(QObject* parent)
     : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
@@ -43,10 +46,14 @@ QString AboutModel::museScoreVersion() const
            : version;
 }
 
-QString AboutModel::museScoreRevision() const
+QString AboutModel::museScoreRevisionLink() const
 {
-    return QString("<a href=\"https://github.com/musescore/MuseScore/commit/%1\">%1</a>")
-           .arg(QString::fromStdString(configuration()->museScoreRevision()));
+    const QString rev = QString::fromStdString(configuration()->museScoreRevision());
+    if (rev.isEmpty()) {
+        return muse::qtrc("global", "Unknown");
+    }
+    const QString revUrl = GITHUB_REVISION_URL + rev;
+    return QString("<a href=\"%1\">%2</a>").arg(revUrl, rev);
 }
 
 QString AboutModel::museScoreBuildDateTime() const
@@ -106,17 +113,23 @@ QVariantMap AboutModel::musicXMLLicenseDeedUrl() const
 
 void AboutModel::copyRevisionToClipboard() const
 {
-    QGuiApplication::clipboard()->setText(
-        QString("OS: %1, Arch.: %2, MuseScore Studio version (%3-bit): %4-%5, revision: "
-                "[%6](https://github.com/musescore/MuseScore/commit/%6)")
-        .arg(QSysInfo::prettyProductName()
-             + ((QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
-                ? " or later" : ""), QSysInfo::currentCpuArchitecture())
-        .arg(QSysInfo::WordSize)
-        .arg(application()->version().toString(), application()->build())
-        +
-        QString(application()->revision().isEmpty() ? "" : ", revision: [%1](https://github.com/musescore/MuseScore/commit/%1)")
-        .arg(application()->revision()));
+    QString osName = QSysInfo::prettyProductName();
+    if (QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11")) {
+        osName += " or later";
+    }
+
+    QString forClipboard = QString("OS: %1, Arch.: %2, MuseScore Studio version (%3-bit): %4-%5")
+                           .arg(osName, QSysInfo::currentCpuArchitecture())
+                           .arg(QSysInfo::WordSize)
+                           .arg(application()->version().toString(), application()->build());
+
+    const QString rev = QString::fromStdString(configuration()->museScoreRevision());
+    if (!rev.isEmpty()) {
+        const QString revUrl = GITHUB_REVISION_URL + rev;
+        forClipboard += QString(", revision: [%1](%2)").arg(rev, revUrl);
+    }
+
+    QGuiApplication::clipboard()->setText(forClipboard);
 }
 
 void AboutModel::toggleDevMode()

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
@@ -88,15 +88,13 @@ QVariantMap AboutModel::musicXMLLicenseDeedUrl() const
 void AboutModel::copyRevisionToClipboard() const
 {
     QGuiApplication::clipboard()->setText(
-        QString("OS: %1, Arch.: %2, MuseScore Studio version (%3-bit): %4-%5, revision: github-musescore-musescore-%6")
+        QString("OS: %1, Arch.: %2, MuseScore Studio version (%3-bit): %4-%5, revision: "
+                "[%6](https://github.com/musescore/MuseScore/commit/%6)")
         .arg(QSysInfo::prettyProductName()
              + ((QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
-                ? " or later" : ""))
-        .arg(QSysInfo::currentCpuArchitecture())
+                ? " or later" : ""), QSysInfo::currentCpuArchitecture())
         .arg(QSysInfo::WordSize)
-        .arg(application()->version().toString())
-        .arg(application()->build())
-        .arg(application()->revision()));
+        .arg(application()->version().toString(), application()->build(), application()->revision()));
 }
 
 void AboutModel::toggleDevMode()

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
@@ -49,6 +49,25 @@ QString AboutModel::museScoreRevision() const
            .arg(QString::fromStdString(configuration()->museScoreRevision()));
 }
 
+QString AboutModel::museScoreBuildDateTime() const
+{
+    auto buildDateISO = []() -> QString {
+        // Attempt to convert __DATE__ into ISO 8601 format (YYYY-MM-DD)
+        QDate date = QDate::fromString(__DATE__, "MMM dd yyyy");
+        if (!date.isValid()) {
+            date = QDate::fromString(__DATE__, "MMM  d yyyy");
+        }
+        return date.isValid() ? date.toString(Qt::ISODate) : __DATE__;
+    };
+
+    QString dateTime;
+    dateTime += buildDateISO();
+    dateTime += " ";
+    dateTime += __TIME__;
+
+    return dateTime;
+}
+
 QVariantMap AboutModel::museScoreUrl() const
 {
     QUrl museScoreUrl(QString::fromStdString(configuration()->museScoreUrl()));

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
@@ -94,7 +94,10 @@ void AboutModel::copyRevisionToClipboard() const
              + ((QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
                 ? " or later" : ""), QSysInfo::currentCpuArchitecture())
         .arg(QSysInfo::WordSize)
-        .arg(application()->version().toString(), application()->build(), application()->revision()));
+        .arg(application()->version().toString(), application()->build())
+        +
+        QString(application()->revision().isEmpty() ? "" : ", revision: [%1](https://github.com/musescore/MuseScore/commit/%1)")
+        .arg(application()->revision()));
 }
 
 void AboutModel::toggleDevMode()

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.cpp
@@ -45,7 +45,8 @@ QString AboutModel::museScoreVersion() const
 
 QString AboutModel::museScoreRevision() const
 {
-    return QString::fromStdString(configuration()->museScoreRevision());
+    return QString("<a href=\"https://github.com/musescore/MuseScore/commit/%1\">%1</a>")
+           .arg(QString::fromStdString(configuration()->museScoreRevision()));
 }
 
 QVariantMap AboutModel::museScoreUrl() const

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.h
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.h
@@ -50,6 +50,7 @@ public:
 
     Q_INVOKABLE QString museScoreVersion() const;
     Q_INVOKABLE QString museScoreRevision() const;
+    Q_INVOKABLE QString museScoreBuildDateTime() const;
     Q_INVOKABLE QVariantMap museScoreUrl() const;
     Q_INVOKABLE QVariantMap museScoreForumUrl() const;
     Q_INVOKABLE QVariantMap museScoreContributionUrl() const;

--- a/src/appshell/qml/MuseScore/AppShell/aboutmodel.h
+++ b/src/appshell/qml/MuseScore/AppShell/aboutmodel.h
@@ -49,7 +49,7 @@ public:
     explicit AboutModel(QObject* parent = nullptr);
 
     Q_INVOKABLE QString museScoreVersion() const;
-    Q_INVOKABLE QString museScoreRevision() const;
+    Q_INVOKABLE QString museScoreRevisionLink() const;
     Q_INVOKABLE QString museScoreBuildDateTime() const;
     Q_INVOKABLE QVariantMap museScoreUrl() const;
     Q_INVOKABLE QVariantMap museScoreForumUrl() const;

--- a/src/engraving/rendering/score/headerfooterlayout.cpp
+++ b/src/engraving/rendering/score/headerfooterlayout.cpp
@@ -359,14 +359,15 @@ TextBlock HeaderFooterLayout::replaceTextMacros(LayoutContext& ctx, const Page* 
                     break;
                 case 'r':
                     if (page->score()->dirty()) {
-                        static String revision; // FIXME
-                        newFragments.back().text += revision;
+                        newFragments.back().text += String(); // FIXME
                     } else {
                         int rev = page->score()->mscoreRevision();
-                        if (rev > 99999) { // MuseScore 1.3 is decimal 5702, 2.0 and later uses a 7-digit hex SHA
-                            newFragments.back().text += String::number(rev, 16);
-                        } else {
+                        if (rev > 0 && rev <= 5709) { // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
                             newFragments.back().text += String::number(rev, 10);
+                        } else if (rev > 0xffffff) { // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
+                            newFragments.back().text += String::number(rev, 16);
+                        } else { // unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
+                            newFragments.back().text += String::number(rev, 10); // or "" or "Unknown"?
                         }
                     }
                     break;

--- a/src/engraving/rendering/score/headerfooterlayout.cpp
+++ b/src/engraving/rendering/score/headerfooterlayout.cpp
@@ -359,7 +359,7 @@ TextBlock HeaderFooterLayout::replaceTextMacros(LayoutContext& ctx, const Page* 
                     break;
                 case 'r':
                     if (page->score()->dirty()) {
-                        newFragments.back().text += String(); // FIXME
+                        newFragments.back().text += application()->revision();
                     } else {
                         int rev = page->score()->mscoreRevision();
                         if (rev > 0 && rev <= 5709) { // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709

--- a/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
@@ -32,6 +32,10 @@ using namespace muse::modularity;
 using namespace mu::notation;
 using namespace mu::project;
 
+//! NOTE: Should match value in aboutmodel.cpp
+static const QString GITHUB_REVISION_URL("https://github.com/musescore/MuseScore/commit/");
+static const QString SOURCEFORGE_REVISION_URL("https://sourceforge.net/p/mscore/code/");
+
 ProjectPropertiesModel::ProjectPropertiesModel(QObject* parent)
     : QAbstractListModel(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
@@ -159,17 +163,23 @@ QString ProjectPropertiesModel::version() const
 
 QString ProjectPropertiesModel::revision() const
 {
-    int rev = m_projectMetaInfo.musescoreRevision;
-    QString revision;
-    if (rev > 0 && rev <= 5709) { // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
-        revision = QString("<a href=\"https://sourceforge.net/p/mscore/code/%1/\">%1</a>").arg(QString::number(rev, 10));
-    } else if (rev > 0xffffff) { // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
-        revision = QString("<a href=\"https://github.com/musescore/MuseScore/commit/%1\">%1</a>").arg(QString::number(rev, 16));
-    } else { // unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
-        revision = QString::number(rev, 10); // or "" or "Unknown"?
+    const int rev = m_projectMetaInfo.musescoreRevision;
+    if (rev > 0 && rev <= 5709) {
+        // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
+        const QString revText = QString::number(rev, 10);
+        const QString revUrl = SOURCEFORGE_REVISION_URL + revText;
+        return QString("<a href=\"%1\">%2</a>").arg(revUrl, revText);
     }
 
-    return revision;
+    if (rev > 0xffffff) {
+        // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
+        const QString revText = QString::number(rev, 16);
+        const QString revUrl = GITHUB_REVISION_URL + revText;
+        return QString("<a href=\"%1\">%2</a>").arg(revUrl, revText);
+    }
+
+    // unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
+    return muse::qtrc("global", "Unknown");
 }
 
 QString ProjectPropertiesModel::apiLevel() const

--- a/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Properties/projectpropertiesmodel.cpp
@@ -161,10 +161,12 @@ QString ProjectPropertiesModel::revision() const
 {
     int rev = m_projectMetaInfo.musescoreRevision;
     QString revision;
-    if (rev > 99999) {     // MuseScore 1.3 is decimal 5702, 2.0 and later uses a 7-digit hex SHA
-        revision = QString::number(rev, 16);
-    } else {
-        revision = QString::number(rev, 10);
+    if (rev > 0 && rev <= 5709) { // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
+        revision = QString("<a href=\"https://sourceforge.net/p/mscore/code/%1/\">%1</a>").arg(QString::number(rev, 10));
+    } else if (rev > 0xffffff) { // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
+        revision = QString("<a href=\"https://github.com/musescore/MuseScore/commit/%1\">%1</a>").arg(QString::number(rev, 16));
+    } else { // unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
+        revision = QString::number(rev, 10); // or "" or "Unknown"?
     }
 
     return revision;


### PR DESCRIPTION
* Make Revision in Score properties a clickable URL to the corresponding commit
* Adjust `$r` Macro replacement to use a similar logic
   No URL in the score though, as that isn't supported yet, see #18055
* Resolve an old FIXME
* Make the Revision in the About box a clickable URL too
* Fixing URL in the About box clipboard
   The old one makes sense on musescore.org, as it automagically turns into a URL there, but it doesn't work on GitHub. The plain number would work on GitHub, but not on musescore.org. This way (using MarkDown syntax) it works on both.
* ~Cater for MuseScore 3.7 Evolution scores (and link to the corresponding commit)~
* Avoid nonsensical link in clipboard
* Add build date and time to About dialog