### PR TITLE
EXPERIMENTAL/POC - DO NOT MERGE - adding volume automation tracks to instruments for playback / export

### DIFF
--- a/src/engraving/automation/automationtypes.h
+++ b/src/engraving/automation/automationtypes.h
@@ -44,6 +44,7 @@ struct AutomationPoint {
 enum class AutomationType : unsigned char {
     Unknown = 0,
     Dynamics,
+    Expression,
 };
 
 using AutomationCurve = std::map<int /*utick*/, AutomationPoint>;

--- a/src/engraving/automation/internal/automation.cpp
+++ b/src/engraving/automation/internal/automation.cpp
@@ -30,6 +30,7 @@ using namespace mu::engraving;
 
 static const std::unordered_map<AutomationType, muse::String> AUTOMATION_TYPE_TO_STRING {
     { AutomationType::Dynamics, u"Dynamics" },
+    { AutomationType::Expression, u"Expression" },
 };
 
 static const std::unordered_map<AutomationPoint::InterpolationType, muse::String> INTERPOLATION_TYPE_TO_STRING {
@@ -211,7 +212,11 @@ void Automation::read(const muse::ByteArray& json)
         const muse::JsonObject curveObj = rootArray.at(i).toObject();
         AutomationCurveKey key;
         key.type = muse::key(AUTOMATION_TYPE_TO_STRING, curveObj.value("type").toString(), AutomationType::Unknown);
-        key.staffId = static_cast<uint64_t>(curveObj.value("staffId").toInt());
+
+        const muse::String staffId = curveObj.value("staffId").toString();
+        key.staffId = !staffId.empty()
+                      ? muse::ID(staffId.toStdString())
+                      : muse::ID(static_cast<uint64_t>(curveObj.value("staffId").toInt()));
 
         if (curveObj.contains("voiceId")) {
             key.voiceIdx = static_cast<size_t>(curveObj.value("voiceId").toInt());

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -22,7 +22,11 @@
 
 #include "playbackmodel.h"
 
+#include <algorithm>
+#include <iterator>
 #include <limits>
+
+#include "engraving/automation/iautomation.h"
 
 #include "dom/fret.h"
 #include "dom/harmony.h"
@@ -37,6 +41,7 @@
 #include "dom/tie.h"
 #include "dom/tremolotwochord.h"
 #include "editing/undo.h"
+#include "types/constants.h"
 
 #include "defer.h"
 #include "log.h"
@@ -48,6 +53,7 @@ using namespace muse::async;
 
 static const String METRONOME_INSTRUMENT_ID(u"metronome");
 static const String CHORD_SYMBOLS_INSTRUMENT_ID(u"chord_symbols");
+static constexpr int AUTOMATION_EXPRESSION_STEP_TICKS = Constants::DIVISION / 4;
 
 const InstrumentTrackId PlaybackModel::METRONOME_TRACK_ID = { 999, METRONOME_INSTRUMENT_ID };
 
@@ -60,6 +66,85 @@ static const Harmony* findChordSymbol(const EngravingItem* item)
     }
 
     return nullptr;
+}
+
+static AutomationCurveKey expressionAutomationKey(const Staff* staff)
+{
+    AutomationCurveKey key;
+    key.type = AutomationType::Expression;
+    key.staffId = staff ? staff->id() : muse::ID();
+    return key;
+}
+
+static ControllerChangeEvent expressionControllerEvent(double value)
+{
+    ControllerChangeEvent event;
+    event.type = ControllerChangeEvent::Expression;
+    event.val = static_cast<float>(std::clamp(value, 0.0, 1.0));
+    return event;
+}
+
+static void appendExpressionEvent(PlaybackEventsMap& events, const Score* score, int utick, double value)
+{
+    events[timestampFromTicks(score, utick)].push_back(expressionControllerEvent(value));
+}
+
+static void appendExpressionCurve(PlaybackEventsMap& events, const Score* score, const AutomationCurve& curve,
+                                  int tickFrom, int tickTo)
+{
+    if (curve.empty()) {
+        return;
+    }
+
+    auto it = curve.lower_bound(tickFrom);
+    if (it != curve.cbegin()) {
+        --it;
+    }
+
+    for (; it != curve.cend(); ++it) {
+        const int tick = it->first;
+        const AutomationPoint& point = it->second;
+        if (tick > tickTo) {
+            break;
+        }
+
+        if (tick > tickFrom && tick <= tickTo) {
+            appendExpressionEvent(events, score, tick, point.outValue);
+        }
+
+        auto nextIt = std::next(it);
+        if (nextIt == curve.cend()) {
+            continue;
+        }
+
+        const int nextTick = nextIt->first;
+        if (nextTick < tickFrom) {
+            continue;
+        }
+
+        if (nextTick <= tick) {
+            continue;
+        }
+
+        const double startValue = point.outValue;
+        const double endValue = nextIt->second.inValue;
+        if (muse::RealIsEqual(startValue, endValue)) {
+            continue;
+        }
+
+        const int durationTicks = nextTick - tick;
+        const int steps = std::max(1, durationTicks / AUTOMATION_EXPRESSION_STEP_TICKS);
+        for (int step = 1; step < steps; ++step) {
+            const int stepTick = tick + (durationTicks * step / steps);
+            if (stepTick < tickFrom || stepTick > tickTo) {
+                continue;
+            }
+
+            const double ratio = static_cast<double>(step) / static_cast<double>(steps);
+            const double value = startValue + ((endValue - startValue) * ratio);
+            appendExpressionEvent(events, score, stepTick, value);
+        }
+    }
 }
 
 void PlaybackModel::load(Score* score)
@@ -666,6 +751,60 @@ void PlaybackModel::updateEvents(const int tickFrom, const int tickTo, const tra
                 m_renderer.renderMetronome(m_score, measure, tickPositionOffset, metronomeProfile, metronomeEvents);
                 collectChangesTracks(METRONOME_TRACK_ID, trackChanges);
             }
+        }
+    }
+
+    appendAutomationExpressionEvents(tickFrom, tickTo, trackFrom, trackTo, trackChanges);
+}
+
+void PlaybackModel::appendAutomationExpressionEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom,
+                                                     const track_idx_t trackTo, ChangedTrackIdSet* trackChanges)
+{
+    TRACEFUNC;
+
+    if (!m_score || !m_score->automation()) {
+        return;
+    }
+
+    for (const Part* part : m_score->parts()) {
+        if (!part || trackTo < part->startTrack() || trackFrom >= part->endTrack()) {
+            continue;
+        }
+
+        PlaybackEventsMap events;
+        for (const Staff* staff : part->staves()) {
+            if (!staff || !staff->isPrimaryStaff()) {
+                continue;
+            }
+
+            const AutomationCurveKey key = expressionAutomationKey(staff);
+            const AutomationCurve& curve = m_score->automation()->curve(key);
+            if (curve.empty()) {
+                continue;
+            }
+
+            const AutomationPoint& activePoint = m_score->automation()->activePoint(key, tickFrom);
+            appendExpressionEvent(events, m_score, tickFrom, activePoint.outValue);
+            appendExpressionCurve(events, m_score, curve, tickFrom, tickTo);
+        }
+
+        if (events.empty()) {
+            continue;
+        }
+
+        for (const InstrumentTrackId& trackId : part->instrumentTrackIdSet()) {
+            auto trackDataIt = m_playbackDataMap.find(trackId);
+            if (trackDataIt == m_playbackDataMap.end()) {
+                continue;
+            }
+
+            PlaybackEventsMap& originEvents = trackDataIt->second.originEvents;
+            for (const auto& [timestamp, eventList] : events) {
+                PlaybackEventList& destination = originEvents[timestamp];
+                destination.insert(destination.begin(), eventList.begin(), eventList.end());
+            }
+
+            collectChangesTracks(trackId, trackChanges);
         }
     }
 }

