### PR TITLE
[4.7.4] run windeployqt only on ci and add muse_deps to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build.qtc
 build-*
 build
 muse
+muse_deps
 win32build
 win32install
 win64build


### PR DESCRIPTION
Backport from main, 29fb8bcfa8

While at it, add muse_deps to .gitignore