### PR TITLE
feat: Add button to duplicate instrument (#25649)

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -645,14 +645,14 @@ static bool scoreContainsSpanner(const Score* score, Spanner* spanner)
     return false;
 }
 
-void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2)
+void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2, bool link)
 {
     // don’t clone system lines for track != 0
     if (isSystemTextLine(s) && s->track() != 0) {
         return;
     }
 
-    Spanner* ns = toSpanner(s->linkedClone());
+    Spanner* ns = toSpanner(link ? s->linkedClone() : s->clone());
     ns->setScore(score);
     ns->moveToDummy();
     ns->setTrack(dstTrack);
@@ -665,35 +665,45 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
 
         ns->setStartElement(0);
         ns->setEndElement(0);
-        if (cr1 && cr1->links()) {
-            for (EngravingObject* e : *cr1->links()) {
-                ChordRest* cr = toChordRest(e);
-                if (cr == cr1) {
-                    continue;
-                }
-                if ((cr->score() == score) && (cr->tick() == ns->tick()) && cr->track() == dstTrack) {
-                    ns->setStartElement(cr);
-                    break;
-                }
-            }
-        }
-        if (cr2 && cr2->links()) {
-            for (EngravingObject* e : *cr2->links()) {
-                ChordRest* cr = toChordRest(e);
-                if (cr == cr2) {
-                    continue;
-                }
-                if ((cr->score() == score) && (cr->tick() == ns->tick2()) && cr->track() == dstTrack2) {
-                    ns->setEndElement(cr);
-                    break;
+        if (link) {
+            if (cr1 && cr1->links()) {
+                for (EngravingObject* e : *cr1->links()) {
+                    ChordRest* cr = toChordRest(e);
+                    if (cr == cr1) {
+                        continue;
+                    }
+                    if ((cr->score() == score) && (cr->tick() == ns->tick()) && cr->track() == dstTrack) {
+                        ns->setStartElement(cr);
+                        break;
+                    }
                 }
             }
-        }
-        if (!ns->startElement()) {
-            LOGD("clone Slur: no start element");
-        }
-        if (!ns->endElement()) {
-            LOGD("clone Slur: no end element");
+            if (cr2 && cr2->links()) {
+                for (EngravingObject* e : *cr2->links()) {
+                    ChordRest* cr = toChordRest(e);
+                    if (cr == cr2) {
+                        continue;
+                    }
+                    if ((cr->score() == score) && (cr->tick() == ns->tick2()) && cr->track() == dstTrack2) {
+                        ns->setEndElement(cr);
+                        break;
+                    }
+                }
+            }
+            if (!ns->startElement()) {
+                LOGD("clone Slur: no start element");
+            }
+            if (!ns->endElement()) {
+                LOGD("clone Slur: no end element");
+            }
+        } else {
+            // Since there are no links, it always needs to be computed if it existed
+            if (s->startElement()) {
+                ns->computeStartElement();
+            }
+            if (s->endElement()) {
+                ns->computeEndElement();
+            }
         }
     } else if (ns->isTrill()) {
         ns->computeStartElement();
@@ -735,7 +745,7 @@ static void updateSpatium(EngravingItem* oldElement, EngravingItem* newElement)
     }
 }
 
-static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& tupletMap, Measure* nm, track_idx_t track)
+static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& tupletMap, Measure* nm, track_idx_t track, bool link = true)
 {
     const auto handleTuplet = [&](Tuplet* tuplet) {
         tuplet->clear();
@@ -749,7 +759,7 @@ static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& 
 
     Tuplet* nt = tupletMap.findNew(ot);
     if (!nt) {
-        nt = toTuplet(ot->linkedClone());
+        nt = toTuplet(link ? ot->linkedClone() : ot->clone());
         handleTuplet(nt);
         tupletMap.add(ot, nt);
 
@@ -757,7 +767,7 @@ static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& 
         while (ot->tuplet()) {
             Tuplet* nt2 = tupletMap.findNew(ot->tuplet());
             if (nt2 == 0) {
-                nt2 = toTuplet(ot->tuplet()->linkedClone());
+                nt2 = toTuplet(link ? ot->tuplet()->linkedClone() : ot->tuplet()->clone());
                 handleTuplet(nt2);
                 tupletMap.add(ot->tuplet(), nt2);
             }
@@ -777,10 +787,10 @@ static void processLinkedClone(EngravingItem* ne, Score* score, track_idx_t stra
     ne->setScore(score);
 }
 
-static void addTies(Note* originalNote, Note* newNote, TieMap& tieMap, Score* score)
+static void addTies(Note* originalNote, Note* newNote, TieMap& tieMap, Score* score, bool link = true)
 {
     if (originalNote->tieFor() && originalNote->tieFor()->type() == ElementType::TIE) {
-        Tie* tie = toTie(originalNote->tieFor()->linkedClone());
+        Tie* tie = toTie(link ? originalNote->tieFor()->linkedClone() : originalNote->tieFor()->clone());
         tie->setScore(score);
         newNote->setTieFor(tie);
         tie->setStartNote(newNote);
@@ -803,7 +813,7 @@ static void addTies(Note* originalNote, Note* newNote, TieMap& tieMap, Score* sc
     }
 }
 
-static void addBackSpanners(Note* on, Note* nn, Score* score)
+static void addBackSpanners(Note* on, Note* nn, Score* score, bool link = true)
 {
     // add back spanners (going back from end to start spanner element
     // makes sure the 'other' spanner anchor element is already set up)
@@ -811,7 +821,7 @@ static void addBackSpanners(Note* on, Note* nn, Score* score)
     for (Spanner* oldSp : on->spannerBack()) {
         Note* newStart = Spanner::startElementFromSpanner(oldSp, nn);
         if (newStart != nullptr) {
-            Spanner* newSp = toSpanner(oldSp->linkedClone());
+            Spanner* newSp = toSpanner(link ? oldSp->linkedClone() : oldSp->clone());
             newSp->setNoteSpan(newStart, nn);
             score->addElement(newSp);
         } else {
@@ -820,7 +830,8 @@ static void addBackSpanners(Note* on, Note* nn, Score* score)
     }
 }
 
-static void addGraceNoteTiesAndBackSpanners(GraceNotesGroup& originalGraceNotes, Chord* newChord, TieMap& tieMap, Score* score)
+static void addGraceNoteTiesAndBackSpanners(GraceNotesGroup& originalGraceNotes, Chord* newChord, TieMap& tieMap, Score* score,
+                                            bool link = true)
 {
     for (Chord* oldGrace : originalGraceNotes) {
         Chord* newGrace = newChord->graceNoteAt(oldGrace->graceIndex());
@@ -833,8 +844,8 @@ static void addGraceNoteTiesAndBackSpanners(GraceNotesGroup& originalGraceNotes,
             Note* originalNote = oldGrace->notes().at(i);
             Note* newNote = newGrace->notes().at(i);
 
-            addTies(originalNote, newNote, tieMap, score);
-            addBackSpanners(originalNote, newNote, score);
+            addTies(originalNote, newNote, tieMap, score, link);
+            addBackSpanners(originalNote, newNote, score, link);
         }
     }
 }
@@ -1226,12 +1237,14 @@ void Excerpt::cloneMeasures(Score* oscore, Score* score)
 }
 
 //! NOTE For staves in the same score
-void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
+void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners, bool link)
 {
     Score* score = srcStaff->score();
     TieMap tieMap;
 
-    score->undo(new Link(dstStaff, srcStaff));
+    if (link) {
+        score->undo(new Link(dstStaff, srcStaff));
+    }
 
     staff_idx_t srcStaffIdx = srcStaff->idx();
     staff_idx_t dstStaffIdx = dstStaff->idx();
@@ -1263,7 +1276,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                         ne = oe->clone();
                     }
                 } else {
-                    ne = oe->linkedClone();
+                    ne = link ? oe->linkedClone() : oe->clone();
                 }
                 if (ne) {
                     ne->setTrack(dstTrack);
@@ -1282,7 +1295,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                     ChordRest* ncr = toChordRest(ne);
                     Tuplet* ot     = ocr->tuplet();
                     if (ot) {
-                        cloneTuplets(ocr, ncr, ot, tupletMap, m, dstTrack);
+                        cloneTuplets(ocr, ncr, ot, tupletMap, m, dstTrack, link);
                     }
 
                     // remove lyrics from chord
@@ -1334,7 +1347,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                         {
                             // Fermatas are special since the belong to a segment but should
                             // be created and linked on each staff.
-                            EngravingItem* ne1 = e->linkedClone();
+                            EngravingItem* ne1 = link ? e->linkedClone() : e->clone();
                             ne1->setTrack(dstTrack);
                             ne1->setParent(seg);
                             ne1->setScore(score);
@@ -1352,19 +1365,19 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                     if (oe->isChord()) {
                         Chord* och = toChord(ocr);
                         Chord* nch = toChord(ncr);
-                        addGraceNoteTiesAndBackSpanners(och->graceNotesBefore(), nch, tieMap, score);
+                        addGraceNoteTiesAndBackSpanners(och->graceNotesBefore(), nch, tieMap, score, link);
                         size_t n = och->notes().size();
                         for (size_t i = 0; i < n; ++i) {
                             Note* on = och->notes().at(i);
                             Note* nn = nch->notes().at(i);
-                            addTies(on, nn, tieMap, score);
+                            addTies(on, nn, tieMap, score, link);
                             // add back spanners (going back from end to start spanner element
                             // makes sure the 'other' spanner anchor element is already set up)
                             // 'on' is the old spanner end note and 'nn' is the new spanner end note
                             for (Spanner* oldSp : on->spannerBack()) {
                                 Note* newStart = Spanner::startElementFromSpanner(oldSp, nn);
                                 if (newStart != nullptr) {
-                                    Spanner* newSp = toSpanner(oldSp->linkedClone());
+                                    Spanner* newSp = toSpanner(link ? oldSp->linkedClone() : oldSp->clone());
                                     newSp->setNoteSpan(newStart, nn);
                                     score->addElement(newSp);
                                 } else {
@@ -1372,7 +1385,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                                 }
                             }
                         }
-                        addGraceNoteTiesAndBackSpanners(och->graceNotesAfter(), nch, tieMap, score);
+                        addGraceNoteTiesAndBackSpanners(och->graceNotesAfter(), nch, tieMap, score, link);
                         addTremoloTwoChord(och, nch, prevTremolo);
 
                         // Check grace note staff move validity
@@ -1407,7 +1420,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
             if (dstTrack == muse::nidx) {
                 continue;
             }
-            cloneSpanner(s, score, dstTrack, dstTrack2);
+            cloneSpanner(s, score, dstTrack, dstTrack2, link);
         }
     }
 
@@ -1415,7 +1428,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
 }
 
 //! NOTE For staves potentially in different scores
-void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& startTick, const Fraction& endTick)
+void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& startTick, const Fraction& endTick, bool link)
 {
     Score* oscore = srcStaff->score();
     Score* score  = dstStaff->score();
@@ -1512,7 +1525,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             if (!cloneElement) {
                 continue;
             }
-            EngravingItem* newEl = oldEl->linkedClone();
+            EngravingItem* newEl = link ? oldEl->linkedClone() : oldEl->clone();
             newEl->setParent(nm);
             newEl->setStaffIdx(oldEl->systemFlag() ? 0 : dstStaffIdx);
             newEl->setScore(score);
@@ -1528,7 +1541,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 EngravingItem* oef = oseg->element(trackZeroVoice(srcTrack));
                 if (oef && !oef->generated() && (oef->isTimeSig() || oef->isKeySig())) {
                     if (!firstVoiceVisible) {
-                        EngravingItem* ne = oef->linkedClone();
+                        EngravingItem* ne = link ? oef->linkedClone() : oef->clone();
                         ne->setTrack(trackZeroVoice(dstTrack));
                         ne->setParent(ns);
                         ne->setScore(score);
@@ -1554,7 +1567,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     if (!cloneAnnotation) {
                         continue;
                     }
-                    EngravingItem* ne1 = e->linkedClone();
+                    EngravingItem* ne1 = link ? e->linkedClone() : e->clone();
                     ne1->setTrack(dstTrack);
                     ne1->setParent(ns);
                     ne1->setScore(score);
@@ -1568,7 +1581,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 }
 
                 oe->setGenerated(false);
-                EngravingItem* ne = oe->linkedClone();
+                EngravingItem* ne = link ? oe->linkedClone() : oe->clone();
                 ne->setTrack(dstTrack);
                 ne->setParent(ns);
                 ne->setScore(score);
@@ -1584,7 +1597,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 ChordRest* ncr = toChordRest(ne);
                 Tuplet* ot = ocr->tuplet();
                 if (ot) {
-                    cloneTuplets(ocr, ncr, ot, tupletMap, nm, dstTrack);
+                    cloneTuplets(ocr, ncr, ot, tupletMap, nm, dstTrack, link);
                 }
 
                 if (!oe->isChord()) {
@@ -1593,17 +1606,17 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
 
                 Chord* och = toChord(ocr);
                 Chord* nch = toChord(ncr);
-                addGraceNoteTiesAndBackSpanners(och->graceNotesBefore(), nch, tieMap, score);
+                addGraceNoteTiesAndBackSpanners(och->graceNotesBefore(), nch, tieMap, score, link);
                 size_t n = och->notes().size();
                 for (size_t i = 0; i < n; ++i) {
                     Note* on = och->notes().at(i);
                     Note* nn = nch->notes().at(i);
-                    addTies(on, nn, tieMap, score);
-                    addBackSpanners(on, nn, score);
+                    addTies(on, nn, tieMap, score, link);
+                    addBackSpanners(on, nn, score, link);
                     GuitarBend* bendBack = on->bendBack();
                     Note* newStartNote = bendBack ? toNote(bendBack->startNote()->findLinkedInStaff(dstStaff)) : nullptr;
                     if (bendBack && newStartNote) {
-                        GuitarBend* newBend = toGuitarBend(bendBack->linkedClone());
+                        GuitarBend* newBend = toGuitarBend(link ? bendBack->linkedClone() : bendBack->clone());
                         newBend->setScore(score);
                         newBend->setParent(newStartNote);
                         newBend->setTrack(newStartNote->track());
@@ -1616,7 +1629,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     GuitarBend* bendFor = on->bendFor();
                     if (bendFor && bendFor->bendType() == GuitarBendType::SLIGHT_BEND) {
                         // Because slight bends aren't detected as "bendBack"
-                        GuitarBend* newBend = toGuitarBend(bendFor->linkedClone());
+                        GuitarBend* newBend = toGuitarBend(link ? bendFor->linkedClone() : bendFor->clone());
                         newBend->setScore(score);
                         newBend->setParent(nn);
                         newBend->setTrack(nn->track());
@@ -1626,7 +1639,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         nn->addSpannerFor(newBend);
                     }
                 }
-                addGraceNoteTiesAndBackSpanners(och->graceNotesAfter(), nch, tieMap, score);
+                addGraceNoteTiesAndBackSpanners(och->graceNotesAfter(), nch, tieMap, score, link);
                 addTremoloTwoChord(och, nch, prevTremolo);
             }
         }
@@ -1677,7 +1690,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             continue;
         }
 
-        cloneSpanner(s, score, dstTrack, dstTrack2);
+        cloneSpanner(s, score, dstTrack, dstTrack2, link);
     }
 
     bool oscoreConcertPitch = oscore->style().styleB(Sid::concertPitch);

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -91,9 +91,9 @@ public:
     static void cloneStaves(Score* sourceScore, Score* dstScore, const std::vector<staff_idx_t>& sourceStavesIndexes,
                             const TracksMap& allTracks);
     static void cloneMeasures(Score* oscore, Score* score);
-    static void cloneStaff(Staff* ostaff, Staff* nstaff, bool cloneSpanners = true);
-    static void cloneStaff2(Staff* ostaff, Staff* nstaff, const Fraction& startTick, const Fraction& endTick);
-    static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2);
+    static void cloneStaff(Staff* ostaff, Staff* nstaff, bool cloneSpanners = true, bool link = true);
+    static void cloneStaff2(Staff* ostaff, Staff* nstaff, const Fraction& startTick, const Fraction& endTick, bool link = true);
+    static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2, bool link = true);
     static void createLinkedTabs(MasterScore* score);
 
 private:

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1362,6 +1362,127 @@ TEST_F(Engraving_PartsTests, inputFromParts) {
 //   staffStyles
 //---------------------------------------------------------
 
+//---------------------------------------------------------
+//   countNotesOnStaff
+//---------------------------------------------------------
+
+static size_t countNotesOnStaff(Score* score, staff_idx_t staffIdx)
+{
+    size_t count = 0;
+    const track_idx_t startTrack = staffIdx * VOICES;
+    const track_idx_t endTrack = startTrack + VOICES;
+    for (Measure* m = score->firstMeasure(); m; m = m->nextMeasure()) {
+        for (Segment* seg = m->first(SegmentType::ChordRest); seg; seg = seg->next(SegmentType::ChordRest)) {
+            for (track_idx_t track = startTrack; track < endTrack; ++track) {
+                EngravingItem* element = seg->element(track);
+                if (element && element->isChord()) {
+                    count += toChord(element)->notes().size();
+                }
+            }
+        }
+    }
+    return count;
+}
+
+//---------------------------------------------------------
+//   duplicateStaffUnlinked
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, duplicateStaffUnlinked)
+{
+    MasterScore* masterScore = ScoreRW::readScore(PARTS_DATA_DIR + u"part-breath.mscx");
+    ASSERT_TRUE(masterScore);
+
+    Staff* sourceStaff = masterScore->staff(0);
+    ASSERT_TRUE(sourceStaff);
+    Part* part = sourceStaff->part();
+    ASSERT_TRUE(part);
+
+    const size_t originalStaffCount = masterScore->staves().size();
+    const size_t sourceNoteCount = countNotesOnStaff(masterScore, 0);
+    EXPECT_GT(sourceNoteCount, 0u);
+
+    masterScore->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
+    Staff* duplicatedStaff = Factory::createStaff(part);
+    duplicatedStaff->setPart(part);
+    masterScore->undoInsertStaff(duplicatedStaff, 1, false);
+    const bool cloneSpanners = true;
+    const bool createLinks = false;
+    Excerpt::cloneStaff(sourceStaff, duplicatedStaff, cloneSpanners, createLinks);
+    masterScore->endCmd();
+
+    EXPECT_EQ(masterScore->staves().size(), originalStaffCount + 1);
+
+    const size_t duplicatedNoteCount = countNotesOnStaff(masterScore, duplicatedStaff->idx());
+    EXPECT_EQ(duplicatedNoteCount, sourceNoteCount);
+
+    EXPECT_FALSE(sourceStaff->isLinked(duplicatedStaff));
+    EXPECT_FALSE(duplicatedStaff->isLinked(sourceStaff));
+
+    delete masterScore;
+}
+
+//---------------------------------------------------------
+//   undoDuplicateStaffUnlinked
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, undoDuplicateStaffUnlinked)
+{
+    MasterScore* masterScore = ScoreRW::readScore(PARTS_DATA_DIR + u"part-breath.mscx");
+    ASSERT_TRUE(masterScore);
+
+    Staff* sourceStaff = masterScore->staff(0);
+    ASSERT_TRUE(sourceStaff);
+    Part* part = sourceStaff->part();
+    ASSERT_TRUE(part);
+
+    const size_t originalStaffCount = masterScore->staves().size();
+    const size_t sourceNoteCount = countNotesOnStaff(masterScore, 0);
+
+    masterScore->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
+    Staff* duplicatedStaff = Factory::createStaff(part);
+    duplicatedStaff->setPart(part);
+    masterScore->undoInsertStaff(duplicatedStaff, 1, false);
+    Excerpt::cloneStaff(sourceStaff, duplicatedStaff, /*cloneSpanners*/ true, /*link*/ false);
+    masterScore->endCmd();
+
+    EXPECT_EQ(masterScore->staves().size(), originalStaffCount + 1);
+
+    masterScore->undoRedo(true, 0);
+
+    EXPECT_EQ(masterScore->staves().size(), originalStaffCount);
+    EXPECT_EQ(countNotesOnStaff(masterScore, 0), sourceNoteCount);
+
+    delete masterScore;
+}
+
+//---------------------------------------------------------
+//   cloneStaffLinkedDefault
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, cloneStaffLinkedDefault)
+{
+    MasterScore* masterScore = ScoreRW::readScore(PARTS_DATA_DIR + u"part-breath.mscx");
+    ASSERT_TRUE(masterScore);
+
+    Staff* sourceStaff = masterScore->staff(0);
+    ASSERT_TRUE(sourceStaff);
+    Part* part = sourceStaff->part();
+    ASSERT_TRUE(part);
+
+    masterScore->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
+    Staff* linkedStaff = Factory::createStaff(part);
+    linkedStaff->setPart(part);
+    masterScore->undoInsertStaff(linkedStaff, 1, false);
+    Excerpt::cloneStaff(sourceStaff, linkedStaff);
+    masterScore->endCmd();
+
+    EXPECT_TRUE(sourceStaff->isLinked(linkedStaff));
+    EXPECT_TRUE(linkedStaff->isLinked(sourceStaff));
+
+    delete masterScore;
+}
+
 #if 0
 TEST_F(Engraving_PartsTests, staffStyles)
 {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
@@ -35,6 +35,7 @@ StyledPopupView {
 
     signal replaceInstrumentRequested()
     signal resetAllFormattingRequested()
+    signal duplicateInstrumentRequested()
 
     contentHeight: contentColumn.childrenRect.height
 
@@ -243,6 +244,22 @@ StyledPopupView {
 
                 onClicked: {
                     root.resetAllFormattingRequested()
+                    root.close()
+                }
+            }
+
+            FlatButton {
+                width: parent.width
+
+                navigation.panel: root.navigationPanel
+                navigation.row: 9
+
+                text: qsTrc("layoutpanel/instrumentsettingspopup", "Duplicate instrument")
+
+                visible: settingsModel.isMainScore
+
+                onClicked: {
+                    root.duplicateInstrumentRequested()
                     root.close()
                 }
             }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -187,6 +187,10 @@ FocusableControl {
                 // Same as above
                 Qt.callLater((root.item as PartTreeItem).resetAllFormatting)
             }
+
+            onDuplicateInstrumentRequested: {
+                Qt.callLater((root.item as PartTreeItem).duplicateInstrument)
+            }
         }
     }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
