### PR TITLE
Fix #24075 (second part):  members of the castilian dulzaina instrument pitched in different key: F and G

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -1537,6 +1537,26 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="f-castilian-dulzaina">
+                  <family>dulzainas</family>
+                  <trackName>Castilian Dulzaina</trackName>
+                  <longName>Castilian Dulzaina</longName>
+                  <shortName>Cast. Dulz.</shortName>
+                  <traitName type="transposition">F</traitName>
+                  <description>Spanish double-reed folk instrument from the Castile region. In F.</description>
+                  <musicXMLid>wind.reed.dulzaina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>62-86</aPitchRange>
+                  <pPitchRange>62-91</pPitchRange>
+                  <transposeDiatonic>3</transposeDiatonic>
+                  <transposeChromatic>5</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
+                        <program value="68"/> <!--Oboe-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="fs-castilian-dulzaina">
                   <family>dulzainas</family>
                   <trackName>Castilian Dulzaina</trackName>
@@ -1547,10 +1567,30 @@
                   <musicXMLid>wind.reed.dulzaina</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>63-91</aPitchRange>
-                  <pPitchRange>63-96</pPitchRange>
+                  <aPitchRange>63-87</aPitchRange>
+                  <pPitchRange>63-92</pPitchRange>
                   <transposeDiatonic>3</transposeDiatonic>
                   <transposeChromatic>6</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
+                        <program value="68"/> <!--Oboe-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="g-castilian-dulzaina">
+                  <family>dulzainas</family>
+                  <trackName>Castilian Dulzaina</trackName>
+                  <longName>Castilian Dulzaina</longName>
+                  <shortName>Cast. Dulz.</shortName>
+                  <traitName type="transposition">G</traitName>
+                  <description>Spanish double-reed folk instrument from the Castile region. In G.</description>
+                  <musicXMLid>wind.reed.dulzaina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-88</aPitchRange>
+                  <pPitchRange>64-93</pPitchRange>
+                  <transposeDiatonic>4</transposeDiatonic>
+                  <transposeChromatic>7</transposeChromatic>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
                         <program value="68"/> <!--Oboe-->

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -815,6 +815,17 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "D Qn.", "d-quena shortName"),
 //: traitName for Quena; tuning: D; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "D", "d-quena traitName"),
 
+//: description for Castilian Dulzaina; transposition: F; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Spanish double-reed folk instrument from the Castile region. In F.", "f-castilian-dulzaina description"),
+//: trackName for Castilian Dulzaina; transposition: F; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "f-castilian-dulzaina trackName"),
+//: longName for Castilian Dulzaina; transposition: F; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "f-castilian-dulzaina longName"),
+//: shortName for Castilian Dulzaina; transposition: F; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Cast. Dulz.", "f-castilian-dulzaina shortName"),
+//: traitName for Castilian Dulzaina; transposition: F; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "F", "f-castilian-dulzaina traitName"),
+
 //: description for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Spanish double-reed folk instrument from the Castile region. In F♯.", "fs-castilian-dulzaina description"),
 //: trackName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
@@ -825,6 +836,17 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "fs-castilian-
 QT_TRANSLATE_NOOP3("engraving/instruments", "Cast. Dulz.", "fs-castilian-dulzaina shortName"),
 //: traitName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "F♯", "fs-castilian-dulzaina traitName"),
+
+//: description for Castilian Dulzaina; transposition: G; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Spanish double-reed folk instrument from the Castile region. In G.", "g-castilian-dulzaina description"),
+//: trackName for Castilian Dulzaina; transposition: G; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "g-castilian-dulzaina trackName"),
+//: longName for Castilian Dulzaina; transposition: G; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "g-castilian-dulzaina longName"),
+//: shortName for Castilian Dulzaina; transposition: G; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Cast. Dulz.", "g-castilian-dulzaina shortName"),
+//: traitName for Castilian Dulzaina; transposition: G; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "G", "g-castilian-dulzaina traitName"),
 
 //: description for Piccolo Heckelphone; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Very rare variant of the heckelphone in F, sounding a fourth higher than the oboe.", "piccolo-heckelphone description"),

--- a/src/engraving/playback/mapping/windssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/windssetupdataresolver.cpp
@@ -102,7 +102,9 @@ PlaybackSetupData WindsSetupDataResolver::doResolve(const Instrument* instrument
         { "f-quena", { SoundId::Quena, SoundCategory::Winds } },
         { "d-quena", { SoundId::Quena, SoundCategory::Winds } },
 
+        { "f-castilian-dulzaina", { SoundId::Dulzaina, SoundCategory::Winds, { SoundSubCategory::Castilian } } },
         { "fs-castilian-dulzaina", { SoundId::Dulzaina, SoundCategory::Winds, { SoundSubCategory::Castilian } } },
+        { "g-castilian-dulzaina", { SoundId::Dulzaina, SoundCategory::Winds, { SoundSubCategory::Castilian } } },
 
         { "piccolo-heckelphone", { SoundId::Heckelphone, SoundCategory::Winds } },
         { "heckelphone", { SoundId::Heckelphone, SoundCategory::Winds } },


### PR DESCRIPTION
Resolves: #24075  (second part )<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This second PR adds two new members of the Castilian dulzaina instrument with different pitches: F and G

Changes:
- New "castilian dulzaina in F (quite uncommon)
- New "castilian dulzaina in G (less common than castilian dulzaina in F#)
- Pitch range for castilian dulzaina in F# ([PR](https://github.com/musescore/MuseScore/pull/31165)) has been changed to a more realistic values

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
