### PR TITLE
Issue #22767: Implement Unmute-all and Unsolo-all buttons to mixer

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -820,6 +820,16 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+    <key>unmute-all</key>
+    <seq>Ctrl+Shift+U</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
+    <key>unsolo-all</key>
+    <seq>Ctrl+Shift+L</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -861,6 +861,16 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+      <key>unmute-all</key>
+      <seq>Ctrl+Shift+U</seq>
+      <autorepeat>0</autorepeat>
+      </SC>
+  <SC>
+      <key>unsolo-all</key>
+      <seq>Ctrl+Shift+L</seq>
+      <autorepeat>0</autorepeat>
+      </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -820,6 +820,16 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+      <key>unmute-all</key>
+      <seq>Ctrl+Shift+U</seq>
+      <autorepeat>0</autorepeat>
+      </SC>
+  <SC>
+      <key>unsolo-all</key>
+      <seq>Ctrl+Shift+L</seq>
+      <autorepeat>0</autorepeat>
+      </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -51,6 +51,7 @@ static const Settings::Key MIXER_VOLUME_SECTION_VISIBLE_KEY(moduleName, "playbac
 static const Settings::Key MIXER_FADER_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/faderSectionVisible");
 static const Settings::Key MIXER_MUTE_AND_SOLO_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/muteAndSoloSectionVisible");
 static const Settings::Key MIXER_TITLE_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/titleSectionVisible");
+static const Settings::Key MIXER_UNMUTE_AND_UNSOLO_SECTION_VISIBLE_KEY(moduleName, "playback/mixer/unMuteAndUnSoloSectionVisible");
 
 static const Settings::Key MIXER_RESET_SOUND_FLAGS_WHEN_CHANGE_SOUND_WARNING(moduleName,
                                                                              "playback/mixer/needToShowAboutResetSoundFlagsWhwnChangeSoundWarning");
@@ -78,6 +79,7 @@ static Settings::Key mixerSectionVisibleKey(MixerSectionType sectionType)
     case MixerSectionType::Fader: return MIXER_FADER_SECTION_VISIBLE_KEY;
     case MixerSectionType::MuteAndSolo: return MIXER_MUTE_AND_SOLO_SECTION_VISIBLE_KEY;
     case MixerSectionType::Title: return MIXER_TITLE_SECTION_VISIBLE_KEY;
+    case MixerSectionType::UnMuteAndUnSolo: return MIXER_UNMUTE_AND_UNSOLO_SECTION_VISIBLE_KEY;
     case MixerSectionType::Unknown: break;
     }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -69,6 +69,8 @@ static const ActionCode REPEAT_CODE("repeat");
 static const ActionCode PLAY_CHORD_SYMBOLS_CODE("play-chord-symbols");
 static const ActionCode PLAYBACK_SETUP("playback-setup");
 static const ActionCode TOGGLE_HEAR_PLAYBACK_WHEN_EDITING_CODE("toggle-hear-playback-when-editing");
+static const ActionCode UNMUTE_ALL_CODE("unmute-all");
+static const ActionCode UNSOLO_ALL_CODE("unsolo-all");
 
 static AudioOutputParams makeReverbOutputParams()
 {
@@ -127,6 +129,8 @@ void PlaybackController::init()
     dispatcher()->reg(this, PLAYBACK_SETUP, this, &PlaybackController::openPlaybackSetupDialog);
     dispatcher()->reg(this, TOGGLE_HEAR_PLAYBACK_WHEN_EDITING_CODE, this, &PlaybackController::toggleHearPlaybackWhenEditing);
     dispatcher()->reg(this, "playback-reload-cache", this, &PlaybackController::reloadPlaybackCache);
+    dispatcher()->reg(this, UNMUTE_ALL_CODE, this, &PlaybackController::unmuteAll);
+    dispatcher()->reg(this, UNSOLO_ALL_CODE, this, &PlaybackController::unsoloAll);
 
     m_onlineSoundsController->regActions();
 
@@ -954,6 +958,41 @@ void PlaybackController::reloadPlaybackCache()
     if (nPlayback) {
         nPlayback->reload();
     }
+}
+
+void PlaybackController::unmuteAll()
+{
+    InstrumentTrackIdSet existingTrackIdSet = notationPlayback()->existingTrackIdSet();
+
+    for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
+        if (instrumentTrackId == notationPlayback()->metronomeTrackId()) {
+            continue;
+        }
+
+        INotationSoloMuteState::SoloMuteState newState = m_notation->soloMuteState()->trackSoloMuteState(instrumentTrackId);
+        if (newState.mute == true) {
+            newState.mute = false;
+
+            setTrackSoloMuteState(instrumentTrackId, newState);
+        }
+    }
+
+    updateSoloMuteStates();
+}
+
+void PlaybackController::unsoloAll()
+{
+    InstrumentTrackIdSet existingTrackIdSet = notationPlayback()->existingTrackIdSet();
+
+    for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
+        INotationSoloMuteState::SoloMuteState newState = trackSoloMuteState(instrumentTrackId);
+        if (newState.solo == true) {
+            newState.solo = false;
+            setTrackSoloMuteState(instrumentTrackId, newState);
+        }
+    }
+
+    updateSoloMuteStates();
 }
 
 void PlaybackController::openPlaybackSetupDialog()

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -190,6 +190,8 @@ private:
     void setMidiUseWrittenPitch(bool useWrittenPitch);
     void toggleLoopPlayback();
     void toggleHearPlaybackWhenEditing();