@@ -23,6 +23,9 @@
 
 #include "async/notifylist.h"
 
+#include "engraving/dom/instrument.h"
+#include "engraving/dom/part.h"
+
 #include "log.h"
 
 using namespace mu::instrumentsscene;
@@ -256,6 +259,45 @@ void PartTreeItem::replaceInstrument()
 
         masterNotation()->parts()->replaceInstrument(instrumentKey, instrument, staffType);
     });
+}
+
+void PartTreeItem::duplicateInstrument()
+{
+    // Get the sourcePart
+    const muse::ID sourcePartId = id();
+    const Part* sourcePart = masterNotation()->parts()->part(sourcePartId);
+
+    if (!sourcePart) {
+        LOGD("duplicateInstrument: Unable to find part");
+        return;
+    }
+
+    // Get the audioSettings
+    project::IProjectAudioSettingsPtr audioSettings;
+    if (auto currentProject = globalContext()->currentProject()) {
+        audioSettings = currentProject->audioSettings();
+    } else {
+        audioSettings = nullptr;
+    }
+
+    auto copyAudioStateForNewPart = [audioSettings, sourcePartId, sourcePart](const Part* newPart) {
+        if (!newPart || !audioSettings) {
+            return;
+        }
+
+        for (const auto& [_, instrument] : sourcePart->instruments()) {
+            if (!instrument) {
+                continue;
+            }
+
+            const mu::engraving::InstrumentTrackId srcTrackId{ sourcePartId, instrument->id() };
+            const mu::engraving::InstrumentTrackId dstTrackId{ newPart->id(), instrument->id() };
+
+            audioSettings->duplicateTrackParams(srcTrackId, dstTrackId);
+        }
+    };
+
+    masterNotation()->parts()->duplicatePart(sourcePartId, copyAudioStateForNewPart);
 }
 
 void PartTreeItem::resetAllFormatting()

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.h
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.h
@@ -27,7 +27,9 @@
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "interactive/iinteractive.h"
+#include "context/iglobalcontext.h"
 #include "notationscene/iselectinstrumentscenario.h"
