### PR TITLE
Fix finding external Musical Text Fonts and their metadata.json files

### DIFF
--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -141,19 +141,19 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
             symbolFontPath = findFontPath(tmp.replace(" ", ""));
         }
 
-        muse::io::path_t textFontPath = findFontPath(fontName + " Text");
         if (symbolFontPath.empty()) {
+            LOGE() << "Music font \"" << fontName << "\" for " << metadataPath << " not found";
+            continue;
+        }
+
+        muse::io::path_t textFontPath = findFontPath(fontName + " Text");
+        if (textFontPath.empty()) {
             QString tmp = fontName;
-            symbolFontPath = findFontPath(tmp.replace(" ", "") + "Text");
+            textFontPath = findFontPath(tmp.replace(" ", "") + "Text");
         }
 
         if (textFontPath.empty()) {
             textFontPath = symbolFontPath;
-        }
-
-        if (symbolFontPath.empty()) {
-            LOGE() << "Music font \"" << fontName << "\" for " << metadataPath << " not found";
-            continue;
         }
 
         LOGI() << "Adding custom SMuFL font: " << fontName

--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -101,25 +101,36 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
 
     while (iterator.hasNext()) {
         iterator.next();
-        QString fontDir = iterator.filePath();
-        muse::io::path_t metadataPath;
-
-        {
-            QDirIterator jsonFilesIterator(fontDir, { "*.json" }, QDir::Files);
-            while (jsonFilesIterator.hasNext()) {
-                jsonFilesIterator.next();
-                metadataPath = jsonFilesIterator.filePath();
+        const QString fontDir = iterator.filePath();
+        const QString fontName = iterator.fileName();
+        muse::io::path_t metadataPath = fontDir + "/" + fontName + ".json";
+        QFile fi(metadataPath.toQString());
+        if (!fi.exists()) {
+            if (!isPrivate) {
+                continue;
             }
-        }
-
-        if (metadataPath.empty()) {
-            continue;
+            metadataPath = fontDir + "/" + fontName.toLower().replace(" ", "_") + "_metadata.json";
+            fi.setFileName(metadataPath.toQString());
+            if (!fi.exists()) {
+                metadataPath = fontDir + "/" + "metadata.json";
+                fi.setFileName(metadataPath.toQString());
+            }
+            if (!fi.exists()) {
+                metadataPath = muse::io::path_t();
+                QDirIterator jsonFilesIterator(fontDir, { "*.json" }, QDir::Files);
+                while (jsonFilesIterator.hasNext()) {
+                    jsonFilesIterator.next();
+                    metadataPath = jsonFilesIterator.filePath();
+                }
+                if (metadataPath.empty()) {
+                    continue;
+                }
+            }
         }
 
         // We assume the font name is the same as the directory name,
         // but maybe we should instead read the metadata.json file to get the font name
 
-        QString fontName = iterator.fileName();
         QString fontFamily = fontName;
 
         if (fontName.contains(u"Text")) {


### PR DESCRIPTION
Fix finding external Musical Text Fonts, if those don't have a space before the "Text" in their filename.

Pretty much looks like the original code had a copy/paste error here.

Log before the change (tested with private fonts):
```
2026-06-09T18:41:44.295 | INFO  | main_thread     | EngravingFontsController::scanDirectory | Adding custom SMuFL font: "Bettenhoven" 
    symbol font path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/Bettenhoven.otf
    text font path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/Bettenhoven.otf
    metadata path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/metadata.json
```
So instead of BettenhovenText.otf it finds (and loads) Bettenhoven.otf.

Log after:
```
2026-06-09T19:18:12.608 | INFO  | main_thread     | EngravingFontsController::scanDirectory | Adding custom SMuFL font: "Bettenhoven" 
    symbol font path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/Bettenhoven.otf
    text font path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/BettenhovenText.otf
    metadata path: C:/Users/USERNAME/Documents/MuseScore5Studio/Score Fonts/Bettenhoven/metadata.json
```
Avoids the need to rename those Text font files

Also make sure their metadata.json files' names follow common naming conventions rather that doing a wildcard search on "*.json" and picking the last match