### PR TITLE
Implement Reset Mixer Settings to Default Button

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -820,6 +820,11 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
+    <key>reset-mixer</key>
+    <seq>Ctrl+Shift+R</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     <seq>Enter</seq>

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -69,6 +69,7 @@ static const ActionCode REPEAT_CODE("repeat");
 static const ActionCode PLAY_CHORD_SYMBOLS_CODE("play-chord-symbols");
 static const ActionCode PLAYBACK_SETUP("playback-setup");
 static const ActionCode TOGGLE_HEAR_PLAYBACK_WHEN_EDITING_CODE("toggle-hear-playback-when-editing");
+static const ActionCode RESET_MIXER_CODE("reset-mixer");
 
 static AudioOutputParams makeReverbOutputParams()
 {
@@ -127,6 +128,7 @@ void PlaybackController::init()
     dispatcher()->reg(this, PLAYBACK_SETUP, this, &PlaybackController::openPlaybackSetupDialog);
     dispatcher()->reg(this, TOGGLE_HEAR_PLAYBACK_WHEN_EDITING_CODE, this, &PlaybackController::toggleHearPlaybackWhenEditing);
     dispatcher()->reg(this, "playback-reload-cache", this, &PlaybackController::reloadPlaybackCache);
+    dispatcher()->reg(this, RESET_MIXER_CODE, this, &PlaybackController::resetMixerToDefaults);
 
     m_onlineSoundsController->regActions();
 
@@ -954,6 +956,84 @@ void PlaybackController::reloadPlaybackCache()
     if (nPlayback) {
         nPlayback->reload();
     }
+}
+
+void PlaybackController::resetMixerToDefaults()
+{
+    IF_ASSERT_FAILED(audioSettings() && notationPlayback()) {
+        return;
+    }
+
+    InstrumentTrackIdSet existingTrackIdSet = notationPlayback()->existingTrackIdSet();
+
+    for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
+        if (!muse::contains(m_instrumentTrackIdMap, instrumentTrackId)) {
+            continue;
+        }
+
+        AudioOutputParams outParams = trackOutputParams(instrumentTrackId);
+        const bool wasMuted = outParams.muted;
+        const bool wasForceMute = outParams.forceMute;
+
+        outParams.volume = 0.f;
+        outParams.balance = 0.f;
+
+        const AudioInputParams inParams = audioSettings()->trackInputParams(instrumentTrackId);
+        const AudioSourceType sourceType = inParams.isValid() ? inParams.type() : AudioSourceType::Fluid;
+        const muse::String instrumentSoundId = inParams.resourceMeta.attributeVal(PLAYBACK_SETUP_DATA_ATTRIBUTE);
+
+        const bool isMetronome = instrumentTrackId == notationPlayback()->metronomeTrackId();
+
+        if (isMetronome) {
+            outParams.muted = wasMuted;
+        } else {
+            const auto soloMuteState = trackSoloMuteState(instrumentTrackId);
+            outParams.solo = soloMuteState.solo;
+            outParams.muted = soloMuteState.mute;
+        }
+        outParams.forceMute = wasForceMute;
+
+        if (!isMetronome) {
+            if (outParams.auxSends.empty()) {
+                const auto& auxMap = m_auxTrackIdMap;
+                for (aux_channel_idx_t idx = 0; idx < static_cast<aux_channel_idx_t>(auxMap.size()); ++idx) {
+                    gain_t signalAmount = configuration()->defaultAuxSendValue(idx, sourceType, instrumentSoundId);
+                    outParams.auxSends.emplace_back(AuxSendParams { signalAmount, true });
+                }
+            } else {
+                for (aux_channel_idx_t idx = 0; idx < static_cast<aux_channel_idx_t>(outParams.auxSends.size()); ++idx) {
+                    gain_t signalAmount = configuration()->defaultAuxSendValue(idx, sourceType, instrumentSoundId);
+                    outParams.auxSends[idx] = AuxSendParams { signalAmount, true };
+                }
+            }
+        }
+
+        audioSettings()->setTrackOutputParams(instrumentTrackId, outParams);
+
+        audio::TrackId trackId = m_instrumentTrackIdMap.at(instrumentTrackId);
+        playback()->setControlParams(trackId, outParams.control());
+        playback()->setAuxSendsParams(trackId, outParams.auxSends);
+    }
+
+    AudioOutputParams masterParams = audioSettings()->masterAudioOutputParams();
+    const bool masterWasMuted = masterParams.muted;
+    const bool masterWasForceMute = masterParams.forceMute;
+
+    masterParams.volume = 0.f;
+    masterParams.balance = 0.f;
+
+    masterParams.muted = masterWasMuted;
+    masterParams.forceMute = masterWasForceMute;
+
+    audioSettings()->setMasterAudioOutputParams(masterParams);
+    playback()->setMasterControlParams(masterParams.control());
+
+    m_mixerResetRequested.notify();
+}
+
+muse::async::Notification PlaybackController::mixerResetRequested() const
+{
+    return m_mixerResetRequested;
 }
 
 void PlaybackController::openPlaybackSetupDialog()

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -132,6 +132,8 @@ public:
     muse::async::Notification onlineSoundsChanged() const override;
     muse::Progress onlineSoundsProcessingProgress() const override;
 
