### PR TITLE
[4.7.4] Fix finding external Musical Text Fonts

### DIFF
--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -137,19 +137,19 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
             symbolFontPath = findFontPath(tmp.replace(" ", ""));
         }
 
-        muse::io::path_t textFontPath = findFontPath(fontName + " Text");
         if (symbolFontPath.empty()) {
+            LOGE() << "Music font \"" << fontName << "\" for " << metadataPath << " not found";
+            continue;
+        }
+
+        muse::io::path_t textFontPath = findFontPath(fontName + " Text");
+        if (textFontPath.empty()) {
             QString tmp = fontName;
-            symbolFontPath = findFontPath(tmp.replace(" ", "") + "Text");
+            textFontPath = findFontPath(tmp.replace(" ", "") + "Text");
         }
 
         if (textFontPath.empty()) {
             textFontPath = symbolFontPath;
-        }
-
-        if (symbolFontPath.empty()) {
-            LOGE() << "Music font \"" << fontName << "\" for " << metadataPath << " not found";
-            continue;
         }
 
         LOGI() << "Adding custom SMuFL font: " << fontName


### PR DESCRIPTION
* find musical text fonts even if the font file names don't have a space before the "Text" in their filename

Backport of #33757, commit 1