### PR TITLE
Add Info-level logs when autosaving a score

### DIFF
--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -151,19 +151,21 @@ void ProjectAutoSaver::onTrySave()
         }
     };
 
+    LOGI() << "[autosave] trying to auto save";
+
     INotationProjectPtr project = globalContext()->currentProject();
     if (!project) {
-        LOGD() << "[autosave] no project";
+        LOGI() << "[autosave] no project";
         return;
     }
 
     if (!project->needAutoSave()) {
-        LOGD() << "[autosave] project does not need save";
+        LOGI() << "[autosave] project does not need save";
         return;
     }
 
     if (!project->canSave()) {
-        LOGD() << "[autosave] project could not be saved";
+        LOGI() << "[autosave] project could not be saved";
         return;
     }
 
@@ -178,7 +180,7 @@ void ProjectAutoSaver::onTrySave()
 
     project->setNeedAutoSave(false);
 
-    LOGD() << "[autosave] successfully saved project";
+    LOGI() << "[autosave] successfully saved project";
 }
 
 muse::io::path_t ProjectAutoSaver::projectPath(INotationProjectPtr project) const


### PR DESCRIPTION
Resolves: #33791

Notes regarding the original issue and the actual fix:

* The autosave success log _was_ present but it had `DEBUG` level. I have bumped it to `INFO` so it will be the same level as the normal save log level (and thus will appear when running Release builds by default).
* I have added a "trying to auto save" log as well. This is not equivalent to the logged `try call action: file-save` on normal save, as the latter is logged automatically by `ActionsDispatcher::doDispatch` but the autosave is not really a user action, so it's not handled by the `ActionsDispatcher`.