### PR TITLE
Fix macOS compile of scorecomp.cpp: cast size_t to uint64_t for TextStream

### DIFF
--- a/src/engraving/tests/utils/scorecomp.cpp
+++ b/src/engraving/tests/utils/scorecomp.cpp
@@ -216,13 +216,13 @@ bool ScoreComp::compareFiles(const String& fullPath1, const String& fullPath2)
         const size_t headerStart1 = start1Set ? start1 + 1 : 0;
         const size_t headerStart2 = start2Set ? start2 + 1 : 0;
 
-        ts << "@@ -" << headerStart1;
+        ts << "@@ -" << static_cast<uint64_t>(headerStart1);
         if (count1 != 1) {
-            ts << "," << count1;
+            ts << "," << static_cast<uint64_t>(count1);
         }
-        ts << " +" << headerStart2;
+        ts << " +" << static_cast<uint64_t>(headerStart2);
         if (count2 != 1) {
-            ts << "," << count2;
+            ts << "," << static_cast<uint64_t>(count2);
         }
         ts << " @@\n";
 


### PR DESCRIPTION
Resolves: #33987

`ScoreComp::compareFiles` writes `size_t` diff-header values into a `muse::TextStream`, which has no `size_t` overload, so on macOS the call is ambiguous and the unit tests fail to compile. Cast the four values to `uint64_t` at the call sites. No behaviour change (on Linux it already resolved to the `uint64_t` overload).

- [x] I signed the [CLA](https://musescore.org/en/cla) (regular contributor)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable). Not applicable: compile-only fix; the existing engraving tests now build on macOS.
