### PR TITLE
Enter lyric melisma with the underscore key on non-US keyboards

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
@@ -63,6 +63,12 @@ static bool seekAllowed(const mu::engraving::EngravingItem* element)
     return muse::contains(ALLOWED_TYPES, element->type());
 }
 
+static bool isEditingLyrics(const INotationInteractionPtr& interaction)
+{
+    const EngravingItem* element = interaction->selection()->element();
+    return interaction->isTextEditingStarted() && element && element->isLyrics();
+}
+
 NotationViewInputController::NotationViewInputController(IControlledView* view, const muse::modularity::ContextPtr& iocCtx)
     : muse::Contextable(iocCtx), m_view(view)
 {
@@ -1451,6 +1457,13 @@ bool NotationViewInputController::shortcutOverrideEvent(QKeyEvent* event)
     }
 
     if (viewInteraction()->isEditingElement()) {
+        // The shortcut layer cannot route the underscore key to the add-melisma
+        // action on non-US keyboard layouts (e.g. JIS, where '_' is its own
+        // dedicated key rather than Shift+'-'). Claim it here so it is delivered
+        // as a key press and handled directly in keyPressEvent().
+        if (key == Qt::Key_Underscore && event->modifiers() == Qt::NoModifier && isEditingLyrics(viewInteraction())) {
+            return true;
+        }
         return viewInteraction()->isEditAllowed(event);
     }
 
@@ -1475,9 +1488,18 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
         m_view->asItem()->setCursor({});
         event->accept();
     } else if (viewInteraction()->isEditingElement()) {
-        viewInteraction()->editElement(event);
-        if (key == Qt::Key_Shift) {
-            viewInteraction()->updateTimeTickAnchors(event);
+        if (key == Qt::Key_Underscore && event->modifiers() == Qt::NoModifier && isEditingLyrics(viewInteraction())) {
+            // Underscore -> melisma in lyrics (the shortcut layer can't map '_'
+            // to add-melisma on non-US keyboard layouts; see shortcutOverrideEvent()).
+            // Dispatch on the next event-loop turn so add-melisma's text-edit
+            // teardown does not run while this key event is still being delivered.
+            QTimer::singleShot(0, m_view->asItem(), [this]() { dispatcher()->dispatch("add-melisma"); });
+            event->accept();
+        } else {
+            viewInteraction()->editElement(event);
+            if (key == Qt::Key_Shift) {
+                viewInteraction()->updateTimeTickAnchors(event);
+            }
         }
     } else if (key == Qt::Key_Shift) {
         viewInteraction()->updateTimeTickAnchors(event);


### PR DESCRIPTION
Refs #14914 (the Japanese-keyboard report; reproduced here on macOS) and #16492 (AZERTY).

A lyric melisma is entered with the underscore character, but its default shortcut is `Shift+-`, which only produces `_` on US‑ANSI keyboards. On layouts where `_` is a dedicated key (e.g. Japanese JIS on macOS) or is produced by a different combination (French AZERTY, German QWERTZ, …), the shortcut layer never routes the underscore key to the `add-melisma` action, so a melisma cannot be entered at all.

This handles the underscore key directly in the notation view while editing lyrics: `Qt::Key_Underscore` with no modifiers is claimed in `shortcutOverrideEvent()` and dispatched to `add-melisma` in `keyPressEvent()`, bypassing the keyboard‑layout‑dependent shortcut path. The dispatch is deferred to the next event‑loop turn (matching how shortcut‑driven actions run) so `add-melisma`'s edit teardown does not run while the key event is still being delivered. `Shift+-` keeps working on US layouts, and non‑lyrics text editing is unaffected — the intercept is gated on actively editing a `Lyrics` element.

**Scope / testing.** Validated on a **macOS** JIS keyboard, where the dedicated `_` key arrives as `Key_Underscore` with no modifiers: pressing it now creates and extends a melisma (incl. consecutive presses); `Shift+-` still creates a melisma on a US layout; typing `_` in non‑lyrics text still inserts a literal underscore.

Note that #14914 was reported on **Windows**, where `_` is produced as `Shift+\` (i.e. *with* a modifier). That path likely delivers a different key event and is **not** covered by this no‑modifier intercept, so it probably needs separate handling/verification on Windows. I deliberately used `Refs` rather than `Resolves` so #14914 isn't auto‑closed before the Windows case is confirmed.

I couldn't add a unit test: the change lives in the live key‑event path (`shortcutOverrideEvent`/`keyPressEvent`) and there's no existing harness for synthesising `QKeyEvent`s through the notation view. Happy to add one if you can point me at a suitable place.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it relates to
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
