### PR TITLE
feat: add select all notes in chord action

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -555,6 +555,10 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
+    <key>select-notes-in-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
@@ -818,10 +822,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>notation-select-all-chord</key>
-    <seq>Ctrl+Alt+A</seq>
     </SC>
   <SC>
     <key>system-break</key>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -820,6 +820,10 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+    <key>notation-select-all-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -579,6 +579,10 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
+    <key>select-notes-in-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
@@ -859,10 +863,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>notation-select-all-chord</key>
-    <seq>Ctrl+Alt+A</seq>
     </SC>
   <SC>
     <key>system-break</key>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -861,6 +861,10 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+    <key>notation-select-all-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -555,6 +555,10 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
+    <key>select-notes-in-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
@@ -818,10 +822,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>notation-select-all-chord</key>
-    <seq>Ctrl+Alt+A</seq>
     </SC>
   <SC>
     <key>system-break</key>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -820,6 +820,10 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+    <key>notation-select-all-chord</key>
+    <seq>Ctrl+Alt+A</seq>
+    </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -25,6 +25,7 @@
 
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/note.h"
+#include "engraving/dom/chord.h"
 #include "engraving/dom/text.h"
 #include "engraving/dom/sig.h"
 #include "notation/notationtypes.h"
@@ -253,6 +254,7 @@ void NotationActionController::init()
     registerAction("select-similar-staff", &Controller::selectAllSimilarElementsInStaff, &Controller::hasSelection);
     registerAction("select-similar-range", &Controller::selectAllSimilarElementsInRange, &Controller::hasSelection);
     registerAction("select-dialog", &Controller::openSelectionMoreOptions, &Controller::hasSelection);
+    registerAction("notation-select-all-chord", &Controller::selectAllChordNotes, &Controller::hasSelection);
     registerAction("notation-select-all", &Interaction::selectAll);
     registerAction("notation-select-section", &Interaction::selectSection);
     registerAction("first-element", &Interaction::selectFirstElement, false, PlayMode::PlayChord);
@@ -1623,6 +1625,41 @@ void NotationActionController::selectAllSimilarElementsInRange()
     if (score->selectionChanged()) {
         currentNotationInteraction()->selectionChanged().notify();
     }
+}
+
+void NotationActionController::selectAllChordNotes()
+{
+    TRACEFUNC;
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    const std::vector<EngravingItem*>& selectedElements = interaction->selection()->elements();
+    if (selectedElements.empty()) {
+        return;
+    }
+
+    std::set<const Chord*> chords;
+    for (const EngravingItem* item : selectedElements) {
+        if (item->isNote()) {
+            chords.insert(toNote(item)->chord());
+        }
+    }
+
+    if (chords.empty()) {
+        return;
+    }
+
+    std::vector<EngravingItem*> allNotes;
+    for (const Chord* chord : chords) {
+        for (Note* note : chord->notes()) {
+            allNotes.push_back(note);
+        }
+    }
+
+    interaction->clearSelection();
+    interaction->select(allNotes, SelectType::ADD);
 }
 
 void NotationActionController::openSelectionMoreOptions()

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -254,7 +254,7 @@ void NotationActionController::init()
     registerAction("select-similar-staff", &Controller::selectAllSimilarElementsInStaff, &Controller::hasSelection);
     registerAction("select-similar-range", &Controller::selectAllSimilarElementsInRange, &Controller::hasSelection);
     registerAction("select-dialog", &Controller::openSelectionMoreOptions, &Controller::hasSelection);
-    registerAction("notation-select-all-chord", &Controller::selectAllChordNotes, &Controller::hasSelection);
+    registerAction("select-notes-in-chord", &Controller::selectAllNotesInChord, &Controller::hasSelection);
     registerAction("notation-select-all", &Interaction::selectAll);
     registerAction("notation-select-section", &Interaction::selectSection);
     registerAction("first-element", &Interaction::selectFirstElement, false, PlayMode::PlayChord);
@@ -1627,7 +1627,7 @@ void NotationActionController::selectAllSimilarElementsInRange()
     }
 }
 
-void NotationActionController::selectAllChordNotes()
+void NotationActionController::selectAllNotesInChord()
 {
     TRACEFUNC;
     auto interaction = currentNotationInteraction();

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -134,7 +134,7 @@ private:
     void selectAllSimilarElements();
     void selectAllSimilarElementsInStaff();
     void selectAllSimilarElementsInRange();
-    void selectAllChordNotes();
+    void selectAllNotesInChord();
     void openSelectionMoreOptions();
 
     void startEditSelectedElement(const muse::actions::ActionData& args);

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -134,6 +134,7 @@ private:
     void selectAllSimilarElements();
     void selectAllSimilarElementsInStaff();
     void selectAllSimilarElementsInRange();
+    void selectAllChordNotes();
     void openSelectionMoreOptions();
 
     void startEditSelectedElement(const muse::actions::ActionData& args);

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -373,6 +373,12 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Select sectio&n"),
              TranslatableString("action", "Select section")
              ),
+    UiAction("notation-select-all-chord",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Select all &notes in chord"),
+             TranslatableString("action", "Select all notes in chord")
+             ),
     UiAction("select-similar",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -373,7 +373,7 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Select sectio&n"),
              TranslatableString("action", "Select section")
              ),
-    UiAction("notation-select-all-chord",
+    UiAction("select-notes-in-chord",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Select all &notes in chord"),


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33670

### Summary
Implements a new action to expand the current note selection to all notes within their chord(s).

When one or more notes are selected:

- All notes in their respective chords are selected
- If multiple notes across different chords are selected, all chords are expanded
- The resulting selection replaces the current selection

### Shortcut
- Windows/Linux: Ctrl + Alt + A
- Mac: Cmd + Opt + A
