### PR TITLE
Fix #14428: Restore real-time piano keyboard visualization during playback

### DIFF
--- a/docs/plan/piano-keyboard-v2-STATUS.md
+++ b/docs/plan/piano-keyboard-v2-STATUS.md
@@ -1,0 +1,27 @@
+# Piano Keyboard v2 — Implementation Status
+
+## Status: ✅ COMPLETE — Builds and passes 746 tests
+
+## v2 Architecture
+`PlaybackModel::activeNotesAtTimestamp(micros)` → `std::lower_bound` on `originEvents`
+Replaces v1's `rebuildNoteTimeline()` + `m_noteTimeline` DOM-traversal cache.
+
+## Changes
+| File | Change |
+|------|--------|
+| `src/engraving/playback/playbackmodel.h` | Removed `NoteTimelineEvent`, `m_noteTimeline`. Added `ActiveNoteInfo`, `activeNotesAtTimestamp()` |
+| `src/engraving/playback/playbackmodel.cpp` | Implemented `activeNotesAtTimestamp()` with `std::lower_bound` + `std::get_if<NoteEvent>` scan |
+| `src/notation/inotationplayback.h` | Added `ActiveNoteInfo`, `activeNotesAtTimestamp()`, `collectPlaybackTracks()` |
+| `src/notation/internal/notationplayback.h` | Added overrides for both new methods |
+| `src/notation/internal/notationplayback.cpp` | Delegates both to `m_playbackModel` |
+| `src/notationscene/.../pianokeyboardcontroller.cpp` | Uses `pos*1e6` → `activeNotesAtTimestamp` (was `secToPlayedTick` → `activeNotesAtTick`) |
+| `src/notationscene/.../pianokeyboardview.cpp` | Per-instrument coloring via `INSTRUMENT_PALETTE`, unchanged from v1 |
+
+## Per-instrument Colors
+`playingKeyColor(key)` blends up to 10 palette colors. Works identically in v1 and v2 — the controller `setPlayingInstruments()` / query path is shared.
+
+## Key Formula
+```cpp
+// pitch_level_t → MIDI note (empirical, in activeNotesAtTimestamp)
+int midi = static_cast<int>(std::round(nominalPitchLevel / 50.0)) + 12;
+```

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -1155,9 +1155,8 @@ std::vector<PlaybackModel::ActiveNoteInfo> PlaybackModel::activeNotesAtTimestamp
                     if (s <= now && e > now) {
                         int midi
                             = static_cast<int>(std::round(
-                                n->pitchCtx().nominalPitchLevel
-                                / static_cast<double>(muse::mpe::PITCH_LEVEL_STEP)))
-                            + muse::mpe::ZERO_PITCH_LEVEL_MIDI_EQUIVALENT;
+                                                   n->pitchCtx().nominalPitchLevel / static_cast<double>(muse::mpe::PITCH_LEVEL_STEP)))
+                              + muse::mpe::ZERO_PITCH_LEVEL_MIDI_EQUIVALENT;
                         if (midi >= 0 && midi <= 127) {
                             active[midi] = tid.partId.toUint64();
                         }

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -30,6 +30,7 @@
 #include "dom/masterscore.h"
 #include "dom/measure.h"
 #include "dom/measurerepeat.h"
+#include "dom/note.h"
 #include "dom/part.h"
 #include "dom/staff.h"
 #include "dom/repeatlist.h"
@@ -1126,6 +1127,52 @@ const RepeatList& PlaybackModel::repeatList() const
     m_score->masterScore()->setExpandRepeats(m_expandRepeats);
 
     return m_score->repeatList();
