### PR TITLE
[4.7.4] Partial tie fixes

### DIFF
--- a/src/engraving/dom/ornament.cpp
+++ b/src/engraving/dom/ornament.cpp
@@ -419,7 +419,7 @@ void Ornament::updateCueNote()
         cueNote->setParent(m_cueNoteChord);
 
         std::vector<Note*> notes = { cueNote };
-        EditChord::addChordParentheses(const_cast<Chord*>(m_cueNoteChord), notes, false, true);
+        EditChord::addChordParentheses(const_cast<Chord*>(m_cueNoteChord), notes, false, true);//BROKEN
     }
     m_cueNoteChord->setTrack(track());
     m_cueNoteChord->setParent(parentChord->segment());

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -8012,15 +8012,28 @@ void Score::doUndoResetPartialSlur(Slur* slur, bool undo)
     const size_t undoIdx = undoStack()->currentIndex();
 
     const ChordRest* startCR = slur ? slur->startCR() : nullptr;
+    // Slurs can only have the same start & end element when they are partial.
+    // If they are no longer partial, we should remove them
+    const bool shouldRemove = slur->startElement() == slur->endElement();
     IF_ASSERT_FAILED(startCR) {
         LOGE() << "Slur is corrupted";
     } else if (!startCR->hasPrecedingJumpItem() && slur->isIncoming()) {
-        if (undo) {
-            startCmd(TranslatableString("engraving", "Reset incoming partial slur"));
-            slur->undoSetIncoming(false);
-            endCmd();
+        if (shouldRemove) {
+            if (undo) {
+                startCmd(TranslatableString("engraving", "Remove invalid incoming partial slur"));
+                undoRemoveElement(slur);
+                endCmd();
+            } else {
+                removeElement(slur);
+            }
         } else {
-            slur->setIncoming(false);
+            if (undo) {
+                startCmd(TranslatableString("engraving", "Reset incoming partial slur"));
+                slur->undoSetIncoming(false);
+                endCmd();
+            } else {
+                slur->setIncoming(false);
+            }
         }
     }
 
@@ -8028,12 +8041,22 @@ void Score::doUndoResetPartialSlur(Slur* slur, bool undo)
     IF_ASSERT_FAILED(endCR) {
         LOGE() << "Slur is corrupted";
     } else if (!endCR->hasFollowingJumpItem() && slur->isOutgoing()) {
-        if (undo) {
-            startCmd(TranslatableString("engraving", "Reset outgoing partial slur"));
-            slur->undoSetOutgoing(false);
-            endCmd();
+        if (shouldRemove) {
+            if (undo) {
+                startCmd(TranslatableString("engraving", "Remove invalid outgoing partial slur"));
+                undoRemoveElement(slur);
+                endCmd();
+            } else {
+                removeElement(slur);
+            }
         } else {
-            slur->setOutgoing(false);
+            if (undo) {
+                startCmd(TranslatableString("engraving", "Reset outgoing partial slur"));
+                slur->undoSetOutgoing(false);
+                endCmd();
+            } else {
+                slur->setOutgoing(false);
+            }
         }
     }
 
@@ -8057,7 +8080,9 @@ void Score::undoRemoveStaleTieJumpPoints(bool undo)
         return;
     }
 
-    for (auto& interval : spanner()) {
+    // Copy, invalid slurs could be removed
+    auto spannerMap = spanner();
+    for (auto& interval : spannerMap) {
         Spanner* sp = interval.second;
         if (!sp || !sp->isSlur()) {
             continue;

--- a/src/engraving/rw/read460/read460.cpp
+++ b/src/engraving/rw/read460/read460.cpp
@@ -792,6 +792,7 @@ bool Read460::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
 
     for (Score* s : score->scoreList()) {     // for all parts
         s->connectTies();
+        s->undoRemoveStaleTieJumpPoints(false);
 
         for (Spanner* sp : score->unmanagedSpanners()) {
             if (sp->isLyricsLine() && toLyricsLine(sp)->isDash()) {

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3836,7 +3836,8 @@ void TRead::lineBreakFromTag(String& str)
 
 void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
 {
-    StaffGroup staffGroup = ctx.staff(ch->staffIdx())->staffTypeForElement(ch)->group();
+    Staff* staff = ctx.staff(ch->staffIdx());
+    StaffGroup staffGroup = staff ? staff->staffTypeForElement(ch)->group() : StaffGroup::STANDARD;
     if (staffGroup == StaffGroup::PERCUSSION) {
         // We should have read all notes by now. They need to be sorted for percussion staves
         const Instrument* instrument = ch->part()->instrument(ch->tick());

--- a/src/engraving/tests/partialtie_data/copyPastePartials02-ref.mscx
+++ b/src/engraving/tests/partialtie_data/copyPastePartials02-ref.mscx
@@ -253,48 +253,27 @@
           <Chord>
             <eid>exvNJKXR4+P_exvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
+            <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
+              <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
+            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
-                <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
+                <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -303,13 +282,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
+              <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>nxvNJKXR4+P_nxvNJKXR4+P</eid>
+            <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -319,10 +298,7 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>oxvNJKXR4+P_oxvNJKXR4+P</eid>
-              <PartialTie>
-                <eid>pxvNJKXR4+P_pxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>

--- a/src/engraving/tests/partialtie_data/copyPastePartials03-ref.mscx
+++ b/src/engraving/tests/partialtie_data/copyPastePartials03-ref.mscx
@@ -253,48 +253,27 @@
           <Chord>
             <eid>exvNJKXR4+P_exvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
+            <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
+              <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
+            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
-                <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
+                <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -303,13 +282,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
+              <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>nxvNJKXR4+P_nxvNJKXR4+P</eid>
+            <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -319,10 +298,7 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>oxvNJKXR4+P_oxvNJKXR4+P</eid>
-              <PartialTie>
-                <eid>pxvNJKXR4+P_pxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -341,50 +317,30 @@
           </Jump>
         <voice>
           <Chord>
-            <eid>qxvNJKXR4+P_qxvNJKXR4+P</eid>
+            <eid>nxvNJKXR4+P_nxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>rxvNJKXR4+P_rxvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>sxvNJKXR4+P_sxvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>txvNJKXR4+P_txvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>oxvNJKXR4+P_oxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>uxvNJKXR4+P_uxvNJKXR4+P</eid>
+            <eid>pxvNJKXR4+P_pxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>vxvNJKXR4+P_vxvNJKXR4+P</eid>
+              <eid>qxvNJKXR4+P_qxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>wxvNJKXR4+P_wxvNJKXR4+P</eid>
+            <eid>rxvNJKXR4+P_rxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
                 <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>xxvNJKXR4+P_xxvNJKXR4+P</eid>
+                <eid>sxvNJKXR4+P_sxvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -393,13 +349,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>yxvNJKXR4+P_yxvNJKXR4+P</eid>
+              <eid>txvNJKXR4+P_txvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>zxvNJKXR4+P_zxvNJKXR4+P</eid>
+            <eid>uxvNJKXR4+P_uxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -409,9 +365,9 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>0xvNJKXR4+P_0xvNJKXR4+P</eid>
+              <eid>vxvNJKXR4+P_vxvNJKXR4+P</eid>
               <PartialTie>
-                <eid>1xvNJKXR4+P_1xvNJKXR4+P</eid>
+                <eid>wxvNJKXR4+P_wxvNJKXR4+P</eid>
                 </PartialTie>
               <pitch>67</pitch>
               <tpc>15</tpc>

--- a/src/engraving/tests/partialtie_data/copyPastePartials04-ref.mscx
+++ b/src/engraving/tests/partialtie_data/copyPastePartials04-ref.mscx
@@ -253,48 +253,27 @@
           <Chord>
             <eid>exvNJKXR4+P_exvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>fxvNJKXR4+P_fxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
+            <eid>gxvNJKXR4+P_gxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
+              <eid>hxvNJKXR4+P_hxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
+            <eid>ixvNJKXR4+P_ixvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
-                <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
+                <eid>jxvNJKXR4+P_jxvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -303,13 +282,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
+              <eid>kxvNJKXR4+P_kxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>nxvNJKXR4+P_nxvNJKXR4+P</eid>
+            <eid>lxvNJKXR4+P_lxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -319,10 +298,7 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>oxvNJKXR4+P_oxvNJKXR4+P</eid>
-              <PartialTie>
-                <eid>pxvNJKXR4+P_pxvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>mxvNJKXR4+P_mxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -341,50 +317,30 @@
           </Jump>
         <voice>
           <Chord>
-            <eid>qxvNJKXR4+P_qxvNJKXR4+P</eid>
+            <eid>nxvNJKXR4+P_nxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>rxvNJKXR4+P_rxvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>sxvNJKXR4+P_sxvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>txvNJKXR4+P_txvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>oxvNJKXR4+P_oxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>uxvNJKXR4+P_uxvNJKXR4+P</eid>
+            <eid>pxvNJKXR4+P_pxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>vxvNJKXR4+P_vxvNJKXR4+P</eid>
+              <eid>qxvNJKXR4+P_qxvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>wxvNJKXR4+P_wxvNJKXR4+P</eid>
+            <eid>rxvNJKXR4+P_rxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
                 <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>xxvNJKXR4+P_xxvNJKXR4+P</eid>
+                <eid>sxvNJKXR4+P_sxvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -393,13 +349,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>yxvNJKXR4+P_yxvNJKXR4+P</eid>
+              <eid>txvNJKXR4+P_txvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>zxvNJKXR4+P_zxvNJKXR4+P</eid>
+            <eid>uxvNJKXR4+P_uxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -409,9 +365,9 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>0xvNJKXR4+P_0xvNJKXR4+P</eid>
+              <eid>vxvNJKXR4+P_vxvNJKXR4+P</eid>
               <PartialTie>
-                <eid>1xvNJKXR4+P_1xvNJKXR4+P</eid>
+                <eid>wxvNJKXR4+P_wxvNJKXR4+P</eid>
                 </PartialTie>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -553,50 +509,30 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>2xvNJKXR4+P_2xvNJKXR4+P</eid>
+            <eid>xxvNJKXR4+P_xxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>3xvNJKXR4+P_3xvNJKXR4+P</eid>
-                </Slur>
-              <next>
-                <location>
-                  </location>
-                </next>
-              </Spanner>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  </location>
-                </prev>
-              </Spanner>
             <Note>
-              <eid>4xvNJKXR4+P_4xvNJKXR4+P</eid>
-              <PartialTie>
-                <partialSpannerDirection>incoming</partialSpannerDirection>
-                <eid>5xvNJKXR4+P_5xvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>yxvNJKXR4+P_yxvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>6xvNJKXR4+P_6xvNJKXR4+P</eid>
+            <eid>zxvNJKXR4+P_zxvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>7xvNJKXR4+P_7xvNJKXR4+P</eid>
+              <eid>0xvNJKXR4+P_0xvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8xvNJKXR4+P_8xvNJKXR4+P</eid>
+            <eid>1xvNJKXR4+P_1xvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <Slur>
                 <partialSpannerDirection>outgoing</partialSpannerDirection>
-                <eid>9xvNJKXR4+P_9xvNJKXR4+P</eid>
+                <eid>2xvNJKXR4+P_2xvNJKXR4+P</eid>
                 </Slur>
               <next>
                 <location>
@@ -605,13 +541,13 @@
                 </next>
               </Spanner>
             <Note>
-              <eid>+xvNJKXR4+P_+xvNJKXR4+P</eid>
+              <eid>3xvNJKXR4+P_3xvNJKXR4+P</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>/xvNJKXR4+P_/xvNJKXR4+P</eid>
+            <eid>4xvNJKXR4+P_4xvNJKXR4+P</eid>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
               <prev>
@@ -621,10 +557,7 @@
                 </prev>
               </Spanner>
             <Note>
-              <eid>AyvNJKXR4+P_AyvNJKXR4+P</eid>
-              <PartialTie>
-                <eid>ByvNJKXR4+P_ByvNJKXR4+P</eid>
-                </PartialTie>
+              <eid>5xvNJKXR4+P_5xvNJKXR4+P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>

--- a/src/engraving/tests/partialtie_data/copyPastePartials05.mscx
+++ b/src/engraving/tests/partialtie_data/copyPastePartials05.mscx
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.70">
+  <programVersion>4.7.4</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>DIDnzJ5UsYH_FmGuFlWSf2I</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2026-06-24</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>qdlYFhqw0AG_Qqsklqi+++P</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <eid>BxQ92AGovtO_KTXM6m9blYK</eid>
+        <startRepeat/>
+        <voice>
+          <KeySig>
+            <eid>TvIW2bnF6rD_VzCgOM9cuWO</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>f0eqNVxZAgO_Dhe1hk7QCeM</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>WWlnDeg00LB_RZCVatyolrM</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>lkhUTCW3ahP_pEww+CFrzbC</eid>
+              <PartialTie>
+                <partialSpannerDirection>incoming</partialSpannerDirection>
+                <eid>f62tAn6T6jL_WiaVZpIF63G</eid>
+                </PartialTie>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>fvVBLto+gQH_wQI2ZUILQzE</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>z+sRHQ6utCI_5ItuBQvwxDO</eid>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>2HDgEA8ruq_z5+zPIvZ1R</eid>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <Rest>
+            <eid>s8yAESt00cL_lDL62vyYoKM</eid>
+            <durationType>half</durationType>
+            </Rest>
+          <Rest>
+            <eid>vnGag5rfMmM_mHZJGNMKcxB</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Chord>
+            <eid>gKs7z0t0VdD_tY7FQ3fljBN</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>HcKjLcmUjrJ_Elo+FIFK9GG</eid>
+              <PartialTie>
+                <eid>Yi7m7bqwOKN_rXC0eMkVqbI</eid>
+                </PartialTie>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>xAbr1otXVNN_NPHYeoi0xbC</eid>
+        <voice>
+          <Rest>
+            <eid>eWQQyS7G38J_UdKhnHnXW2J</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>SW6tzsZv/OG_yZPkrAWh3sB</eid>
+        <voice>
+          <Rest>
+            <eid>R4mBIYz5+oC_zWs8djBlnqI</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>JV935hgxVeB_9GyS9kg0LdC</eid>
+        <voice>
+          <Rest>
+            <eid>hGbuAkWg1OB_0mXeKMHq7QN</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>qkv3pd0iUOK_enZt0oJMjhM</eid>
+        <voice>
+          <Rest>
+            <eid>/9wk/TTS4rH_1hgDNB9fMFB</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/partialtie_tests.cpp
+++ b/src/engraving/tests/partialtie_tests.cpp
@@ -642,3 +642,60 @@ TEST_F(Engraving_PartialTieTests, deleteAllMeasures)
     deleteScoreWithPartialTies(test1);
     deleteScoreWithPartialTies(test2);
 }
+
+TEST_F(Engraving_PartialTieTests, copyPasteRemoveInvalidPartialTies)
+{
+    Score* score = ScoreRW::readScore(PARTIALTIE_DATA_DIR + u"copyPastePartials05.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    Measure* m2 = m1->nextMeasure();
+    Measure* m3 = m2->nextMeasure();
+    Measure* m4 = m3->nextMeasure();
+    EXPECT_TRUE(m1);
+    EXPECT_TRUE(m2);
+    EXPECT_TRUE(m3);
+    EXPECT_TRUE(m4);
+
+    // Select measures 1 and 2
+    score->select(m1, SelectType::RANGE, 0);
+    score->select(m2, SelectType::RANGE, 0);
+
+    EXPECT_TRUE(score->selection().canCopy());
+    String mimeType = score->selection().mimeType();
+    EXPECT_TRUE(!mimeType.isEmpty());
+    QMimeData* mimeData = new QMimeData;
+    QByteArray ba = score->selection().mimeData().toQByteArray();
+    mimeData->setData(mimeType, ba);
+
+    // Paste at measure 4
+    EXPECT_TRUE(m4->first(SegmentType::ChordRest)->element(0));
+    score->select(m4->first(SegmentType::ChordRest)->element(0));
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    QMimeDataAdapter ma(mimeData);
+    score->cmdPaste(&ma, 0);
+    score->endCmd();
+    score->doLayout();
+
+    // Measure 4 beat 1 — no ties expected
+    const Fraction tick1 = Fraction(3, 1);
+    Segment* seg1 = score->tick2segment(tick1, false, SegmentType::ChordRest);
+    EXPECT_TRUE(seg1);
+    EXPECT_TRUE(seg1->element(0) && seg1->element(0)->isChord());
+    Note* note1 = toChord(seg1->element(0))->upNote();
+    EXPECT_TRUE(note1);
+    EXPECT_FALSE(note1->tieBack());
+    EXPECT_FALSE(note1->tieFor());
+
+    // Measure 5 beat 4 — no ties expected
+    const Fraction tick2 = Fraction(19, 4);
+    Segment* seg2 = score->tick2segment(tick2, false, SegmentType::ChordRest);
+    EXPECT_TRUE(seg2);
+    EXPECT_TRUE(seg2->element(0) && seg2->element(0)->isChord());
+    Note* note2 = toChord(seg2->element(0))->upNote();
+    EXPECT_TRUE(note2);
+    EXPECT_FALSE(note2->tieBack());
+    EXPECT_FALSE(note2->tieFor());
+
+    delete score;
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/partialtiepopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/partialtiepopupmodel.cpp
@@ -52,7 +52,11 @@ bool PartialTiePopupModel::canOpen(const EngravingItem* element)
     }
 
     Tie* tieItem = toTieSegment(element)->tie();
-    if (!tieItem || !tieItem->tieJumpPoints()) {
+    if (!tieItem) {
+        return false;
+    }
+    tieItem->updatePossibleJumpPoints();
+    if (!tieItem->tieJumpPoints()) {
         return false;
     }
 


### PR DESCRIPTION
Resolves: #33777 
Resolves: Partial tie popup not opening after edit to score
https://github.com/user-attachments/assets/8f6ce4a1-37cc-4edd-ba60-139e2e5e673c
Resolves: Invalid partial slurs not being removed after editing the score:
https://github.com/user-attachments/assets/d5b4de8f-12ee-4610-80d7-df3405816ac5