+#include "project/iprojectaudiosettings.h"
 
 namespace mu::instrumentsscene {
 class PartTreeItem : public AbstractLayoutPanelTreeItem, public muse::Contextable, public muse::async::Asyncable
@@ -39,6 +41,7 @@ class PartTreeItem : public AbstractLayoutPanelTreeItem, public muse::Contextabl
 
     muse::ContextInject<notation::ISelectInstrumentsScenario> selectInstrumentsScenario { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
+    muse::ContextInject<context::IGlobalContext> globalContext { this };
 
 public:
     PartTreeItem(notation::IMasterNotationPtr masterNotation, notation::INotationPtr notation, QObject* parent,
@@ -62,6 +65,7 @@ public:
     Q_INVOKABLE QString instrumentId() const;
     Q_INVOKABLE void replaceInstrument();
     Q_INVOKABLE void resetAllFormatting();
+    Q_INVOKABLE void duplicateInstrument();
 
 protected:
     void listenVisibilityChanged();

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "async/notification.h"
 
 #include "notationtypes.h"
@@ -83,6 +85,8 @@ public:
     virtual bool appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId) = 0;
 
     virtual void insertPart(Part* part, size_t index) = 0;
+
+    virtual const Part* duplicatePart(const muse::ID& partId, std::function<void(const Part* newPart)>) = 0;
 
     virtual void replacePart(const muse::ID& partId, Part* newPart) = 0;
     virtual void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument,

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -739,6 +739,34 @@ void NotationParts::insertPart(Part* part, size_t index)
     notifyAboutPartAdded(part);
 }
 
+const Part* NotationParts::duplicatePart(const ID& partId, std::function<void(const Part* newPart)> copyAudioStateForNewPart)
+{
+    TRACEFUNC;
+
+    Part* sourcePart = partModifiable(partId);
+    if (!sourcePart) {
+        return nullptr;
+    }
+
+    startEdit(TranslatableString("undoableAction", "Duplicate instrument"));
+
+    EditSystemLocks::removeSystemLocksContainingMMRests(score());
+
+    Part* newPart = doDuplicatePart(sourcePart);
+
+    const bool lambdaExists = (copyAudioStateForNewPart != nullptr);
+    const bool newPartExists = (newPart != nullptr);
+    if (lambdaExists && newPartExists) {
+        copyAudioStateForNewPart(newPart);
+    }
+
+    apply();
+
+    notifyAboutPartAdded(newPart);
+
+    return newPart;
+}
+
 void NotationParts::replacePart(const ID& partId, Part* newPart)
 {
     TRACEFUNC;
@@ -1059,6 +1087,67 @@ void NotationParts::doInsertPart(Part* part, size_t index)
     }
 
     score()->remapBracketsAndBarlines();
+}
+
+Part* NotationParts::doDuplicatePart(Part* sourcePart)
+{
+    TRACEFUNC;
+
+    const InstrumentList sourceInstruments = sourcePart->instruments();
+    const std::vector<Staff*> sourceStaves = sourcePart->staves();
+    const size_t insertionIndex = muse::indexOf(score()->parts(), sourcePart) + 1;
+
+    // Create new part from clone
+    Part* newPart = sourcePart->clone();
+    newPart->setId(ID());
+    newPart->clearStaves();
+    newPart->setInstruments({});
+
+    if (Excerpt* excerpt = score()->excerpt()) {
+        score()->undo(new AddPartToExcerpt(excerpt, newPart, insertionIndex));
+    } else {
+        score()->undoInsertPart(newPart, insertionIndex);
+    }
+
+    // Copy the instruments
+    for (const auto& [tick, sourceInstrument] : sourceInstruments) {
+        if (!sourceInstrument) {
+            continue;
+        }
+
+        Instrument* instrumentCopy = new Instrument(*sourceInstrument);
+
+        // Get a new number for the instrument (so the name isn't the same)
+        InstrumentTemplate templateWithJustId;
+        templateWithJustId.id = instrumentCopy->id();
+
+        const int copyNumber = resolveNewInstrumentNumber(templateWithJustId, {});
+        instrumentCopy->setNumber(copyNumber);
+
+        newPart->setInstrument(instrumentCopy, tick);
+    }
+
+    // Copy the staves
+    for (size_t i = 0; i < sourceStaves.size(); ++i) {
+        Staff* sourceStaff = sourceStaves[i];
+
+        // Create a new staff based on the previous one
+        Staff* staffCopy = engraving::Factory::createStaff(newPart);
+        staffCopy->setId(ID());
+        staffCopy->setScore(score());
+        staffCopy->setPart(newPart);
+        staffCopy->init(sourceStaff);
+
+        insertStaff(staffCopy, static_cast<int>(i), /*createRests*/ true);
+
+        const bool cloneSpanners = true;
+        const bool createLinks = false;
+        mu::engraving::Excerpt::cloneStaff(sourceStaff, staffCopy, cloneSpanners, createLinks);
+    }
+
+    score()->remapBracketsAndBarlines();
+
+    return newPart;
 }
 
 void NotationParts::removeStaves(const IDList& stavesIds)

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -77,6 +77,7 @@ public:
     bool appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId) override;
 
     void insertPart(Part* part, size_t index) override;
