### PR TITLE
Add .contextProperties.ini for qmllint and qmlls

### DIFF
--- a/.contextProperties.ini
+++ b/.contextProperties.ini
@@ -1,0 +1,2 @@
+[General]
+disableUnqualifiedAccess = "ui,qsTrc"


### PR DESCRIPTION
Silence warnings about context properties that we know to be valid.

Later, we should replace these context properties with a Singleton QML object.