### PR TITLE
Fix stale Symbol magnification after partial layout

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -5476,12 +5476,14 @@ void TLayout::layoutSymbol(const Symbol* item, Symbol::LayoutData* ldata, const 
 
     LD_INDEPENDENT;
 
-    if (ldata->isValid()) {
+    double expectedMag = item->staff() ? item->staff()->staffMag(item->tick()) : ldata->mag();
+
+    if (ldata->isValid() && RealIsEqual(ldata->mag(), expectedMag)) {
         return;
     }
 
     if (item->staff()) {
-        ldata->setMag(item->staff()->staffMag(item->tick()));
+        ldata->setMag(expectedMag);
     }
     ldata->setBbox(item->scoreFont()
                    ? item->scoreFont()->bbox(item->sym(), item->magS() * item->symbolsSize())


### PR DESCRIPTION
Resolves: #33738  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
`TLayout::layoutSymbol()` already derives Symbol magnification from the staff magnification. However, it could return early when `ldata->isValid()` was true, even if `ldata->mag()` no longer matched the expected staff magnification.

This caused stale reduced magnification from small/cue/grace note contexts to be reused.

https://github.com/user-attachments/assets/81e349d1-2c5f-4383-9029-18850535f73b



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).



