### PR TITLE
added playback commands state

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "muse_framework"]
 	path = muse
-	url = https://github.com/musescore/muse_framework.git
+	url = git@github.com:igorkorsukov/muse_framework.git

--- a/src/playback/CMakeLists.txt
+++ b/src/playback/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(playback PRIVATE
     iplaybackconfiguration.h
     isoundprofilesrepository.h
     playbacktypes.h
+    playbackcommands.h
 
     internal/playbackcontroller.cpp
     internal/playbackcontroller.h
@@ -34,8 +35,10 @@ target_sources(playback PRIVATE
     internal/onlinesoundscontroller.h
     internal/playbackuiactions.cpp
     internal/playbackuiactions.h
-    internal/playbackcommands.cpp
-    internal/playbackcommands.h 
+    internal/playbackcommandsregister.cpp
+    internal/playbackcommandsregister.h
+    internal/playbackcommandsstate.cpp
+    internal/playbackcommandsstate.h
     internal/playbackconfiguration.cpp
     internal/playbackconfiguration.h
     internal/soundprofilesrepository.cpp

--- a/src/playback/internal/playbackcommandsregister.cpp
+++ b/src/playback/internal/playbackcommandsregister.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "playbackcommands.h"
+#include "playbackcommandsregister.h"
+
+#include "../playbackcommands.h"
 
 using namespace muse;
 using namespace muse::rcommand;
@@ -29,21 +31,21 @@ using namespace mu::playback;
 
 static const std::vector<CommandInfo> s_commandInfos = {
     CommandInfo{
-        Command("command://playback/play"),
+        PLAY_COMMAND,
         TranslatableString("playback", "Play"),
         TranslatableString("playback", "Play the current score"),
         InputSchema(),
         Decoration(IconCode::Code::PLAY)
     },
     CommandInfo{
-        Command("command://playback/pause"),
+        PAUSE_COMMAND,
         TranslatableString("playback", "Pause"),
         TranslatableString("playback", "Pause playback"),
         InputSchema(),
         Decoration(IconCode::Code::PAUSE)
     },
     CommandInfo{
-        Command("command://playback/stop"),
+        STOP_COMMAND,
         TranslatableString("playback", "Stop"),
         TranslatableString("playback", "Stop playback"),
         InputSchema(),
@@ -51,12 +53,24 @@ static const std::vector<CommandInfo> s_commandInfos = {
     }
 };
 
-std::string PlaybackCommands::moduleName() const
+std::string PlaybackCommandsRegister::moduleName() const
 {
     return "playback";
 }
 
-const std::vector<CommandInfo>& PlaybackCommands::commandInfos() const
+const std::vector<muse::rcommand::Command>& PlaybackCommandsRegister::commandList() const
+{
+    static std::vector<muse::rcommand::Command> commands;
+    if (commands.empty()) {
+        commands.reserve(s_commandInfos.size());
+        for (const auto& info : s_commandInfos) {
+            commands.push_back(info.command);
+        }
+    }
+    return commands;
+}
+
+const std::vector<CommandInfo>& PlaybackCommandsRegister::commandInfoList() const
 {
     return s_commandInfos;
 }

--- a/src/playback/internal/playbackcommandsregister.h
+++ b/src/playback/internal/playbackcommandsregister.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "rcommand/imodulecommandsregister.h"
+
+namespace mu::playback {
+class PlaybackCommandsRegister : public muse::rcommand::IModuleCommandsRegister
+{
+public:
+    PlaybackCommandsRegister() = default;
+
+    std::string moduleName() const override;
+
+    const std::vector<muse::rcommand::Command>& commandList() const override;
+    const std::vector<muse::rcommand::CommandInfo>& commandInfoList() const override;
+};
+}

--- a/src/playback/internal/playbackcommandsstate.cpp
+++ b/src/playback/internal/playbackcommandsstate.cpp
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "playbackcommandsstate.h"
+
+#include "../playbackcommands.h"
+
+using namespace muse;
+using namespace muse::rcommand;
+using namespace mu::playback;
+
+static const muse::Uri PROJECT_PAGE_URI("musescore://notation");
+
+std::string PlaybackCommandsState::moduleName() const
+{
+    return "playback";
+}
+
+void PlaybackCommandsState::init()
+{
+    globalContext()->currentProjectChanged().onNotify(this, [this]() {
+        updateCommandStates();
+    });
+
+    interactive()->opened().onReceive(this, [this](const muse::Uri&) {
+        updateCommandStates();
+    });
+
+    playbackController()->isPlayAllowedChanged().onNotify(this, [this]() {
+        updateCommandStates();
+    });
+
+    // playbackController()->isPlayingChanged().onNotify(this, [this]() {
+    //     updateCommandStates();
+    // });
+
+    m_moduleRegister = commandsRegister()->moduleRegister(moduleName());
+    IF_ASSERT_FAILED(m_moduleRegister) {
+        return;
+    }
+
+    updateCommandStates();
+}
+
+void PlaybackCommandsState::deinit()
+{
+    globalContext()->currentProjectChanged().disconnect(this);
+    interactive()->opened().disconnect(this);
+    playbackController()->isPlayAllowedChanged().disconnect(this);
+    playbackController()->isPlayingChanged().disconnect(this);
+}
+
+void PlaybackCommandsState::updateCommandStates()
+{
+    IF_ASSERT_FAILED(m_moduleRegister) {
+        return;
+    }
+    for (const auto& command : m_moduleRegister->commandList()) {
+        CommandState newState = commandState(command);
+        if (m_commandStates[command] != newState) {
+            m_commandStates[command] = newState;
+            m_commandStateChanged.send(command, newState);
+        }
+    }
+}
+
+CommandState PlaybackCommandsState::commandState(const Command& command) const
+{
+    if (!isProjectOpened()) {
+        return CommandState(false, false);
+    }
+
+    if (!playbackController()->isPlayAllowed()) {
+        return CommandState(false, false);
+    }
+
+    if (command == PLAY_COMMAND) {
+        return CommandState(true, playbackController()->isPlaying());
+    } else if (command == PAUSE_COMMAND) {
+        return CommandState(true, false);
+    } else if (command == STOP_COMMAND) {
+        return CommandState(true, false);
+    }
+
+    return CommandState();
+}
+
+async::Channel<Command, CommandState> PlaybackCommandsState::commandStateChanged() const
+{
+    return m_commandStateChanged;
+}
+
+bool PlaybackCommandsState::isProjectOpened() const
+{
+    if (!globalContext()->currentProject()) {
+        return false;
+    }
+
+    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/playback/internal/playbackcommandsstate.h
+++ b/src/playback/internal/playbackcommandsstate.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <map>
+
+#include "rcommand/imodulecommandsstate.h"
+#include "global/async/asyncable.h"
+
+#include "global/modularity/ioc.h"
+#include "interactive/iinteractive.h"
+#include "context/iglobalcontext.h"
+#include "../iplaybackcontroller.h"
+#include "rcommand/icommandsregister.h"
+
+namespace mu::playback {
+class PlaybackCommandsState : public muse::rcommand::IModuleCommandsState, public muse::Contextable, public muse::async::Asyncable
+{
+    muse::GlobalInject<muse::rcommand::ICommandsRegister> commandsRegister;
+    muse::ContextInject<muse::IInteractive> interactive = { this };
+    muse::ContextInject<context::IGlobalContext> globalContext = { this };
+    muse::ContextInject<IPlaybackController> playbackController = { this };
+
+public:
+    PlaybackCommandsState(const muse::modularity::ContextPtr& ctx)
+        : muse::Contextable(ctx) {}
+
+    std::string moduleName() const override;
+
+    void init() override;
+    void deinit() override;
+
+    muse::rcommand::CommandState commandState(const muse::rcommand::Command& command) const override;
+    muse::async::Channel<muse::rcommand::Command, muse::rcommand::CommandState> commandStateChanged() const override;
+
+private:
+
+    bool isProjectOpened() const;
+    void updateCommandStates();
+
+    muse::rcommand::IModuleCommandsRegisterPtr m_moduleRegister;
+    std::map<muse::rcommand::Command, muse::rcommand::CommandState> m_commandStates;
+    muse::async::Channel<muse::rcommand::Command, muse::rcommand::CommandState> m_commandStateChanged;
+};
+}

--- a/src/playback/playbackcommands.h
+++ b/src/playback/playbackcommands.h
@@ -22,15 +22,10 @@
 
 #pragma once
 
-#include "rcommand/imodulecommands.h"
+#include "rcommand/commandtypes.h"
 
 namespace mu::playback {
-class PlaybackCommands : public muse::rcommand::IModuleCommands
-{
-public:
-    PlaybackCommands() = default;
-
-    std::string moduleName() const override;
-    const std::vector<muse::rcommand::CommandInfo>& commandInfos() const override;
-};
+inline static const muse::rcommand::Command PLAY_COMMAND("command://playback/play");
+inline static const muse::rcommand::Command PAUSE_COMMAND("command://playback/pause");
+inline static const muse::rcommand::Command STOP_COMMAND("command://playback/stop");
 }

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -26,11 +26,13 @@
 
 #include "ui/iuiactionsregister.h"
 #include "rcommand/icommandsregister.h"
+#include "rcommand/icommandsstate.h"
 #include "interactive/iinteractiveuriregister.h"
 
 #include "internal/playbackcontroller.h"
 #include "internal/playbackuiactions.h"
-#include "internal/playbackcommands.h"
+#include "internal/playbackcommandsregister.h"
+#include "internal/playbackcommandsstate.h"
 #include "internal/playbackconfiguration.h"
 #include "internal/soundprofilesrepository.h"
 
@@ -62,7 +64,7 @@ void PlaybackModule::resolveImports()
 
     auto cr = globalIoc()->resolve<muse::rcommand::ICommandsRegister>(mname);
     if (cr) {
-        cr->reg(std::make_shared<PlaybackCommands>());
+        cr->reg(std::make_shared<PlaybackCommandsRegister>());
     }
 }
 
@@ -91,6 +93,11 @@ void PlaybackContext::resolveImports()
     auto ar = ioc()->resolve<muse::ui::IUiActionsRegister>(mname);
     if (ar) {
         ar->reg(m_playbackUiActions);
+    }
+
+    auto cs = ioc()->resolve<muse::rcommand::ICommandsState>(mname);
+    if (cs) {
+        cs->reg(std::make_shared<PlaybackCommandsState>(iocContext()));
     }
 }
 


### PR DESCRIPTION
Key points:
* Like with the register, there is a single interface for obtaining the state of any command; it uses the states of specific modules. 
* The implementation of calculating the states of specific commands is located in the module that processes these commands. 
* We need to manage all state changes ourselves to notify about state changes. (For simplicity, we can think of this as the availability of menu items, although in reality it's not directly related to menus.)
* I added constants for the commands there, and I'm still confused by this decision, since it will lead to one module being dependent on another... But in our case, they are already linked at the compiler level; the main thing is not to link them at the link level.