### PR TITLE
[4.7.4] Fix #33800: crash on open corrupted score

### DIFF
--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -71,7 +71,9 @@ void EIDRegister::removeItem(const EngravingObject* item)
     m_itemToEid.erase(itemIter);
 
     auto eidIter = m_eidToItem.find(eid);
-    DO_ASSERT(eidIter != m_eidToItem.end());
+    IF_ASSERT_FAILED(eidIter != m_eidToItem.end()) {
+        return;
+    }
 
     m_eidToItem.erase(eidIter);
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33800