### PR TITLE
Fix Preferences apply silently discarding changes when a page fails to instantiate

### DIFF
--- a/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
@@ -116,7 +116,9 @@ StyledDialogView {
             for (var i in pages) {
                 var page = pages[i]
                 var obj = root.prv.pagesObjects[page.id]
-                obj.reset()
+                if (obj) {
+                    obj.reset()
+                }
             }
 
             Qt.callLater(preferencesModel.resetFactorySettings)
@@ -182,7 +184,9 @@ StyledDialogView {
                 for (var i in pages) {
                     var page = pages[i]
                     var obj = root.prv.pagesObjects[page.id]
-                    ok = obj && ok & obj.apply()
+                    if (obj) {
+                        ok &= obj.apply()
+                    }
                 }
 
                 if (ok) {

--- a/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PreferencesDialog.qml
@@ -182,7 +182,7 @@ StyledDialogView {
                 for (var i in pages) {
                     var page = pages[i]
                     var obj = root.prv.pagesObjects[page.id]
-                    ok &= obj.apply()
+                    ok = obj && ok & obj.apply()
                 }
 
                 if (ok) {

--- a/src/preferences/qml/MuseScore/Preferences/PreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/PreferencesPage.qml
@@ -27,7 +27,7 @@ import Muse.UiComponents
 
 Rectangle {
     id: root
-    height: parent.height
+    height: parent ? parent.height : 0
     color: ui.theme.backgroundSecondaryColor
 
     default property alias contentData: content.data


### PR DESCRIPTION
Related to: #33841

When a preference page fails to instantiate (e.g. due to a null-parent binding on the first layout pass), it is skipped and never stored in `prv.pagesObjects`. The apply loop in `PreferencesDialog` iterated all
pages from `availablePages()` without guarding against missing entries, so `obj.apply()` threw a TypeError on `undefined`, corrupting the `ok` accumulator and preventing `root.hide()`. Changes were silently discarded with no UI feedback.

1. `PreferencesDialog.qml`: guard `obj` before calling `apply()`.
2. `PreferencesPage.qml`: null-safe `parent` binding to avoid the TypeError during instantiation.

Reproduced on macOS 15 (arm64), MuseScore 4.7.3 and 5.0.0 developer builds with `-DMUE_BUILD_MACOS_INTEGRATION=OFF`.

* [x] I signed the [CLA](https://musescore.org/en/cla) as [manolo](https://musescore.org/en/user/): manolo
* [x] The title of the PR describes the problem it addresses.
* [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
* [x] The code in the PR follows the coding rules.
* [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
* [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
* [x] No prior attempts to resolve this problem exist.
* [x] There are no unnecessary changes.
* [x] I created a unit test or vtest to verify the changes I made (if applicable). *(Not applicable, QML logic fix)*