### PR TITLE
Fix #33531: Page view menu positioning [4.7.4]

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
@@ -226,7 +226,6 @@ void MenuView::updateGeometry()
         } else {
             // move to the left to an area that doesn't fit
             movePos(m_globalPos.x() - (viewRect.right() - paddedAnchorRect.right()) + padding() * 2, m_globalPos.y());
-            newPopupPos = PopupPosition::Left;
         }
     }
 


### PR DESCRIPTION
Resolves: #33531

Two problems:
- `newPopupPos` was being set to `PopupPosition::Left` (introduced in [#31657](https://github.com/musescore/MuseScore/pull/31657)). This is inaccurate since we're not actually placing the menu to the left - we're just shuffling it left by the overlap amount (it's still placed above).
- ~~The `movePos` call is incorrect/outdated - instead of shuffling left by the overlap amount we're actually shuffling it right by `padding() * 2` (see the 4.6.5 screenshot attached to the original issue - the menu is offset).~~