--- a/src/engraving/playback/playbackmodel.h
+++ b/src/engraving/playback/playbackmodel.h
@@ -122,6 +122,8 @@ private:
     void updateContext(const InstrumentTrackId& trackId);
     void updateEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom, const track_idx_t trackTo,
                       ChangedTrackIdSet* trackChanges = nullptr);
+    void appendAutomationExpressionEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom,
+                                          const track_idx_t trackTo, ChangedTrackIdSet* trackChanges = nullptr);
 
     void reloadMetronomeEvents();
 

--- a/src/engraving/tests/automation/automation_tests.cpp
+++ b/src/engraving/tests/automation/automation_tests.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "engraving/automation/internal/automationcontroller.h"
 #include "engraving/automation/iautomation.h"
 #include "engraving/dom/staff.h"
@@ -44,6 +46,12 @@ class Engraving_AutomationTests : public ::testing::Test
 {
 };
 
+static AutomationPoint makePoint(double inValue, double outValue,
+                                 InterpolationType interpolation = InterpolationType::Linear)
+{
+    return AutomationPoint { inValue, outValue, interpolation, std::nullopt };
+}
+
 static void checkCurvesMatch(const AutomationCurve& actualCurve, const AutomationCurve& expectedCurve)
 {
     EXPECT_EQ(actualCurve.size(), expectedCurve.size());
@@ -61,13 +69,13 @@ static void checkCurvesMatch(const AutomationCurve& actualCurve, const Automatio
 TEST_F(Engraving_AutomationTests, Init_Dynamics)
 {
     // [GIVEN] Score with dynamics
-    Score* score = ScoreRW::readScore(AUTOMATION_DATA_DIR + u"dynamics.mscx");
+    std::unique_ptr<Score> score(ScoreRW::readScore(AUTOMATION_DATA_DIR + u"dynamics.mscx"));
     ASSERT_TRUE(score);
     ASSERT_FALSE(score->staves().empty());
 
     // [WHEN] Calculate the dynamics curve
     AutomationController controller;
-    controller.init(score);
+    controller.init(score.get());
 
     // [THEN] Curve matches expectations
     AutomationCurveKey key;
@@ -78,20 +86,20 @@ TEST_F(Engraving_AutomationTests, Init_Dynamics)
 
     // 1st measure
     AutomationCurve expectedCurve;
-    expectedCurve[480] = AutomationPoint { MID_VALUE, P_VALUE, InterpolationType::Linear }; // 2nd beat: p
-    expectedCurve[1440] = AutomationPoint { P_VALUE, MP_VALUE, InterpolationType::Linear }; // 4th beat: mp
+    expectedCurve[480] = makePoint(MID_VALUE, P_VALUE); // 2nd beat: p
+    expectedCurve[1440] = makePoint(P_VALUE, MP_VALUE); // 4th beat: mp
 
     // 2nd measure
-    expectedCurve[1920] = AutomationPoint { MP_VALUE, F_VALUE, InterpolationType::Linear }; // 1st beat: sf
-    expectedCurve[2400] = AutomationPoint { F_VALUE, MP_VALUE, InterpolationType::Linear }; // 2nd beat: mp
-    expectedCurve[2880] = AutomationPoint { MP_VALUE, P_VALUE, InterpolationType::Exponential }; // 3rd beat: p (pf)
-    expectedCurve[3264] = AutomationPoint { P_VALUE, F_VALUE, InterpolationType::Linear }; // 4th beat: f (pf)
+    expectedCurve[1920] = makePoint(MP_VALUE, F_VALUE); // 1st beat: sf
+    expectedCurve[2400] = makePoint(F_VALUE, MP_VALUE); // 2nd beat: mp
+    expectedCurve[2880] = makePoint(MP_VALUE, P_VALUE, InterpolationType::Exponential); // 3rd beat: p (pf)
+    expectedCurve[3264] = makePoint(P_VALUE, F_VALUE); // 4th beat: f (pf)
 
     // 3rd measure
-    expectedCurve[4800] = AutomationPoint { F_VALUE, P_VALUE, InterpolationType::Linear }; // 3rd beat: p (hairpin starts)
+    expectedCurve[4800] = makePoint(F_VALUE, P_VALUE); // 3rd beat: p (hairpin starts)
 
     // 4th measure
-    expectedCurve[5760] = AutomationPoint { FF_VALUE, FF_VALUE, InterpolationType::Linear }; // 1st beat: ff (hairpin ends)
+    expectedCurve[5760] = makePoint(FF_VALUE, FF_VALUE); // 1st beat: ff (hairpin ends)
 
     checkCurvesMatch(actualCurve, expectedCurve);
 
@@ -101,9 +109,36 @@ TEST_F(Engraving_AutomationTests, Init_Dynamics)
 
     // 3rd measure
     expectedCurve.clear();
-    expectedCurve[3840] = AutomationPoint { MID_VALUE, F_VALUE, InterpolationType::Linear }; // 1st beat: f (applied only to 2nd voice)
+    expectedCurve[3840] = makePoint(MID_VALUE, F_VALUE); // 1st beat: f (applied only to 2nd voice)
 
     checkCurvesMatch(actualCurve, expectedCurve);
 
-    delete score;
+}
+
+TEST_F(Engraving_AutomationTests, ReadWrite_ExpressionStaffId)
+{
+    std::unique_ptr<Score> score(ScoreRW::readScore(AUTOMATION_DATA_DIR + u"dynamics.mscx"));
+    ASSERT_TRUE(score);
+    ASSERT_FALSE(score->staves().empty());
+
+    AutomationController controller;
+    controller.init(score.get());
+
+    AutomationCurveKey key;
+    key.type = AutomationType::Expression;
+    key.staffId = score->staff(0)->id();
+
+    AutomationPoint point;
+    point.inValue = 0.25;
+    point.outValue = 0.75;
+    point.interpolation = InterpolationType::Linear;
+    controller.automation()->addPoint(key, 480, point);
+
+    AutomationController roundTripController;
+    roundTripController.automation()->read(controller.automation()->toJson());
+
+    AutomationCurve expectedCurve;
+    expectedCurve[480] = point;
+    checkCurvesMatch(roundTripController.automation()->curve(key), expectedCurve);
+
 }

--- a/src/engraving/tests/playback/playbackmodel_tests.cpp
+++ b/src/engraving/tests/playback/playbackmodel_tests.cpp
@@ -29,9 +29,11 @@
 #include "mpe/tests/utils/articulationutils.h"
 #include "mpe/tests/mocks/articulationprofilesrepositorymock.h"
 
+#include "engraving/automation/iautomation.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/measure.h"
 #include "engraving/dom/chord.h"
+#include "engraving/dom/staff.h"
 
 #include "engraving/playback/playbackmodel.h"
 
@@ -1198,8 +1200,8 @@ TEST_F(Engraving_PlaybackModelTests, Metronome_6_4_Repeat)
 TEST_F(Engraving_PlaybackModelTests, Note_Entry_Playback_Note)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    Score* score = ScoreRW::readScore(
-        PLAYBACK_MODEL_TEST_FILES_DIR + "note_entry_playback/note_entry_playback_note.mscx");
+    std::unique_ptr<Score> score(ScoreRW::readScore(
+        PLAYBACK_MODEL_TEST_FILES_DIR + "note_entry_playback/note_entry_playback_note.mscx"));
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
@@ -1228,7 +1230,7 @@ TEST_F(Engraving_PlaybackModelTests, Note_Entry_Playback_Note)
     // [GIVEN] The playback model requested to be loaded
     PlaybackModel model(modularity::globalCtx());
     model.profilesRepository.set(m_repositoryMock);
-    model.load(score);
+    model.load(score.get());
 
     PlaybackData result = model.resolveTrackPlaybackData(part->id(), part->instrumentId());
 
@@ -1260,6 +1262,65 @@ TEST_F(Engraving_PlaybackModelTests, Note_Entry_Playback_Note)
 
     // [WHEN] User has clicked on the first note
     model.triggerEventsForItems({ firstNote }, QUARTER_NOTE_DURATION, true /*flushSounds*/);
+}
+
+TEST_F(Engraving_PlaybackModelTests, Automation_Expression_Events)
+{
+    // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
+    std::unique_ptr<Score> score(ScoreRW::readScore(
+        PLAYBACK_MODEL_TEST_FILES_DIR + "note_entry_playback/note_entry_playback_note.mscx"));
+
+    ASSERT_TRUE(score);
+    ASSERT_FALSE(score->staves().empty());
+    ASSERT_EQ(score->parts().size(), 1);
+    ASSERT_TRUE(score->automation());
+
+    const Part* part = score->parts().front();
+    ASSERT_TRUE(part);
+
+    AutomationCurveKey key;
+    key.type = AutomationType::Expression;
+    key.staffId = score->staff(0)->id();
+
+    AutomationPoint startExpressionPoint;
+    startExpressionPoint.inValue = 0.25;
+    startExpressionPoint.outValue = 0.25;
+
+    AutomationPoint secondBeatExpressionPoint;
+    secondBeatExpressionPoint.inValue = 0.75;
+    secondBeatExpressionPoint.outValue = 0.75;
+
+    score->automation()->addPoint(key, 0, startExpressionPoint);
+    score->automation()->addPoint(key, 480, secondBeatExpressionPoint);
+
+    // [GIVEN] The articulation profiles repository will be returning required profiles
+    ON_CALL(*m_repositoryMock, defaultProfile(_)).WillByDefault(Return(m_defaultProfile));
+
+    // [WHEN] The playback model is loaded
+    PlaybackModel model(modularity::globalCtx());
+    model.profilesRepository.set(m_repositoryMock);
+    model.load(score.get());
+
+    PlaybackData result = model.resolveTrackPlaybackData(part->id(), part->instrumentId());
+
+    // [THEN] Expression automation is emitted as controller-change playback events
+    ASSERT_TRUE(result.originEvents.contains(0));
+    const PlaybackEventList& startEvents = result.originEvents.at(0);
+    ASSERT_FALSE(startEvents.empty());
+    ASSERT_TRUE(std::holds_alternative<ControllerChangeEvent>(startEvents.front()));
+
+    const ControllerChangeEvent& startExpression = std::get<ControllerChangeEvent>(startEvents.front());
+    EXPECT_EQ(startExpression.type, ControllerChangeEvent::Expression);
+    EXPECT_NEAR(startExpression.val.raw(), 0.25f, 0.0001f);
+
+    ASSERT_TRUE(result.originEvents.contains(QUARTER_NOTE_DURATION));
+    const PlaybackEventList& beatTwoEvents = result.originEvents.at(QUARTER_NOTE_DURATION);
+    ASSERT_FALSE(beatTwoEvents.empty());
+    ASSERT_TRUE(std::holds_alternative<ControllerChangeEvent>(beatTwoEvents.front()));
+
+    const ControllerChangeEvent& beatTwoExpression = std::get<ControllerChangeEvent>(beatTwoEvents.front());
+    EXPECT_EQ(beatTwoExpression.type, ControllerChangeEvent::Expression);
+    EXPECT_NEAR(beatTwoExpression.val.raw(), 0.75f, 0.0001f);
 }
 
 /**

--- a/src/notation/inotationautomation.h
+++ b/src/notation/inotationautomation.h
@@ -36,8 +36,11 @@ public:
 
     virtual QVariant automationLinesData() const = 0;
     virtual muse::async::Notification automationLinesDataChanged() const = 0;
+    virtual void refreshAutomationView() = 0;
 
     virtual void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y) = 0;
+    virtual void requestAddAutomationPoint(qsizetype lineIdx, qreal x, qreal y) = 0;
+    virtual void requestRemoveAutomationPoint(qsizetype lineIdx, qsizetype pointIdx) = 0;
 };
 
 using INotationAutomationPtr = std::shared_ptr<INotationAutomation>;

--- a/src/notation/internal/notationautomation.cpp
+++ b/src/notation/internal/notationautomation.cpp
@@ -21,29 +21,323 @@
  */
 
 #include "notationautomation.h"
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+#include <vector>
+
 #include "engraving/automation/iautomation.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/editing/undo.h"
 
 using namespace mu::notation;
 
-// TODO: This will do for now, but it needs to be smarter because there will be gaps between ChordRest/TimeTick segment types (e.g.
-// barlines). This method effectively needs to return the closest segment of the desired type (and probably whether canvasX is before
-// or after the segment). If the canvasX is before the closest segment, then we'll go on to use the start tick of the segment. If it's
-// after, we'll use the end tick of the segment....
-static const Segment* segmentForCanvasX(const System* system, double canvasX)
+static constexpr mu::engraving::AutomationType AUTOMATION_VIEW_TYPE = mu::engraving::AutomationType::Expression;
+static constexpr double AUTOMATION_VIEW_DEFAULT_VALUE = 0.5;
+
+static double automationValueToLineY(double value)
+{
+    return 1.0 - std::clamp(value, 0.0, 1.0);
+}
+
+static double lineYToAutomationValue(double y)
+{
+    return 1.0 - std::clamp(static_cast<double>(y), 0.0, 1.0);
+}
+
+static mu::engraving::AutomationCurveKey automationKey(const mu::engraving::Staff* staff)
+{
+    mu::engraving::AutomationCurveKey key;
+    key.type = AUTOMATION_VIEW_TYPE;
+    key.staffId = staff ? staff->id() : muse::ID();
+    return key;
+}
+
+static bool hasAutomationPointAtTick(const mu::engraving::IAutomation* automation,
+                                     const mu::engraving::AutomationCurveKey& key, int tick)
+{
+    IF_ASSERT_FAILED(automation) {
+        return false;
+    }
+
+    const mu::engraving::AutomationCurve& curve = automation->curve(key);
+    return curve.find(tick) != curve.cend();
+}
+
+static mu::engraving::AutomationPoint automationPoint(double value)
+{
+    mu::engraving::AutomationPoint point;
+    point.inValue = value;
+    point.outValue = value;
+    return point;
+}
+
+static bool automationPointsEqual(const mu::engraving::AutomationPoint& left,
+                                  const mu::engraving::AutomationPoint& right)
+{
+    return muse::RealIsEqual(left.inValue, right.inValue)
+           && muse::RealIsEqual(left.outValue, right.outValue)
+           && left.interpolation == right.interpolation
+           && left.itemId == right.itemId;
+}
+
+static bool automationCurvesEqual(const mu::engraving::AutomationCurve& left,
+                                  const mu::engraving::AutomationCurve& right)
+{
+    if (left.size() != right.size()) {
+        return false;
+    }
+
+    auto leftIt = left.cbegin();
+    auto rightIt = right.cbegin();
+    while (leftIt != left.cend()) {
+        if (leftIt->first != rightIt->first || !automationPointsEqual(leftIt->second, rightIt->second)) {
+            return false;
+        }
+
+        ++leftIt;
+        ++rightIt;
+    }
+
+    return true;
+}
+
+static void replaceAutomationCurve(mu::engraving::IAutomation* automation,
+                                   const mu::engraving::AutomationCurveKey& key,
+                                   const mu::engraving::AutomationCurve& curve)
+{
+    IF_ASSERT_FAILED(automation) {
+        return;
+    }
+
+    const mu::engraving::AutomationCurve currentCurve = automation->curve(key);
+    for (const auto& point : currentCurve) {
+        automation->removePoint(key, point.first);
+    }
+
+    for (const auto& [tick, point] : curve) {
+        automation->addPoint(key, tick, point);
+    }
+}
+
+class ChangeAutomationCurve : public mu::engraving::UndoCommand
+{
+public:
+    ChangeAutomationCurve(mu::engraving::Score* score, mu::engraving::AutomationCurveKey key,
+                          mu::engraving::AutomationCurve before, mu::engraving::AutomationCurve after)
+        : m_score(score), m_key(std::move(key)), m_before(std::move(before)), m_after(std::move(after))
+    {
+    }
+
+    const char* name() const override
+    {
+        return "ChangeAutomationCurve";
+    }
+
+protected:
+    void flip(mu::engraving::EditData*) override
+    {
+        IF_ASSERT_FAILED(m_score && m_score->automation()) {
+            return;
+        }
+
+        replaceAutomationCurve(m_score->automation(), m_key, m_atAfter ? m_before : m_after);
+        m_atAfter = !m_atAfter;
+    }
+
+private:
+    mu::engraving::Score* m_score = nullptr;
+    mu::engraving::AutomationCurveKey m_key;
+    mu::engraving::AutomationCurve m_before;
+    mu::engraving::AutomationCurve m_after;
+    bool m_atAfter = true;
+};
+
+static const Segment* firstAutomationSegmentForSystem(const System* system)
 {
     IF_ASSERT_FAILED(system) {
         return nullptr;
     }
+
     const mu::engraving::SegmentType type = Segment::CHORD_REST_OR_TIME_TICK_TYPE;
     const Segment* seg = system->firstMeasure() ? system->firstMeasure()->first(type) : nullptr;
-    while (seg && seg->system() == system) {
-        if (canvasX >= seg->canvasX() && canvasX <= seg->canvasX() + seg->width()) {
-            return seg;
-        }
+    while (seg && seg->system() != system) {
         seg = seg->next1(type);
     }
-    return nullptr;
+    return seg && seg->system() == system ? seg : nullptr;
+}
+
+struct TickCanvasPoint {
+    int tick = 0;
+    double canvasX = 0.0;
+};
+
+using TickCanvasMap = std::vector<TickCanvasPoint>;
+
+static void appendTickCanvasPoint(TickCanvasMap& points, int tick, double canvasX)
+{
+    if (!points.empty() && tick == points.back().tick) {
+        points.back().canvasX = canvasX;
+        return;
+    }
+
+    if (points.empty() || tick > points.back().tick) {
+        points.push_back({ tick, canvasX });
+    }
+}
+
+static TickCanvasMap tickCanvasMapForSystem(const System* system, double staffStartCanvasX, double staffEndCanvasX,
+                                            int startTick, int endTick)
+{
+    TickCanvasMap points;
+    points.reserve(16);
+    appendTickCanvasPoint(points, startTick, staffStartCanvasX);
+
+    const mu::engraving::SegmentType type = Segment::CHORD_REST_OR_TIME_TICK_TYPE;
+    const Segment* seg = firstAutomationSegmentForSystem(system);
+    while (seg && seg->system() == system) {
+        const double segStartCanvasX = seg->canvasX();
+        const double segEndCanvasX = segStartCanvasX + seg->width();
+        const int segStartTick = seg->tick().ticks();
+        const int segEndTick = segStartTick + seg->ticks().ticks();
+
+        appendTickCanvasPoint(points, segStartTick, segStartCanvasX);
+        appendTickCanvasPoint(points, segEndTick, segEndCanvasX);
+
+        seg = seg->next1(type);
+    }
+
+    appendTickCanvasPoint(points, endTick, staffEndCanvasX);
+    return points;
+}
+
+static int interpolatedTick(double x, double leftX, double rightX, int leftTick, int rightTick)
+{
+    if (rightTick <= leftTick || muse::RealIsEqual(leftX, rightX)) {
+        return leftTick;
+    }
+
+    const double ratio = std::clamp((x - leftX) / (rightX - leftX), 0.0, 1.0);
+    return leftTick + static_cast<int>(ratio * (rightTick - leftTick));
+}
+
+static double interpolatedCanvasX(int tick, int leftTick, int rightTick, double leftX, double rightX)
+{
+    if (rightTick <= leftTick || muse::RealIsEqual(leftX, rightX)) {
+        return leftX;
+    }
+
+    const double ratio = std::clamp(static_cast<double>(tick - leftTick) / static_cast<double>(rightTick - leftTick),
+                                    0.0, 1.0);
+    return leftX + (ratio * (rightX - leftX));
+}
+
+static int tickForCanvasX(const TickCanvasMap& tickCanvasMap, double canvasX, bool* ok)
+{
+    if (ok) {
+        *ok = false;
+    }
+
+    IF_ASSERT_FAILED(!tickCanvasMap.empty()) {
+        return 0;
+    }
+
+    auto right = std::lower_bound(tickCanvasMap.cbegin(), tickCanvasMap.cend(), canvasX,
+                                  [](const TickCanvasPoint& point, double x) {
+        return point.canvasX < x;
+    });
+
+    if (ok) {
+        *ok = true;
+    }
+
+    if (right == tickCanvasMap.cbegin()) {
+        return right->tick;
+    }
+
+    if (right == tickCanvasMap.cend()) {
+        return tickCanvasMap.back().tick;
+    }
+
+    if (muse::RealIsEqual(right->canvasX, canvasX)) {
+        return right->tick;
+    }
+
+    auto left = std::prev(right);
+    return interpolatedTick(canvasX, left->canvasX, right->canvasX, left->tick, right->tick);
+}
+
+static double canvasXForTick(const TickCanvasMap& tickCanvasMap, int tick)
+{
+    IF_ASSERT_FAILED(!tickCanvasMap.empty()) {
+        return 0.0;
+    }
+
+    auto right = std::lower_bound(tickCanvasMap.cbegin(), tickCanvasMap.cend(), tick,
+                                  [](const TickCanvasPoint& point, int value) {
+        return point.tick < value;
+    });
+
+    if (right == tickCanvasMap.cbegin()) {
+        return right->canvasX;
+    }
+
+    if (right == tickCanvasMap.cend()) {
+        return tickCanvasMap.back().canvasX;
+    }
+
+    if (right->tick == tick) {
+        return right->canvasX;
+    }
+
+    auto left = std::prev(right);
+    return interpolatedCanvasX(tick, left->tick, right->tick, left->canvasX, right->canvasX);
+}
+
+static bool hasAutomationViewCurve(const mu::engraving::Score* score)
+{
+    IF_ASSERT_FAILED(score && score->automation()) {
+        return false;
+    }
+
+    for (const mu::engraving::Staff* staff : score->staves()) {
+        if (!staff || !staff->isPrimaryStaff()) {
+            continue;
+        }
+
+        if (!score->automation()->curve(automationKey(staff)).empty()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void seedAutomationViewCurves(mu::engraving::Score* score)
+{
+    IF_ASSERT_FAILED(score && score->automation()) {
+        return;
+    }
+
+    const int startTick = 0;
+    const int endTick = score->lastMeasure() ? score->lastMeasure()->endTick().ticks() : startTick;
+
+    for (const mu::engraving::Staff* staff : score->staves()) {
+        if (!staff || !staff->isPrimaryStaff()) {
+            continue;
+        }
+
+        const mu::engraving::AutomationCurveKey expressionKey = automationKey(staff);
+        if (!score->automation()->curve(expressionKey).empty()) {
+            continue;
+        }
+
+        score->automation()->addPoint(expressionKey, startTick, automationPoint(AUTOMATION_VIEW_DEFAULT_VALUE));
+        if (endTick > startTick) {
+            score->automation()->addPoint(expressionKey, endTick, automationPoint(AUTOMATION_VIEW_DEFAULT_VALUE));
+        }
+    }
 }
 
 NotationAutomation::NotationAutomation(IGetScore* getScore,
@@ -64,8 +358,6 @@ void NotationAutomation::setAutomationModeEnabled(bool enabled)
     }
 
     if (enabled) {
-        // TODO: Optimization - we don't need to init all the lines every time. Only the bits that
-        // changed since the last time automation was enabled...
         initAutomationLinesData();
     }
 
@@ -90,15 +382,15 @@ void NotationAutomation::initAutomationLinesData()
         return;
     }
 
-    if (m_automationLinesData.isEmpty()) {
-        // TODO: Placeholder - init this elsewhere. Also note that automation data doesn't currently
-        // update through score interactions (such as deleting dynamics, etc)...
+    if (m_automationLinesData.isEmpty() && !hasAutomationViewCurve(masterScore)) {
         masterScore->initAutomation();
+        seedAutomationViewCurves(masterScore);
     }
 
     QVariantList automationLinesData;
-    for (const System* system : score()->systems()) {
-        const QVariantList linesData = linesDataForSystem(system);
+    const std::vector<System*>& systems = score()->systems();
+    for (size_t systemIdx = 0; systemIdx < systems.size(); ++systemIdx) {
+        const QVariantList linesData = linesDataForSystem(systems.at(systemIdx), systemIdx);
         if (!linesData.empty()) {
             automationLinesData << linesData;
         }
@@ -107,43 +399,16 @@ void NotationAutomation::initAutomationLinesData()
     m_automationLinesDataChanged.notify();
 }
 
-QVariantList NotationAutomation::linesDataForSystem(const System* system) const
+QVariantList NotationAutomation::linesDataForSystem(const System* system, size_t systemIdx) const
 {
     QVariantList lines;
 
-    const int systemStartTick = system->first()->tick().ticks();
-    const int systemEndTick = system->last()->endTick().ticks();
-
     staff_idx_t staffIdx = system->firstVisibleStaff();
     while (staffIdx != muse::nidx) {
-        const Staff* staff = score()->staff(staffIdx);
-        const SysStaff* sysStaff = system->staff(staffIdx);
-        IF_ASSERT_FAILED(staff && sysStaff) {
-            staffIdx = system->nextVisibleStaff(staffIdx);
-            continue;
+        const QVariantMap lineData = lineDataForSysStaff(staffIdx, systemIdx, system);
+        if (!lineData.isEmpty()) {
+            lines << lineData;
         }
-
-        if (!staff->isPrimaryStaff()) {
-            staffIdx = system->nextVisibleStaff(staffIdx);
-            continue;
-        }
-
-        const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
-        const QVariantList staffLinesData = linesDataForSysStaff(staff, staffCanvasRect, systemStartTick, systemEndTick);
-        if (staffLinesData.isEmpty()) {
-            staffIdx = system->nextVisibleStaff(staffIdx);
-            continue;
-        }
-
-        QVariantMap lineData;
-        lineData["staffIdx"] = static_cast<int>(staffIdx);
-        lineData["x"] = staffCanvasRect.x();
-        lineData["y"] = staffCanvasRect.y();
-        lineData["width"] = staffCanvasRect.width();
-        lineData["height"] = staffCanvasRect.height();
-        lineData["points"] = staffLinesData;
-
-        lines << lineData;
 
         staffIdx = system->nextVisibleStaff(staffIdx);
     }
@@ -151,8 +416,48 @@ QVariantList NotationAutomation::linesDataForSystem(const System* system) const
     return lines;
 }
 
-QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect,
-                                                      int startTick, int endTick) const
+QVariantMap NotationAutomation::lineDataForSysStaff(staff_idx_t staffIdx, size_t systemIdx, const System* system) const
+{
+    IF_ASSERT_FAILED(system && system->first() && system->last()) {
+        return {};
+    }
+
+    const Staff* staff = score()->staff(staffIdx);
+    const SysStaff* sysStaff = system->staff(staffIdx);
+    IF_ASSERT_FAILED(staff && sysStaff) {
+        return {};
+    }
+
+    if (!staff->isPrimaryStaff()) {
+        return {};
+    }
+
+    const int systemStartTick = system->first()->tick().ticks();
+    const int systemEndTick = system->last()->endTick().ticks();
+    const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
+    const QVariantList staffLinesData = pointsDataForSysStaff(staff, system, staffCanvasRect,
+                                                              systemStartTick, systemEndTick);
+    if (staffLinesData.isEmpty()) {
+        return {};
+    }
+
+    QVariantMap lineData;
+    lineData["staffIdx"] = static_cast<int>(staffIdx);
+    lineData["systemIdx"] = static_cast<qulonglong>(systemIdx);
+    lineData["x"] = staffCanvasRect.x();
+    lineData["y"] = staffCanvasRect.y();
+    lineData["width"] = staffCanvasRect.width();
+    lineData["height"] = staffCanvasRect.height();
+    lineData["startTick"] = systemStartTick;
+    lineData["endTick"] = systemEndTick;
+    lineData["points"] = staffLinesData;
+
+    return lineData;
+}
+
+QVariantList NotationAutomation::pointsDataForSysStaff(const Staff* staff, const System* system,
+                                                       const muse::RectF& sysStaffCanvasRect, int startTick,
+                                                       int endTick) const
 {
     QVariantList points;
     const auto addPoint = [&points](double x, double y, int tick, PointType pointType) {
@@ -168,37 +473,37 @@ QVariantList NotationAutomation::linesDataForSysStaff(const Staff* staff, const 
         return points;
     }
 
-    const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
-    for (auto& point : automation()->curve(key)) {
+    const mu::engraving::AutomationCurveKey key = automationKey(staff);
+    const mu::engraving::AutomationCurve& curve = automation()->curve(key);
+    const TickCanvasMap tickCanvasMap = tickCanvasMapForSystem(system, sysStaffCanvasRect.x(),
+                                                               sysStaffCanvasRect.x() + sysStaffCanvasRect.width(),
+                                                               startTick, endTick);
+
+    const mu::engraving::AutomationPoint& startPoint = automation()->activePoint(key, startTick);
+    addPoint(0.0, automationValueToLineY(startPoint.outValue), startTick, PointType::BOTH);
+
+    for (const auto& point : curve) {
         const int tick = point.first;
-        if (tick < startTick || tick > endTick) {
+        if (tick <= startTick || tick >= endTick) {
             continue;
         }
 
-        const Fraction frac = Fraction::fromTicks(tick);
-        const Segment* seg = score()->tick2leftSegmentMM(frac);
-        IF_ASSERT_FAILED(seg) {
-            continue;
-        }
-
-        // The point's tick may not exactly match that of a segment. For this reason we can only calculate the x position
-        // of our points based on a "tickRatio". This ratio is based on the "tick difference" between the point tick and
-        // the segment's tick, and the duration of the segment (in ticks)...
-        const int tickDiff = tick - seg->tick().ticks();
-        const double tickRatio = static_cast<double>(tickDiff) / seg->ticks().ticks();
-        const double pointXInSeg = tickRatio * seg->width(); // The point's x relative to the segment
-
-        const double segXInStaff = seg->canvasX() - sysStaffCanvasRect.x(); // The segment's x relative to the staff
-        const double pointXInStaff = (segXInStaff + pointXInSeg) / sysStaffCanvasRect.width();
+        const double pointCanvasX = canvasXForTick(tickCanvasMap, tick);
+        const double pointXInStaff = (pointCanvasX - sysStaffCanvasRect.x()) / sysStaffCanvasRect.width();
 
         // Point in/out values are always between 0 and 1 - higher value == lower Y...
         const mu::engraving::AutomationPoint& autoPoint = point.second;
         if (muse::RealIsEqual(autoPoint.inValue, autoPoint.outValue)) {
-            addPoint(pointXInStaff, 1 - autoPoint.inValue, tick, PointType::BOTH);
+            addPoint(pointXInStaff, automationValueToLineY(autoPoint.inValue), tick, PointType::BOTH);
             continue;
         }
-        addPoint(pointXInStaff, 1 - autoPoint.inValue, tick, PointType::IN);
-        addPoint(pointXInStaff, 1 - autoPoint.outValue, tick, PointType::OUT);
+        addPoint(pointXInStaff, automationValueToLineY(autoPoint.inValue), tick, PointType::IN);
+        addPoint(pointXInStaff, automationValueToLineY(autoPoint.outValue), tick, PointType::OUT);
+    }
+
+    if (endTick > startTick) {
+        const mu::engraving::AutomationPoint& endPoint = automation()->activePoint(key, endTick);
+        addPoint(1.0, automationValueToLineY(endPoint.outValue), endTick, PointType::BOTH);
     }
 
     return points;
@@ -219,6 +524,120 @@ mu::engraving::IAutomation* NotationAutomation::automation() const
     return score() ? score()->automation() : nullptr;
 }
 
+void NotationAutomation::refreshAutomationView()
+{
+    m_automationLinesData.clear();
+    initAutomationLinesData();
+    m_notationChanged.send(muse::RectF());
+}
+
+bool NotationAutomation::refreshAutomationLinesForStaff(staff_idx_t staffIdx)
+{
+    const std::vector<System*>& systems = score()->systems();
+    bool refreshed = false;
+
+    for (qsizetype lineIdx = 0; lineIdx < m_automationLinesData.size(); ++lineIdx) {
+        const QVariantMap lineData = m_automationLinesData.at(lineIdx).toMap();
+        bool ok = false;
+        const staff_idx_t lineStaffIdx = static_cast<staff_idx_t>(lineData.value("staffIdx").toInt(&ok));
+        if (!ok || lineStaffIdx != staffIdx) {
+            continue;
+        }
+
+        const qulonglong systemIdxRaw = lineData.value("systemIdx").toULongLong(&ok);
+        if (!ok || systemIdxRaw >= systems.size()) {
+            return false;
+        }
+
+        const QVariantMap refreshedLineData = lineDataForSysStaff(staffIdx, static_cast<size_t>(systemIdxRaw),
+                                                                  systems.at(static_cast<size_t>(systemIdxRaw)));
+        if (refreshedLineData.isEmpty()) {
+            return false;
+        }
+
+        m_automationLinesData.replace(lineIdx, refreshedLineData);
+        refreshed = true;
+    }
+
+    if (!refreshed) {
+        return false;
+    }
+
+    m_automationLinesDataChanged.notify();
+    m_notationChanged.send(muse::RectF());
+    return true;
+}
+
+void NotationAutomation::notifyAutomationChanged(staff_idx_t staffIdx)
+{
+    mu::engraving::Score* s = score();
+    IF_ASSERT_FAILED(s) {
+        return;
+    }
+
+    if (!refreshAutomationLinesForStaff(staffIdx)) {
+        refreshAutomationView();
+    }
+
+    mu::engraving::ScoreChanges changes;
+    changes.tickFrom = 0;
+    changes.tickTo = s->lastMeasure() ? s->lastMeasure()->endTick().ticks() : 0;
+    changes.staffIdxFrom = staffIdx;
+    changes.staffIdxTo = staffIdx + 1;
+    s->changesChannel().send(changes);
+}
+
+int NotationAutomation::tickForLineX(const QVariantMap& lineData, staff_idx_t staffIdx, qreal x, bool* ok)
+{
+    if (ok) {
+        *ok = false;
+    }
+
+    bool dataOk = false;
+    const int startTick = lineData.value("startTick").toInt(&dataOk);
+    IF_ASSERT_FAILED(dataOk) {
+        return 0;
+    }
+
+    const int endTick = lineData.value("endTick").toInt(&dataOk);
+    IF_ASSERT_FAILED(dataOk) {
+        return 0;
+    }
+
+    const qulonglong systemIdxRaw = lineData.value("systemIdx").toULongLong(&dataOk);
+    IF_ASSERT_FAILED(dataOk) {
+        return 0;
+    }
+
+    const std::vector<System*>& systems = score()->systems();
+    IF_ASSERT_FAILED(systemIdxRaw < systems.size()) {
+        refreshAutomationView();
+        return 0;
+    }
+
+    const System* system = systems.at(static_cast<size_t>(systemIdxRaw));
+    const SysStaff* sysStaff = system ? system->staff(staffIdx) : nullptr;
+    IF_ASSERT_FAILED(sysStaff) {
+        refreshAutomationView();
+        return 0;
+    }
+
+    const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
+    const double staffStartCanvasX = staffCanvasRect.x();
+    const double staffEndCanvasX = staffStartCanvasX + staffCanvasRect.width();
+    const double pointCanvasX = staffStartCanvasX
+                                + std::clamp(static_cast<double>(x), 0.0, 1.0) * (staffEndCanvasX - staffStartCanvasX);
+    const TickCanvasMap tickCanvasMap = tickCanvasMapForSystem(system, staffStartCanvasX, staffEndCanvasX,
+                                                               startTick, endTick);
+
+    bool tickOk = false;
+    const int tick = tickForCanvasX(tickCanvasMap, pointCanvasX, &tickOk);
+    if (ok) {
+        *ok = tickOk;
+    }
+    return tick;
+}
+
 void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y)
 {
     IF_ASSERT_FAILED(automation() && lineIdx < m_automationLinesData.size()) {
@@ -230,7 +649,7 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
         return;
     }
 
-    bool ok;
+    bool ok = false;
     const staff_idx_t staffIdx = static_cast<staff_idx_t>(lineData.value("staffIdx").toInt(&ok));
     IF_ASSERT_FAILED(ok && staffIdx != muse::nidx) {
         return;
@@ -254,10 +673,35 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
     }
 
     const PointType pointType = static_cast<PointType>(pointTypeRaw);
-    const mu::engraving::AutomationCurveKey key { mu::engraving::AutomationType::Dynamics, staff->id(), std::nullopt };
+    const mu::engraving::AutomationCurveKey key = automationKey(staff);
+    const mu::engraving::AutomationCurve beforeChange = automation()->curve(key);
+    score()->startCmd(muse::TranslatableString("undoableAction", "Edit automation"));
 
-    // Point in/out values are always between 0 and 1 - higher value == lower Y...
-    const double newValue = 1.0 - y;
+    auto finishChange = [this, staffIdx, key, beforeChange]() {
+        const mu::engraving::AutomationCurve afterChange = automation()->curve(key);
+        if (!automationCurvesEqual(afterChange, beforeChange)) {
+            score()->undoStack()->pushWithoutPerforming(new ChangeAutomationCurve(score(), key, beforeChange,
+                                                                                  afterChange));
+        }
+
+        score()->endCmd();
+        notifyAutomationChanged(staffIdx);
+    };
+
+    const double newValue = lineYToAutomationValue(y);
+
+    bool tickOk = false;
+    const int newTick = tickForLineX(lineData, staffIdx, x, &tickOk);
+    if (!tickOk) {
+        score()->endCmd(true);
+        return;
+    }
+    const bool pointExistsAtOldTick = hasAutomationPointAtTick(automation(), key, oldTick);
+
+    if (!pointExistsAtOldTick) {
+        const mu::engraving::AutomationPoint& activePoint = automation()->activePoint(key, oldTick);
+        automation()->addPoint(key, oldTick, automationPoint(activePoint.outValue));
+    }
 
     if (pointType == PointType::IN || pointType == PointType::BOTH) {
         automation()->setPointInValue(key, oldTick, newValue);
@@ -266,34 +710,13 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
         automation()->setPointOutValue(key, oldTick, newValue);
     }
 
-    //! NOTE: newSeg will always be in the same system as oldSeg...
-    const Segment* oldSeg = score()->tick2leftSegmentMM(Fraction::fromTicks(oldTick));
-    const System* system = oldSeg ? oldSeg->system() : nullptr;
-    const SysStaff* sysStaff = system ? system->staff(staffIdx) : nullptr;
-    IF_ASSERT_FAILED(sysStaff) {
-        return;
-    }
-
-    const muse::RectF staffCanvasRect = sysStaff->bbox().translated(system->canvasPos());
-    const double staffStartCanvasX = staffCanvasRect.x();
-    const double staffEndCanvasX = staffStartCanvasX + staffCanvasRect.width();
-    const double pointCanvasX = staffStartCanvasX + x * (staffEndCanvasX - staffStartCanvasX);
-
-    // TODO: See segmentForCanvasX - it needs to be a bit smarter...
-    const Segment* newSeg = segmentForCanvasX(system, pointCanvasX);
-    IF_ASSERT_FAILED(newSeg) {
-        return;
-    }
-
-    const double segStartCanvasX = newSeg->canvasX();
-    const double setEndCanvasX = segStartCanvasX + newSeg->width();
-
-    const int segStartTick = newSeg->tick().ticks();
-    const int segEndTick = segStartTick + newSeg->ticks().ticks();
-
-    const double tickRatio = (pointCanvasX - segStartCanvasX) / (setEndCanvasX - segStartCanvasX);
-    const int newTick = segStartTick + static_cast<int>(tickRatio * (segEndTick - segStartTick));
     if (newTick == oldTick) {
+        finishChange();
+        return;
+    }
+
+    if (hasAutomationPointAtTick(automation(), key, newTick)) {
+        finishChange();
         return;
     }
 
@@ -303,11 +726,12 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
 
     if (pointType == PointType::BOTH) {
         automation()->movePoint(key, oldTick, newTick);
+        finishChange();
         return;
     }
 
     const mu::engraving::AutomationPoint& oldPoint = automation()->activePoint(key, oldTick);
-    const mu::engraving::AutomationPoint newPoint = { newValue, newValue };
+    const mu::engraving::AutomationPoint newPoint = automationPoint(newValue);
     if (pointType == PointType::IN) {
         automation()->setPointInValue(key, oldTick, oldPoint.outValue);
     }
@@ -315,4 +739,108 @@ void NotationAutomation::requestChangeAutomationPoint(qsizetype lineIdx, qsizety
         automation()->setPointOutValue(key, oldTick, oldPoint.inValue);
     }
     automation()->addPoint(key, newTick, newPoint);
+    finishChange();
+}
+
+void NotationAutomation::requestAddAutomationPoint(qsizetype lineIdx, qreal x, qreal y)
+{
+    IF_ASSERT_FAILED(automation() && lineIdx < m_automationLinesData.size()) {
+        return;
+    }
+
+    const QVariantMap lineData = m_automationLinesData.at(lineIdx).toMap();
+    IF_ASSERT_FAILED(!lineData.isEmpty()) {
+        return;
+    }
+
+    bool ok = false;
+    const staff_idx_t staffIdx = static_cast<staff_idx_t>(lineData.value("staffIdx").toInt(&ok));
+    IF_ASSERT_FAILED(ok && staffIdx != muse::nidx) {
+        return;
+    }
+
+    const Staff* staff = score()->staff(staffIdx);
+    IF_ASSERT_FAILED(staff) {
+        return;
+    }
+
+    bool tickOk = false;
+    const int tick = tickForLineX(lineData, staffIdx, x, &tickOk);
+    if (!tickOk) {
+        return;
+    }
+
+    const mu::engraving::AutomationCurveKey key = automationKey(staff);
+    const double newValue = lineYToAutomationValue(y);
+    const mu::engraving::AutomationCurve beforeChange = automation()->curve(key);
+    score()->startCmd(muse::TranslatableString("undoableAction", "Edit automation"));
+
+    if (!hasAutomationPointAtTick(automation(), key, tick)) {
+        automation()->addPoint(key, tick, automationPoint(newValue));
+    } else {
+        automation()->setPointInValue(key, tick, newValue);
+        automation()->setPointOutValue(key, tick, newValue);
+    }
+
+    const mu::engraving::AutomationCurve afterChange = automation()->curve(key);
+    if (!automationCurvesEqual(afterChange, beforeChange)) {
+        score()->undoStack()->pushWithoutPerforming(new ChangeAutomationCurve(score(), key, beforeChange,
+                                                                              afterChange));
+    }
+
+    score()->endCmd();
+    notifyAutomationChanged(staffIdx);
+}
+
+void NotationAutomation::requestRemoveAutomationPoint(qsizetype lineIdx, qsizetype pointIdx)
+{
+    IF_ASSERT_FAILED(automation() && lineIdx < m_automationLinesData.size()) {
+        return;
+    }
+
+    const QVariantMap lineData = m_automationLinesData.at(lineIdx).toMap();
+    IF_ASSERT_FAILED(!lineData.isEmpty()) {
+        return;
+    }
+
+    bool ok = false;
+    const staff_idx_t staffIdx = static_cast<staff_idx_t>(lineData.value("staffIdx").toInt(&ok));
+    IF_ASSERT_FAILED(ok && staffIdx != muse::nidx) {
+        return;
+    }
+
+    const Staff* staff = score()->staff(staffIdx);
+    const QVariantList pointsList = lineData.value("points").toList();
+    IF_ASSERT_FAILED(staff && !pointsList.isEmpty() && pointIdx < pointsList.size()) {
+        return;
+    }
+
+    const QVariantMap point = pointsList.at(pointIdx).toMap();
+    IF_ASSERT_FAILED(!point.isEmpty()) {
+        return;
+    }
+
+    const int tick = point.value("tick").toInt(&ok);
+    IF_ASSERT_FAILED(ok) {
+        return;
+    }
+
+    const mu::engraving::AutomationCurveKey key = automationKey(staff);
+    if (!hasAutomationPointAtTick(automation(), key, tick)) {
+        refreshAutomationView();
+        return;
+    }
+
+    const mu::engraving::AutomationCurve beforeChange = automation()->curve(key);
+    score()->startCmd(muse::TranslatableString("undoableAction", "Edit automation"));
+    automation()->removePoint(key, tick);
+
+    const mu::engraving::AutomationCurve afterChange = automation()->curve(key);
+    if (!automationCurvesEqual(afterChange, beforeChange)) {
+        score()->undoStack()->pushWithoutPerforming(new ChangeAutomationCurve(score(), key, beforeChange,
+                                                                              afterChange));
+    }
+
+    score()->endCmd();
+    notifyAutomationChanged(staffIdx);
 }

--- a/src/notation/internal/notationautomation.h
+++ b/src/notation/internal/notationautomation.h
@@ -46,9 +46,12 @@ public:
     muse::async::Notification automationModeEnabledChanged() const override;
 
     QVariant automationLinesData() const override;
-    muse::async::Notification automationLinesDataChanged() const override; // TODO: probably a channel specifying indices
+    muse::async::Notification automationLinesDataChanged() const override;
+    void refreshAutomationView() override;
 
     void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y) override;
+    void requestAddAutomationPoint(qsizetype lineIdx, qreal x, qreal y) override;
+    void requestRemoveAutomationPoint(qsizetype lineIdx, qsizetype pointIdx) override;
 
 private:
     enum class PointType : unsigned char {
@@ -60,8 +63,13 @@ private:
 
     void initAutomationLinesData();
 
-    QVariantList linesDataForSystem(const System* system) const;
-    QVariantList linesDataForSysStaff(const Staff* staff, const muse::RectF& sysStaffCanvasRect, int startTick, int endTick) const;
+    QVariantList linesDataForSystem(const System* system, size_t systemIdx) const;
+    QVariantMap lineDataForSysStaff(staff_idx_t staffIdx, size_t systemIdx, const System* system) const;
+    QVariantList pointsDataForSysStaff(const Staff* staff, const System* system, const muse::RectF& sysStaffCanvasRect,
+                                       int startTick, int endTick) const;
+    int tickForLineX(const QVariantMap& lineData, staff_idx_t staffIdx, qreal x, bool* ok);
+    bool refreshAutomationLinesForStaff(staff_idx_t staffIdx);
+    void notifyAutomationChanged(staff_idx_t staffIdx);
 
     mu::engraving::Score* score() const;
     mu::engraving::IAutomation* automation() const;

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -2618,8 +2618,8 @@ const UiActionList NotationUiActions::s_actions = {
     UiAction(TOGGLE_AUTOMATION_CODE,
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Automation"),
-             TranslatableString("action", "Toggle automation"),
+             TranslatableString("action", "Automation view"),
+             TranslatableString("action", "Toggle automation view"),
              IconCode::Code::AUTOMATION,
              Checkable::Yes
              ),

--- a/src/notationscene/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/NotationView.qml
@@ -231,7 +231,15 @@ FocusScope {
                         onPointChangeRequested: function(lineIdx, pointIdx, x, y) {
                             notationView.requestChangeAutomationPoint(lineIdx, pointIdx, x, y)
                         }
-                     }
+
+                        onPointAddRequested: function(lineIdx, x, y) {
+                            notationView.requestAddAutomationPoint(lineIdx, x, y)
+                        }
+
+                        onPointRemoveRequested: function(lineIdx, pointIdx) {
+                            notationView.requestRemoveAutomationPoint(lineIdx, pointIdx)
+                        }
+                    }
 
                     NotationRegionsBeingProcessedView {
                         notationViewRect: Qt.rect(notationView.x, notationView.y, notationView.width, notationView.height)

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -337,6 +337,10 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
 
     m_notation->viewModeChanged().onNotify(this, [this]() {
         ensureViewportInsideScrollableArea();
+
+        if (notationAutomation() && notationAutomation()->isAutomationModeEnabled()) {
+            notationAutomation()->refreshAutomationView();
+        }
     });
 
     // FIXME: only un-/re-subscribe when master notation changes
@@ -347,6 +351,12 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
 
     notationAutomation()->automationLinesDataChanged().onNotify(this, [this]() {
         emit automationLinesDataChanged();
+    });
+
+    m_notation->undoStack()->undoRedoNotification().onNotify(this, [this]() {
+        if (notationAutomation() && notationAutomation()->isAutomationModeEnabled()) {
+            notationAutomation()->refreshAutomationView();
+        }
     });
 
     if (isMainView()) {
@@ -398,6 +408,7 @@ void AbstractNotationPaintView::onUnloadNotation(INotationPtr)
     m_notation->viewModeChanged().disconnect(this);
     notationAutomation()->automationModeEnabledChanged().disconnect(this);
     notationAutomation()->automationLinesDataChanged().disconnect(this);
+    m_notation->undoStack()->undoRedoNotification().disconnect(this);
 
     if (isMainView()) {
         disconnect(this, &QQuickPaintedItem::focusChanged, this, nullptr);
@@ -1706,4 +1717,20 @@ void AbstractNotationPaintView::requestChangeAutomationPoint(qsizetype lineIdx, 
         return;
     }
     notationAutomation()->requestChangeAutomationPoint(lineIdx, pointIdx, x, y);
+}
+
+void AbstractNotationPaintView::requestAddAutomationPoint(qsizetype lineIdx, qreal x, qreal y)
+{
+    IF_ASSERT_FAILED(notationAutomation()) {
+        return;
+    }
+    notationAutomation()->requestAddAutomationPoint(lineIdx, x, y);
+}
+
+void AbstractNotationPaintView::requestRemoveAutomationPoint(qsizetype lineIdx, qsizetype pointIdx)
+{
+    IF_ASSERT_FAILED(notationAutomation()) {
+        return;
+    }
+    notationAutomation()->requestRemoveAutomationPoint(lineIdx, pointIdx);
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.h
@@ -106,6 +106,8 @@ public:
     Q_INVOKABLE void setPlaybackCursorItem(QQuickItem* cursor);
 
     Q_INVOKABLE void requestChangeAutomationPoint(qsizetype lineIdx, qsizetype pointIdx, qreal x, qreal y);
+    Q_INVOKABLE void requestAddAutomationPoint(qsizetype lineIdx, qreal x, qreal y);
+    Q_INVOKABLE void requestRemoveAutomationPoint(qsizetype lineIdx, qsizetype pointIdx);
 
     qreal width() const override;
     qreal height() const override;


### PR DESCRIPTION
## Purpose for the PR

Hello. I’ve been using MuseScore for a while now and one feature that I’ve always really wanted was a more granular way to control the volume of a given instrument at *specific* points in the score in addition to the dynamic markings. The mixer slider is great, but it applies volume changes statically/globally for an instrument for the entire score. I was wanting something like MIDI CC 11 / “expression” in a DAW. That’s what this pull request is meant to demo. Here’s a technical breakdown:

## Technical Overview

This PR adds an experimental **Automation View** for staff-level expression automation. Automation data is stored as `AutomationType::Expression` curves keyed by staff ID, with default midpoint value `0.5` representing unchanged playback gain. Values below `0.5` reduce playback level and values above `0.5` increase it.

The notation scene now exposes automation line data to QML and renders editable automation curves through the existing automation overlay/polyline UI path. Users can toggle the view, add/remove points, drag points vertically and horizontally, and persist the resulting automation curve data with the score. Automation edits are routed through undoable score commands so undo/redo refreshes both the stored curve and visible overlay.

For playback, the engraving playback model converts staff expression automation curves into `ControllerChangeEvent::Expression` events and inserts them into track playback data. The audio engine consumes those expression events for MuseSampler-backed playback by applying a time-interpolated gain envelope in `EventAudioNode`, so the same automation affects live playback and offline audio export. Export rendering also clears and sanitizes audio buffers per chunk to avoid stale sample data or non-finite samples during MP3/WAV generation.

The implementation includes focused coverage for expression automation serialization and playback event generation, plus cleanup around ownership/style: test scores use RAII, automation overlay polylines have explicit Qt ownership/deferred cleanup, and temporary diagnostic logging has been removed.

## FULL TRANSPARENCY
This was 100% vibe-coded with Codex using ChatGPT 5.5. I’m a mobile app developer who hasn’t really touched C++ in years so this codebase is a little outside my normal wheelhouse. That said, I had the AI agent do multiple passes to check for memory leaks, do style cleanup based on the style guidelines, and optimize. Please don't make me sad and relegate this PR into oblivion because AI was involved. Please at least consider the concept! A feature like this would be so amazing in MuseScore! 🙏🏻

At this point, I’m not presenting this as something to merge as it is. I mostly just want to present the idea and see what people think. It's a proof-of-concept. Pull it down, build it, try it out!

## Demos
Small demo video to show what it looks and sounds like in playback:

<p align="center">
  <video src="https://github.com/user-attachments/assets/5faf9d3d-5c4b-45f1-b6f0-7a28247ea80a" width="70%" controls>
  </video>
</p>
</details>

As an experiment, I tried using this on [a larger project from MuseScore](https://musescore.com/user/14433131/scores/7068100). I took just the first 24 measures, added some volume automation data to smooth out the playback and it worked wonderfully. I made multiple adjustments, but the most obvious thing to notice is how absurdly loud the pizz cellos are in the "before" and how much better they sound in the "after". Note: these are using the Vienna library. 

|Before|After|
|--|--|
|[et_flying_before.mp3](https://github.com/user-attachments/files/28677074/et_flying_before.mp3)|[et_flying_after.mp3](https://github.com/user-attachments/files/28677077/et_flying_after.mp3)|

## Checklist
- [x] I signed the [CLA](https://musescore.org/en/cla) as [davidearlrhodes](https://musescore.com/user/48234177): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits. // I mean, no, but please don't nuke the PR over it
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested. // Well, not totally but that's why I'm putting it up for you more experienced C++ devs to look at.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).