### PR TITLE
Re-design PropertiesPanelTabButtons to hug contents instead of having equal widths

### DIFF
--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabBar.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabBar.qml
@@ -31,4 +31,29 @@ StyledTabBar {
     background: Item {
         implicitHeight: 28
     }
+
+    // Equally divided share given to overflowing tabs, or Infinity when everything fits:
+    readonly property real truncatedItemWidth: {
+        let items = contentChildren.filter(i => i.visible)
+        if (items.length === 0) {
+            return Infinity
+        }
+
+        let totalSpacing = (items.length - 1) * root.spacing
+        let totalContent = items.reduce((s, i) => s + i.implicitWidth, 0)
+        if (totalContent + totalSpacing <= root.width) {
+            return Infinity
+        }
+
+        let share = (root.width - totalSpacing) / items.length
+        let prev = -1
+        while (share !== prev) {
+            prev = share
+            let fittedItems = items.filter(i => i.implicitWidth < share)
+            let totalFittedWidth = fittedItems.reduce((s, i) => s + i.implicitWidth, 0)
+            share = (root.width - totalFittedWidth - totalSpacing) / (items.length - fittedItems.length)
+        }
+        return share
+    }
+
 }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabBar.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabBar.qml
@@ -30,6 +30,11 @@ StyledTabBar {
 
     background: Item {
         implicitHeight: 28
+
+        SeparatorLine {
+            id: underlineStroke
+            anchors.bottom: parent.bottom
+        }
     }
 
     // Equally divided share given to overflowing tabs, or Infinity when everything fits:
@@ -45,13 +50,17 @@ StyledTabBar {
             return Infinity
         }
 
-        let share = (root.width - totalSpacing) / items.length
+        let availableWidth = Math.max(0, root.width - totalSpacing)
+        let share = availableWidth / items.length
         let prev = -1
         while (share !== prev) {
             prev = share
             let fittedItems = items.filter(i => i.implicitWidth < share)
             let totalFittedWidth = fittedItems.reduce((s, i) => s + i.implicitWidth, 0)
-            share = (root.width - totalFittedWidth - totalSpacing) / (items.length - fittedItems.length)
+            let remaining = items.length - fittedItems.length
+            share = remaining > 0
+                    ? Math.max(0, (root.width - totalFittedWidth - totalSpacing) / remaining)
+                    : 0
         }
         return share
     }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
@@ -24,6 +24,8 @@ import QtQuick
 import Muse.UiComponents
 
 StyledTabButton {
-    fillWidth: true
+    readonly property PropertiesPanelTabBar propertiesTabBar: tabBar as PropertiesPanelTabBar
+
     font: ui.theme.bodyBoldFont
+    width: propertiesTabBar ? Math.min(implicitWidth, propertiesTabBar.truncatedItemWidth) : implicitWidth
 }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
@@ -28,4 +28,6 @@ StyledTabButton {
 
     font: ui.theme.bodyBoldFont
     width: Math.min(implicitWidth, maxWidth)
+    leftPadding: 4
+    rightPadding: 4
 }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/common/PropertiesPanelTabButton.qml
@@ -24,8 +24,8 @@ import QtQuick
 import Muse.UiComponents
 
 StyledTabButton {
-    readonly property PropertiesPanelTabBar propertiesTabBar: tabBar as PropertiesPanelTabBar
+    required property real maxWidth
 
     font: ui.theme.bodyBoldFont
-    width: propertiesTabBar ? Math.min(implicitWidth, propertiesTabBar.truncatedItemWidth) : implicitWidth
+    width: Math.min(implicitWidth, maxWidth)
 }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/FretFrameSettings.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/FretFrameSettings.qml
@@ -56,6 +56,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Chords")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "ChordsTab"
             navigation.panel: root.navigationPanel
@@ -64,6 +65,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Frame")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "FrameTab"
             navigation.panel: root.navigationPanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/internal/FretDiagramTabPanel.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/internal/FretDiagramTabPanel.qml
@@ -48,6 +48,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "General")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "GeneralTab"
             navigation.panel: root.navigationPanel
@@ -56,6 +57,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Settings")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "SettingsTab"
             navigation.panel: root.navigationPanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/GradualTempoChangeSettings.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/GradualTempoChangeSettings.qml
@@ -51,6 +51,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Position")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "PositionTab"
             navigation.panel: root.navigationPanel
@@ -59,6 +60,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Style")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "StyleTab"
             navigation.panel: root.navigationPanel
@@ -67,6 +69,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Text")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "TextTab"
             navigation.panel: root.navigationPanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/HairpinLineSettings.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/HairpinLineSettings.qml
@@ -53,6 +53,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Position")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "PositionTab"
             navigation.panel: root.navigationPanel
@@ -61,6 +62,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Style")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "StyleTab"
             navigation.panel: root.navigationPanel
@@ -69,6 +71,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Text")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "TextTab"
             navigation.panel: root.navigationPanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/LineSettings.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/lines/LineSettings.qml
@@ -53,6 +53,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Style")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "StyleTab"
             navigation.panel: root.navigationPanel
@@ -61,6 +62,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: qsTrc("propertiespanel", "Text")
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "TextTab"
             navigation.panel: root.navigationPanel

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/NoteSettings.qml
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/NoteSettings.qml
@@ -70,6 +70,7 @@ Column {
 
         PropertiesPanelTabButton {
             text: root.headModel?.title ?? ""
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "HeadTab"
             navigation.panel: root.navigationPanel
@@ -79,6 +80,7 @@ Column {
         PropertiesPanelTabButton {
             visible: root.headModel ? !root.headModel.isTrillCueNote : true
             text: root.stemModel ? root.stemModel.title : ""
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "StemTab"
             navigation.panel: root.navigationPanel
@@ -88,6 +90,7 @@ Column {
         PropertiesPanelTabButton {
             visible: root.headModel ? !root.headModel.isTrillCueNote : true
             text: root.beamModel ? root.beamModel.title : ""
+            maxWidth: tabBar.truncatedItemWidth
 
             navigation.name: "BeamTab"
             navigation.panel: root.navigationPanel


### PR DESCRIPTION
Resolves: #32604

Related to muse_framework: https://github.com/musescore/muse_framework/pull/82 (Add tooltips to StyledTabButton)

Instead of evenly dividing the available tab bar width amongst the tab buttons, the buttons' width now fits their content (up to a maximum).

If the sum of the widths of all buttons surpasses the available tab bar width, then we identify some buttons to truncate by looking for buttons which surpass a threshold (this process may take multiple iterations).

Then, the widths of the buttons which are _not_ to be truncated, simply fit their contents. The remaining tab bar width which is not occupied by "fitted" items is equally distributed amongst the "too wide" items, and their text is truncated accordingly.


<img width="309" height="172" alt="Captura de pantalla 2026-06-25 a las 9 57 56" src="https://github.com/user-attachments/assets/8c453cf8-d946-4f62-bc05-72af282fd371" />


<img width="353" height="119" alt="Captura de pantalla 2026-06-25 a las 10 00 39" src="https://github.com/user-attachments/assets/e6d6587a-7bac-4d25-a454-5ab92e3aba8a" />


<img width="400" height="154" alt="Grabación de pantalla 2026-06-25 a las 10 05 25-2" src="https://github.com/user-attachments/assets/577c2e8a-af49-480e-a710-0bdb07446213" />

