### PR TITLE
Fix #33751: Init order of API engine [4.7.4]

### DIFF
--- a/src/framework/extensions/internal/extensionsprovider.cpp
+++ b/src/framework/extensions/internal/extensionsprovider.cpp
@@ -112,8 +112,8 @@ const Manifest& ExtensionsProvider::manifest(const Uri& uri) const
         return *it;
     }
 
-    static Manifest _dymmy;
-    return _dymmy;
+    static Manifest _dummy;
+    return _dummy;
 }
 
 muse::async::Channel<Manifest> ExtensionsProvider::manifestChanged() const

--- a/src/framework/extensions/internal/scriptengine.cpp
+++ b/src/framework/extensions/internal/scriptengine.cpp
@@ -40,10 +40,9 @@ ScriptEngine::ScriptEngine(const modularity::ContextPtr& iocCtx, int apiversion)
     : m_iocContext(iocCtx)
 {
     m_engine = new QJSEngine();
-    m_apiengine = new JsApiEngine(m_engine, m_iocContext);
-
     m_engine->installExtensions(QJSEngine::ConsoleExtension);
     m_engine->setProperty("apiversion", apiversion);
+    m_apiengine = new JsApiEngine(m_engine, m_iocContext);
 
     QJSValue globalObj = m_engine->globalObject();
     if (apiversion == 1) {

--- a/src/framework/global/modularity/ioccontext.cpp
+++ b/src/framework/global/modularity/ioccontext.cpp
@@ -55,7 +55,7 @@ muse::modularity::ContextPtr muse::iocCtxForQmlContext(const QQmlContext* ctx)
     //     return modularity::ContextPtr();
     // }
 
-    //! NOTE At the monent, it can be null, need add ioc context to extension qml engine
+    //! NOTE At the moment, it can be null, need add ioc context to extension qml engine
     if (!qmlIoc) {
         return modularity::ContextPtr();
     }


### PR DESCRIPTION
Resolves: #33751

The `QJSEngine`'s API version was being set after the construction of `JsApiEngine`, which was defaulting to version 2. The courtesy accidentals plugin uses version 1, so we were getting mismatches between integers and strings when comparing element types (see `makeEnum` in `engravingapiv1.h`).