+    const Part* duplicatePart(const muse::ID& partId, std::function<void(const Part* newPart)> copyAudioStateForNewPart) override;
 
     void replacePart(const muse::ID& partId, Part* newPart) override;
     void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument,
@@ -123,6 +124,7 @@ private:
     void doAppendStaff(Staff* staff, Part* destinationPart, bool createRests=true);
     void doSetStaffConfig(Staff* staff, const StaffConfig& config, Fraction tick = Fraction(0, 1));
     void doInsertPart(Part* part, size_t index);
+    Part* doDuplicatePart(Part* part);
 
     Staff* staffModifiable(const muse::ID& staffId) const;
 

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -229,6 +229,49 @@ void ProjectAudioSettings::removeTrackParams(const InstrumentTrackId& partId)
     }
 }
 
+bool ProjectAudioSettings::duplicateTrackParams(const InstrumentTrackId& srcTrackId,
+                                                const InstrumentTrackId& dstTrackId)
+{
+    const bool inputParamsCopied = copyInputParamsBetweenTracks(srcTrackId, dstTrackId);
+    const bool outputParamsCopied = copyOutputParamsBetweenTracks(srcTrackId, dstTrackId);
+
+    const bool somethingWasCopied = inputParamsCopied || outputParamsCopied;
+    if (somethingWasCopied) {
+        m_settingsChanged.notify();
+    }
+
+    return somethingWasCopied;
+}
+
+bool ProjectAudioSettings::copyInputParamsBetweenTracks(const InstrumentTrackId& srcTrackId,
+                                                        const InstrumentTrackId& dstTrackId)
+{
+    auto srcEntry = m_trackInputParamsMap.find(srcTrackId);
+    if (srcEntry == m_trackInputParamsMap.end()) {
+        return false;
+    }
+
+    AudioInputParams sourceParamsCopy = srcEntry->second;
+    m_trackInputParamsMap[dstTrackId] = sourceParamsCopy;
+    m_trackInputParamsChanged.send(dstTrackId);
+
+    return true;
+}
+
+bool ProjectAudioSettings::copyOutputParamsBetweenTracks(const InstrumentTrackId& srcTrackId,
+                                                         const InstrumentTrackId& dstTrackId)
+{
+    auto srcEntry = m_trackOutputParamsMap.find(srcTrackId);
+    if (srcEntry == m_trackOutputParamsMap.end()) {
+        return false;
+    }
+
+    AudioOutputParams sourceParamsCopy = srcEntry->second;
+    m_trackOutputParamsMap[dstTrackId] = sourceParamsCopy;
+
+    return true;
+}
+
 const SoundProfileName& ProjectAudioSettings::activeSoundProfile() const
 {
     return m_activeSoundProfileName;

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -62,6 +62,8 @@ public:
 
     void removeTrackParams(const engraving::InstrumentTrackId& partId) override;
 
+    bool duplicateTrackParams(const engraving::InstrumentTrackId& srcTrackId, const engraving::InstrumentTrackId& dstTrackId) override;
+
     const playback::SoundProfileName& activeSoundProfile() const override;
     void setActiveSoundProfile(const playback::SoundProfileName& profileName) override;
 
@@ -75,8 +77,13 @@ public:
 
 private:
     friend class NotationProject;
+    friend class Project_AudioSettingsTests;
+
     ProjectAudioSettings(const muse::modularity::ContextPtr& iocCtx)
         : muse::Contextable(iocCtx) {}
+
+    bool copyInputParamsBetweenTracks(const engraving::InstrumentTrackId& srcTrackId, const engraving::InstrumentTrackId& dstTrackId);
+    bool copyOutputParamsBetweenTracks(const engraving::InstrumentTrackId& srcTrackId, const engraving::InstrumentTrackId& dstTrackId);
 
     AudioInputParams inputParamsFromJson(const QJsonObject& object) const;
     AudioOutputParams outputParamsFromJson(const QJsonObject& object) const;

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -102,6 +102,8 @@ public:
 
     virtual void removeTrackParams(const engraving::InstrumentTrackId& trackId) = 0;
 
+    virtual bool duplicateTrackParams(const engraving::InstrumentTrackId& srcTrackId, const engraving::InstrumentTrackId& dstTrackId) = 0;
+
     virtual const playback::SoundProfileName& activeSoundProfile() const = 0;
     virtual void setActiveSoundProfile(const playback::SoundProfileName& profileName) = 0;
 

--- a/src/project/tests/CMakeLists.txt
+++ b/src/project/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/mscmetareadermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projectconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mscmetareadertests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/projectaudiosettingstests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/templatesrepositorytest.cpp
 )
 

