### PR TITLE
Fix appendPart not applying tablature staff type from template

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4374,8 +4374,7 @@ void Score::appendPart(const InstrumentTemplate* t)
     part->initFromInstrTemplate(t);
     for (staff_idx_t i = 0; i < t->staffCount; ++i) {
         Staff* staff = Factory::createStaff(part);
-        StaffType* stt = staff->staffType(Fraction(0, 1));
-        staff->init(t, stt, int(i));
+        staff->init(t, nullptr, int(i));
         undoInsertStaff(staff, i);
     }
     undoInsertPart(part, m_parts.size());

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3893,9 +3893,8 @@ void Score::appendPart(const InstrumentTemplate* t)
     part->initFromInstrTemplate(t);
     for (staff_idx_t i = 0; i < t->staffCount; ++i) {
         Staff* staff = Factory::createStaff(part);
-        StaffType* stt = staff->staffType(Fraction(0, 1));
         undoInsertStaff(staff, i);
-        staff->init(t, stt, int(i));
+        staff->init(t, nullptr, int(i));
     }
     undoInsertPart(part, m_parts.size());
     setUpTempoMapLater();

--- a/src/engraving/tests/scoreutils_tests.cpp
+++ b/src/engraving/tests/scoreutils_tests.cpp
@@ -23,9 +23,12 @@
 #include <gtest/gtest.h>
 
 #include "engraving/compat/scoreaccess.h"
+#include "engraving/dom/clef.h"
 #include "engraving/dom/factory.h"
+#include "engraving/dom/instrtemplate.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/staff.h"
+#include "engraving/dom/stafftype.h"
 
 using namespace mu::engraving;
 
@@ -116,6 +119,55 @@ TEST_F(Engraving_ScoreUtilsTests, StaffTestMergeMatchingRests)
     score->staff(0)->setMergeMatchingRests(AutoOnOff::OFF);
     // [THEN] rests display unmerged
     EXPECT_FALSE(score->staff(0)->shouldMergeMatchingRests());
+
+    delete score;
+}
+
+TEST_F(Engraving_ScoreUtilsTests, AppendPartFromTablatureTemplate)
+{
+    // [GIVEN] A score and the Classical Guitar (tablature) instrument template
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    const InstrumentTemplate* t = searchTemplate(String(u"guitar-nylon-tablature"));
+    ASSERT_NE(t, nullptr);
+    ASSERT_NE(t->staffTypePreset, nullptr);
+    ASSERT_EQ(t->staffTypePreset->group(), StaffGroup::TAB);
+
+    // [WHEN] The part is appended via the engraving API used by the plugin layer
+    score->appendPart(t);
+
+    // [THEN] The resulting staff is a TAB staff, not a default standard staff
+    ASSERT_EQ(score->parts().size(), 1u);
+    Part* part = score->parts().front();
+    EXPECT_TRUE(part->hasTabStaff());
+    EXPECT_FALSE(part->hasPitchedStaff());
+
+    ASSERT_EQ(part->nstaves(), 1u);
+    const StaffType* stt = part->staff(0)->staffType(Fraction(0, 1));
+    EXPECT_EQ(stt->group(), StaffGroup::TAB);
+    EXPECT_EQ(stt->lines(), 6);
+
+    delete score;
+}
+
+TEST_F(Engraving_ScoreUtilsTests, AppendPartFromStandardTemplatePreservesClefs)
+{
+    // [GIVEN] A score and the Piano template (two staves, treble + bass)
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+    const InstrumentTemplate* t = searchTemplate(String(u"piano"));
+    ASSERT_NE(t, nullptr);
+
+    // [WHEN] The part is appended
+    score->appendPart(t);
+
+    // [THEN] Both staves are standard, with the template's per-staff clefs applied
+    ASSERT_EQ(score->parts().size(), 1u);
+    Part* part = score->parts().front();
+    EXPECT_TRUE(part->hasPitchedStaff());
+    EXPECT_FALSE(part->hasTabStaff());
+
+    ASSERT_EQ(part->nstaves(), 2u);
+    EXPECT_EQ(part->staff(0)->defaultClefType().concertClef, ClefType::G);
+    EXPECT_EQ(part->staff(1)->defaultClefType().concertClef, ClefType::F);
 
     delete score;
 }


### PR DESCRIPTION
Resolves: #33820

## Summary

`Score::appendPart(const InstrumentTemplate*)` was passing the freshly-created default StaffType into `Staff::init` as the explicit preset, which shadowed `t->staffTypePreset` and forced every appended staff to a default standard 5-line — breaking tablature templates via the plugin API.

Passing `nullptr` lets `Staff::init` fall through to `t->staffTypePreset`, as the post-#29478 refactor intended.

## Prior attempt

#29478 (commit `451b451bd8`, "Set default clefs when creating parts") was the first attempt at this consolidation: it correctly replaced the old hand-rolled body of `appendPart` with a delegation to `Staff::init`. But it left the vestigial `stt = staff->staffType(Fraction(0, 1))` local from the previous body and threaded it into the new `init` call. Since `Factory::createStaff` constructs a Staff with the default STANDARD preset already assigned, that pointer is non-null and `Staff::init` takes the `if (staffType)` branch, shadowing `t->staffTypePreset` and defeating the refactor's intent.

This PR drops the stale local and passes `nullptr` instead, finishing what #29478 started.

 ## Changes
 - `src/engraving/dom/score.cpp`: drop the vestigial `stt` local; pass `nullptr` to `Staff::init` so the template's `staffTypePreset` wins.
 - `src/engraving/tests/scoreutils_tests.cpp`: two regression tests
 - `AppendPartFromTablatureTemplate` — appending the `guitar-nylon-tablature` template yields a TAB-group, 6-line staff.
 - `AppendPartFromStandardTemplatePreservesClefs` — appending the `piano` template still yields the per-staff treble + bass default clefs.

## Local validation
``` 
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from Engraving_ScoreUtilsTests
[ RUN      ] Engraving_ScoreUtilsTests.AppendPartFromTablatureTemplate
[       OK ] Engraving_ScoreUtilsTests.AppendPartFromTablatureTemplate (3 ms)
[ RUN      ] Engraving_ScoreUtilsTests.AppendPartFromStandardTemplatePreservesClefs
[       OK ] Engraving_ScoreUtilsTests.AppendPartFromStandardTemplatePreservesClefs (3 ms)
[----------] 2 tests from Engraving_ScoreUtilsTests (6 ms total)
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (6 ms total)
[  PASSED  ] 2 tests.
```     

 ---
- [x] I signed the [CLA](https://musescore.org/en/cla) as [tokyo246](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine — see "Local validation" above.
- [x] Prior attempt #29478 listed in the PR description; this PR finishes its refactor by dropping the vestigial `stt` local.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made.
