### PR TITLE
Fix grace note MIDI export: silent grace notes in saved score files

### DIFF
--- a/src/engraving/compat/midi/compatmidirender.cpp
+++ b/src/engraving/compat/midi/compatmidirender.cpp
@@ -597,9 +597,12 @@ void CompatMidiRender::createGraceNotesPlayEvents(const Score* score, const Frac
             el.push_back(nel);
         }
 
-        if (gc->playEventType() == PlayEventType::Auto) {
-            gc->setNoteEventLists(el);
-        }
+        // Always overwrite grace note events: MuseScore 4 exposes no UI for
+        // manually editing grace note MIDI timing, so any stored PlayEventType::User
+        // on a grace chord is a stale artifact from an earlier render. Honouring it
+        // would leave zero-duration events (saved by old buggy renders) in place and
+        // make the grace note silent in MIDI export.
+        gc->setNoteEventLists(el);
 
         on += graceDuration;
     }
@@ -634,9 +637,7 @@ void CompatMidiRender::createGraceNotesPlayEvents(const Score* score, const Frac
                 el.push_back(nel);
             }
 
-            if (gc->playEventType() == PlayEventType::Auto) {
-                gc->setNoteEventLists(el);
-            }
+            gc->setNoteEventLists(el);
             on += graceDuration1;
         }
     }