--- a/src/project/tests/projectaudiosettingstests.cpp
+++ b/src/project/tests/projectaudiosettingstests.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gmock/gmock.h>
+
+#include "project/internal/projectaudiosettings.h"
+
+using namespace muse;
+using namespace muse::audio;
+using namespace mu::engraving;
+
+namespace mu::project {
+class Project_AudioSettingsTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_settings = std::shared_ptr<ProjectAudioSettings>(new ProjectAudioSettings(modularity::ContextPtr()));
+        m_pianoOnPart1 = { muse::ID(static_cast<uint64_t>(1)), String(u"keyboard.piano") };
+        m_pianoOnPart2 = { muse::ID(static_cast<uint64_t>(2)), String(u"keyboard.piano") };
+    }
+
+    static AudioResourceMeta makeVstResource(const AudioResourceId& id, const AudioResourceVendor& vendor)
+    {
+        AudioResourceMeta meta;
+        meta.id = id;
+        meta.vendor = vendor;
+        meta.type = AudioResourceType::VstPlugin;
+        meta.hasNativeEditorSupport = true;
+        return meta;
+    }
+
+    static AudioInputParams makeVstInput(const AudioResourceId& id)
+    {
+        AudioInputParams input;
+        input.resourceMeta = makeVstResource(id, AudioResourceVendor("TestVendor"));
+        return input;
+    }
+
+    static AudioFxParams makeFxEffect(const AudioResourceId& id)
+    {
+        AudioFxParams fx;
+        fx.resourceMeta = makeVstResource(id, AudioResourceVendor("TestVendor"));
+        fx.active = true;
+        return fx;
+    }
+
+    std::shared_ptr<ProjectAudioSettings> m_settings;
+    InstrumentTrackId m_pianoOnPart1;
+    InstrumentTrackId m_pianoOnPart2;
+};
+}
+
+using namespace mu::project;
+
+TEST_F(Project_AudioSettingsTests, DuplicateCopiesInputAndOutputParams)
+{
+    AudioInputParams sourceInput = makeVstInput(AudioResourceId("Steinway"));
+
+    AudioOutputParams sourceOutput;
+    sourceOutput.volume = -6.0f;
+    sourceOutput.balance = 0.5f;
+    sourceOutput.muted = true;
+    sourceOutput.fxChain[0] = makeFxEffect(AudioResourceId("Reverb"));
+
+    m_settings->setTrackInputParams(m_pianoOnPart1, sourceInput);
+    m_settings->setTrackOutputParams(m_pianoOnPart1, sourceOutput);
+
+    bool copySucceeded = m_settings->duplicateTrackParams(m_pianoOnPart1, m_pianoOnPart2);
+
+    EXPECT_TRUE(copySucceeded);
+    EXPECT_EQ(m_settings->trackInputParams(m_pianoOnPart2), sourceInput);
+    EXPECT_TRUE(m_settings->trackHasExistingOutputParams(m_pianoOnPart2));
+    EXPECT_EQ(m_settings->trackOutputParams(m_pianoOnPart2), sourceOutput);
+}


