### PR TITLE
Automation - fix assertion failure when creating from template

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -104,7 +104,6 @@ void AbstractNotationPaintView::load()
 
     m_inputController->setReadonly(m_readonly);
     m_inputController->init();
-    m_notationAutomationController->init();
 
     m_elapsedTimer.start();
 
@@ -763,6 +762,8 @@ void AbstractNotationPaintView::onNotationSetup()
     TRACEFUNC;
     onCurrentNotationChanged();
     onPlayingChanged();
+
+    m_notationAutomationController->init();
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onCurrentNotationChanged();


### PR DESCRIPTION
Assertion failure triggers because we're attempting to init the automation controller for template previews. We can avoid this by putting the init call in `onNotationSetup` which is overridden by `TemplatePaintView` (we do something similar for playback with the `disablePlayback` parameter).