+    muse::async::Notification mixerResetRequested() const override;
+
 private:
     muse::audio::IPlayerPtr currentPlayer() const;
 
@@ -215,6 +217,8 @@ private:
     void updateSoloMuteStates();
     void updateAuxMuteStates();
 
+    void resetMixerToDefaults();
+
     using TrackAddFinished = std::function<void ()>;
 
     void addTrack(const engraving::InstrumentTrackId& instrumentTrackId, const TrackAddFinished& onFinished);
@@ -239,6 +243,7 @@ private:
     muse::async::Notification m_isPlayingChanged;
     muse::async::Notification m_totalPlayTimeChanged;
     muse::async::Notification m_currentTempoChanged;
+    muse::async::Notification m_mixerResetRequested;
     muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> m_currentPlaybackPositionChanged;
     muse::async::Channel<muse::actions::ActionCode> m_actionCheckedChanged;
 

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -201,6 +201,14 @@ const UiActionList PlaybackUiActions::s_diagnosticActions = {
              )
 };
 
+const UiActionList PlaybackUiActions::s_mixerActions = {
+    UiAction("reset-mixer",
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Reset mixer to default settings")
+             )
+};
+
 const UiActionList PlaybackUiActions::s_onlineSoundsActions = {
     UiAction(CLEAR_ONLINE_SOUNDS_CACHE_CODE,
              mu::context::UiCtxAny,
@@ -264,6 +272,7 @@ const UiActionList& PlaybackUiActions::actionsList() const
         alist.insert(alist.end(), s_settingsActions.cbegin(), s_settingsActions.cend());
         alist.insert(alist.end(), s_loopBoundaryActions.cbegin(), s_loopBoundaryActions.cend());
         alist.insert(alist.end(), s_diagnosticActions.cbegin(), s_diagnosticActions.cend());
+        alist.insert(alist.end(), s_mixerActions.cbegin(), s_mixerActions.cend());
         alist.insert(alist.end(), s_onlineSoundsActions.cbegin(), s_onlineSoundsActions.cend());
     }
     return alist;

--- a/src/playback/internal/playbackuiactions.h
+++ b/src/playback/internal/playbackuiactions.h
@@ -63,6 +63,7 @@ private:
     static const muse::ui::UiActionList s_settingsActions;
     static const muse::ui::UiActionList s_loopBoundaryActions;
     static const muse::ui::UiActionList s_diagnosticActions;
+    static const muse::ui::UiActionList s_mixerActions;
     static const muse::ui::UiActionList s_onlineSoundsActions;
 
     std::shared_ptr<PlaybackController> m_controller;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -120,5 +120,7 @@ public:
     virtual const std::map<muse::audio::TrackId, muse::audio::AudioResourceMeta>& onlineSounds() const = 0;
     virtual muse::async::Notification onlineSoundsChanged() const = 0;
     virtual muse::Progress onlineSoundsProcessingProgress() const = 0;
+
+    virtual muse::async::Notification mixerResetRequested() const = 0;
 };
 }