+    void unmuteAll();
+    void unsoloAll();
 
     void reloadPlaybackCache();
 

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -201,6 +201,19 @@ const UiActionList PlaybackUiActions::s_diagnosticActions = {
              )
 };
 
+const UiActionList PlaybackUiActions::s_mixerActions = {
+    UiAction("unmute-all",
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Unmute All Channels")
+             ),
+    UiAction("unsolo-all",
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Unsolo All Channels")
+             )
+};
+
 const UiActionList PlaybackUiActions::s_onlineSoundsActions = {
     UiAction(CLEAR_ONLINE_SOUNDS_CACHE_CODE,
              mu::context::UiCtxAny,
@@ -264,6 +277,7 @@ const UiActionList& PlaybackUiActions::actionsList() const
         alist.insert(alist.end(), s_settingsActions.cbegin(), s_settingsActions.cend());
         alist.insert(alist.end(), s_loopBoundaryActions.cbegin(), s_loopBoundaryActions.cend());
         alist.insert(alist.end(), s_diagnosticActions.cbegin(), s_diagnosticActions.cend());
+        alist.insert(alist.end(), s_mixerActions.cbegin(), s_mixerActions.cend());
         alist.insert(alist.end(), s_onlineSoundsActions.cbegin(), s_onlineSoundsActions.cend());
     }
     return alist;

--- a/src/playback/internal/playbackuiactions.h
+++ b/src/playback/internal/playbackuiactions.h
@@ -64,6 +64,7 @@ private:
     static const muse::ui::UiActionList s_loopBoundaryActions;
     static const muse::ui::UiActionList s_diagnosticActions;
     static const muse::ui::UiActionList s_onlineSoundsActions;
+    static const muse::ui::UiActionList s_mixerActions;
 
     std::shared_ptr<PlaybackController> m_controller;
     muse::async::Channel<muse::actions::ActionCodeList> m_actionEnabledChanged;

--- a/src/playback/playbacktypes.h
+++ b/src/playback/playbacktypes.h
@@ -44,6 +44,7 @@ enum class MixerSectionType {
     Volume,
     Fader,
     MuteAndSolo,
+    UnMuteAndUnSolo,
     Title
 };
 
@@ -57,6 +58,7 @@ inline QList<MixerSectionType> allMixerSectionTypes()
         MixerSectionType::Volume,
         MixerSectionType::Fader,
         MixerSectionType::MuteAndSolo,
+        MixerSectionType::UnMuteAndUnSolo,
         MixerSectionType::Title
     };
 

--- a/src/playback/qml/MuseScore/Playback/CMakeLists.txt
+++ b/src/playback/qml/MuseScore/Playback/CMakeLists.txt
@@ -74,6 +74,7 @@ qt_add_qml_module(playback_qml
         internal/SoundFlag/ParamsGridView.qml
         internal/VolumePressureMeter.qml
         internal/VolumeSlider.qml
+        internal/MixerUnMuteAndUnSoloSection.qml
         MixerPanel.qml
         NotationRegionsBeingProcessedView.qml
         OnlineSoundsStatusView.qml

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -305,21 +305,34 @@ ColumnLayout {
                 }
             }
 
