### PR TITLE
Engraving tests: rewrite ScoreComp::compareFiles without diff

### DIFF
--- a/src/engraving/tests/utils/scorecomp.cpp
+++ b/src/engraving/tests/utils/scorecomp.cpp
@@ -22,22 +22,102 @@
 
 #include "scorecomp.h"
 
-#include <QProcess>
-#include <QTextStream>
+#include <algorithm>
+#include <cstdio>
+#include <string_view>
+#include <vector>
+
+#include "global/io/buffer.h"
+#include "global/serialization/textstream.h"
 
 #include "scorerw.h"
 
-using namespace muse::io;
 using namespace mu::engraving;
+using namespace muse;
+using namespace muse::io;
+
+struct Edit {
+    enum class Type {
+        Equal,
+        Delete,
+        Insert,
+    };
+
+    Type type = Type::Equal;
+    size_t idx1 = 0;
+    size_t idx2 = 0;
+};
+
+static std::vector<std::string_view> splitLines(const ByteArray& data)
+{
+    const char* buf = data.constChar();
+    const size_t size = data.size();
+
+    std::vector<std::string_view> lines;
+    size_t start = 0;
+
+    for (size_t i = 0; i <= size; ++i) {
+        if (i == size || buf[i] == '\n') {
+            std::string_view line(buf + start, i - start);
+            if (!line.empty() && line.back() == '\r') {
+                line.remove_suffix(1);
+            }
+            lines.push_back(line);
+            start = i + 1;
+        }
+    }
+
+    if (!lines.empty() && lines.back().empty()) {
+        lines.pop_back();
+    }
+
+    return lines;
+}
+
+static std::vector<Edit> computeDiff(const std::vector<std::string_view>& lines1, const std::vector<std::string_view>& lines2)
+{
+    const size_t m = lines1.size();
+    const size_t n = lines2.size();
+
+    std::vector<std::vector<size_t> > dp(m + 1, std::vector<size_t>(n + 1, 0));
+    for (size_t i = 1; i <= m; ++i) {
+        for (size_t j = 1; j <= n; ++j) {
+            if (lines1[i - 1] == lines2[j - 1]) {
+                dp[i][j] = dp[i - 1][j - 1] + 1;
+            } else {
+                dp[i][j] = std::max(dp[i - 1][j], dp[i][j - 1]);
+            }
+        }
+    }
+
+    std::vector<Edit> edits;
+    size_t i = m;
+    size_t j = n;
+
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && lines1[i - 1] == lines2[j - 1]) {
+            edits.push_back({ Edit::Type::Equal, i - 1, j - 1 });
+            --i;
+            --j;
+        } else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+            edits.push_back({ Edit::Type::Insert, 0, j - 1 });
+            --j;
+        } else {
+            edits.push_back({ Edit::Type::Delete, i - 1, 0 });
+            --i;
+        }
+    }
+
+    std::reverse(edits.begin(), edits.end());
+    return edits;
+}
 
 bool ScoreComp::saveCompareScore(Score* score, const String& saveName, const String& compareWithLocalPath)
 {
     if (!ScoreRW::saveScore(score, saveName)) {
         return false;
     }
-    bool val = compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
-
-    return val;
+    return ScoreComp::compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
 }
 
 bool ScoreComp::saveCompareMimeData(muse::ByteArray mimeData, const muse::String& saveName, const muse::String& compareWithLocalPath)
