### PR TITLE
Fix #33713: Full-measure rest collides with its own fermata

### DIFF
--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -624,8 +624,8 @@ void RestLayout::checkFullMeasureRestCollisions(const System* system, LayoutCont
                 const EngravingItem* shapeItem = shapeEl.item();
                 return shapeItem && ((shapeItem->isRest() && toRest(shapeItem)->isFullMeasureRest())
                                      || (shapeItem->type() == ElementType::FERMATA
-                                        && shapeItem->explicitParent() == fullMeasureRest->segment()
-                                        && shapeItem->track() == fullMeasureRest->track())
+                                         && shapeItem->explicitParent() == fullMeasureRest->segment()
+                                         && shapeItem->track() == fullMeasureRest->track())
                                      || shapeItem->isBarLine() || shapeItem->isAccidental());
             });
 

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -620,13 +620,10 @@ void RestLayout::checkFullMeasureRestCollisions(const System* system, LayoutCont
                 double xSegment = segment.pagePos().x() - system->pagePos().x();
                 measureShape.add(segment.staffShape(staffIdx).translated(PointF(xSegment, 0.0)));
             }
-            measureShape.remove_if([fullMeasureRest] (const ShapeElement& shapeEl) {
+            measureShape.remove_if([] (const ShapeElement& shapeEl) {
                 const EngravingItem* shapeItem = shapeEl.item();
                 return shapeItem && ((shapeItem->isRest() && toRest(shapeItem)->isFullMeasureRest())
-                                     || (shapeItem->type() == ElementType::FERMATA
-                                         && shapeItem->explicitParent() == fullMeasureRest->segment()
-                                         && shapeItem->track() == fullMeasureRest->track())
-                                     || shapeItem->isBarLine() || shapeItem->isAccidental());
+                                     || shapeItem->isBarLine() || shapeItem->isAccidental() || shapeItem->isFermata());
             });
 
             if (measureShape.size() == 0) {

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -620,9 +620,12 @@ void RestLayout::checkFullMeasureRestCollisions(const System* system, LayoutCont
                 double xSegment = segment.pagePos().x() - system->pagePos().x();
                 measureShape.add(segment.staffShape(staffIdx).translated(PointF(xSegment, 0.0)));
             }
-            measureShape.remove_if([] (const ShapeElement& shapeEl) {
+            measureShape.remove_if([fullMeasureRest] (const ShapeElement& shapeEl) {
                 const EngravingItem* shapeItem = shapeEl.item();
                 return shapeItem && ((shapeItem->isRest() && toRest(shapeItem)->isFullMeasureRest())
+                                     || (shapeItem->type() == ElementType::FERMATA
+                                        && shapeItem->explicitParent() == fullMeasureRest->segment()
+                                        && shapeItem->track() == fullMeasureRest->track())
                                      || shapeItem->isBarLine() || shapeItem->isAccidental());
             });
 


### PR DESCRIPTION
Resolves: #33713  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
### Problem

The issue was caused by `checkFullMeasureRestCollisions()`. It removed the full-measure rest itself from `measureShape`, but did not remove the fermata associated with that same rest. As a result, the full-measure rest was checked against its own fermata and moved during collision avoidance.

### Solution

Exclude fermatas on the same segment and track as the full-measure rest being checked.

https://github.com/user-attachments/assets/115a962b-2617-4391-a0c3-ef3edc154013

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).