### PR TITLE
[4.7.4] Fix missing parens on ornament cue notes

### DIFF
--- a/src/engraving/dom/ornament.cpp
+++ b/src/engraving/dom/ornament.cpp
@@ -418,8 +418,8 @@ void Ornament::updateCueNote()
         m_cueNoteChord->add(cueNote);
         cueNote->setParent(m_cueNoteChord);
 
-        std::vector<Note*> notes = { cueNote };
-        EditChord::addChordParentheses(const_cast<Chord*>(m_cueNoteChord), notes, false, true);//BROKEN
+        std::list<Note*> notes = { cueNote };
+        score()->cmdAddParenthesesToNotes(notes);
     }
     m_cueNoteChord->setTrack(track());
     m_cueNoteChord->setParent(parentChord->segment());


### PR DESCRIPTION
Resolves: #33938 

These used to be generated, but there's no reason for them to be. This was also conflicting with our (pretty convoluted & delicate at this point) generated paren code.