### PR TITLE
Fix spanners' `visible` property propagation to new segments in Spanner::add()

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -474,6 +474,7 @@ void Spanner::add(EngravingItem* e)
     ls->setTrack(track());
 //      ls->setAutoplace(autoplace());
     ls->EngravingItem::setZ(z());
+    ls->EngravingItem::setVisible(visible());
     m_segments.push_back(ls);
     e->added();
 }

--- a/src/engraving/editing/editvisibility.cpp
+++ b/src/engraving/editing/editvisibility.cpp
@@ -60,7 +60,7 @@ void EditVisibility::toggleVisible(Transaction& tx, Score* score)
     bool allVisible = true;
 
     for (EngravingItem* item : score->selection().elements()) {
-        if (!item->visible()) {
+        if (!item->getProperty(Pid::VISIBLE).toBool()) {
             allVisible = false;
             break;
         }

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -440,7 +440,7 @@ private:
     TrillHash m_trillStart;
     TrillHash m_trillStop;
     MusicXmlInstrumentMap m_instrMap;
-    PlayingTechniqueType m_currPlayTechnique;
+    PlayingTechniqueType m_currPlayTechnique = PlayingTechniqueType::Undefined;
     bool m_isMxl = false;
 };
 


### PR DESCRIPTION
Resolves: #33714

When an invisible tie is copied and pasted, the pasted tie loses its invisibility: it can't be toggled with the `v` key, and on save the` <Tie>` element is written with no `<TieSegment>` child (possibly the cause of it not rendering properly in musescore.com).

A tie tracks visibility in two places that are meant to stay in sync: the `Tie` (spanner) itself and its `TieSegment`. These are normally kept aligned by `Spanner::setVisible`, which writes both.

However, a `SpannerSegment` is layout-related, not durable. When a tie is added to a score (e.g. during paste, via `undoAddElement` -> `eraseSpannerSegments`), its segments are erased and re-generated from scratch during layout. When re-creating the segments (in `Spanner::fixupSegments`) we were not copying the tie's visible flag onto them, so the re-generated segments defaulted to visible, while the tie itself stayed invisible.

This lack of sync caused the following:
* While drawing, we read the visibility using `getProperty(Pid::VISIBLE)`, which delegates to the `Spanner`, so the tie looked correct (i.e. grayed-out).
* The `v` shortcut (`cmdToggleVisible`) was not working because it uses the segment's own `visible()` flag, then writes through `undoChangeProperty(VISIBLE)`, which delegates to the spanner (already invisible). The values match, so the change was ignored.
    * I have fixed this inconsistency in this specific place, but the `visible()`/`setVisible()` vs. `getProperty()`/`setProperty()` inconsisntencies may be present in other places throughout the code.
    * This value was properly restored when the "visible" checkbox from the properties panel is used because, again, it uses `setProperty()` (which delegates to the `Spanner`).
* On save, unless something else had changed, the tie segment reported itself as visible (through `visible()`), so `isUserModified()` was false and the `<TieSegment>` was never written.