-            MixerMuteAndSoloSection {
-                id: muteAndSoloSection
+            Item {
+                width: contentColumn.width
+                height: muteAndSoloSection.height
 
-                visible: contextMenuModel.muteAndSoloSectionVisible
-                headerVisible: contextMenuModel.labelsSectionVisible
-                headerWidth: prv.headerWidth
-                channelItemWidth: prv.channelItemWidth
+                MixerMuteAndSoloSection {
+                    id: muteAndSoloSection
 
-                model: mixerPanelModel
+                    visible: contextMenuModel.muteAndSoloSectionVisible
+                    headerVisible: contextMenuModel.labelsSectionVisible
+                    headerWidth: prv.headerWidth
+                    channelItemWidth: prv.channelItemWidth
 
-                navigationRowStart: 600
-                needReadChannelName: prv.isPanelActivated
+                    model: mixerPanelModel
+                    navigationRowStart: 600
+                    needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: function(index) {
-                    prv.setNavigateControlIndex(index)
+                    onNavigateControlIndexChanged: function(index) {
+                        prv.setNavigateControlIndex(index)
+                    }
+                }
+
+                MixerUnMuteAndUnSoloSection {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: contextMenuModel.unMuteAndUnSoloSectionVisible
+                    headerVisible: contextMenuModel.labelsSectionVisible
+                    headerWidth: prv.headerWidth
+                    model: mixerPanelModel
                 }
             }
 

--- a/src/playback/qml/MuseScore/Playback/internal/MixerUnMuteAndUnSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerUnMuteAndUnSoloSection.qml
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+
+import Muse.Ui
+import Muse.UiComponents
+import MuseScore.Playback
+
+Item {
+    id: root
+
+    property var model: undefined
+    property int headerWidth: 98
+    property bool headerVisible: true
+    property alias unMuteButton: unMuteAllButton
+    property alias unSoloButton: unSoloAllButton
+
+    height: 28
+    width: headerWidth
+    visible: headerVisible
+
+    Row {
+        anchors.centerIn: parent
+        spacing: 6
+
+        FlatToggleButton {
+            id: unMuteAllButton
+
+            height: 20
+            width: 20
+
+            icon: IconCode.MUTE
+
+            enabled: parent.enabled
+            visible: parent.visible
+
+            navigation.name: "UnMuteAllButton"
+            navigation.panel: root.channelItem.panel
+            navigation.row: root.navigationRowStart
+            navigation.accessible.name: root.accessibleName + " " + qsTrc("playback", "Unmute All")
+            navigation.onActiveChanged: {
+                if (navigation.active) {
+                    root.navigateControlIndexChanged({row: navigation.row, column: navigation.column})
+                }
+            }
+
+            onToggled: {
+                for (let i = 0; i < model.rowCount(); i++) {
+                    let item = model.get(i);
+
+                    if(item.channelItem.type === MixerChannelItem.Metronome){
+                        continue
+                    }
+
+                    item.channelItem.muted = false
+                }
+            }
+        }
+
+        FlatToggleButton {
+            id: unSoloAllButton
+
+            height: 20
+            width: 20
+
+            icon: IconCode.SOLO
+
+            enabled: parent.enabled
+            visible: parent.visible
+
+            navigation.name: "UnSoloAllButton"
+            navigation.panel: root.channelItem.panel
+            navigation.row: root.navigationRowStart + 1
+            navigation.accessible.name: root.accessibleName + " " + qsTrc("playback", "Unsolo All")
+            navigation.onActiveChanged: {
+                if (navigation.active) {
+                    root.navigateControlIndexChanged({row: navigation.row, column: navigation.column})
+                }
+            }
+
+            onToggled: {
+                for (let i = 0; i < model.rowCount(); i++) {
+                    let item = model.get(i);
+                    item.channelItem.solo = false
+                }
+            }
+        }
+    }
+}

--- a/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.cpp
@@ -49,6 +49,7 @@ static TranslatableString mixerSectionTitle(MixerSectionType type)
     case MixerSectionType::Fader: return TranslatableString("playback", "Fader");
     case MixerSectionType::MuteAndSolo: return TranslatableString("playback", "Mute and solo");
     case MixerSectionType::Title: return TranslatableString("playback", "Name");
+    case MixerSectionType::UnMuteAndUnSolo: return TranslatableString("playback", "Unmute and Unsolo");
     case MixerSectionType::Unknown: break;
     }
 
@@ -121,6 +122,11 @@ bool MixerPanelContextMenuModel::titleSectionVisible() const
     return isSectionVisible(MixerSectionType::Title);
 }
 