--- a/src/playback/qml/MuseScore/Playback/CMakeLists.txt
+++ b/src/playback/qml/MuseScore/Playback/CMakeLists.txt
@@ -70,6 +70,7 @@ qt_add_qml_module(playback_qml
         internal/PlaybackSpeedPopup.qml
         internal/PlaybackSpeedSlider.qml
         internal/PlaybackToolBarActions.qml
+        internal/ResetMixerButton.qml
         internal/SoundFlag/MuseSoundsParams.qml
         internal/SoundFlag/ParamsGridView.qml
         internal/VolumePressureMeter.qml

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -42,6 +42,10 @@ ColumnLayout {
     property Component toolbarComponent: MixerPanelToolbar {
         navigation.section: root.navigationSection
         navigation.order: root.contentNavigationPanelOrderStart
+
+        onResetMixerRequested: {
+            root.resetMixer()
+        }
     }
 
     signal resizeRequested(var newWidth, var newHeight)
@@ -86,6 +90,25 @@ ColumnLayout {
             flickable.contentX = Math.min(targetScrollPosition + prv.channelItemWidth - flickable.width, maxContentX)
         } else if (targetScrollPosition < flickable.contentX) {
             flickable.contentX = Math.max(targetScrollPosition - prv.channelItemWidth, 0)
+        }
+    }
+
+    function resetMixer() {
+        for (let i = 0; i < mixerPanelModel.count; i++) {
+            let item = mixerPanelModel.get(i)
+            if (!item || !item.channelItem) {
+                continue
+            }
+
+            item.channelItem.volumeLevel = 0
+            item.channelItem.balance = 0
+
+            let auxList = item.channelItem.auxSendItemList
+            for (let j = 0; j < auxList.length; j++) {
+                let aux = auxList[j]
+                aux.isActive = true
+                aux.audioSignalPercentage = 30
+            }
         }
     }
 

--- a/src/playback/qml/MuseScore/Playback/internal/MixerPanelToolbar.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerPanelToolbar.qml
@@ -30,12 +30,25 @@ Item {
 
     property alias navigation: navPanel
 
+    signal resetMixerRequested()
+
     anchors.fill: parent
 
     NavigationPanel {
         id: navPanel
         name: "MixerPanelToolbarPanel"
         enabled: root.enabled && root.visible
+    }
+
+    ResetMixerButton {
+        id: resetMixerButton
+
+        anchors.fill: parent
+        navigationPanel: navPanel
+
+        onResetMixerRequested: {
+            root.resetMixerRequested()
+        }
     }
 
     // TODO: https://github.com/musescore/MuseScore/issues/16722

--- a/src/playback/qml/MuseScore/Playback/internal/ResetMixerButton.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/ResetMixerButton.qml
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+Item {
+    id: root
+
+    property NavigationPanel navigationPanel: null
+
+    signal resetMixerRequested()
+
+    anchors.fill: parent
+
+    FlatButton {
+        id: resetMixerButton
+
+        anchors.right: parent.right
+        anchors.rightMargin: 6
+        anchors.verticalCenter: parent.verticalCenter
+
+        width: 90
+
+        text: qsTrc("playback", "Reset Mixer")
+        transparent: false
+        accentButton: false
+
+        navigation.name: "Reset mixer"
+        navigation.panel: root.navigationPanel
+        navigation.row: 0
+
+        onClicked: {
+            resetVolumesConfirmPopup.toggleOpened()
+        }
+    }
+
+    StyledPopupView {
+        id: resetVolumesConfirmPopup
+
+        anchorItem: root
+
+        contentWidth: 360
+        contentHeight: popupContentColumn.implicitHeight
+
+        placementPolicies: PopupView.PreferBelow | PopupView.PreferAbove
+        closePolicies: PopupView.CloseOnEscape | PopupView.CloseOnPressOutsideParent
+
+        ColumnLayout {
+            id: popupContentColumn
+
+            width: 360
+            spacing: 12
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                StyledTextLabel {
+                    Layout.fillWidth: true
+                    font: ui.theme.bodyBoldFont
+                    text: qsTrc("playback", "Confirm mixer reset")
+                    horizontalAlignment: Text.AlignLeft
+                }
+
+                FlatButton {
+                    icon: IconCode.CLOSE_X_ROUNDED
+                    transparent: true
+                    accentButton: false
+
+                    navigation.name: qsTrc("global", "Close")
+                    navigation.panel: root.navigationPanel
+                    navigation.row: 1
+
+                    onClicked: {
+                        resetVolumesConfirmPopup.close()
+                    }
+                }
+            }
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+                text: qsTrc("playback", "This will reset the mixer to default settings. Are you sure you want to continue?")
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                FlatButton {
+                    text: qsTrc("global", "Cancel")
+                    transparent: true
+                    accentButton: false
+
+                    navigation.panel: root.navigationPanel
+                    navigation.row: 2
+
+                    onClicked: {
+                        resetVolumesConfirmPopup.close()
+                    }
+                }
+
+                FlatButton {
+                    text: qsTrc("global", "Confirm")
+                    transparent: false
+                    accentButton: true
+
+                    navigation.panel: root.navigationPanel
+                    navigation.row: 3
+
+                    onClicked: {
+                        resetVolumesConfirmPopup.close()
+                        root.resetMixerRequested()
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
@@ -312,6 +312,15 @@ void MixerChannelItem::loadAuxSendItems(const AuxSendsParams& auxSends)
 
     m_outParams.auxSends = auxSends;
 
+    for (size_t i = 0; i < auxSends.size(); ++i) {
+        const auto index = static_cast<aux_channel_idx_t>(i);
+        auto it = m_auxSendItems.find(index);
+        if (it != m_auxSendItems.end()) {
+            it.value()->setIsActive(auxSends[i].active);
+            it.value()->setAudioSignalPercentage(static_cast<int>(auxSends[i].signalAmount * 100.f));
+        }
+    }
+
     configuration()->isAuxSendVisibleChanged().onReceive(this, [this](aux_channel_idx_t index, bool visible) {
         if (visible) {
             IF_ASSERT_FAILED(index < m_outParams.auxSends.size()) {

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -66,6 +66,22 @@ void MixerPanelModel::init()
         removeItem(trackId);
     });
 
+    controller()->mixerResetRequested().onNotify(this, [this]() {
+        for (MixerChannelItem* item : m_mixerChannelList) {
+            const InstrumentTrackId& instrumentTrackId = item->instrumentTrackId();
+            if (!instrumentTrackId.isValid()) {
+                continue;
+            }
+            AudioOutputParams outParams = audioSettings()->trackOutputParams(instrumentTrackId);
+            loadOutputParams(item, std::move(outParams));
+        }
+
+        if (m_masterChannelItem) {
+            AudioOutputParams masterParams = audioSettings()->masterAudioOutputParams();
+            loadOutputParams(m_masterChannelItem, std::move(masterParams));
+        }
+    });
+
     reload();
 }
 

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -86,6 +86,8 @@ public:
     MOCK_METHOD(double, tempoMultiplier, (), (const, override));
     MOCK_METHOD(void, setTempoMultiplier, (double), (override));
 
+    MOCK_METHOD(muse::async::Notification, mixerResetRequested, (), (const, override));
+
     MOCK_METHOD(muse::Progress, loadingProgress, (), (const, override));
 
     MOCK_METHOD(void, applyProfile, (const SoundProfileName&), (override));


### PR DESCRIPTION
Resolves: #24685<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Added button and shortcut (Crtl+Shift+R) that reverts all changes in the Mixer Workspace Panel back to "New-Score" defaults (Volume, Pan, Aux sends and Reverb).
When the button is pressed, a pop-up window appears asking to confirm the reset, since the changes will be permanent.<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [joanaaguia](https://musescore.org/en/user/6245329): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).