### PR TITLE
[4.7.4] Fix #33626: show error dialog when transpose dialog has been closed

### DIFF
--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1818,7 +1818,9 @@ void NotationActionController::openBreaksDialog()
 
 void NotationActionController::openTransposeDialog()
 {
-    interactive()->open("musescore://notation/transpose");
+    interactive()->open("musescore://notation/transpose").onResolve(this, [this](const Val&) {
+        currentNotationInteraction()->checkAndShowError();
+    });
 }
 
 void NotationActionController::openPartsDialog()

--- a/src/notationscene/widgets/transposedialog.cpp
+++ b/src/notationscene/widgets/transposedialog.cpp
@@ -22,9 +22,6 @@
 
 #include "transposedialog.h"
 
-#include "async/notifylist.h"
-
-#include "notation/internal/mscoreerrorscontroller.h"
 #include "ui/view/widgetstatestore.h"
 
 using namespace mu::notation;
@@ -209,7 +206,6 @@ INotationSelectionPtr TransposeDialog::selection() const
 void TransposeDialog::apply()
 {
     TransposeOptions options;
-
     options.mode = mode();
     options.direction = direction();
     options.key = transposeKey();
@@ -221,8 +217,6 @@ void TransposeDialog::apply()
     saveState();
 
     interaction()->transpose(options);
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
 
     if (m_allSelected) {
         interaction()->clearSelection();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33626
Resolves: https://github.com/musescore/MuseScore/issues/33496