+bool MixerPanelContextMenuModel::unMuteAndUnSoloSectionVisible() const
+{
+    return isSectionVisible(MixerSectionType::UnMuteAndUnSolo);
+}
+
 void MixerPanelContextMenuModel::load()
 {
     AbstractMenuModel::load();
@@ -149,6 +155,7 @@ void MixerPanelContextMenuModel::load()
         buildSectionVisibleItem(MixerSectionType::Labels),
         buildSectionVisibleItem(MixerSectionType::Sound),
         buildSectionVisibleItem(MixerSectionType::AudioFX),
+        buildSectionVisibleItem(MixerSectionType::UnMuteAndUnSolo),
     };
 
     for (aux_channel_idx_t idx = 0; idx < AUX_CHANNEL_NUM; ++idx) {
@@ -317,6 +324,9 @@ void MixerPanelContextMenuModel::emitMixerSectionVisibilityChanged(MixerSectionT
         break;
     case MixerSectionType::Title:
         emit titleSectionVisibleChanged();
+        break;
+    case MixerSectionType::UnMuteAndUnSolo:
+        emit unMuteAndUnSoloSectionVisibleChanged();
         break;
     case MixerSectionType::Unknown:
         break;

--- a/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.h
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelcontextmenumodel.h
@@ -44,6 +44,7 @@ class MixerPanelContextMenuModel : public muse::uicomponents::AbstractMenuModel,
     Q_PROPERTY(bool faderSectionVisible READ faderSectionVisible NOTIFY faderSectionVisibleChanged)
     Q_PROPERTY(bool muteAndSoloSectionVisible READ muteAndSoloSectionVisible NOTIFY muteAndSoloSectionVisibleChanged)
     Q_PROPERTY(bool titleSectionVisible READ titleSectionVisible NOTIFY titleSectionVisibleChanged)
+    Q_PROPERTY(bool unMuteAndUnSoloSectionVisible READ unMuteAndUnSoloSectionVisible NOTIFY unMuteAndUnSoloSectionVisibleChanged)
 
     QML_ELEMENT
 
@@ -62,6 +63,7 @@ public:
     bool faderSectionVisible() const;
     bool muteAndSoloSectionVisible() const;
     bool titleSectionVisible() const;
+    bool unMuteAndUnSoloSectionVisible() const;
 
     Q_INVOKABLE void load() override;
 
@@ -75,6 +77,7 @@ signals:
     void faderSectionVisibleChanged();
     void muteAndSoloSectionVisibleChanged();
     void titleSectionVisibleChanged();
+    void unMuteAndUnSoloSectionVisibleChanged();
 
 private:
     bool isSectionVisible(MixerSectionType sectionType) const;

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -263,6 +263,20 @@ void MixerPanelModel::clear()
 
 void MixerPanelModel::setupConnections()
 {
+    currentProject()->masterNotation()->notation()->soloMuteState()->trackSoloMuteStateChanged().onReceive(
+        this, [this](const InstrumentTrackId& instrumentTrackId,
+                     const notation::INotationSoloMuteState::SoloMuteState& newState) {
+        const IPlaybackController::InstrumentTrackIdMap& trackIdMap = controller()->instrumentTrackIdMap();
+        auto it = trackIdMap.find(instrumentTrackId);
+        if (it == trackIdMap.end()) {
+            return;
+        }
+
+        if (MixerChannelItem* item = findChannelItem(it->second)) {
+            item->loadSoloMuteState(newState);
+        }
+    });
+
     audioSettings()->auxSoloMuteStateChanged().onReceive(
         this, [this](const aux_channel_idx_t index,
                      notation::INotationSoloMuteState::SoloMuteState newSoloMuteState) {

--- a/tools/codestyle/tidy_file.sh
+++ b/tools/codestyle/tidy_file.sh
@@ -15,11 +15,13 @@ trap 'echo >&2 "$0: Error $?, line ${LINENO}, args: $*"; exit ${FAIL_FAST}' ERR
 # the git index when multiple instances of this script are run in parallel.
 
 HERE="${BASH_SOURCE%/*}" # path to dir that contains this script
+REPO_ROOT="${HERE}/../.."
+UNCRUSTIFY_CONFIG="${REPO_ROOT}/muse/tools/codestyle/uncrustify_muse.cfg" # lives in framework submodule
 
 function uncrustify_file()
 {
     local file="$1" lang="$2" status
-    uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l "${lang}" -f "${file}"
+    uncrustify -c "${UNCRUSTIFY_CONFIG}" --no-backup -l "${lang}" -f "${file}"
     status=$?
     rm -f "${file}.uncrustify" # remove possible temporary file
     return ${status}


### PR DESCRIPTION
Resolves: #22767

This commit adds a button to unmute all muted channels in the mixer and another to unsolo all soloed channels in the mixer. Removing the need to do these actions to each channel one by one.
It also adds a shortcut to unmute all (ctrl+shift+m) and a shortcut to unsolo all (ctrl+shift+l) following the same logic as the buttons.


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [misousa07](https://musescore.org/en/user/6532990): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).