### PR TITLE
Update .gitignore for ignoring 4.7 artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ __pycache__/
 # Stuff from 3.x builds
 /share/sound/MuseScore_General*
 
+# Stuff from 4.x builds
+src/braille/thirdparty/liblouis/liblouis/config.h
+src/braille/thirdparty/liblouis/liblouis/liblouis.h
+
 # User overrides of SetupBuildEnvironment
 /buildscripts/cmake/SetupBuildEnvironment.user.cmake
 


### PR DESCRIPTION
eases switching back and forth between 4.7 and main

Also update to latest muse_deps and muse_frameworks submodules