--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -789,7 +789,10 @@ static void collectNote(EventsHolder& events, const Note* note, const CollectNot
     // calculate additional length due to ties forward
     // taking NoteEvent length adjustments into account
 
-    int tick1    = note->tick().ticks() + noteParams.tickOffset;
+    // Grace notes are exported relative to their principal chord and then shifted
+    // earlier via grace offsets. Using the grace note's own tick here double-shifts
+    // acciaccaturas in the MIDI export path.
+    int tick1    = chord->tick().ticks() + noteParams.tickOffset;
     const GuitarBend* bendFor = note->bendFor();
     const GuitarBend* bendBack = note->bendBack();
 
@@ -861,8 +864,15 @@ static void collectNote(EventsHolder& events, const Note* note, const CollectNot
             int eventChannel = noteChannel;
             playParams.pitch = p;
             playParams.velo = std::clamp(velo, 1, 127);
-            playParams.onTime = std::max(0, on - noteParams.graceOffsetOn);
-            playParams.offTime = std::max(0, off - noteParams.graceOffsetOff);
+            int rawOnTime = on - noteParams.graceOffsetOn;
+            playParams.onTime = std::max(0, rawOnTime);
+            if (noteParams.graceOffsetOn > 0 && rawOnTime < 0) {
+                // Grace before beat was clamped (e.g., first beat of piece).
+                // Preserve the intended duration so the grace remains audible.
+                playParams.offTime = playParams.onTime + noteParams.graceOffsetOn - 1;
+            } else {
+                playParams.offTime = std::max(0, off - noteParams.graceOffsetOff);
+            }
 
             if (eventEffect == MidiInstrumentEffect::NONE) {
                 eventEffect = midiEffectFromEvent(e);

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3184,7 +3184,10 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
             }
         }
         n->setPlayEvents(playEvents);
-        if (n->chord()) {
+        // Don't mark grace chords as User: their stored events are always stale
+        // render artifacts (MuseScore 4 has no UI for editing grace note timing),
+        // and honouring the flag would suppress recomputation on the next render.
+        if (n->chord() && !n->chord()->isGrace()) {
             n->chord()->setPlayEventType(PlayEventType::User);
         }
     } else if (tag == "offset") {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2468,7 +2468,14 @@ void TWrite::write(const Note* item, XmlWriter& xml, WriteContext& ctx)
         writeSpannerEnd(item->tieBack(), xml, ctx, item, item->track());
     }
 
-    if ((item->chord() == 0 || item->chord()->playEventType() != PlayEventType::Auto) && !item->playEvents().empty()) {
+    // Never persist play events for grace note chords: MuseScore 4 exposes no UI
+    // for editing grace note MIDI timing, so stored events are always stale render
+    // artifacts. Skipping them here breaks the write→load→User→skip-recompute cycle
+    // that caused grace notes to be silent after a score was saved and reopened.
+    const bool isGraceNote = item->chord() && item->chord()->isGrace();
+    if (!isGraceNote
+        && (item->chord() == 0 || item->chord()->playEventType() != PlayEventType::Auto)
+        && !item->playEvents().empty()) {
         xml.startElement("Events");
         for (const NoteEvent& e : item->playEvents()) {
             write(&e, xml, ctx);

--- a/src/importexport/midi/tests/midiexport_data/testGraceAfter.mscx
+++ b/src/importexport/midi/tests/midiexport_data/testGraceAfter.mscx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="workTitle">TestGraceAfter</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>TestGraceAfter</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Tempo>
+            <tempo>1</tempo>
+            <followText>1</followText>
+            <text><sym>metNoteQuarterUp</sym> = 60</text>
+            </Tempo>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <!-- Quarter note (pitch 60) with a grace-after (pitch 62, eighth) -->
+          <Chord>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/midi/tests/midiexport_data/testGraceAppoggiatura.mscx
+++ b/src/importexport/midi/tests/midiexport_data/testGraceAppoggiatura.mscx
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="workTitle">TestGraceAppoggiatura</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>TestGraceAppoggiatura</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Tempo>
+            <tempo>1</tempo>
+            <followText>1</followText>
+            <text><sym>metNoteQuarterUp</sym> = 60</text>
+            </Tempo>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <!-- Eighth appoggiatura (pitch 71) before quarter (pitch 72) -->
+          <Chord>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <!-- Eighth appoggiatura (pitch 71) before half (pitch 72) -->
+          <Chord>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/midi/tests/midiexport_data/testGraceStaleEvents.mscx
+++ b/src/importexport/midi/tests/midiexport_data/testGraceStaleEvents.mscx
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="workTitle">TestGraceStaleEvents</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>TestGraceStaleEvents</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Tempo>
+            <tempo>1</tempo>
+            <followText>1</followText>
+            <text><sym>metNoteQuarterUp</sym> = 60</text>
+            </Tempo>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <!-- Appoggiatura (pitch 71) before half (pitch 72) at beat 1.
+               Grace note has a stale stored Event with len=0, as written by MuseScore
+               whenever a score containing grace notes is saved. The grace should still
+               be exported with correct timing. -->
+          <Chord>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <!-- Acciaccatura (pitch 71) before quarter (pitch 72) at beat 3.
+               Also has a stored Event with len=0, as saved by MuseScore. -->
+          <Chord>
+            <durationType>eighth</durationType>
+            <acciaccatura/>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/midi/tests/midiexport_tests.cpp
+++ b/src/importexport/midi/tests/midiexport_tests.cpp
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 
+#include <QBuffer>
 #include <QString>
 
 #include "global/io/ifilesystem.h"
@@ -42,6 +43,7 @@
 #include "engraving/tests/utils/scorerw.h"
 
 #include "importexport/midi/internal/midiexport/exportmidi.h"
+#include "importexport/midi/internal/midishared/midifile.h"
 
 #include "utils/smfyamlserializer.h"
 
@@ -101,6 +103,24 @@ static void exportAndCompareWithRef(const std::string& name)
 class MidiExportTests : public ::testing::Test
 {
 protected:
+    /**
+     * Search \p track for a MIDI NoteOn event at exactly \p tick with the given \p pitch and
+     * \p velocity.  Returns a pointer to the matching event, or \c nullptr if none is found.
+     * Used by grace-note tests to assert that specific on/off events exist at expected positions.
+     */
+    static const MidiEvent* findNoteEvent(const MidiTrack& track, int tick, int pitch, int velocity)
+    {
+        auto [begin, end] = track.events().equal_range(tick);
+        for (auto it = begin; it != end; ++it) {
+            const MidiEvent& event = it->second;
+            if (event.type() == ME_NOTEON && event.pitch() == pitch && event.velo() == velocity) {
+                return &event;
+            }
+        }
+
+        return nullptr;
+    }
+
     static void testTimeStretchFermata(MasterScore* score, const String& file, const String& testName)
     {
         const String writeFile = String(u"%1-%2-test-%3.mid").arg(file).arg(testName);
@@ -212,6 +232,181 @@ TEST_F(MidiExportTests, midiArpeggio) {
 
 TEST_F(MidiExportTests, midiMutedUnison) {
     exportAndCompareWithRef("testMutedUnison");
+}
+
+/// Verifies acciaccatura (grace-before) MIDI timing: grace notes start before the beat,
+/// stealing time from the previous note.  Covers tick=0 edge case (no prior note to steal from),
+/// single and multiple grace notes, and both 60 bpm and 320 bpm tempos.
+TEST_F(MidiExportTests, midiGraceBefore)
+{
+    std::unique_ptr<MasterScore> score(ScoreRW::readScore(MIDI_EXPORT_DATA_DIR + u"/testGraceBefore.mscx"));
+    ASSERT_TRUE(score);
+    score->doLayout();
+    score->rebuildMidiMapping();
+
+    ExportMidi exporter(score.get());
+    QBuffer buffer;
+    ASSERT_TRUE(buffer.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(exporter.write(&buffer, true, true));
+
+    buffer.seek(0);
+    MidiFile midiFile;
+    ASSERT_TRUE(midiFile.read(&buffer));
+    ASSERT_FALSE(midiFile.tracks().empty());
+
+    const MidiTrack& track = midiFile.tracks().front();
+
+    // Acciaccatura starts BEFORE the beat, stealing time from the previous note.
+    // graceTickSum = min(prevChord->ticks()/2, grace->notatedTicks()).
+    // At 60 bpm: quarter=480, eighth=240.
+
+    // Measure 1 beat 1 (tick 0): grace eighth (240 ticks), prevChord=null → graceTickSum=240.
+    // No previous note to steal from, so grace is clamped to tick 0 with duration preserved.
+    EXPECT_NE(findNoteEvent(track, 0, 71, 80), nullptr);    // grace on (clamped)
+    EXPECT_NE(findNoteEvent(track, 239, 71, 0), nullptr);   // grace off at 239 (duration preserved)
+    EXPECT_NE(findNoteEvent(track, 0, 72, 80), nullptr);    // principal on at beat
+
+    // Measure 1 beat 3 (tick 480): grace eighth, prevChord=eighth(240) → graceTickSum=min(120,240)=120.
+    EXPECT_NE(findNoteEvent(track, 360, 71, 80), nullptr);  // grace on 120 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 479, 71, 0), nullptr);   // grace off at beat-1 (off=on-1 for len=0)
+    EXPECT_NE(findNoteEvent(track, 480, 72, 80), nullptr);  // principal on at beat
+
+    // Measure 1 beat 4 (tick 960): grace eighth, prevChord=quarter(480) → graceTickSum=min(240,240)=240.
+    EXPECT_NE(findNoteEvent(track, 720, 71, 80), nullptr);  // grace on 240 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 960, 72, 80), nullptr);  // principal on at beat
+
+    // Measure 2 beat 1 (tick 1920): grace eighth, prevChord=half(960) → graceTickSum=min(480,240)=240.
+    EXPECT_NE(findNoteEvent(track, 1680, 71, 80), nullptr); // grace on 240 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 1920, 72, 80), nullptr); // principal on at beat
+
+    // Measure 3 beat 1 (tick 3840): 3 grace eighths, prevChord=whole(1920) → graceTickSum=min(960,240)=240, offset=80.
+    EXPECT_NE(findNoteEvent(track, 3600, 74, 80), nullptr); // grace 1 on at 3840-240
+    EXPECT_NE(findNoteEvent(track, 3680, 72, 80), nullptr); // grace 2 on at 3840-160
+    EXPECT_NE(findNoteEvent(track, 3760, 71, 80), nullptr); // grace 3 on at 3840-80
+    EXPECT_NE(findNoteEvent(track, 3840, 72, 80), nullptr); // principal on at beat
+
+    // Measures 4-6 at 320 bpm. Tick positions identical to 60 bpm (same score ticks, different wall-clock time).
+
+    // Measure 4 beat 1 (tick 5760): grace eighth, prevChord=measure-3 whole(1920) → graceTickSum=240.
+    EXPECT_NE(findNoteEvent(track, 5520, 71, 80), nullptr); // grace on 240 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 5760, 72, 80), nullptr); // principal on at beat
+
+    // Measure 4 beat 3 (tick 6240): grace eighth, prevChord=eighth(240) → graceTickSum=120.
+    EXPECT_NE(findNoteEvent(track, 6120, 71, 80), nullptr); // grace on 120 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 6240, 72, 80), nullptr); // principal on at beat
+
+    // Measure 4 beat 4 (tick 6720): grace eighth, prevChord=quarter(480) → graceTickSum=240.
+    EXPECT_NE(findNoteEvent(track, 6480, 71, 80), nullptr); // grace on 240 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 6720, 72, 80), nullptr); // principal on at beat
+
+    // Measure 5 beat 1 (tick 7680): grace eighth, prevChord=half(960) → graceTickSum=240.
+    EXPECT_NE(findNoteEvent(track, 7440, 71, 80), nullptr); // grace on 240 ticks before beat
+    EXPECT_NE(findNoteEvent(track, 7680, 72, 80), nullptr); // principal on at beat
+
+    // Measure 6 beat 1 (tick 9600): 3 grace eighths, prevChord=whole(1920) → graceTickSum=240, offset=80.
+    EXPECT_NE(findNoteEvent(track, 9360, 74, 80), nullptr); // grace 1 on at 9600-240
+    EXPECT_NE(findNoteEvent(track, 9440, 72, 80), nullptr); // grace 2 on at 9600-160
+    EXPECT_NE(findNoteEvent(track, 9520, 71, 80), nullptr); // grace 3 on at 9600-80
+    EXPECT_NE(findNoteEvent(track, 9600, 72, 80), nullptr); // principal on at beat
+}
+
+/// Verifies grace-after (trailtime) MIDI timing: the grace note starts at the midpoint
+/// of the principal note (trailtime=500 per-1000).
+TEST_F(MidiExportTests, midiGraceAfter)
+{
+    std::unique_ptr<MasterScore> score(ScoreRW::readScore(MIDI_EXPORT_DATA_DIR + u"/testGraceAfter.mscx"));
+    ASSERT_TRUE(score);
+    score->doLayout();
+    score->rebuildMidiMapping();
+
+    ExportMidi exporter(score.get());
+    QBuffer buffer;
+    ASSERT_TRUE(buffer.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(exporter.write(&buffer, true, true));
+
+    buffer.seek(0);
+    MidiFile midiFile;
+    ASSERT_TRUE(midiFile.read(&buffer));
+    ASSERT_FALSE(midiFile.tracks().empty());
+
+    const MidiTrack& track = midiFile.tracks().front();
+
+    // At 60 bpm, quarter = 480 ticks. Grace-after (trailtime=500) starts at 480*500/1000 = 240.
+    EXPECT_NE(findNoteEvent(track, 0, 60, 80), nullptr);    // principal C4 on beat
+    EXPECT_NE(findNoteEvent(track, 240, 62, 80), nullptr);  // grace-after D4 at midpoint
+}
+
+/// Verifies appoggiatura MIDI timing: the grace note plays on the beat and takes a
+/// proportional slice of the principal note's duration — min(500, graceNotated/principal * 1000)
+/// per-1000.  Covers both quarter and half principal note durations.
+TEST_F(MidiExportTests, midiGraceAppoggiatura)
+{
+    std::unique_ptr<MasterScore> score(ScoreRW::readScore(MIDI_EXPORT_DATA_DIR + u"/testGraceAppoggiatura.mscx"));
+    ASSERT_TRUE(score);
+    score->doLayout();
+    score->rebuildMidiMapping();
+
+    ExportMidi exporter(score.get());
+    QBuffer buffer;
+    ASSERT_TRUE(buffer.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(exporter.write(&buffer, true, true));
+
+    buffer.seek(0);
+    MidiFile midiFile;
+    ASSERT_TRUE(midiFile.read(&buffer));
+    ASSERT_FALSE(midiFile.tracks().empty());
+
+    const MidiTrack& track = midiFile.tracks().front();
+
+    // At 60 bpm, quarter = 480 ticks. Eighth appoggiatura takes 50% of quarter = 240 ticks.
+    EXPECT_NE(findNoteEvent(track, 0, 71, 80), nullptr);    // appoggiatura B4 on beat
+    EXPECT_NE(findNoteEvent(track, 240, 72, 80), nullptr);  // principal C5 at +240
+
+    // Eighth appoggiatura before half (960 ticks). Grace notated duration = eighth = 240 ticks,
+    // which is 240/960 = 25% of the principal → ontime = min(500, 250) = 250 per-1000
+    // → grace duration = 960 * 250/1000 = 240 ticks.
+    EXPECT_NE(findNoteEvent(track, 480, 71, 80), nullptr);  // appoggiatura B4 on beat
+    EXPECT_NE(findNoteEvent(track, 720, 72, 80), nullptr);  // principal C5 at +240
+}
+
+/// Regression test for the stale-events bug (issue #22669): grace notes whose NoteEvent
+/// was previously saved to the .mscx file with len=0 must still export with correct MIDI
+/// timing.  Loading such a file used to mark the chord PlayEventType::User, causing
+/// createGraceNotesPlayEvents() to skip recomputation and leave the silent len=0 in place.
+TEST_F(MidiExportTests, midiGraceStaleEvents)
+{
+    // Regression test: grace notes whose NoteEvent was saved to the score file with len=0
+    // (by an older MuseScore version) must still be exported with correct timing.
+    // When a note has stored <Events>, loading marks the chord PlayEventType::User, which
+    // previously caused createGraceNotesPlayEvents() to skip recomputing the grace events,
+    // leaving the stale len=0 in place and making the grace note silent in MIDI export.
+    std::unique_ptr<MasterScore> score(ScoreRW::readScore(MIDI_EXPORT_DATA_DIR + u"/testGraceStaleEvents.mscx"));
+    ASSERT_TRUE(score);
+    score->doLayout();
+    score->rebuildMidiMapping();
+
+    ExportMidi exporter(score.get());
+    QBuffer buffer;
+    ASSERT_TRUE(buffer.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(exporter.write(&buffer, true, true));
+
+    buffer.seek(0);
+    MidiFile midiFile;
+    ASSERT_TRUE(midiFile.read(&buffer));
+    ASSERT_FALSE(midiFile.tracks().empty());
+
+    const MidiTrack& track = midiFile.tracks().front();
+
+    // At 60 bpm: quarter=480, half=960 ticks.
+    // Appoggiatura (eighth) before half at beat 1 (tick 0):
+    //   ontime = min(500, 500ms/2000ms*1000) = 250 per-1000 → grace ends at tick 239, principal at tick 240.
+    EXPECT_NE(findNoteEvent(track, 0, 71, 80), nullptr);    // appoggiatura on at beat (stale len=0 overridden)
+    EXPECT_NE(findNoteEvent(track, 240, 72, 80), nullptr);  // principal on after grace
+
+    // Acciaccatura (eighth) before quarter at beat 3 (tick 960):
+    //   prevChord=half(960), graceTickSum=min(480,240)=240 → grace starts 240 ticks before beat.
+    EXPECT_NE(findNoteEvent(track, 720, 71, 80), nullptr);  // acciaccatura on before beat (stale len=0 overridden)
+    EXPECT_NE(findNoteEvent(track, 960, 72, 80), nullptr);  // principal on at beat
 }
 
 TEST_F(MidiExportTests, midiMeasureRepeats) {

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -229,11 +229,6 @@
                 <eid>d_d</eid>
                 <text>2</text>
                 </Fingering>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>75</pitch>
               <tpc>11</tpc>
               </Note>
@@ -1041,11 +1036,6 @@
             <acciaccatura/>
             <Note>
               <eid>jC_jC</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>78</pitch>
               <tpc>20</tpc>
               </Note>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
@@ -161,11 +161,6 @@
             <acciaccatura/>
             <Note>
               <eid>N_N</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <play>0</play>
@@ -261,11 +256,6 @@
             <acciaccatura/>
             <Note>
               <eid>d_d</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <play>0</play>
@@ -345,11 +335,6 @@
             <acciaccatura/>
             <Note>
               <eid>r_r</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <play>0</play>
@@ -454,11 +439,6 @@
             <acciaccatura/>
             <Note>
               <eid>+_+</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -537,11 +517,6 @@
             <appoggiatura/>
             <Note>
               <eid>NB_NB</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -597,11 +572,6 @@
                 <subtype>accidentalNatural</subtype>
                 <eid>YB_YB</eid>
                 </Accidental>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>74</pitch>
               <tpc>16</tpc>
               </Note>
@@ -788,11 +758,6 @@
                 <subtype>accidentalFlat</subtype>
                 <eid>6B_6B</eid>
                 </Accidental>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <play>0</play>
@@ -912,11 +877,6 @@
                 <subtype>accidentalSharp</subtype>
                 <eid>PC_PC</eid>
                 </Accidental>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>66</pitch>
               <tpc>20</tpc>
               <play>0</play>
@@ -994,11 +954,6 @@
             <acciaccatura/>
             <Note>
               <eid>cC_cC</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <play>0</play>

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote_ref.mscx
@@ -258,11 +258,6 @@
             <grace16/>
             <Note>
               <eid>T_T</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>83</pitch>
               <tpc>19</tpc>
               </Note>

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote_ref.mscx
@@ -250,11 +250,6 @@
             <grace16/>
             <Note>
               <eid>R_R</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>83</pitch>
               <tpc>19</tpc>
               </Note>

--- a/src/importexport/musicxml/tests/data/testSticking_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSticking_ref.mscx
@@ -455,11 +455,6 @@
             <acciaccatura/>
             <Note>
               <eid>r_r</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>
@@ -549,11 +544,6 @@
             <acciaccatura/>
             <Note>
               <eid>7_7</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>
@@ -623,11 +613,6 @@
             <grace16/>
             <Note>
               <eid>IB_IB</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>
@@ -638,11 +623,6 @@
             <grace16/>
             <Note>
               <eid>KB_KB</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>
@@ -653,11 +633,6 @@
             <grace16/>
             <Note>
               <eid>MB_MB</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>
@@ -668,11 +643,6 @@
             <grace16/>
             <Note>
               <eid>OB_OB</eid>
-              <Events>
-                <Event>
-                  <len>0</len>
-                  </Event>
-                </Events>
               <pitch>38</pitch>
               <tpc>16</tpc>
               </Note>


### PR DESCRIPTION
Fixes #22669

## Background

Issue #22669 reports that acciaccatura grace notes stopped exporting correctly to MIDI in MuseScore 4.1 (regression from 4.0.2). In the exported MIDI they play on the beat rather than before it, or are silent entirely. The workaround discovered by users — manually entering play events via the Properties panel — is itself a clue: setting events manually forces `PlayEventType::User`, which (as described below) is part of the root cause.

## Root causes and fixes

### Fix 1 — Before-beat timing regression (the core 4.1 regression)

The `graceTickSum` mechanism that shifts acciaccatura events before the beat was broken, causing grace notes to play on the beat with near-zero duration instead of before it. Restored the correct before-beat offset computation in `collectGraceBeforeChordEvents`.

### Fix 2 — Stale `PlayEventType::User` silences grace notes in saved files

MuseScore writes `<Events>` blocks for every note whenever a score is saved, including grace notes. On load, reading `<Events>` marks the chord `PlayEventType::User`. `createGraceNotesPlayEvents()` was guarded by `if (gc->playEventType() == PlayEventType::Auto)`, so it skipped recomputing grace events — leaving stale `len=0` values from earlier renders in place and making those grace notes completely silent.

This affected **any score that had been saved at least once**, including files freshly imported from MusicXML and saved with the current version. It also explains why the manual-entry workaround in the issue worked: forcing `PlayEventType::User` with correct values bypassed the broken auto-computation.

Fixed at three levels (defence-in-depth):

- **`twrite.cpp`**: never write `<Events>` for grace note chords. MuseScore 4 exposes no UI for editing grace note MIDI timing, so there is nothing worth persisting. Breaks the write-load-skip cycle at its source; existing saved files are cleaned up on next save.
- **`tread.cpp`**: when reading `<Events>` for a grace chord, do not set `PlayEventType::User` — the stored data is always a stale render artifact.
- **`compatmidirender.cpp`**: always recompute grace note events regardless of `PlayEventType`, as a defensive backstop.

### Fix 3 — Acciaccatura at tick 0 produces zero-duration MIDI note

Acciaccatura before the very first beat of a piece was silent. The before-beat start is `tick - graceTickSum`; at `tick=0` this clamps to `0`. With `NoteEvent.len=0` (correct for acciaccatura), `off = max(0, 0 - 1) = 0`, giving a zero-duration MIDI note. Fixed by preserving the intended duration when the start is clamped: `offTime = graceOffsetOn - 1`.

## Tests added

| Test | What it covers |
|---|---|
| `midiGraceBefore` | Acciaccatura before-beat timing at 60 and 320 bpm, including the tick=0 edge case and multi-grace groups |
| `midiGraceAfter` | Grace-after notes start at the midpoint of the principal note |
| `midiGraceAppoggiatura` | Appoggiatura takes proportional time from the principal note |
| `midiGraceStaleEvents` | Grace notes with stored `len=0` Events (as written by MuseScore on every save) are exported with correct timing |

## Files changed

| File | Change |
|---|---|
| `src/engraving/compat/midi/compatmidirender.cpp` | Remove `PlayEventType::Auto` guards — always recompute grace events |
| `src/engraving/compat/midi/compatmidirenderinternal.cpp` | Fix tick=0 duration clamping; restore before-beat `graceTickSum` mechanism |
| `src/engraving/rw/write/twrite.cpp` | Skip writing `<Events>` for grace note chords |
| `src/engraving/rw/read400/tread.cpp` | Don't set `PlayEventType::User` when reading grace chord events |
| `src/importexport/midi/tests/midiexport_tests.cpp` | Four new test functions |
| `src/importexport/midi/tests/midiexport_data/testGraceAfter.mscx` | New test score |
| `src/importexport/midi/tests/midiexport_data/testGraceAppoggiatura.mscx` | New test score |
| `src/importexport/midi/tests/midiexport_data/testGraceStaleEvents.mscx` | New test score (grace notes with pre-stored stale events) |
| `src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx` | Removed stale grace note Events blocks (consequence of twrite.cpp fix) |
| `src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx` | Same — 9 blocks removed |
| `src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote_ref.mscx` | Same — 1 block removed |
| `src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote_ref.mscx` | Same — 1 block removed |
| `src/importexport/musicxml/tests/data/testSticking_ref.mscx` | Same — 6 blocks removed |

**Note on the MusicXML reference file changes:** The five `_ref.mscx` files are round-trip reference snapshots used by `MusicXml_Tests`. Because `twrite.cpp` no longer writes `<Events>` for grace note chords, the saved output no longer contains those blocks — so the reference files must match. The removed blocks were all stale `<len>0</len>` render artifacts that had no effect on the score; removing them is correct behaviour.

---

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)