### PR DESCRIPTION
Closes #25649

- Add button and signal to InstrumentSettingsPopup.qml
- Hook the button to PartTreeItem::duplicateInstrument
- Create PartTreeItem::duplicateInstrument
- Create NotationParts::duplicatePart
  - Create NotationParts::doDuplicatePart
  - Change Excerpt::cloneStaff, Excerpt::cloneStaff2, Excerpt::cloneSpanner to support unlinked clones
- Add ProjectAudioSettings::duplicateTrackParams (and helpers)

- Add Excerpt::cloneStaff tests
- Add ProjectAudioSettings::duplicateTrackParams tests

Resolves: #25649

# Major changes
- Added a button to duplicate an instrument.
- Excerpt::cloneStaff and Excerpt::cloneStaff2 only supported linked clones. Now they (and all helpers) support unlinked clones.
	- Added tests to test this new behaviour and to make sure that the past behaviour is maintained.
- Added a few functions, along with helpers, to duplicate track parameters.
	- Added tests to test these functions.

# Rationale behind some of the decisions

1. Why is `copyAudioStateForNewPart` passed as a lambda instead of just passing the captured variables as parameters?

So as to not have to add `#include "project/..."` inside `notationparts.cpp`.

We do understand that this might not be the best way of going about it, so if there's a better way of doing this (or if adding the include is acceptable) we can change it.

