### PR TITLE
Fix #33744: Crash when `tick2` < `tick` [4.7.4]

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1390,7 +1390,12 @@ void Spanner::setTick(const Fraction& v)
 
 void Spanner::setTick2(const Fraction& f)
 {
-    setTicks(f - m_tick);
+    Fraction ticks = f - m_tick;
+    IF_ASSERT_FAILED(f >= m_tick) {
+        ticks = m_tick - f;
+        m_tick = f;
+    }
+    setTicks(ticks);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -8010,7 +8010,11 @@ void Score::doUndoRemoveStaleTieJumpPoints(Tie* tie, bool undo)
 void Score::doUndoResetPartialSlur(Slur* slur, bool undo)
 {
     const size_t undoIdx = undoStack()->currentIndex();
-    if (!slur->startCR()->hasPrecedingJumpItem() && slur->isIncoming()) {
+
+    const ChordRest* startCR = slur ? slur->startCR() : nullptr;
+    IF_ASSERT_FAILED(startCR) {
+        LOGE() << "Slur is corrupted";
+    } else if (!startCR->hasPrecedingJumpItem() && slur->isIncoming()) {
         if (undo) {
             startCmd(TranslatableString("engraving", "Reset incoming partial slur"));
             slur->undoSetIncoming(false);
@@ -8020,7 +8024,10 @@ void Score::doUndoResetPartialSlur(Slur* slur, bool undo)
         }
     }
 
-    if (!slur->endCR()->hasFollowingJumpItem() && slur->isOutgoing()) {
+    const ChordRest* endCR = slur ? slur->endCR() : nullptr;
+    IF_ASSERT_FAILED(endCR) {
+        LOGE() << "Slur is corrupted";
+    } else if (!endCR->hasFollowingJumpItem() && slur->isOutgoing()) {
         if (undo) {
             startCmd(TranslatableString("engraving", "Reset outgoing partial slur"));
             slur->undoSetOutgoing(false);


### PR DESCRIPTION
Resolves: #33744

Follow-up to 7a82c390163dc954873a6d719156c904af0043b3, which introduced the crash. In this case, we're trying to `setTick2` with a value that precedes `m_tick`. This is not normal behaviour, so the fix I've gone for takes place in an `IF_ASSERT_FAILED` block where we make sure that the new value for `tick2` is instead used to set `m_tick` (and then our original `m_tick` effectively becomes `tick2`, so we update our ticks accordingly).

I've also included some null checks/asserts in `Score::doUndoResetPartialSlur` to avoid any similar crashes.