### PR TITLE
Fix VBox gap not saved

### DIFF
--- a/src/engraving/compat/engravingcompat.cpp
+++ b/src/engraving/compat/engravingcompat.cpp
@@ -237,7 +237,8 @@ void EngravingCompat::adjustVBoxDistances(MasterScore* masterScore)
                     VBox* first = static_cast<VBox*>(mb);
                     VBox* second = static_cast<VBox*>(nextmb);
                     if (first->bottomGap() > 0_sp && second->topGap() > 0_sp) {
-                        first->setBottomGap(first->bottomGap() + second->topGap()); // Because pre-4.6 these used to be added
+                        first->setProperty(Pid::BOTTOM_GAP, first->bottomGap() + second->topGap()); // Because pre-4.6 these used to be added
+                        first->setPropertyFlags(Pid::BOTTOM_GAP, PropertyFlags::UNSTYLED);
                     }
                 }
             }


### PR DESCRIPTION
Resolves: #33846

Turns out it has nothing to do with the image. It's the gap between the two top frames (the one with the title and the one with the image) that wasn't being saves correctly.