### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/score/systemheaderlayout.cpp
+++ b/src/engraving/rendering/score/systemheaderlayout.cpp
@@ -1172,6 +1172,10 @@ String SystemHeaderLayout::formattedSharedStaffLabel(staff_idx_t staffIdx, const
     case SharedLabelOrientation::VERTICAL:
         actualOrientation = totInstrumentCount > verticalLimit ? SharedLabelOrientation::VOICE : orientation;
         break;
+    default: // should not happen, but don't leave actualOrientation uninitialized
+        ASSERT_X("Unexpected SharedLabelOrientation value: " << static_cast<int>(orientation));
+        actualOrientation = SharedLabelOrientation::VOICE;
+        break;
     }
 
     if (actualOrientation == SharedLabelOrientation::HORIZONTAL || actualOrientation == SharedLabelOrientation::VERTICAL) {

--- a/src/engraving/rendering/score/systemheaderlayout.cpp
+++ b/src/engraving/rendering/score/systemheaderlayout.cpp
@@ -1159,7 +1159,7 @@ String SystemHeaderLayout::formattedSharedStaffLabel(staff_idx_t staffIdx, const
         }
     }
 
-    int totInstrumentCount = instrumentsMappedToFirstVoice.size() + instrumentsMappedToSecondVoice.size();
+    size_t totInstrumentCount = instrumentsMappedToFirstVoice.size() + instrumentsMappedToSecondVoice.size();
 
     SharedLabelOrientation actualOrientation;
     switch (orientation) {


### PR DESCRIPTION
* reg.: 'initializing': conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg.: potentially uninitialized local variable 'actualOrientation' used (C4701)