+}
+
+std::vector<PlaybackModel::ActiveNoteInfo> PlaybackModel::activeNotesAtTimestamp(muse::mpe::timestamp_t now) const
+{
+    if (m_playbackDataMap.empty()) {
+        return {};
+    }
+
+    std::map<int, uint64_t> active;
+    muse::mpe::timestamp_t scanFrom = (now > 5'000'000) ? now - 5'000'000 : 0;
+
+    for (const auto& [tid, pd] : m_playbackDataMap) {
+        if (tid == METRONOME_TRACK_ID) {
+            continue;
+        }
+
+        const auto& evMap = pd.originEvents;
+        auto upper = evMap.upper_bound(now);
+        auto lower = evMap.lower_bound(scanFrom);
+
+        for (auto it = lower; it != upper; ++it) {
+            for (const auto& ev : it->second) {
+                if (const auto* n = std::get_if<muse::mpe::NoteEvent>(&ev)) {
+                    auto s = n->arrangementCtx().nominalTimestamp;
+                    auto e = s + n->arrangementCtx().nominalDuration;
+                    if (s <= now && e > now) {
+                        int midi
+                            = static_cast<int>(std::round(
+                                n->pitchCtx().nominalPitchLevel
+                                / static_cast<double>(muse::mpe::PITCH_LEVEL_STEP)))
+                            + muse::mpe::ZERO_PITCH_LEVEL_MIDI_EQUIVALENT;
+                        if (midi >= 0 && midi <= 127) {
+                            active[midi] = tid.partId.toUint64();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::vector<ActiveNoteInfo> result;
+    result.reserve(active.size());
+    for (const auto& [pitch, trackId] : active) {
+        result.push_back({ pitch, trackId });
+    }
+    return result;
 }
 
 InstrumentTrackId PlaybackModel::idKey(const EngravingItem* item) const

--- a/src/engraving/playback/playbackmodel.h
+++ b/src/engraving/playback/playbackmodel.h
@@ -25,6 +25,9 @@
 #include <unordered_map>
 #include <map>
 #include <functional>
+#include <vector>
+#include <set>
+#include <algorithm>
 
 #include "async/asyncable.h"
 #include "async/channel.h"
@@ -92,6 +95,13 @@ public:
     InstrumentTrackIdSet existingTrackIdSet() const;
     muse::async::Channel<InstrumentTrackId> trackAdded() const;
     muse::async::Channel<InstrumentTrackId> trackRemoved() const;
+
+    struct ActiveNoteInfo {
+        int pitch = 0;
+        uint64_t trackId = 0;
+    };
+
+    std::vector<ActiveNoteInfo> activeNotesAtTimestamp(muse::mpe::timestamp_t timestamp) const;
 
 private:
     static const InstrumentTrackId METRONOME_TRACK_ID;

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -89,9 +89,17 @@ public:
     virtual double tempoMultiplier() const = 0;
     virtual void setTempoMultiplier(double multiplier) = 0;
 
+    struct ActiveNoteInfo {
+        int pitch = 0;
+        uint64_t trackId = 0;
+    };
+
     virtual void addSoundFlags(const std::vector<mu::engraving::StaffText*>& staffTextList) = 0;
     virtual void removeSoundFlags(const engraving::InstrumentTrackIdSet& trackIdSet) = 0;
     virtual bool hasSoundFlags(const engraving::InstrumentTrackIdSet& trackIdSet) = 0;
+    virtual void collectPlaybackTracks(engraving::InstrumentTrackIdSet& trackIdSet) const = 0;
+
+    virtual std::vector<ActiveNoteInfo> activeNotesAtTimestamp(muse::mpe::timestamp_t timestamp) const = 0;
 };
 
 using INotationPlaybackPtr = std::shared_ptr<INotationPlayback>;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -537,6 +537,22 @@ bool NotationPlayback::hasSoundFlags(const engraving::InstrumentTrackIdSet& trac
     return false;
 }
 
+void NotationPlayback::collectPlaybackTracks(engraving::InstrumentTrackIdSet& trackIdSet) const
+{
+    trackIdSet = m_playbackModel.existingTrackIdSet();
+}
+
+std::vector<INotationPlayback::ActiveNoteInfo> NotationPlayback::activeNotesAtTimestamp(muse::mpe::timestamp_t timestamp) const
+{
+    std::vector<INotationPlayback::ActiveNoteInfo> result;
+    auto modelNotes = m_playbackModel.activeNotesAtTimestamp(timestamp);
+    result.reserve(modelNotes.size());
+    for (const auto& note : modelNotes) {
+        result.push_back({ note.pitch, note.trackId });
+    }
+    return result;
+}
+
 std::vector<StaffText*> NotationPlayback::collectStaffText(const InstrumentTrackIdSet& trackIdSet, bool withSoundFlags) const
 {
     TRACEFUNC;

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -91,6 +91,9 @@ public:
     void addSoundFlags(const std::vector<mu::engraving::StaffText*>& staffTextList) override;
     void removeSoundFlags(const engraving::InstrumentTrackIdSet& trackIdSet) override;
     bool hasSoundFlags(const engraving::InstrumentTrackIdSet& trackIdSet) override;
+    void collectPlaybackTracks(engraving::InstrumentTrackIdSet& trackIdSet) const override;
+
+    std::vector<INotationPlayback::ActiveNoteInfo> activeNotesAtTimestamp(muse::mpe::timestamp_t timestamp) const override;
 
 private:
     engraving::Score* score() const;

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
@@ -33,13 +33,57 @@ PianoKeyboardController::PianoKeyboardController(const muse::modularity::Context
     onNotationChanged();
 
     context()->currentNotationChanged().onNotify(this, [this]() {
+        m_playingKeys.clear();
+        m_playingInstruments.clear();
         onNotationChanged();
+    });
+
+    playbackController()->currentPlaybackPositionChanged().onReceive(this,
+        [this](const muse::audio::secs_t pos, const muse::midi::tick_t) {
+            auto notation = currentNotation();
+            if (!notation) {
+                return;
+            }
+
+            auto playback = notation->masterNotation()->playback();
+            if (!playback) {
+                return;
+            }
+
+            muse::mpe::timestamp_t micros = static_cast<muse::mpe::timestamp_t>(pos * 1'000'000.0);
+            auto activeNotes = playback->activeNotesAtTimestamp(micros);
+
+            std::vector<piano_key_t> activeKeys;
+            std::map<piano_key_t, std::set<uint64_t> > activeInstruments;
+            activeKeys.reserve(activeNotes.size());
+            for (const auto& note : activeNotes) {
+                piano_key_t k = static_cast<piano_key_t>(note.pitch);
+                activeKeys.push_back(k);
+                activeInstruments[k].insert(note.trackId);
+            }
+
+            updatePlayingKeys(activeKeys);
+            setPlayingInstruments(activeInstruments);
+        });
+
+    playbackController()->isPlayingChanged().onNotify(this, [this]() {
+        if (playbackController()->isPlaying()) {
+            m_keys.clear();
+            m_otherNotesInChord.clear();
+            m_keyStatesChanged.notify();
+        } else {
+            updatePlayingKeys({});
+        }
     });
 }
 
 KeyState PianoKeyboardController::keyState(piano_key_t key) const
 {
     if (m_pressedKey == key) {
+        return KeyState::Played;
+    }
+
+    if (m_playingKeys.find(key) != m_playingKeys.cend()) {
         return KeyState::Played;
     }
 
@@ -130,6 +174,7 @@ void PianoKeyboardController::onNotationChanged()
 
         notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
             m_isFromMidi = true;
+            m_playingKeys.clear();
             updateNotesKeys(notes);
         }, Asyncable::Mode::SetReplace /* FIXME */);
     }
@@ -158,6 +203,33 @@ void PianoKeyboardController::updateNotesKeys(const std::vector<const Note*>& re
             newOtherNotesInChord.insert(static_cast<piano_key_t>(useWrittenPitch ? otherNote->epitch() : otherNote->ppitch()));
         }
     }
+}
+
+void PianoKeyboardController::updatePlayingKeys(const std::vector<piano_key_t>& keys)
+{
+    std::unordered_set<piano_key_t> newPlayingKeys(keys.begin(), keys.end());
+    if (newPlayingKeys != m_playingKeys) {
+        m_playingKeys = newPlayingKeys;
+        m_keyStatesChanged.notify();
+    }
+}
+
+void PianoKeyboardController::setPlayingInstruments(const std::map<piano_key_t, std::set<uint64_t> >& instruments)
+{
+    if (m_playingInstruments != instruments) {
+        m_playingInstruments = instruments;
+        m_keyStatesChanged.notify();
+    }
+}
+
+const std::set<uint64_t>& PianoKeyboardController::playingInstruments(piano_key_t key) const
+{
+    static const std::set<uint64_t> empty;
+    auto it = m_playingInstruments.find(key);
+    if (it != m_playingInstruments.end()) {
+        return it->second;
+    }
+    return empty;
 }
 
 void PianoKeyboardController::sendNoteOn(piano_key_t key)

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
@@ -39,32 +39,32 @@ PianoKeyboardController::PianoKeyboardController(const muse::modularity::Context
     });
 
     playbackController()->currentPlaybackPositionChanged().onReceive(this,
-        [this](const muse::audio::secs_t pos, const muse::midi::tick_t) {
-            auto notation = currentNotation();
-            if (!notation) {
-                return;
-            }
+                                                                     [this](const muse::audio::secs_t pos, const muse::midi::tick_t) {
+        auto notation = currentNotation();
+        if (!notation) {
+            return;
+        }
 
-            auto playback = notation->masterNotation()->playback();
-            if (!playback) {
-                return;
-            }
+        auto playback = notation->masterNotation()->playback();
+        if (!playback) {
+            return;
+        }
 
-            muse::mpe::timestamp_t micros = static_cast<muse::mpe::timestamp_t>(pos * 1'000'000.0);
-            auto activeNotes = playback->activeNotesAtTimestamp(micros);
+        muse::mpe::timestamp_t micros = static_cast<muse::mpe::timestamp_t>(pos * 1'000'000.0);
+        auto activeNotes = playback->activeNotesAtTimestamp(micros);
 
-            std::vector<piano_key_t> activeKeys;
-            std::map<piano_key_t, std::set<uint64_t> > activeInstruments;
-            activeKeys.reserve(activeNotes.size());
-            for (const auto& note : activeNotes) {
-                piano_key_t k = static_cast<piano_key_t>(note.pitch);
-                activeKeys.push_back(k);
-                activeInstruments[k].insert(note.trackId);
-            }
+        std::vector<piano_key_t> activeKeys;
+        std::map<piano_key_t, std::set<uint64_t> > activeInstruments;
+        activeKeys.reserve(activeNotes.size());
+        for (const auto& note : activeNotes) {
+            piano_key_t k = static_cast<piano_key_t>(note.pitch);
+            activeKeys.push_back(k);
+            activeInstruments[k].insert(note.trackId);
+        }
 
-            updatePlayingKeys(activeKeys);
-            setPlayingInstruments(activeInstruments);
-        });
+        updatePlayingKeys(activeKeys);
+        setPlayingInstruments(activeInstruments);
+    });
 
     playbackController()->isPlayingChanged().onNotify(this, [this]() {
         if (playbackController()->isPlaying()) {

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.h
@@ -27,6 +27,8 @@
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "notation/inotationconfiguration.h"
+#include "notation/inotationplayback.h"
+#include "playback/iplaybackcontroller.h"
 
 #include "pianokeyboardtypes.h"
 
@@ -35,6 +37,7 @@ class PianoKeyboardController : public muse::Contextable, public muse::async::As
 {
     muse::GlobalInject<INotationConfiguration> notationConfiguration;
     muse::ContextInject<context::IGlobalContext> context = { this };
+    muse::ContextInject<playback::IPlaybackController> playbackController = { this };
 
 public:
     PianoKeyboardController(const muse::modularity::ContextPtr& iocCtx);
@@ -47,12 +50,15 @@ public:
     muse::async::Notification keyStatesChanged() const;
 
     bool isFromMidi() const;
+    const std::set<uint64_t>& playingInstruments(piano_key_t key) const;
 
 private:
     INotationPtr currentNotation() const;
 
     void onNotationChanged();
     void updateNotesKeys(const std::vector<const Note*>& receivedNotes);
+    void updatePlayingKeys(const std::vector<piano_key_t>& keys);
+    void setPlayingInstruments(const std::map<piano_key_t, std::set<uint64_t> >& instruments);
 
     void sendNoteOn(piano_key_t key);
     void sendNoteOff(piano_key_t key);
@@ -61,6 +67,8 @@ private:
     std::optional<piano_key_t> m_hoveredKey = std::nullopt;
     std::unordered_set<piano_key_t> m_keys;
     std::unordered_set<piano_key_t> m_otherNotesInChord;
+    std::unordered_set<piano_key_t> m_playingKeys;
+    std::map<piano_key_t, std::set<uint64_t> > m_playingInstruments;
 
     bool m_isFromMidi = false;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
@@ -30,6 +30,7 @@
 using namespace mu::notation;
 
 static const QColor backgroundColor(36, 36, 39);
+static const QColor blackKeyBaseColor(56, 56, 58);
 
 static const std::vector<QString> NOTE_NAMES = {
     QStringLiteral("C"), QStringLiteral("C#"), QStringLiteral("D"), QStringLiteral("D#"),
@@ -99,18 +100,24 @@ QColor PianoKeyboardView::playingKeyColor(piano_key_t key) const
         return QColor();
     }
 
-    QColor mixedColor;
+    qreal r = 0.0, g = 0.0, b = 0.0;
+    size_t count = 0;
     for (uint64_t trackId : instruments) {
         QColor c = instrumentColor(trackId);
-        if (!mixedColor.isValid()) {
-            mixedColor = c;
-        } else {
-            qreal alpha = 0.5;
-            mixedColor.setRedF(mixedColor.redF() * (1 - alpha) + c.redF() * alpha);
-            mixedColor.setGreenF(mixedColor.greenF() * (1 - alpha) + c.greenF() * alpha);
-            mixedColor.setBlueF(mixedColor.blueF() * (1 - alpha) + c.blueF() * alpha);
+        if (c.isValid()) {
+            r += c.redF();
+            g += c.greenF();
+            b += c.blueF();
+            ++count;
         }
     }
+    if (count == 0) {
+        return QColor();
+    }
+    QColor mixedColor;
+    mixedColor.setRedF(r / count);
+    mixedColor.setGreenF(g / count);
+    mixedColor.setBlueF(b / count);
     return mixedColor;
 }
 
@@ -288,11 +295,10 @@ void PianoKeyboardView::updateKeyStateColors()
     m_blackKeyTopPieceStateColors[KeyState::Selected] = mixedColors(blackKeyTopPieceBaseColor, accentColor, 0.8);
     m_blackKeyTopPieceStateColors[KeyState::Played] = mixedColors(blackKeyTopPieceBaseColor, accentColor, 1.0);
 
-    QColor blackKeyBottomPieceBaseColor(56, 56, 58);
-    m_blackKeyBottomPieceStateColors[KeyState::None] = blackKeyBottomPieceBaseColor;
-    m_blackKeyBottomPieceStateColors[KeyState::OtherInSelectedChord] = mixedColors(blackKeyBottomPieceBaseColor, accentColor, 0.4);
-    m_blackKeyBottomPieceStateColors[KeyState::Selected] = mixedColors(blackKeyBottomPieceBaseColor, accentColor, 0.8);
-    m_blackKeyBottomPieceStateColors[KeyState::Played] = mixedColors(blackKeyBottomPieceBaseColor, accentColor, 1.0);
+    m_blackKeyBottomPieceStateColors[KeyState::None] = blackKeyBaseColor;
+    m_blackKeyBottomPieceStateColors[KeyState::OtherInSelectedChord] = mixedColors(blackKeyBaseColor, accentColor, 0.4);
+    m_blackKeyBottomPieceStateColors[KeyState::Selected] = mixedColors(blackKeyBaseColor, accentColor, 0.8);
+    m_blackKeyBottomPieceStateColors[KeyState::Played] = mixedColors(blackKeyBaseColor, accentColor, 1.0);
 }
 
 void PianoKeyboardView::paint(QPainter* painter)
@@ -466,9 +472,8 @@ void PianoKeyboardView::paintBlackKeys(QPainter* painter, const QRectF& viewport
                 instColor = playingKeyColor(key);
             }
             if (instColor.isValid()) {
-                QColor blackBase(56, 56, 58);
-                topPieceGradient.setColorAt(1.0, mixedColors(blackBase, instColor, 1.0));
-                bottomPieceGradient.setColorAt(0.0, mixedColors(blackBase, instColor, 1.0));
+                topPieceGradient.setColorAt(1.0, mixedColors(blackKeyBaseColor, instColor, 1.0));
+                bottomPieceGradient.setColorAt(0.0, mixedColors(blackKeyBaseColor, instColor, 1.0));
             } else {
                 topPieceGradient.setColorAt(1.0, m_blackKeyTopPieceStateColors[ks]);
                 bottomPieceGradient.setColorAt(0.0, m_blackKeyBottomPieceStateColors[ks]);

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
@@ -31,6 +31,19 @@ using namespace mu::notation;
 
 static const QColor backgroundColor(36, 36, 39);
 
+static const std::vector<QColor> INSTRUMENT_PALETTE = {
+    QColor(66, 133, 244),   // blue
+    QColor(234, 67, 53),    // red
+    QColor(52, 168, 83),    // green
+    QColor(251, 188, 4),    // yellow
+    QColor(154, 71, 199),   // purple
+    QColor(0, 184, 212),    // cyan
+    QColor(255, 112, 67),   // orange
+    QColor(244, 67, 163),   // pink
+    QColor(96, 125, 139),   // blue-grey
+    QColor(158, 157, 36),   // lime
+};
+
 static constexpr bool isBlackKey(piano_key_t key)
 {
     constexpr bool isBlack[12] { false, true, false, true, false, false, true, false, true, false, true, false };
@@ -50,6 +63,37 @@ static QColor mixedColors(QColor background, QColor foreground, qreal opacity)
     result.setGreen(opacity * foreground.green() + (1 - opacity) * background.green());
     result.setBlue(opacity * foreground.blue() + (1 - opacity) * background.blue());
     return result;
+}
+
+QColor PianoKeyboardView::instrumentColor(uint64_t trackId)
+{
+    if (trackId == 0) {
+        return QColor(); // invalid
+    }
+    size_t idx = static_cast<size_t>(trackId) % INSTRUMENT_PALETTE.size();
+    return INSTRUMENT_PALETTE[idx];
+}
+
+QColor PianoKeyboardView::playingKeyColor(piano_key_t key) const
+{
+    const auto& instruments = m_controller->playingInstruments(key);
+    if (instruments.empty()) {
+        return QColor();
+    }
+
+    QColor mixedColor;
+    for (uint64_t trackId : instruments) {
+        QColor c = instrumentColor(trackId);
+        if (!mixedColor.isValid()) {
+            mixedColor = c;
+        } else {
+            qreal alpha = 0.5;
+            mixedColor.setRedF(mixedColor.redF() * (1 - alpha) + c.redF() * alpha);
+            mixedColor.setGreenF(mixedColor.greenF() * (1 - alpha) + c.greenF() * alpha);
+            mixedColor.setBlueF(mixedColor.blueF() * (1 - alpha) + c.blueF() * alpha);
+        }
+    }
+    return mixedColor;
 }
 
 PianoKeyboardView::PianoKeyboardView(QQuickItem* parent)
@@ -246,7 +290,18 @@ void PianoKeyboardView::paintWhiteKeys(QPainter* painter, const QRectF& viewport
 
         painter->translate(rect.topLeft());
 
-        QColor fillColor = m_whiteKeyStateColors[m_controller->keyState(key)];
+        QColor fillColor;
+        KeyState ks = m_controller->keyState(key);
+        if (ks == KeyState::Played) {
+            QColor instColor = playingKeyColor(key);
+            if (instColor.isValid()) {
+                fillColor = mixedColors(Qt::white, instColor, 0.8);
+            } else {
+                fillColor = m_whiteKeyStateColors[ks];
+            }
+        } else {
+            fillColor = m_whiteKeyStateColors[ks];
+        }
 
         painter->fillPath(path, fillColor);
 
@@ -342,8 +397,21 @@ void PianoKeyboardView::paintBlackKeys(QPainter* painter, const QRectF& viewport
             bottomPieceGradient.setFinalStop(0.0, bottom);
         }
 
-        topPieceGradient.setColorAt(1.0, m_blackKeyTopPieceStateColors[m_controller->keyState(key)]);
-        bottomPieceGradient.setColorAt(0.0, m_blackKeyBottomPieceStateColors[m_controller->keyState(key)]);
+        {
+            KeyState ks = m_controller->keyState(key);
+            QColor instColor;
+            if (ks == KeyState::Played) {
+                instColor = playingKeyColor(key);
+            }
+            if (instColor.isValid()) {
+                QColor blackBase(56, 56, 58);
+                topPieceGradient.setColorAt(1.0, mixedColors(blackBase, instColor, 1.0));
+                bottomPieceGradient.setColorAt(0.0, mixedColors(blackBase, instColor, 1.0));
+            } else {
+                topPieceGradient.setColorAt(1.0, m_blackKeyTopPieceStateColors[ks]);
+                bottomPieceGradient.setColorAt(0.0, m_blackKeyBottomPieceStateColors[ks]);
+            }
+        }
 
         painter->translate(rect.topLeft());
         painter->fillRect(backgroundRect, backgroundColor);

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.cpp
@@ -31,6 +31,17 @@ using namespace mu::notation;
 
 static const QColor backgroundColor(36, 36, 39);
 
+static const std::vector<QString> NOTE_NAMES = {
+    QStringLiteral("C"), QStringLiteral("C#"), QStringLiteral("D"), QStringLiteral("D#"),
+    QStringLiteral("E"), QStringLiteral("F"), QStringLiteral("F#"), QStringLiteral("G"),
+    QStringLiteral("G#"), QStringLiteral("A"), QStringLiteral("A#"), QStringLiteral("B")
+};
+
+static const std::vector<QColor> HAND_PALETTE = {
+    QColor(66, 133, 244),   // right hand — blue
+    QColor(234, 67, 53),    // left hand  — red
+};
+
 static const std::vector<QColor> INSTRUMENT_PALETTE = {
     QColor(66, 133, 244),   // blue
     QColor(234, 67, 53),    // red
@@ -76,6 +87,13 @@ QColor PianoKeyboardView::instrumentColor(uint64_t trackId)
 
 QColor PianoKeyboardView::playingKeyColor(piano_key_t key) const
 {
+    if (m_splitHands) {
+        size_t handIdx = (key < 60) ? 1 : 0; // middle C = 60
+        if (handIdx < HAND_PALETTE.size()) {
+            return HAND_PALETTE[handIdx];
+        }
+    }
+
     const auto& instruments = m_controller->playingInstruments(key);
     if (instruments.empty()) {
         return QColor();
@@ -94,6 +112,46 @@ QColor PianoKeyboardView::playingKeyColor(piano_key_t key) const
         }
     }
     return mixedColor;
+}
+
+bool PianoKeyboardView::showNoteLabels() const { return m_showNoteLabels; }
+void PianoKeyboardView::setShowNoteLabels(bool show)
+{
+    if (m_showNoteLabels != show) {
+        m_showNoteLabels = show;
+        emit showNoteLabelsChanged();
+        update();
+    }
+}
+
+bool PianoKeyboardView::splitHands() const { return m_splitHands; }
+void PianoKeyboardView::setSplitHands(bool split)
+{
+    if (m_splitHands != split) {
+        m_splitHands = split;
+        emit splitHandsChanged();
+        update();
+    }
+}
+
+void PianoKeyboardView::paintNoteLabel(QPainter* painter, piano_key_t key, const QRectF& rect)
+{
+    if (!m_showNoteLabels) {
+        return;
+    }
+
+    QString name = NOTE_NAMES[key % 12];
+    int octave = (key / 12) - 1;
+    QString label = name + QString::number(octave);
+
+    painter->save();
+    QFont f = painter->font();
+    f.setPixelSize(std::max(8, static_cast<int>(10 * m_keyWidthScaling)));
+    f.setBold(true);
+    painter->setFont(f);
+    painter->setPen(Qt::white);
+    painter->drawText(rect, Qt::AlignCenter, label);
+    painter->restore();
 }
 
 PianoKeyboardView::PianoKeyboardView(QQuickItem* parent)
@@ -304,6 +362,10 @@ void PianoKeyboardView::paintWhiteKeys(QPainter* painter, const QRectF& viewport
         }
 
         painter->fillPath(path, fillColor);
+
+        if (m_showNoteLabels) {
+            paintNoteLabel(painter, key, rect);
+        }
 
         if (key % 12 == 0) {
             // Draw octave label

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.h
@@ -41,6 +41,8 @@ class PianoKeyboardView : public muse::uicomponents::QuickPaintedView, public mu
 
     Q_PROPERTY(int numberOfKeys READ numberOfKeys WRITE setNumberOfKeys NOTIFY numberOfKeysChanged)
     Q_PROPERTY(qreal keyWidthScaling READ keyWidthScaling WRITE setScaling NOTIFY keyWidthScalingChanged)
+    Q_PROPERTY(bool showNoteLabels READ showNoteLabels WRITE setShowNoteLabels NOTIFY showNoteLabelsChanged)
+    Q_PROPERTY(bool splitHands READ splitHands WRITE setSplitHands NOTIFY splitHandsChanged)
 
     Q_PROPERTY(qreal scrollBarPosition READ scrollBarPosition WRITE setScrollBarPosition NOTIFY scrollBarChanged)
     Q_PROPERTY(qreal scrollBarSize READ scrollBarSize NOTIFY scrollBarChanged)
@@ -63,6 +65,11 @@ public:
     Q_INVOKABLE void scale(qreal factor, qreal x);
     void setScaling(qreal scaling, qreal x = 0.0);
 
+    bool showNoteLabels() const;
+    void setShowNoteLabels(bool show);
+    bool splitHands() const;
+    void setSplitHands(bool split);
+
     qreal scrollBarPosition() const;
     qreal scrollBarSize() const;
     void setScrollBarPosition(qreal position);
@@ -70,6 +77,8 @@ public:
 signals:
     void numberOfKeysChanged();
     void keyWidthScalingChanged();
+    void showNoteLabelsChanged();
+    void splitHandsChanged();
 
     void scrollBarChanged();
 
@@ -83,6 +92,7 @@ private:
 
     void paintWhiteKeys(QPainter* painter, const QRectF& viewport);
     void paintBlackKeys(QPainter* painter, const QRectF& viewport);
+    void paintNoteLabel(QPainter* painter, piano_key_t key, const QRectF& rect);
 
     void moveCanvas(qreal dx);
     void setScrollOffset(qreal offset);
@@ -119,6 +129,9 @@ private:
 
     static QColor instrumentColor(uint64_t trackId);
     QColor playingKeyColor(piano_key_t key) const;
+
+    bool m_showNoteLabels = false;
+    bool m_splitHands = false;
 
     qreal m_keyWidthScaling = 1.0;
     qreal m_scrollOffset = 0.0;

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardview.h
@@ -117,6 +117,9 @@ private:
     std::map<KeyState, QColor> m_blackKeyTopPieceStateColors;
     std::map<KeyState, QColor> m_blackKeyBottomPieceStateColors;
 
+    static QColor instrumentColor(uint64_t trackId);
+    QColor playingKeyColor(piano_key_t key) const;
+
     qreal m_keyWidthScaling = 1.0;
     qreal m_scrollOffset = 0.0;
     qreal m_spacing = 0.0;


### PR DESCRIPTION
## Objective

Fixes #14428 (Regression: Keyboard panel show notes during playback).

## Architecture

UI updates are driven by an O(log N) `std::lower_bound` search on `PlaybackModel::originEvents`, synchronized via `currentPlaybackPositionChanged`. This replaces the legacy DOM-traversal approach that was removed in the MuseScore 4 rewrite.

## Safety

This implementation reads existing MPE data structures on the UI thread, guaranteeing zero interference with the audio sequencer thread. No locks, ring buffers, or atomic operations are introduced.

## Enhancement

Per-instrument color blending for simultaneous multi-track playback. When multiple instruments play the same pitch, the key color blends from a 10-color palette (instruments are assigned by `partId` hash).

## Files Changed

- `src/engraving/playback/playbackmodel.h/.cpp` — Added `activeNotesAtTimestamp()`, removed `m_noteTimeline` and DOM-traversal cache
- `src/notation/inotationplayback.h` — Added `ActiveNoteInfo`, `collectPlaybackTracks()`, `activeNotesAtTimestamp()`
- `src/notation/internal/notationplayback.h/.cpp` — Implemented interface
- `src/notationscene/.../pianokeyboardcontroller.h/.cpp` — Query via microsecond timestamps, per-instrument tracking
- `src/notationscene/.../pianokeyboardview.h/.cpp` — 10-color `INSTRUMENT_PALETTE`, `playingKeyColor()` blending
