### PR TITLE
Fix #33883: Account for accidentals in other voices when spacing chord brackets

### DIFF
--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1656,6 +1656,26 @@ static void layoutSegmentElements(Segment* segment, track_idx_t startTrack, trac
     }
 }
 
+static void relayoutChordBracketsAfterSegmentLayout(const std::vector<Chord*>& chords, LayoutContext& ctx)
+{
+    for (Chord* chord : chords) {
+        bool hasChordBracket = false;
+
+        for (EngravingItem* e : chord->el()) {
+            if (!e->isChordBracket()) {
+                continue;
+            }
+
+            hasChordBracket = true;
+            TLayout::layoutItem(e, ctx);
+        }
+
+        if (hasChordBracket) {
+            ChordLayout::fillShape(chord, chord->mutldata(), ctx.conf());
+        }
+    }
+}
+
 void ChordLayout::skipAccidentals(Segment* segment, track_idx_t startTrack, track_idx_t endTrack)
 {
     for (track_idx_t track = startTrack; track < endTrack; ++track) {
@@ -2301,6 +2321,10 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
             TLayout::layoutOrnamentCueNote(ornament, ctx);
         }
     }
+
+    // Chord brackets depend on the final layouts of all voices in the same segment and visual staff.
+    // Re-layout them after the segment elements have been laid out.
+    relayoutChordBracketsAfterSegmentLayout(posInfo.chords, ctx);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -870,21 +870,24 @@ void TLayout::layoutArpeggio(const Arpeggio* item, Arpeggio::LayoutData* ldata, 
     }
 }
 
-static Shape chordBracketObstacleShape(const ChordBracket* item)
+static Shape getChordsShape(const ChordBracket* item)
 {
     Chord* owner = item->chord();
-    Shape ownerShape = owner->shape();
-    ownerShape.removeTypes({ ElementType::CHORD_BRACKET, ElementType::ARPEGGIO });
+    Shape result = owner->shape();
+    result.removeTypes({ ElementType::CHORD_BRACKET, ElementType::ARPEGGIO });
     if (!owner->segment() || !owner->staff()) {
-        return ownerShape;
+        return result;
     }
 
-    Shape result;
     const track_idx_t startTrack = staff2track(owner->staffIdx());
     const track_idx_t endTrack = startTrack + VOICES;
 
     for (track_idx_t track = startTrack; track < endTrack; ++track) {
         EngravingItem* e = owner->segment()->element(track);
+        if (track == owner->track()) {
+            continue;
+        }
+
         if (!e || !e->isChord()) {
             continue;
         }
@@ -900,7 +903,7 @@ static Shape chordBracketObstacleShape(const ChordBracket* item)
         result.add(chordShape);
     }
 
-    return result.empty() ? ownerShape : result;
+    return result;
 }
 
 void TLayout::layoutChordBracket(const ChordBracket* item, Arpeggio::LayoutData* ldata, const LayoutConfiguration& conf)
@@ -929,7 +932,7 @@ void TLayout::layoutChordBracket(const ChordBracket* item, Arpeggio::LayoutData*
     const Note* upnote = item->chord()->upNote();
     ldata->setPosY(upnote->y() + upnote->ldata()->bbox().top());
 
-    Shape chordShape = chordBracketObstacleShape(item);
+    Shape chordShape = getChordsShape(item);
     Shape itemShape = item->shape().translated(PointF(0.0, item->ldata()->pos().y()));
     if (item->rightSide()) {
         double x = HorizontalSpacing::minHorizontalDistance(chordShape, itemShape, spatium);

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -870,6 +870,39 @@ void TLayout::layoutArpeggio(const Arpeggio* item, Arpeggio::LayoutData* ldata, 
     }
 }
 
+static Shape chordBracketObstacleShape(const ChordBracket* item)
+{
+    Chord* owner = item->chord();
+    Shape ownerShape = owner->shape();
+    ownerShape.removeTypes({ ElementType::CHORD_BRACKET, ElementType::ARPEGGIO });
+    if (!owner->segment() || !owner->staff()) {
+        return ownerShape;
+    }
+
+    Shape result;
+    const track_idx_t startTrack = staff2track(owner->staffIdx());
+    const track_idx_t endTrack = startTrack + VOICES;
+
+    for (track_idx_t track = startTrack; track < endTrack; ++track) {
+        EngravingItem* e = owner->segment()->element(track);
+        if (!e || !e->isChord()) {
+            continue;
+        }
+
+        Chord* chord = toChord(e);
+        if (chord->vStaffIdx() != owner->vStaffIdx()) {
+            continue;
+        }
+
+        Shape chordShape = chord->shape();
+        chordShape.removeTypes({ ElementType::CHORD_BRACKET, ElementType::ARPEGGIO });
+        chordShape.translate(chord->pos() - owner->pos());
+        result.add(chordShape);
+    }
+
+    return result.empty() ? ownerShape : result;
+}
+
 void TLayout::layoutChordBracket(const ChordBracket* item, Arpeggio::LayoutData* ldata, const LayoutConfiguration& conf)
 {
     double spatium = item->spatium();
@@ -896,8 +929,7 @@ void TLayout::layoutChordBracket(const ChordBracket* item, Arpeggio::LayoutData*
     const Note* upnote = item->chord()->upNote();
     ldata->setPosY(upnote->y() + upnote->ldata()->bbox().top());
 
-    Shape chordShape = item->chord()->shape();
-    chordShape.removeTypes({ ElementType::CHORD_BRACKET, ElementType::ARPEGGIO });
+    Shape chordShape = chordBracketObstacleShape(item);
     Shape itemShape = item->shape().translated(PointF(0.0, item->ldata()->pos().y()));
     if (item->rightSide()) {
         double x = HorizontalSpacing::minHorizontalDistance(chordShape, itemShape, spatium);


### PR DESCRIPTION
Resolves: #33883  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Chord bracket placement previously used only the owning chord shape, so accidentals from another voice in the same segment/staff could be ignored.
This change includes chord shapes from other voices in the same segment and owning staff, restricted to the same visual staff.

https://github.com/user-attachments/assets/70d736c4-c3c4-4a3e-ae87-73c61028ff5e

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->
- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->9zu8co
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).