### PR TITLE
[4.7.4] Fix #33923: Last note in a loop playing permanently

### DIFF
--- a/src/framework/audio/engine/internal/sequenceplayer.cpp
+++ b/src/framework/audio/engine/internal/sequenceplayer.cpp
@@ -42,8 +42,7 @@ SequencePlayer::SequencePlayer(IGetTracks* getTracks, IClockPtr clock, const mod
         }
 
         if (m_tracksFollowClockSeek) {
-            const bool flushSound = type == IClock::ActionType::Seek;
-            seekAllTracks(m_clock->currentTime(), flushSound);
+            seekAllTracks(m_clock->currentTime(), true /*flushSound*/);
         }
     });
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33923