### PR TITLE
[4.7.4] Fix #33945: crash when opening score with empty NoteParenGroup

### DIFF
--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3893,6 +3893,17 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
         return;
     }
 
+    for (const NoteParenthesisInfo* existing : ch->noteParentheses()) {
+        for (Note* note : notes) {
+            if (muse::contains(existing->notes(), note)) {
+                LOGW() << "Skipping duplicate NoteParenGroup: note already covered by existing group";
+                delete leftParen;
+                delete rightParen;
+                return;
+            }
+        }
+    }
+
     if (!leftParen) {
         leftParen = Factory::createParenthesis(ch);
         leftParen->setParent(ch);

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3886,6 +3886,13 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
         }
     }
 
+    if (notes.empty()) {
+        LOGW() << "NoteParenGroup has no valid notes, skipping";
+        delete leftParen;
+        delete rightParen;
+        return;
+    }
+
     if (!leftParen) {
         leftParen = Factory::createParenthesis(ch);
         leftParen->setParent(ch);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33945