### PR TITLE
[4.7.4] Restore old note name plugin behaviour

### DIFF
--- a/share/plugins/note_names/notenames.qml
+++ b/share/plugins/note_names/notenames.qml
@@ -137,7 +137,7 @@ MuseScore {
                 // Then apply new names
                 var text = newElement(Element.TEXT) // This adds the text to the note: Better for grace notes and easier to remove
                 text.text = nameNote(note)
-                text.autoplace = false
+                text.subStyle = Tid.STAFF
                 if (note.noteType != NoteType.NORMAL) {
                     text.fontSize *= curScore.style.value("graceNoteMag")
                 }

--- a/share/plugins/tuning/tuning.qml
+++ b/share/plugins/tuning/tuning.qml
@@ -255,6 +255,7 @@ MuseScore {
                 for (var j in chord.notes) {
                     var note = chord.notes[j]
                     var text = newElement(Element.TEXT) // This adds the text to the note: Better for grace notes and easier to remove
+                    text.subStyle = Tid.STAFF
                     text.text = note.tuning.toString()
                     text.fontSize *= curScore.style.value("smallNoteMag")
                                      // * (chord.noteType != NoteType.NORMAL ? curScore.style.value("graceNoteMag") : 1)


### PR DESCRIPTION
Resolves: #33886 
This makes sure the text has the staff text style and that autoplace is enabled.