### PR TITLE
Remove position property for measure numbers

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
@@ -730,7 +730,7 @@ void TextSettingsModel::updateIsPositionAvailable()
 {
     bool available = false;
     for (EngravingItem* item : m_elementList) {
-        if (item->isTextLineBase()) {
+        if (item->isTextLineBase() || item->isMeasureNumber()) {
             available = false;
             break;
         } else if (!item->hasVoiceAssignmentProperties()) {


### PR DESCRIPTION
Resolves: #33012

Since we've overhauled the measure number positioning options, being able to override the position of one individual measure number via property wasn't really part of the plan hence why the buttons don't do anything in Property. I'm removing them for the patch, but we may come back to this and expande the original feature in 5.0.