@@ -45,58 +125,123 @@ bool ScoreComp::saveCompareMimeData(muse::ByteArray mimeData, const muse::String
     if (!ScoreRW::saveMimeData(mimeData, saveName)) {
         return false;
     }
-
-    bool val = compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
-
-    return val;
+    return ScoreComp::compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
 }
 
 bool ScoreComp::compareFiles(const String& fullPath1, const String& fullPath2)
 {
-    QString cmd = "diff";
-    QStringList args;
-    args.append("-u");
-    args.append("--strip-trailing-cr");
-    args.append(fullPath1);
-    args.append(fullPath2);
+    TRACEFUNC;
 
-    QProcess p;
-    p.start(cmd, args);
-    if (!p.waitForStarted()) {
-        QTextStream err(stderr);
-        err << p.program() << " failed to start:\n";
-        err << "| " << p.errorString() << "\n";
-
-        return false;
-    }
-    if (!p.waitForFinished()) {
-        QTextStream err(stderr);
-        err << p.program() << " failed to finish:\n";
-        err << "| " << p.errorString() << "\n";
-
+    RetVal<ByteArray> rv1 = fileSystem()->readFile(fullPath1);
+    if (!rv1.ret) {
+        LOGE() << "Failed to read: " << fullPath1 << ", err: " << rv1.ret.toString();
         return false;
     }
 
-    // QProcess::exitCode() is only valid when QProcess::exitStatus() == NormalExit
-    if (p.exitStatus() != QProcess::NormalExit) {
-        QTextStream err(stderr);
-        err << p.program() << " exited abnormally\n";
-        err << "| " << p.errorString() << "\n";
-
+    RetVal<ByteArray> rv2 = fileSystem()->readFile(fullPath2);
+    if (!rv2.ret) {
+        LOGE() << "Failed to read: " << fullPath2 << ", err: " << rv2.ret.toString();
         return false;
     }
 
-    if (const int code = p.exitCode()) {
-        QTextStream err(stderr);
-        QTextStream out(stdout);
-        out << p.readAllStandardOutput();
-        err << p.readAllStandardError();
-
-        err << String("%1 %2 failed with code: %3 \n")
-            .arg(p.program(), p.arguments().join(' '))
-            .arg(code);
-        return false;
+    const std::vector<std::string_view> lines1 = splitLines(rv1.val);
+    const std::vector<std::string_view> lines2 = splitLines(rv2.val);
+    if (lines1 == lines2) {
+        return true;
     }
 
-    return true;
+    ByteArray outputBuf;
+    Buffer buf(&outputBuf);
+    buf.open(IODevice::WriteOnly);
+    TextStream ts(&buf);
+
+    ts << "--- " << fullPath1 << "\n";
+    ts << "+++ " << fullPath2 << "\n";
+
+    const std::vector<Edit> edits = computeDiff(lines1, lines2);
+    constexpr size_t CTX = 3;
+    const size_t n = edits.size();
+
+    size_t i = 0;
+    while (i < n) {
+        if (edits[i].type == Edit::Type::Equal) {
+            ++i;
+            continue;
+        }
+
+        const size_t hunkStart = i >= CTX ? i - CTX : 0;
+
+        size_t pos = i;
+        while (pos < n) {
+            while (pos < n && edits[pos].type != Edit::Type::Equal) {
+                ++pos;
+            }
+            size_t eqEnd = pos;
+            while (eqEnd < n && edits[eqEnd].type == Edit::Type::Equal) {
+                ++eqEnd;
+            }
+            if (eqEnd < n && (eqEnd - pos) < 2 * CTX) {
+                pos = eqEnd;
+            } else {
+                break;
+            }
+        }
+
+        const size_t hunkEnd = std::min(n, pos + CTX);
+
+        size_t start1 = 0;
+        size_t start2 = 0;
+        size_t count1 = 0;
+        size_t count2 = 0;
+        bool start1Set = false;
+        bool start2Set = false;
+        for (size_t k = hunkStart; k < hunkEnd; ++k) {
+            const Edit& e = edits[k];
+            if (e.type != Edit::Type::Insert) {
+                if (!start1Set) {
+                    start1 = e.idx1;
+                    start1Set = true;
+                }
+                ++count1;
+            }
+            if (e.type != Edit::Type::Delete) {
+                if (!start2Set) {
+                    start2 = e.idx2;
+                    start2Set = true;
+                }
+                ++count2;
+            }
+        }
+
+        const size_t headerStart1 = start1Set ? start1 + 1 : 0;
+        const size_t headerStart2 = start2Set ? start2 + 1 : 0;
+
+        ts << "@@ -" << headerStart1;
+        if (count1 != 1) {
+            ts << "," << count1;
+        }
+        ts << " +" << headerStart2;
+        if (count2 != 1) {
+            ts << "," << count2;
+        }
+        ts << " @@\n";
+
+        for (size_t k = hunkStart; k < hunkEnd; ++k) {
+            const Edit& e = edits[k];
+            if (e.type == Edit::Type::Equal) {
+                ts << " " << lines1[e.idx1] << "\n";
+            } else if (e.type == Edit::Type::Delete) {
+                ts << "-" << lines1[e.idx1] << "\n";
+            } else {
+                ts << "+" << lines2[e.idx2] << "\n";
+            }
+        }
+
+        i = hunkEnd;
+    }
+
+    ts.flush();
+    std::fwrite(outputBuf.constChar(), 1, outputBuf.size(), stdout);
+
+    return false;
 }

--- a/src/engraving/tests/utils/scorecomp.h
+++ b/src/engraving/tests/utils/scorecomp.h
@@ -20,20 +20,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_ENGRAVING_SCORECOMP_H
-#define MU_ENGRAVING_SCORECOMP_H
+#pragma once
+
+#include "global/modularity/ioc.h"
+#include "global/io/ifilesystem.h"
 
 #include "engraving/dom/score.h"
 
 namespace mu::engraving {
 class ScoreComp
 {
-public:
+    static inline muse::GlobalInject<muse::io::IFileSystem> fileSystem;
 
+public:
     static bool saveCompareScore(Score*, const String& saveName, const String& compareWithLocalPath);
     static bool saveCompareMimeData(muse::ByteArray mimeData, const String& saveName, const String& compareWithLocalPath);
     static bool compareFiles(const String& fullPath1, const String& fullPath2);
 };
 }
-
-#endif // MU_ENGRAVING_SCORECOMP_H

--- a/src/importexport/bb/tests/CMakeLists.txt
+++ b/src/importexport/bb/tests/CMakeLists.txt
@@ -20,11 +20,18 @@
 
 set(MODULE_TEST iex_bb_tests)
 
+set(ENGRAVING_TEST_UTILS_DIR ${CMAKE_SOURCE_DIR}/src/engraving/tests/utils)
+
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/testbase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/testbase.h
    # ${CMAKE_CURRENT_LIST_DIR}/tst_biab.cpp
+
+    ${ENGRAVING_TEST_UTILS_DIR}/scorecomp.cpp
+    ${ENGRAVING_TEST_UTILS_DIR}/scorecomp.h
+    ${ENGRAVING_TEST_UTILS_DIR}/scorerw.cpp
+    ${ENGRAVING_TEST_UTILS_DIR}/scorerw.h
 )
 
 set(MODULE_TEST_LINK

--- a/src/importexport/bb/tests/testbase.cpp
+++ b/src/importexport/bb/tests/testbase.cpp
@@ -22,9 +22,6 @@
 
 #include "testbase.h"
 
-#include <QProcess>
-#include <QTextStream>
-
 #include "io/file.h"
 
 #include "engraving/dom/masterscore.h"
@@ -35,6 +32,7 @@
 #include "engraving/compat/writescorehook.h"
 #include "engraving/infrastructure/localfileinfoprovider.h"
 #include "engraving/rw/rwregister.h"
+#include "engraving/tests/utils/scorecomp.h"
 
 #include "log.h"
 
@@ -93,26 +91,7 @@ bool MTest::saveScore(Score* score, const QString& name) const
 
 bool MTest::compareFilesFromPaths(const QString& f1, const QString& f2)
 {
-    QString cmd = "diff";
-    QStringList args;
-    args.append("-u");
-    args.append("--strip-trailing-cr");
-    args.append(f2);
-    args.append(f1);
-    QProcess p;
-    LOGD() << "Running " << cmd << " with arg1: " << f2 << " and arg2: " << f1;
-    p.start(cmd, args);
-    if (!p.waitForFinished() || p.exitCode()) {
-        QByteArray ba = p.readAll();
-        //LOGD("%s", qPrintable(ba));
-        //LOGD("   <diff -u %s %s failed", qPrintable(compareWith),
-        //   qPrintable(QString(root + "/" + saveName)));
-        QTextStream outputText(stdout);
-        outputText << QString(ba);
-        outputText << QString("   <diff -u %1 %2 failed").arg(f2).arg(f1);
-        return false;
-    }
-    return true;
+    return ScoreComp::compareFiles(String::fromQString(f1), String::fromQString(f2));
 }
 
 bool MTest::compareFiles(const QString& saveName, const QString& compareWith) const

--- a/src/importexport/bww/tests/CMakeLists.txt
+++ b/src/importexport/bww/tests/CMakeLists.txt
@@ -20,11 +20,18 @@
 
 set(MODULE_TEST iex_bww_tests)
 
+set(ENGRAVING_TEST_UTILS_DIR ${CMAKE_SOURCE_DIR}/src/engraving/tests/utils)
+
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/testbase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/testbase.h
     # ${CMAKE_CURRENT_LIST_DIR}/tst_bww_io.cpp outdate
+
+    ${ENGRAVING_TEST_UTILS_DIR}/scorecomp.cpp
+    ${ENGRAVING_TEST_UTILS_DIR}/scorecomp.h
+    ${ENGRAVING_TEST_UTILS_DIR}/scorerw.cpp
+    ${ENGRAVING_TEST_UTILS_DIR}/scorerw.h
 )
 
 set(MODULE_TEST_LINK

--- a/src/importexport/bww/tests/testbase.cpp
+++ b/src/importexport/bww/tests/testbase.cpp
@@ -22,9 +22,6 @@
 
 #include "testbase.h"
 
-#include <QProcess>
-#include <QTextStream>
-
 #include "io/file.h"
 
 #include "engraving/dom/masterscore.h"
@@ -34,6 +31,7 @@
 #include "engraving/compat/scoreaccess.h"
 #include "engraving/compat/writescorehook.h"
 #include "engraving/rw/rwregister.h"
+#include "engraving/tests/utils/scorecomp.h"
 
 #include "log.h"
 
@@ -86,26 +84,7 @@ bool MTest::saveScore(Score* score, const QString& name) const
 
 bool MTest::compareFilesFromPaths(const QString& f1, const QString& f2)
 {
-    QString cmd = "diff";
-    QStringList args;
-    args.append("-u");
-    args.append("--strip-trailing-cr");
-    args.append(f2);
-    args.append(f1);
-    QProcess p;
-    LOGD() << "Running " << cmd << " with arg1: " << f2 << " and arg2: " << f1;
-    p.start(cmd, args);
-    if (!p.waitForFinished() || p.exitCode()) {
-        QByteArray ba = p.readAll();
-        //LOGD("%s", qPrintable(ba));
-        //LOGD("   <diff -u %s %s failed", qPrintable(compareWith),
-        //   qPrintable(QString(root + "/" + saveName)));
-        QTextStream outputText(stdout);
-        outputText << QString(ba);
-        outputText << QString("   <diff -u %1 %2 failed").arg(f2).arg(f1);
-        return false;
-    }
-    return true;
+    return ScoreComp::compareFiles(String::fromQString(f1), String::fromQString(f2));
 }
 
 bool MTest::compareFiles(const QString& saveName, const QString& compareWith) const


### PR DESCRIPTION
Advantages:
* Easier to set up the dev environment on Windows
* Tests may run faster since there is no longer a need to launch diff as a separate process
