### PR TITLE
[4.7.4] Fix crash on open score

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/src/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -578,10 +578,6 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
 
     loadPageContent(newPage);
     restorePageState(newPage);
-
-    // Calls such as clearRegistry lead to deferred deletes of docks. Ensure these
-    // have been fully processed before attempting to re-init (see issue #31997)
-    qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete);
     initDocks(newPage);
 
     newPage->setParams(params);


### PR DESCRIPTION
Caused by: https://github.com/musescore/MuseScore/pull/33211

I can reliably reproduce it using [this score](https://musescore.org/en/node/394196) on Windows, but there is currently [another crash](https://github.com/musescore/MuseScore/issues/33945) preventing it from opening

Update: we've decided to revert #33211 for 4.7 and keep it in the main branch, because there may still be some hidden deleteLater() calls that could cause similar crashes