### PR TITLE
Import explicit MusicXML sound jump attributes regardless of inferTextType

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -4644,26 +4644,27 @@ static String countSegno(const String& plainWords)
 void MusicXmlParserDirection::handleRepeats(Measure* measure, const Fraction tick, bool& measureHasCoda,
                                             SegnoStack& segnos, DelayedDirectionsList& delayedDirections)
 {
-    if (!configuration()->inferTextType()) {
-        return;
-    }
     // Try to recognize the various repeats
+    // The explicit repeat attributes of the <sound> element are always honoured;
+    // only the purely text-based fallback depends on the inferTextType preference
     String repeat;
     const String plainWords = MScoreTextToMusicXml::toPlainText(m_wordsText.toLower().simplified());
+    const String wordsRepeat = matchRepeat(plainWords);
     if (!m_sndCoda.empty()) {
         repeat = u"coda";
     } else if (!m_sndDacapo.empty()) {
-        repeat = u"daCapo";
+        // the accompanying words may refine the jump type (e.g. "D.C. al Fine")
+        repeat = wordsRepeat.startsWith(u"daCapo") ? wordsRepeat : u"daCapo";
     } else if (!m_sndDalsegno.empty()) {
-        repeat = u"dalSegno";
+        repeat = wordsRepeat.startsWith(u"dalSegno") ? wordsRepeat : u"dalSegno";
     } else if (!m_sndFine.empty()) {
         repeat = u"fine";
     } else if (!m_sndSegno.empty()) {
         repeat = u"segno";
     } else if (!m_sndToCoda.empty()) {
         repeat = u"toCoda";
-    } else {
-        repeat = matchRepeat(plainWords);
+    } else if (configuration()->inferTextType()) {
+        repeat = wordsRepeat;
     }
     // Check if repeat number has become detached
     if (repeat == u"coda" || repeat == u"segno") {

--- a/src/importexport/musicxml/tests/data/testDCalCoda_ref.xml
+++ b/src/importexport/musicxml/tests/data/testDCalCoda_ref.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>D.C. al Coda</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Leon Vinken</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Guitar</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Guitar</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          <clef-octave-change>-1</clef-octave-change>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words>To Coda</words>
+          <symbol>coda</symbol>
+          </direction-type>
+        <sound tocoda="codab"/>
+        </direction>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="5">
+      <print>
+        <measure-layout>
+          <measure-distance>100</measure-distance>
+          </measure-layout>
+        </print>
+      <direction placement="above">
+        <direction-type>
+          <coda/>
+          </direction-type>
+        <sound coda="codab"/>
+        </direction>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words>D.C. al Coda</words>
+          </direction-type>
+        <sound dacapo="yes"/>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
@@ -400,8 +400,8 @@
           <style>repeat_right</style>
           <text>D.S. al Coda</text>
           <jumpTo>segno</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
+          <playUntil>coda</playUntil>
+          <continueAt>codab</continueAt>
           </Jump>
         <voice>
           <Chord>

--- a/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
@@ -400,8 +400,8 @@
           <style>repeat_right</style>
           <text>D.S. al Coda</text>
           <jumpTo>segno</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
+          <playUntil>coda</playUntil>
+          <continueAt>codab</continueAt>
           </Jump>
         <voice>
           <Chord>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -23,6 +23,8 @@
 #include <gtest/gtest.h>
 
 #include "engraving/engravingerrors.h"
+#include "engraving/dom/jump.h"
+#include "engraving/dom/marker.h"
 #include "engraving/dom/masterscore.h"
 
 #include "settings.h"
@@ -520,10 +522,41 @@ TEST_F(MusicXml_Tests, dalSegno) {
     musicXmlIoTest("testDalSegno");
 }
 TEST_F(MusicXml_Tests, dcalCoda) {
-    musicXmlIoTest("testDCalCoda");
+    // "D.C. al Coda" with <sound dacapo="yes"/> imports as a D.C. al Coda jump,
+    // so the exported <sound tocoda> attribute becomes linked to the coda marker
+    musicXmlIoTestRef("testDCalCoda");
 }
 TEST_F(MusicXml_Tests, dcalFine) {
     musicXmlIoTest("testDCalFine");
+}
+TEST_F(MusicXml_Tests, dcalFineNoInferTextType) {
+    // Explicit <sound dacapo="yes"/> and <sound fine="yes"/> attributes must be
+    // imported as Jump/Marker elements even when text type inference is disabled
+    MScore::debugMode = true;
+
+    setValue(PREF_IMPORT_MUSICXML_INFERTEXT, Val(false));
+
+    MasterScore* score = readScore(XML_IO_DATA_DIR + u"testDCalFine.xml");
+    ASSERT_TRUE(score);
+
+    const Jump* jump = nullptr;
+    const Marker* marker = nullptr;
+    for (const MeasureBase* mb = score->first(); mb; mb = mb->next()) {
+        for (const EngravingItem* el : mb->el()) {
+            if (el->isJump()) {
+                jump = toJump(el);
+            } else if (el->isMarker()) {
+                marker = toMarker(el);
+            }
+        }
+    }
+
+    ASSERT_TRUE(jump);
+    EXPECT_EQ(jump->jumpType(), JumpType::DC_AL_FINE);
+    ASSERT_TRUE(marker);
+    EXPECT_EQ(marker->markerType(), MarkerType::FINE);
+
+    delete score;
 }
 TEST_F(MusicXml_Tests, directions1) {
     musicXmlIoTestRef("testDirections1");


### PR DESCRIPTION
Resolves: #33801

The `<sound>` element attributes `dacapo`, `dalsegno`, `fine`, `segno`, `coda` and `tocoda` are the explicit, machine-readable MusicXML representation of jump/marker semantics. Since 07eb65ed03 they were only imported when the "Infer text type based on content where possible" preference (default **off**) was enabled, because the entire `handleRepeats()` function was gated behind it. With default settings, such directions were imported as plain `StaffText`, so playback and MIDI export silently ignored the jumps.

This PR restructures `handleRepeats()` so that the explicit `<sound>` attribute handling always runs, and only the purely text-based `matchRepeat()` fallback depends on the preference. Additionally, the words accompanying a `dacapo`/`dalsegno` sound attribute may now refine the jump type within the same family: "D.C. al Fine" with `dacapo="yes"` imports as a D.C. al Fine jump (stopping at the Fine marker) instead of a plain D.C. that plays to the end, and "D.S. al Coda" with `dalsegno` imports as a D.S. al Coda jump that actually takes the coda.

Test changes:
- New test `dcalFineNoInferTextType` verifies that a `DC_AL_FINE` jump and `FINE` marker are created with `importInferTextType = false` (previously no Jump/Marker was created at all; the existing tests force the preference on, which is why CI never caught this).
- `testDSalCoda_ref.mscx` / `testDSalCodaMisplaced_ref.mscx` regenerated: the "D.S. al Coda" jump now has `playUntil=coda` / `continueAt=codab` instead of `playUntil=end` / `continueAt=""` (the old references enshrined a jump that never took the coda).
- `dcalCoda` converted from a roundtrip test to a reference comparison: the exported `<sound tocoda>` value is now linked to the coda marker's label (`tocoda="codab"` matching `coda="codab"`) instead of the unlinked `tocoda="1"` in the source file.

Verified end-to-end: a 4-measure score (C ‖: D E :‖ F with Fine after m.1 and D.C. al Fine in m.4) now exports MIDI as `C D E D E F C` with default settings; previously it produced `C D E D E F` (jump dropped), or `C D E D E F C D E F` with the preference enabled (jump taken but Fine ignored).

- [x] I signed the [CLA](https://musescore.org/en/cla) as [jonas.hogstrom](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
