### PR TITLE
Partially restore synthesized bold rendering on Window and Linux screens

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1740,8 +1740,30 @@ void TDraw::draw(const TextBlock& textBlock, const TextBase* item, Painter* pain
 
 void TDraw::draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)
 {
+#ifndef Q_OS_MACOS
+    drawTextWorkaround(textFragment, item, painter);
+    return;
+#endif
     painter->setFont(textFragment.font(item));
     painter->drawText(textFragment.pos, textFragment.text);
+}
+
+void TDraw::drawTextWorkaround(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)
+{
+    Font f = textFragment.font(item);
+    const String& text = textFragment.text;
+    const PointF& pos = textFragment.pos;
+
+    painter->setFont(f);
+
+    double mm = painter->worldTransform().m11();
+    bool useWorkaround = !(MScore::pdfPrinting) && (mm < 1.0) && f.bold() && !(f.underline() || f.strike());
+    if (!useWorkaround) {
+        painter->drawText(pos, text);
+        return;
+    }
+
+    painter->drawTextWorkaround(pos, text);
 }
 
 void TDraw::drawTextLineBaseSegment(const TextLineBaseSegment* item, Painter* painter, const PaintOptions& opt)

--- a/src/engraving/rendering/score/tdraw.h
+++ b/src/engraving/rendering/score/tdraw.h
@@ -322,6 +322,7 @@ private:
     static void drawTextBase(const TextBase* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const TextBlock& textBlock, const TextBase* item, muse::draw::Painter* painter);
     static void draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter);
+    static void drawTextWorkaround(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter);
     static void drawTextLineBaseSegment(const TextLineBaseSegment* item, muse::draw::Painter* painter, const PaintOptions& opt);
 
     static void setMask(const EngravingItem* item, muse::draw::Painter* painter);

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -305,6 +305,12 @@ void BufferedPaintProvider::drawText(const RectF& rect, int flags, const String&
     editableData().texts.push_back(DrawText { DrawText::Rect, rect, flags, text });
 }
 
+void BufferedPaintProvider::drawTextWorkaround(const Font& f, const PointF& pos, const String& text)
+{
+    setFont(f);
+    editableData().texts.push_back(DrawText { DrawText::Point, RectF(pos, SizeF()), 0, text });
+}
+
 void BufferedPaintProvider::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     drawText(point, String::fromUcs4(&ucs4Code, 1));

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -72,6 +72,7 @@ public:
 
     void drawText(const PointF& point, const String& text) override;
     void drawText(const RectF& rect, int flags, const String& text) override;
+    void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -247,6 +247,67 @@ void QPainterProvider::drawText(const RectF& rect, int flags, const String& text
     m_painter->drawText(rect.toQRectF(), flags, text);
 }
 
+void QPainterProvider::drawTextWorkaround(const Font& f, const PointF& pos, const String& text)
+{
+    m_painter->save();
+    double mm = m_painter->worldTransform().m11();
+    double dx = m_painter->worldTransform().dx();
+    double dy = m_painter->worldTransform().dy();
+    // diagonal elements will now be changed to 1.0
+    m_painter->setWorldTransform(QTransform(1.0, 0.0, 0.0, 1.0, dx, dy));
+
+    // correction factor for bold text drawing, due to the change of the diagonal elements
+    double factor = 1.0 / mm;
+    QFont fnew(f.toQFont(), m_painter->device());
+    fnew.setPointSizeF(f.pointSizeF() / factor);
+    QRawFont fRaw = QRawFont::fromFont(fnew);
+    QTextLayout textLayout(text, f.toQFont(), m_painter->device());
+    textLayout.beginLayout();
+    while (true) {
+        QTextLine line = textLayout.createLine();
+        if (!line.isValid()) {
+            break;
+        }
+    }
+    textLayout.endLayout();
+    // glyphruns with correct positions, but potentially wrong glyphs
+    // (see bug https://musescore.org/en/node/117191 regarding positions and DPI)
+    QList<QGlyphRun> glyphruns = textLayout.glyphRuns();
+    double offset = 0;
+    // glyphrun drawing has an offset equal to the max ascent of the text fragment
+    for (int i = 0; i < glyphruns.length(); i++) {
+        double value = glyphruns.at(i).rawFont().ascent() / factor;
+        if (value > offset) {
+            offset = value;
+        }
+    }
+    for (int i = 0; i < glyphruns.length(); i++) {
+        QVector<QPointF> positions1 = glyphruns.at(i).positions();
+        QVector<QPointF> positions2;
+        // calculate the new positions for the scaled geometry
+        for (int j = 0; j < positions1.length(); j++) {
+            QPointF newPoint = positions1.at(j) / factor;
+            positions2.append(newPoint);
+        }
+        QGlyphRun glyphrun2 = glyphruns.at(i);
+        glyphrun2.setPositions(positions2);
+        // change the glyphs with the correct glyphs
+        // and account for glyph substitution
+        if (glyphrun2.rawFont().familyName() != fnew.family()) {
+            QFont f2(fnew);
+            f2.setFamily(glyphrun2.rawFont().familyName());
+            glyphrun2.setRawFont(QRawFont::fromFont(f2));
+        } else {
+            glyphrun2.setRawFont(fRaw);
+        }
+        m_painter->drawGlyphRun(QPointF(pos.x() / factor, pos.y() / factor - offset), glyphrun2);
+        positions2.clear();
+    }
+    // Restore the QPainter to its former state
+    m_painter->setWorldTransform(QTransform(mm, 0.0, 0.0, mm, dx, dy));
+    m_painter->restore();
+}
+
 void QPainterProvider::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     static QHash<char32_t, QString> cache;

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -76,6 +76,7 @@ public:
 
     void drawText(const PointF& point, const String& text) override;
     void drawText(const RectF& rect, int flags, const String& text) override;
+    void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -76,6 +76,7 @@ public:
 
     virtual void drawText(const PointF& point, const String& text) = 0;
     virtual void drawText(const RectF& rect, int flags, const String& text) = 0;
+    virtual void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) = 0;
 
     virtual void drawSymbol(const PointF& point, char32_t ucs4Code) = 0;
 

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -454,6 +454,16 @@ void Painter::drawText(const RectF& rect, int flags, const String& text)
     }
 }
 
+void Painter::drawTextWorkaround(const PointF& pos, const String& text)
+{
+    applyFontSizeScaling();
+
+    m_provider->drawTextWorkaround(font(), pos, text);
+    if (extended) {
+        m_provider->drawTextWorkaround(font(), pos, text);
+    }
+}
+
 void Painter::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     applyFontSizeScaling();

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -133,6 +133,8 @@ public:
 
     void drawText(const RectF& rect, int flags, const String& text);
 
+    void drawTextWorkaround(const PointF& pos, const String& text);
+
     void drawSymbol(const PointF& point, char32_t ucs4Code);
 
     void fillRect(const RectF& rect, const Brush& brush);


### PR DESCRIPTION
Resolves: #33693 

Reverts: 07e6c92f822f5b787960b746ae3b4d9929fbe0da

See in particular [this comment](https://github.com/musescore/MuseScore/issues/33693#issuecomment-4766681527) for more context.