### PR TITLE
[4.7] Don't scan annotations on hidden staves

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -364,12 +364,6 @@ bool EngravingItem::collectForDrawing() const
         return false;
     }
 
-    bool isAnnotation = parent() && parent()->isSegment() && toSegment(parent())->element(track()) != this;
-    if (isAnnotation) {
-        Segment* segment = toSegment(parent());
-        return systemFlag() || (segment->measure() && segment->measure()->visible(staffIdx()));
-    }
-
     return true;
 }
 

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -679,19 +679,6 @@ NoteCaseType Harmony::bassRenderCase() const
     return noteCase;
 }
 
-bool Harmony::collectForDrawing() const
-{
-    if (!visible() && !score()->isShowInvisible()) {
-        return false;
-    }
-
-    if (Segment* parentSeg = getParentSeg()) {
-        return systemFlag() || (parentSeg->measure() && parentSeg->measure()->visible(staffIdx()));
-    }
-
-    return true;
-}
-
 //---------------------------------------------------------
 //   startEdit
 //---------------------------------------------------------

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -314,8 +314,6 @@ public:
     void setFamily(const String& val) override { m_fontFamily = val; }
     void setSize(const double& val) override { m_fontSize = val; }
 
-    bool collectForDrawing() const override;
-
     struct LayoutData : public TextBase::LayoutData {
         ld_field<double> harmonyHeight = { "[Harmony] harmonyHeight", 0.0 };    // used for calculating the height is frame while editing.
         ld_field<std::vector<LineF> > polychordDividerLines = { "[Harmony] polychordDividerLine", std::vector<LineF>() };

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1489,6 +1489,9 @@ void Segment::scanElements(std::function<void(EngravingItem*)> func)
         e->scanElements(func);
     }
     for (EngravingItem* e : annotations()) {
+        if (!e->systemFlag() && (!measure() || !measure()->visible(e->staffIdx()))) {
+            continue;
+        }
         e->scanElements(func);
     }
 }


### PR DESCRIPTION
Resolves: #33782 

We don't scan elements in Segment's `elist()` when they are on invisible staves. We should do the same for annotations instead of waiting until `collectForDrawing` to make this decision. Otherwise, every time an annotation has a child element, we'll have to add special logic.