### PR TITLE
[4.7.4] Fix filled arrowhead color for lines

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1807,7 +1807,7 @@ void TDraw::drawTextLineBaseSegment(const TextLineBaseSegment* item, Painter* pa
         if (tl->beginHookType() == HookType::ARROW_FILLED) {
             Brush brush;
             brush.setStyle(BrushStyle::SolidPattern);
-            brush.setColor(item->curColor(opt));
+            brush.setColor(color);
             painter->setBrush(brush);
             painter->setNoPen();
             painter->drawPolygon(ldata->beginArrow);
@@ -1840,7 +1840,7 @@ void TDraw::drawTextLineBaseSegment(const TextLineBaseSegment* item, Painter* pa
         if (tl->endHookType() == HookType::ARROW_FILLED) {
             Brush brush;
             brush.setStyle(BrushStyle::SolidPattern);
-            brush.setColor(item->curColor(opt));
+            brush.setColor(color);
             painter->setBrush(brush);
             painter->setNoPen();
             painter->drawPolygon(ldata->endArrow);


### PR DESCRIPTION
Backport of #33750
Resolves: #33723