2. Why change `Excerpt::cloneStaff2` to support unlinked clones despite not using it?

Because it shares some of its functions with `Excerpt::cloneStaff`, which we do use.

While we did test it, it was far from as thoroughly as `Excerpt::cloneStaff`. Despite that, the changes should break no past functionality, so there should be no problem in having them.

# Other Notes
- Although we tested it manually, there are sure to be edge cases we didn't take into account. Thus, if anyone has a highly complex score they wouldn't mind sharing, especially one that's using niche use-cases, we'd appreciate it if you sent it here so we could test it and find bugs.
- We tested VSTs programmatically, but not manually. They *should* work, but we'd appreciate it if anyone vouched for the fact that they actually do.

# Bugs

1. Some of the mixer settings don't get duplicated.

This is due to #33391 so it's likely best to not merge this until that's fixed (we verified that it's caused by that by using other unrelated channels to set the values. You can see more information in [my comment](https://github.com/musescore/MuseScore/issues/33391#issuecomment-4566653154)).


2. Creating an instrument, duplicating it, and then deleting results in:

```
ASSERT failure in void QQuickTreeModelAdaptor1::modelRowsAboutToBeRemoved(const QModelIndex&, int, int): "Consistency test failed", file /path/to/MuseScore/muse/framework/uicomponents/qml/Muse/UiComponents/LegacyTreeView/qquicktreemodeladaptor.cpp, line 669`
```

But the same thing happens when creating a score with an instrument, inserting another one, and deleting the first one so we believe it's not our fault. This was only tested with our changes and we didn't find an issue related to this, so if someone manages to replicate, they can let us know and we'll open an issue.

3. Chord brackets are still linked.

We noticed that currently, chord brackets, specifically, are still linked after duplication (changing one changes the other).

This is easily fixed with the diff:

```diff
diff --git a/src/engraving/dom/chord.cpp b/src/engraving/dom/chord.cpp
index 12fd9b026a..7d8b5809f5 100644
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -392,7 +392,7 @@ Chord::Chord(const Chord& c, bool link)
 
     for (EngravingItem* e : c.el()) {
         if (e->isChordBracket()) {
-            EngravingItem* clonedChordBracket = e->linkedClone();
+            EngravingItem* clonedChordBracket = link ? e->linkedClone() : e->clone();
             add(clonedChordBracket);
         }
     }
```

But this change is outside the scope of the feature. If need-be, I (@shnCanos) can make a separate PR with this change.

We were unable to find an issue relating to this.

# Video showing the feature

https://github.com/user-attachments/assets/2a97f58d-48ec-417f-b039-cc14b9b0f142

[Link to the score used in the video](https://musescore.com/user/101554/scores/117279)

- [x] I signed the [CLA](https://musescore.org/en/cla) as [shncanos](https://musescore.com/user/118014740) (@shnCanos) and [joaocastrosil](https://musescore.com/user/118017353) (@jvcastroo-ist)
- [x] The title of the PR describes the problem it addresses.
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).