### PR TITLE
Remove `EditData` parameter from undo/redo methods

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -551,7 +551,7 @@ void MasterScore::initAndAddExcerpt(Excerpt* excerpt, bool fakeUndo)
 
     auto excerptCmd = new AddExcerpt(excerpt);
     if (fakeUndo) {
-        excerptCmd->redo(nullptr);
+        excerptCmd->redo();
     } else {
         excerpt->excerptScore()->undo(excerptCmd);
     }

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -167,10 +167,10 @@ bool Lyrics::isMelisma() const
 //   paste
 //---------------------------------------------------------
 
-void Lyrics::paste(EditData& ed, const String& txt)
+void Lyrics::paste(const String& txt)
 {
     if (txt.startsWith('<') && txt.contains('>')) {
-        TextBase::paste(ed, txt);
+        TextBase::paste(txt);
         return;
     }
 
@@ -183,14 +183,14 @@ void Lyrics::paste(EditData& ed, const String& txt)
     StringList hyph = sl.at(0).split(u'-');
     score()->startCmd(TranslatableString("undoableAction", "Paste lyrics"));
 
-    deleteSelectedText(ed);
+    deleteSelectedText();
 
     if (hyph.size() > 1) {
-        score()->undo(new InsertText(cursorFromEditData(ed), hyph[0]), &ed);
+        score()->undo(new InsertText(cursor(), hyph[0]));
         hyph.removeAt(0);
         sl[0] =  hyph.join(u"-");
     } else if (sl.size() > 1 && sl[1] == u"-") {
-        score()->undo(new InsertText(cursorFromEditData(ed), sl[0]), &ed);
+        score()->undo(new InsertText(cursor(), sl[0]));
         sl.removeAt(0);
         sl.removeAt(0);
     } else if (sl[0].startsWith(u"_")) {
@@ -200,17 +200,17 @@ void Lyrics::paste(EditData& ed, const String& txt)
         }
     } else if (sl[0].contains(u"_")) {
         size_t p = sl[0].indexOf(u'_');
-        score()->undo(new InsertText(cursorFromEditData(ed), sl[0]), &ed);
+        score()->undo(new InsertText(cursor(), sl[0]));
         sl[0] = sl[0].mid(p + 1);
         if (sl[0].isEmpty()) {
             sl.removeAt(0);
         }
     } else if (sl.size() > 1 && sl[1] == "_") {
-        score()->undo(new InsertText(cursorFromEditData(ed), sl[0]), &ed);
+        score()->undo(new InsertText(cursor(), sl[0]));
         sl.removeAt(0);
         sl.removeAt(0);
     } else {
-        score()->undo(new InsertText(cursorFromEditData(ed), sl[0]), &ed);
+        score()->undo(new InsertText(cursor(), sl[0]));
         sl.removeAt(0);
     }
 

--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -91,7 +91,7 @@ public:
     bool allowTimeAnchor() const override { return false; }
 
     using EngravingObject::undoChangeProperty;
-    void paste(EditData& ed, const String& txt) override;
+    void paste(const String& txt) override;
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -506,7 +506,7 @@ public:
     void undoPropertyChanged(EngravingObject*, Pid, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
     UndoStack* undoStack() const;
     TransactionManager* transactionManager() const;
-    void undo(UndoableCommand*, EditData* = nullptr) const;
+    void undo(UndoableCommand*) const;
     void undoRemoveMeasures(Measure*, Measure*, bool preserveTies = false, bool moveStaffTypeChanges = true);
     void undoChangeMeasureRepeatCount(Measure* m, int count, staff_idx_t staffIdx);
     void undoAddBracket(Staff* staff, size_t level, BracketType type, size_t span);

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -462,7 +462,7 @@ void TextCursor::setFormat(FormatId id, FormatValue val)
 {
     if (!hasSelection()) {
         if (!editing()) {
-            m_text->selectAll(this);
+            m_text->selectAll();
         } else if (format()->formatValue(id) == val) {
             return;
         }
@@ -2148,27 +2148,27 @@ void TextBase::genText()
 //   selectAll
 //---------------------------------------------------------
 
-void TextBase::selectAll(TextCursor* cursor)
+void TextBase::selectAll()
 {
     const LayoutData* ldata = this->ldata();
     if (!ldata || ldata->blocks.empty()) {
         return;
     }
 
-    cursor->setSelectColumn(0);
-    cursor->setSelectLine(0);
-    cursor->setRow(ldata->rows() - 1);
-    cursor->setColumn(cursor->curLine().columns());
+    cursor()->setSelectColumn(0);
+    cursor()->setSelectLine(0);
+    cursor()->setRow(ldata->rows() - 1);
+    cursor()->setColumn(cursor()->curLine().columns());
 }
 
-void TextBase::select(EditData& editData, SelectTextType type)
+void TextBase::select(SelectTextType type)
 {
     switch (type) {
     case SelectTextType::Word:
-        cursorFromEditData(editData)->selectWord();
+        cursor()->selectWord();
         break;
     case SelectTextType::All:
-        selectAll(cursorFromEditData(editData));
+        selectAll();
         break;
     }
 }
@@ -2210,9 +2210,7 @@ RectF TextBase::pageRectangle() const
 
 void TextBase::dragTo(EditData& ed)
 {
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-    cursor->set(ed.pos, TextCursor::MoveMode::KeepAnchor);
+    cursor()->set(ed.pos, TextCursor::MoveMode::KeepAnchor);
     score()->setUpdateAll();
     score()->update();
 }
@@ -2241,8 +2239,7 @@ std::vector<LineF> TextBase::dragAnchorLines() const
 bool TextBase::mousePress(EditData& ed)
 {
     bool shift = ed.modifiers & ShiftModifier;
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    if (!ted->cursor()->set(ed.startMove, shift ? TextCursor::MoveMode::KeepAnchor : TextCursor::MoveMode::MoveAnchor)) {
+    if (!cursor()->set(ed.startMove, shift ? TextCursor::MoveMode::KeepAnchor : TextCursor::MoveMode::MoveAnchor)) {
         return false;
     }
 
@@ -3105,11 +3102,10 @@ void TextBase::endDrag(EditData& ed)
 void TextBase::editCut(EditData& ed)
 {
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-    String s = cursor->selectedText(true);
+    String s = cursor()->selectedText(true);
 
     if (!s.isEmpty()) {
-        ted->selectedText = cursor->selectedText(true);
+        ted->selectedText = cursor()->selectedText(true);
         ed.curGrip = Grip::START;
         ed.key     = Key_Delete;
         ed.s       = String();
@@ -3127,9 +3123,8 @@ void TextBase::editCopy(EditData& ed)
     // store selection as rich and plain text
     //
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-    ted->selectedText = cursor->selectedText(true);
-    ted->selectedPlainText = cursor->selectedText(false);
+    ted->selectedText = cursor()->selectedText(true);
+    ted->selectedPlainText = cursor()->selectedText(false);
 }
 
 bool TextBase::nudge(const EditData& ed)
@@ -3155,17 +3150,6 @@ bool TextBase::nudge(const EditData& ed)
     }
     undoChangeProperty(Pid::OFFSET, offset() + addOffset, PropertyFlags::UNSTYLED);
     return true;
-}
-
-//---------------------------------------------------------
-//   cursor
-//---------------------------------------------------------
-
-TextCursor* TextBase::cursorFromEditData(const EditData& ed)
-{
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    assert(ted);
-    return ted->cursor();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -330,7 +330,7 @@ public:
     String plainText() const;
     void resetFormatting();
 
-    void insertText(EditData&, const String&);
+    void insertText(const String&);
 
     double lineSpacing() const;
     double lineHeight() const;
@@ -360,19 +360,19 @@ public:
     virtual void endEdit(EditData&) override;
     virtual RectF drag(EditData&) override;
     virtual void endDrag(EditData&) override;
-    void movePosition(EditData&, TextCursor::MoveOperation);
+    void movePosition(TextCursor::MoveOperation);
 
     bool mousePress(EditData& ed);
     void dragTo(EditData& ed);
 
-    bool deleteSelectedText(EditData&);
+    bool deleteSelectedText();
 
-    void selectAll(TextCursor*);
-    void select(EditData&, SelectTextType);
+    void selectAll();
+    void select(SelectTextType);
     bool isPrimed() const { return m_primed; }
     void setPrimed(bool primed) { m_primed = primed; }
 
-    virtual void paste(EditData& ed, const String& txt);
+    virtual void paste(const String& txt);
 
     RectF pageRectangle() const;
 
@@ -399,7 +399,7 @@ public:
 
     static bool validateText(String& s);
     bool inHexState() const { return m_hexState >= 0; }
-    void endHexState(EditData&);
+    void endHexState();
 
     muse::draw::Font font() const;
     muse::draw::FontMetrics fontMetrics() const;
@@ -414,7 +414,6 @@ public:
     void styleChanged() override;
     void editInsertText(TextCursor*, const String&);
 
-    TextCursor* cursorFromEditData(const EditData&);
     TextCursor* cursor() const { return m_cursor; }
 
     void setTextInvalid() { m_textInvalid = true; }
@@ -531,7 +530,7 @@ protected:
 
     bool nudge(const EditData& ed);
 
-    void insertSym(EditData& ed, SymId id);
+    void insertSym(SymId id);
     void prepareFormat(const String& token, TextCursor& cursor);
     bool prepareFormat(const String& token, CharFormat& format);
 

--- a/src/engraving/editing/addremoveelement.cpp
+++ b/src/engraving/editing/addremoveelement.cpp
@@ -108,7 +108,7 @@ void AddElement::endUndoRedo(bool isUndo) const
     }
 }
 
-void AddElement::undo(EditData*)
+void AddElement::undo()
 {
     Score* score = element->score();
 
@@ -119,7 +119,7 @@ void AddElement::undo(EditData*)
     endUndoRedo(true);
 }
 
-void AddElement::redo(EditData*)
+void AddElement::redo()
 {
     Score* score = element->score();
 
@@ -241,7 +241,7 @@ void RemoveElement::cleanup(bool wasDone)
     }
 }
 
-void RemoveElement::undo(EditData*)
+void RemoveElement::undo()
 {
     Score* score = element->score();
 
@@ -264,7 +264,7 @@ void RemoveElement::undo(EditData*)
     }
 }
 
-void RemoveElement::redo(EditData*)
+void RemoveElement::redo()
 {
     Score* score = element->score();
 
@@ -329,7 +329,7 @@ ChangeElement::ChangeElement(EngravingItem* oe, EngravingItem* ne)
     newElement = ne;
 }
 
-void ChangeElement::flip(EditData*)
+void ChangeElement::flip()
 {
     const LinkedObjects* links = oldElement->links();
     if (links) {
@@ -390,7 +390,7 @@ void ChangeElement::flip(EditData*)
 //   ChangeParent
 //---------------------------------------------------------
 
-void ChangeParent::flip(EditData*)
+void ChangeParent::flip()
 {
     EngravingItem* p = element->parentItem();
     staff_idx_t si = element->staffIdx();
@@ -473,7 +473,7 @@ Unlink::Unlink(EngravingObject* _e)
     assert(le);
 }
 
-void ChangeSegmentParent::flip(EditData*)
+void ChangeSegmentParent::flip()
 {
     Measure* p = segment->measure();
     Fraction oldTick = segment->rtick();

--- a/src/engraving/editing/addremoveelement.h
+++ b/src/engraving/editing/addremoveelement.h
@@ -34,8 +34,8 @@ class AddElement : public UndoableCommand
     EngravingItem* element = nullptr;
 
     void endUndoRedo(bool) const;
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
 public:
     AddElement(EngravingItem*);
@@ -58,8 +58,8 @@ class RemoveElement : public UndoableCommand
 
 public:
     RemoveElement(EngravingItem*);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool) override;
     const char* name() const override;
 
@@ -77,7 +77,7 @@ class ChangeElement : public UndoableCommand
     EngravingItem* oldElement = nullptr;
     EngravingItem* newElement = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeElement(EngravingItem* oldElement, EngravingItem* newElement);
@@ -95,7 +95,7 @@ class ChangeParent : public UndoableCommand
     EngravingItem* parent = nullptr;
     staff_idx_t staffIdx = muse::nidx;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeParent(EngravingItem* e, EngravingItem* p, staff_idx_t si)
@@ -114,7 +114,7 @@ class ChangeSegmentParent : public UndoableCommand
     Measure* parent = nullptr;
     Fraction tick;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeSegmentParent(Segment* s, Measure* p, Fraction t)
@@ -148,8 +148,8 @@ class Unlink : public LinkUnlink
     OBJECT_ALLOCATOR(engraving, Unlink)
 public:
     Unlink(EngravingObject*);
-    void undo(EditData*) override { link(); }
-    void redo(EditData*) override { unlink(); }
+    void undo() override { link(); }
+    void redo() override { unlink(); }
 
     UNDO_TYPE(CommandType::Unlink)
     UNDO_NAME("Unlink")
@@ -161,8 +161,8 @@ class Link : public LinkUnlink
 public:
     Link(EngravingObject*, EngravingObject*);
 
-    void undo(EditData*) override { unlink(); }
-    void redo(EditData*) override { link(); }
+    void undo() override { unlink(); }
+    void redo() override { link(); }
 
     UNDO_TYPE(CommandType::Link)
     UNDO_NAME("Link")

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -353,7 +353,7 @@ void Score::endCmd(bool rollback, bool layoutAllParts)
 //    Deprecated: use Transaction::push instead.
 //---------------------------------------------------------
 
-void Score::undo(UndoableCommand* cmd, EditData* ed) const
+void Score::undo(UndoableCommand* cmd) const
 {
     Transaction* tx = masterScore()->transactionManager()->currentTransaction();
     if (!tx) {
@@ -362,12 +362,12 @@ void Score::undo(UndoableCommand* cmd, EditData* ed) const
             LOGW() << "called outside of transaction";
         }
 
-        cmd->redo(ed);
+        cmd->redo();
         delete cmd;
         return;
     }
 
-    tx->push(cmd, ed);
+    tx->push(cmd);
 }
 
 #ifndef NDEBUG

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -5173,7 +5173,7 @@ bool Score::undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyV
         switch (propertyPropagate) {
         case PropertyPropagation::PROPAGATE:
             if (linkedItem->getProperty(propId) != currentPropValue) {
-                tx.push(new ChangeProperty(linkedItem, propId, currentPropValue, propFlags), nullptr);
+                tx.push(new ChangeProperty(linkedItem, propId, currentPropValue, propFlags));
                 changed = true;
             }
             break;

--- a/src/engraving/editing/editbrackets.cpp
+++ b/src/engraving/editing/editbrackets.cpp
@@ -30,14 +30,14 @@ using namespace mu::engraving;
 //   AddBracket
 //---------------------------------------------------------
 
-void AddBracket::redo(EditData*)
+void AddBracket::redo()
 {
     staff->setBracketType(level, bracketType);
     staff->setBracketSpan(level, span);
     staff->triggerLayout();
 }
 
-void AddBracket::undo(EditData*)
+void AddBracket::undo()
 {
     staff->setBracketType(level, BracketType::NO_BRACKET);
     staff->triggerLayout();
@@ -47,13 +47,13 @@ void AddBracket::undo(EditData*)
 //   RemoveBracket
 //---------------------------------------------------------
 
-void RemoveBracket::redo(EditData*)
+void RemoveBracket::redo()
 {
     staff->setBracketType(level, BracketType::NO_BRACKET);
     staff->triggerLayout();
 }
 
-void RemoveBracket::undo(EditData*)
+void RemoveBracket::undo()
 {
     staff->setBracketType(level, bracketType);
     staff->setBracketSpan(level, span);

--- a/src/engraving/editing/editbrackets.h
+++ b/src/engraving/editing/editbrackets.h
@@ -36,8 +36,8 @@ class RemoveBracket : public UndoableCommand
     BracketType bracketType = BracketType::NORMAL;
     size_t span = 0;
 
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
 public:
     RemoveBracket(Staff* s, size_t l, BracketType t, size_t sp)
@@ -57,8 +57,8 @@ class AddBracket : public UndoableCommand
     BracketType bracketType = BracketType::NORMAL;
     size_t span = 0;
 
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
 public:
     AddBracket(Staff* s, size_t l, BracketType t, size_t sp)

--- a/src/engraving/editing/editchord.cpp
+++ b/src/engraving/editing/editchord.cpp
@@ -342,7 +342,7 @@ void EditChord::doRemoveAllNoteParentheses(Chord* chord, Parenthesis* leftParen)
 //   ChangeChordStaffMove
 //---------------------------------------------------------
 
-void ChangeChordStaffMove::flip(EditData*)
+void ChangeChordStaffMove::flip()
 {
     int v = chordRest->staffMove();
     staff_idx_t oldStaff = chordRest->vStaffIdx();
@@ -370,7 +370,7 @@ void ChangeChordStaffMove::flip(EditData*)
 //   SwapCR
 //---------------------------------------------------------
 
-void SwapCR::flip(EditData*)
+void SwapCR::flip()
 {
     Segment* s1 = cr1->segment();
     Segment* s2 = cr2->segment();
@@ -396,7 +396,7 @@ void SwapCR::flip(EditData*)
 //   ChangeSpanArpeggio
 //---------------------------------------------------------
 
-void ChangeSpanArpeggio::flip(EditData*)
+void ChangeSpanArpeggio::flip()
 {
     Arpeggio* f_spanArp = m_chord->spanArpeggio();
 
@@ -404,14 +404,14 @@ void ChangeSpanArpeggio::flip(EditData*)
     m_spanArpeggio = f_spanArp;
 }
 
-void AddNoteParenthesisInfo::redo(EditData*)
+void AddNoteParenthesisInfo::redo()
 {
     m_chord->addNoteParenthesisInfo(m_noteParenInfo);
 
     m_chord->triggerLayout();
 }
 
-void mu::engraving::AddNoteParenthesisInfo::undo(EditData*)
+void mu::engraving::AddNoteParenthesisInfo::undo()
 {
     m_chord->removeNoteParenthesisInfo(m_noteParenInfo);
 
@@ -426,14 +426,14 @@ void AddNoteParenthesisInfo::cleanup(bool wasDone)
     }
 }
 
-void RemoveNoteParenthesisInfo::redo(EditData*)
+void RemoveNoteParenthesisInfo::redo()
 {
     m_chord->removeNoteParenthesisInfo(m_noteParenInfo);
 
     m_chord->triggerLayout();
 }
 
-void RemoveNoteParenthesisInfo::undo(EditData*)
+void RemoveNoteParenthesisInfo::undo()
 {
     m_chord->addNoteParenthesisInfo(m_noteParenInfo);
 
@@ -448,14 +448,14 @@ void RemoveNoteParenthesisInfo::cleanup(bool wasDone)
     }
 }
 
-void RemoveSingleNoteParentheses::redo(EditData*)
+void RemoveSingleNoteParentheses::redo()
 {
     m_chord->removeNoteFromParenthesisInfo(m_note, m_paren);
 
     m_chord->triggerLayout();
 }
 
-void RemoveSingleNoteParentheses::undo(EditData*)
+void RemoveSingleNoteParentheses::undo()
 {
     m_chord->addNoteToParenthesisInfo(m_note, m_paren);
 

--- a/src/engraving/editing/editchord.h
+++ b/src/engraving/editing/editchord.h
@@ -61,7 +61,7 @@ class ChangeChordStaffMove : public UndoableCommand
     ChordRest* chordRest = nullptr;
     int staffMove = 0;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeChordStaffMove(ChordRest* cr, int v)
@@ -79,7 +79,7 @@ class SwapCR : public UndoableCommand
     ChordRest* cr1 = nullptr;
     ChordRest* cr2 = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     SwapCR(ChordRest* a, ChordRest* b)
@@ -97,7 +97,7 @@ class ChangeSpanArpeggio : public UndoableCommand
     Chord* m_chord = nullptr;
     Arpeggio* m_spanArpeggio = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 public:
     ChangeSpanArpeggio(Chord* chord, Arpeggio* spanArp)
         : m_chord(chord), m_spanArpeggio(spanArp) {}
@@ -110,8 +110,8 @@ class AddNoteParenthesisInfo : public UndoableCommand
 {
     OBJECT_ALLOCATOR(engraving, AddNoteParenthesisInfo)
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
     void cleanup(bool wasDone) override;
 
@@ -130,8 +130,8 @@ class RemoveNoteParenthesisInfo : public UndoableCommand
 {
     OBJECT_ALLOCATOR(engraving, RemoveNoteParenthesisInfo)
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
     void cleanup(bool wasDone) override;
 
@@ -154,8 +154,8 @@ class RemoveSingleNoteParentheses : public UndoableCommand
     Note* m_note = nullptr;
     Parenthesis* m_paren = nullptr;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     RemoveSingleNoteParentheses(Chord* chord, Note* note, Parenthesis* paren)

--- a/src/engraving/editing/editclef.cpp
+++ b/src/engraving/editing/editclef.cpp
@@ -74,7 +74,7 @@ ChangeClefType::ChangeClefType(Clef* c, ClefType cl, ClefType tc)
     transposingClef = tc;
 }
 
-void ChangeClefType::flip(EditData*)
+void ChangeClefType::flip()
 {
     ClefType ocl = clef->concertClef();
     ClefType otc = clef->transposingClef();

--- a/src/engraving/editing/editclef.h
+++ b/src/engraving/editing/editclef.h
@@ -35,7 +35,7 @@ class ChangeClefType : public UndoableCommand
     ClefType concertClef;
     ClefType transposingClef;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeClefType(Clef*, ClefType cl, ClefType tc);

--- a/src/engraving/editing/editexcerpt.cpp
+++ b/src/engraving/editing/editexcerpt.cpp
@@ -40,13 +40,13 @@ AddExcerpt::~AddExcerpt()
     }
 }
 
-void AddExcerpt::undo(EditData*)
+void AddExcerpt::undo()
 {
     deleteExcerpt = true;
     excerpt->masterScore()->removeExcerpt(excerpt);
 }
 
-void AddExcerpt::redo(EditData*)
+void AddExcerpt::redo()
 {
     deleteExcerpt = false;
     excerpt->masterScore()->addExcerpt(excerpt);
@@ -81,13 +81,13 @@ RemoveExcerpt::~RemoveExcerpt()
     }
 }
 
-void RemoveExcerpt::undo(EditData*)
+void RemoveExcerpt::undo()
 {
     deleteExcerpt = false;
     excerpt->masterScore()->addExcerpt(excerpt, index);
 }
 
-void RemoveExcerpt::redo(EditData*)
+void RemoveExcerpt::redo()
 {
     deleteExcerpt = true;
     excerpt->masterScore()->removeExcerpt(excerpt);
@@ -108,7 +108,7 @@ std::vector<EngravingObject*> RemoveExcerpt::objectItems() const
 //   SwapExcerpt
 //---------------------------------------------------------
 
-void SwapExcerpt::flip(EditData*)
+void SwapExcerpt::flip()
 {
     Excerpt* tmp = score->excerpts().at(pos1);
     score->excerpts()[pos1] = score->excerpts().at(pos2);
@@ -120,7 +120,7 @@ void SwapExcerpt::flip(EditData*)
 //   ChangeExcerptTitle
 //---------------------------------------------------------
 
-void ChangeExcerptTitle::flip(EditData*)
+void ChangeExcerptTitle::flip()
 {
     String s = title;
     title = excerpt->name();
@@ -139,7 +139,7 @@ AddPartToExcerpt::AddPartToExcerpt(Excerpt* e, Part* p, size_t targetPartIdx)
     assert(m_part);
 }
 
-void AddPartToExcerpt::undo(EditData*)
+void AddPartToExcerpt::undo()
 {
     muse::remove(m_excerpt->parts(), m_part);
 
@@ -148,7 +148,7 @@ void AddPartToExcerpt::undo(EditData*)
     }
 }
 
-void AddPartToExcerpt::redo(EditData*)
+void AddPartToExcerpt::redo()
 {
     std::vector<Part*>& excerptParts = m_excerpt->parts();
     if (m_targetPartIdx < excerptParts.size()) {

--- a/src/engraving/editing/editexcerpt.h
+++ b/src/engraving/editing/editexcerpt.h
@@ -40,8 +40,8 @@ public:
     AddExcerpt(Excerpt* ex);
     ~AddExcerpt() override;
 
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     std::vector<EngravingObject*> objectItems() const override;
 
@@ -61,8 +61,8 @@ public:
     RemoveExcerpt(Excerpt* ex);
     ~RemoveExcerpt() override;
 
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     std::vector<EngravingObject*> objectItems() const override;
 
@@ -78,7 +78,7 @@ class SwapExcerpt : public UndoableCommand
     int pos1 = 0;
     int pos2 = 0;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     SwapExcerpt(MasterScore* s, int p1, int p2)
@@ -96,7 +96,7 @@ class ChangeExcerptTitle : public UndoableCommand
     Excerpt* excerpt = nullptr;
     String title;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeExcerptTitle(Excerpt* x, const String& t)
@@ -116,8 +116,8 @@ class AddPartToExcerpt : public UndoableCommand
 
 public:
     AddPartToExcerpt(Excerpt* e, Part* p, size_t targetPartIdx);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool wasDone) override;
 
     UNDO_TYPE(CommandType::AddPartToExcerpt)

--- a/src/engraving/editing/editfretboarddiagram.cpp
+++ b/src/engraving/editing/editfretboarddiagram.cpp
@@ -86,14 +86,14 @@ void FretUndoData::updateDiagram()
 //   FretDataChange
 //---------------------------------------------------------
 
-void FretDataChange::redo(EditData*)
+void FretDataChange::redo()
 {
     m_undoData = FretUndoData(m_diagram);
 
     m_diagram->updateDiagram(m_harmonyName);
 }
 
-void FretDataChange::undo(EditData*)
+void FretDataChange::undo()
 {
     m_undoData.updateDiagram();
 }
@@ -102,7 +102,7 @@ void FretDataChange::undo(EditData*)
 //   FretDot
 //---------------------------------------------------------
 
-void FretDot::redo(EditData*)
+void FretDot::redo()
 {
     undoData = FretUndoData(diagram);
 
@@ -110,7 +110,7 @@ void FretDot::redo(EditData*)
     diagram->triggerLayout();
 }
 
-void FretDot::undo(EditData*)
+void FretDot::undo()
 {
     undoData.updateDiagram();
     diagram->triggerLayout();
@@ -120,7 +120,7 @@ void FretDot::undo(EditData*)
 //   FretMarker
 //---------------------------------------------------------
 
-void FretMarker::redo(EditData*)
+void FretMarker::redo()
 {
     undoData = FretUndoData(diagram);
 
@@ -128,7 +128,7 @@ void FretMarker::redo(EditData*)
     diagram->triggerLayout();
 }
 
-void FretMarker::undo(EditData*)
+void FretMarker::undo()
 {
     undoData.updateDiagram();
     diagram->triggerLayout();
@@ -138,7 +138,7 @@ void FretMarker::undo(EditData*)
 //   FretBarre
 //---------------------------------------------------------
 
-void FretBarre::redo(EditData*)
+void FretBarre::redo()
 {
     undoData = FretUndoData(diagram);
 
@@ -146,7 +146,7 @@ void FretBarre::redo(EditData*)
     diagram->triggerLayout();
 }
 
-void FretBarre::undo(EditData*)
+void FretBarre::undo()
 {
     undoData.updateDiagram();
     diagram->triggerLayout();
@@ -156,7 +156,7 @@ void FretBarre::undo(EditData*)
 //   FretClear
 //---------------------------------------------------------
 
-void FretClear::redo(EditData*)
+void FretClear::redo()
 {
     undoData = FretUndoData(diagram);
 
@@ -164,7 +164,7 @@ void FretClear::redo(EditData*)
     diagram->triggerLayout();
 }
 
-void FretClear::undo(EditData*)
+void FretClear::undo()
 {
     undoData.updateDiagram();
     diagram->triggerLayout();
@@ -179,13 +179,13 @@ AddFretDiagramToFretBox::AddFretDiagramToFretBox(FretDiagram* f, size_t idx)
 {
 }
 
-void AddFretDiagramToFretBox::redo(EditData*)
+void AddFretDiagramToFretBox::redo()
 {
     FBox* fbox = toFBox(m_fretDiagram->parent());
     fbox->addAtIdx(m_fretDiagram, m_idx);
 }
 
-void AddFretDiagramToFretBox::undo(EditData*)
+void AddFretDiagramToFretBox::undo()
 {
     FBox* fbox = toFBox(m_fretDiagram->parent());
     fbox->remove(m_fretDiagram);
@@ -203,13 +203,13 @@ RemoveFretDiagramFromFretBox::RemoveFretDiagramFromFretBox(FretDiagram* f)
     m_idx = muse::indexOf(el, m_fretDiagram);
 }
 
-void RemoveFretDiagramFromFretBox::redo(EditData*)
+void RemoveFretDiagramFromFretBox::redo()
 {
     FBox* fbox = toFBox(m_fretDiagram->parent());
     fbox->remove(m_fretDiagram);
 }
 
-void RemoveFretDiagramFromFretBox::undo(EditData*)
+void RemoveFretDiagramFromFretBox::undo()
 {
     FBox* fbox = toFBox(m_fretDiagram->parent());
     fbox->addAtIdx(m_fretDiagram, m_idx);

--- a/src/engraving/editing/editfretboarddiagram.h
+++ b/src/engraving/editing/editfretboarddiagram.h
@@ -59,8 +59,8 @@ class FretDataChange : public UndoableCommand
     FretUndoData m_undoData;
     String m_harmonyName;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     FretDataChange(FretDiagram* d, const String& harmonyName)
@@ -84,8 +84,8 @@ class FretDot : public UndoableCommand
     FretDotType dtype;
     FretUndoData undoData;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     FretDot(FretDiagram* d, int _string, int _fret, bool _add = false, FretDotType _dtype = FretDotType::NORMAL)
@@ -105,8 +105,8 @@ class FretMarker : public UndoableCommand
     FretMarkerType mtype;
     FretUndoData undoData;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     FretMarker(FretDiagram* d, int _string, FretMarkerType _mtype)
@@ -127,8 +127,8 @@ class FretBarre : public UndoableCommand
     bool add = 0;
     FretUndoData undoData;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     FretBarre(FretDiagram* d, int _string, int _fret, bool _add = false)
@@ -146,8 +146,8 @@ class FretClear : public UndoableCommand
     FretDiagram* diagram = nullptr;
     FretUndoData undoData;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     FretClear(FretDiagram* d)
@@ -165,8 +165,8 @@ class AddFretDiagramToFretBox : public UndoableCommand
     FretDiagram* m_fretDiagram = nullptr;
     size_t m_idx = muse::nidx;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     AddFretDiagramToFretBox(FretDiagram* f, size_t idx);
@@ -183,8 +183,8 @@ class RemoveFretDiagramFromFretBox : public UndoableCommand
     FretDiagram* m_fretDiagram = nullptr;
     size_t m_idx = muse::nidx;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     RemoveFretDiagramFromFretBox(FretDiagram* f);

--- a/src/engraving/editing/editharppedaldiagram.cpp
+++ b/src/engraving/editing/editharppedaldiagram.cpp
@@ -34,7 +34,7 @@ using namespace mu::engraving;
 //   ChangeHarpPedalState
 //---------------------------------------------------------
 
-void ChangeHarpPedalState::flip(EditData*)
+void ChangeHarpPedalState::flip()
 {
     std::array<PedalPosition, HARP_STRING_NO> f_state = diagram->getPedalState();
     if (f_state == pedalState) {
@@ -68,7 +68,7 @@ std::vector<EngravingObject*> ChangeHarpPedalState::objectItems() const
 //   ChangeSingleHarpPedal
 //---------------------------------------------------------
 
-void ChangeSingleHarpPedal::flip(EditData*)
+void ChangeSingleHarpPedal::flip()
 {
     HarpStringType f_type = type;
     PedalPosition f_pos = diagram->getPedalState()[type];

--- a/src/engraving/editing/editharppedaldiagram.h
+++ b/src/engraving/editing/editharppedaldiagram.h
@@ -33,7 +33,7 @@ class ChangeHarpPedalState : public UndoableCommand
     HarpPedalDiagram* diagram;
     std::array<PedalPosition, HARP_STRING_NO> pedalState;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeHarpPedalState(HarpPedalDiagram* _diagram, std::array<PedalPosition, HARP_STRING_NO> _pedalState)
@@ -52,7 +52,7 @@ class ChangeSingleHarpPedal : public UndoableCommand
     HarpStringType type;
     PedalPosition pos;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeSingleHarpPedal(HarpPedalDiagram* _diagram, HarpStringType _type, PedalPosition _pos)

--- a/src/engraving/editing/editinstrumentchange.cpp
+++ b/src/engraving/editing/editinstrumentchange.cpp
@@ -36,7 +36,7 @@ using namespace mu::engraving;
 //   ChangeInstrument
 //---------------------------------------------------------
 
-void ChangeInstrument::flip(EditData*)
+void ChangeInstrument::flip()
 {
     Part* part = is->staff()->part();
     Fraction tickStart = is->segment()->tick();

--- a/src/engraving/editing/editinstrumentchange.h
+++ b/src/engraving/editing/editinstrumentchange.h
@@ -35,7 +35,7 @@ class ChangeInstrument : public UndoableCommand
     InstrumentChange* is = nullptr;
     Instrument* instrument = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeInstrument(InstrumentChange* _is, Instrument* i)

--- a/src/engraving/editing/editkeysig.cpp
+++ b/src/engraving/editing/editkeysig.cpp
@@ -37,7 +37,7 @@ ChangeKeySig::ChangeKeySig(KeySig* k, KeySigEvent newKeySig, bool sc, bool addEv
     : keysig(k), ks(newKeySig), showCourtesy(sc), evtInStaff(addEvtToStaff)
 {}
 
-void ChangeKeySig::flip(EditData*)
+void ChangeKeySig::flip()
 {
     Segment* segment = keysig->segment();
     Fraction tick = segment->tick();

--- a/src/engraving/editing/editkeysig.h
+++ b/src/engraving/editing/editkeysig.h
@@ -37,7 +37,7 @@ class ChangeKeySig : public UndoableCommand
     bool showCourtesy = false;
     bool evtInStaff = false;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeKeySig(KeySig* k, KeySigEvent newKeySig, bool sc, bool addEvtToStaff = true);

--- a/src/engraving/editing/editmeasures.cpp
+++ b/src/engraving/editing/editmeasures.cpp
@@ -366,7 +366,7 @@ ChangeMeasureLen::ChangeMeasureLen(Measure* m, Fraction l)
     len         = l;
 }
 
-void ChangeMeasureLen::flip(EditData*)
+void ChangeMeasureLen::flip()
 {
     Fraction oLen = measure->ticks();
 
@@ -391,7 +391,7 @@ void ChangeMeasureLen::flip(EditData*)
 //   ChangeMMRest
 //---------------------------------------------------------
 
-void ChangeMMRest::flip(EditData*)
+void ChangeMMRest::flip()
 {
     Measure* mmr = m->mmRest();
     m->setMMRest(mmrest);
@@ -402,14 +402,14 @@ void ChangeMMRest::flip(EditData*)
 //   ChangeMeasureRepeatCount
 //---------------------------------------------------------
 
-void ChangeMeasureRepeatCount::flip(EditData*)
+void ChangeMeasureRepeatCount::flip()
 {
     int oldCount = m->measureRepeatCount(staffIdx);
     m->setMeasureRepeatCount(count, staffIdx);
     count = oldCount;
 }
 
-void ChangeMMRestNext::flip(EditData*)
+void ChangeMMRestNext::flip()
 {
     assert(m_mmrest->isMMRest());
     MeasureBase* oldNext = m_mmrest->next();
@@ -418,7 +418,7 @@ void ChangeMMRestNext::flip(EditData*)
     m_next = oldNext;
 }
 
-void ChangeMMRestPrev::flip(EditData*)
+void ChangeMMRestPrev::flip()
 {
     assert(m_mmrest->isMMRest());
     MeasureBase* oldPrev = m_mmrest->prev();

--- a/src/engraving/editing/editmeasures.h
+++ b/src/engraving/editing/editmeasures.h
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include "transaction/undoablecommand.h"
@@ -44,8 +45,8 @@ protected:
 public:
     InsertRemoveMeasures(MeasureBase* _fm, MeasureBase* _lm, bool _moveStc)
         : fm(_fm), lm(_lm), moveStc(_moveStc) {}
-    virtual void undo(EditData*) override = 0;
-    virtual void redo(EditData*) override = 0;
+    virtual void undo() override = 0;
+    virtual void redo() override = 0;
     UNDO_CHANGED_OBJECTS({ fm, lm })
 };
 
@@ -55,8 +56,8 @@ class RemoveMeasures : public InsertRemoveMeasures
 public:
     RemoveMeasures(MeasureBase* m1, MeasureBase* m2, bool moveStc = true)
         : InsertRemoveMeasures(m1, m2, moveStc) {}
-    void undo(EditData*) override { insertMeasures(); }
-    void redo(EditData*) override { removeMeasures(); }
+    void undo() override { insertMeasures(); }
+    void redo() override { removeMeasures(); }
 
     UNDO_TYPE(CommandType::RemoveMeasures)
     UNDO_NAME("RemoveMeasures")
@@ -68,8 +69,8 @@ class InsertMeasures : public InsertRemoveMeasures
 public:
     InsertMeasures(MeasureBase* m1, MeasureBase* m2, bool moveStc = true)
         : InsertRemoveMeasures(m1, m2, moveStc) {}
-    void redo(EditData*) override { insertMeasures(); }
-    void undo(EditData*) override { removeMeasures(); }
+    void redo() override { insertMeasures(); }
+    void undo() override { removeMeasures(); }
 
     UNDO_TYPE(CommandType::InsertMeasures)
     UNDO_NAME("InsertMeasures")
@@ -82,7 +83,7 @@ class ChangeMeasureLen : public UndoableCommand
     Measure* measure = nullptr;
     Fraction len;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMeasureLen(Measure*, Fraction);
@@ -99,7 +100,7 @@ class ChangeMMRest : public UndoableCommand
     Measure* m;
     Measure* mmrest;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMMRest(Measure* _m, Measure* _mmr)
@@ -120,7 +121,8 @@ class ChangeMMRestNext : public UndoableCommand
     Measure* m_mmrest = nullptr;
     MeasureBase* m_next = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
+
 public:
     ChangeMMRestNext(Measure* mmrest, MeasureBase* next)
         : m_mmrest(mmrest), m_next(next) {}
@@ -136,7 +138,8 @@ class ChangeMMRestPrev : public UndoableCommand
     Measure* m_mmrest = nullptr;
     MeasureBase* m_prev = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
+
 public:
     ChangeMMRestPrev(Measure* mmrest, MeasureBase* prev)
         : m_mmrest(mmrest), m_prev(prev) {}
@@ -153,7 +156,7 @@ class ChangeMeasureRepeatCount : public UndoableCommand
     int count = 0;
     staff_idx_t staffIdx = muse::nidx;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMeasureRepeatCount(Measure* _m, int _count, staff_idx_t _staffIdx)

--- a/src/engraving/editing/editnote.cpp
+++ b/src/engraving/editing/editnote.cpp
@@ -57,7 +57,7 @@ class ChangePitch : public UndoableCommand
     int tpc1 = 0;
     int tpc2 = 0;
 
-    void flip(EditData*) override
+    void flip() override
     {
         int f_pitch = note->pitch();
         int f_tpc1  = note->tpc1();
@@ -109,7 +109,7 @@ class ChangeFretting : public UndoableCommand
     int tpc1 = 0;
     int tpc2 = 0;
 
-    void flip(EditData*) override
+    void flip() override
     {
         int f_pitch = note->pitch();
         int f_string= note->string();
@@ -661,7 +661,7 @@ void EditNote::undoChangePitch(Score* score, Note* note, int pitch, int tpc1, in
 
     for (EngravingObject* e : note->linkList()) {
         Note* n = toNote(e);
-        tx.push(new ChangePitch(n, pitch, tpc1, tpc2), 0);
+        tx.push(new ChangePitch(n, pitch, tpc1, tpc2));
     }
 }
 
@@ -675,7 +675,7 @@ void EditNote::undoChangeFretting(Score* score, Note* note, int pitch, int strin
 
     for (EngravingObject* e : note->linkList()) {
         Note* n = toNote(e);
-        tx.push(new ChangeFretting(n, pitch, string, fret, tpc1, tpc2), 0);
+        tx.push(new ChangeFretting(n, pitch, string, fret, tpc1, tpc2));
     }
 }
 
@@ -688,7 +688,7 @@ ChangeVelocity::ChangeVelocity(Note* n, int o)
 {
 }
 
-void ChangeVelocity::flip(EditData*)
+void ChangeVelocity::flip()
 {
     int v = note->userVelocity();
     note->setUserVelocity(userVelocity);
@@ -699,7 +699,7 @@ void ChangeVelocity::flip(EditData*)
 //   ChangeNoteEventList::flip
 //---------------------------------------------------------
 
-void ChangeNoteEventList::flip(EditData*)
+void ChangeNoteEventList::flip()
 {
     // Get copy of current list.
     NoteEventList nel = note->playEvents();
@@ -719,7 +719,7 @@ void ChangeNoteEventList::flip(EditData*)
 //   ChangeNoteEvent::flip
 //---------------------------------------------------------
 
-void ChangeNoteEvent::flip(EditData*)
+void ChangeNoteEvent::flip()
 {
     NoteEvent e = *oldEvent;
     *oldEvent   = newEvent;
@@ -736,7 +736,7 @@ void ChangeNoteEvent::flip(EditData*)
 //   ChangeChordPlayEventType::flip
 //---------------------------------------------------------
 
-void ChangeChordPlayEventType::flip(EditData*)
+void ChangeChordPlayEventType::flip()
 {
     // Flips data between NoteEventList's.
     size_t n = chord->notes().size();

--- a/src/engraving/editing/editnote.h
+++ b/src/engraving/editing/editnote.h
@@ -59,7 +59,7 @@ class ChangeVelocity : public UndoableCommand
     Note* note = nullptr;
     int userVelocity = 0;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeVelocity(Note*, int);
@@ -77,7 +77,7 @@ class ChangeNoteEventList : public UndoableCommand
     NoteEventList newEvents;
     PlayEventType newPetype;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeNoteEventList(Note* n, NoteEventList& ne)
@@ -95,7 +95,7 @@ class ChangeNoteEvent : public UndoableCommand
     NoteEvent newEvent;
     PlayEventType newPetype;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeNoteEvent(Note* n, NoteEvent* oe, const NoteEvent& ne)
@@ -112,7 +112,7 @@ class ChangeChordPlayEventType : public UndoableCommand
     PlayEventType petype;
     std::vector<NoteEventList> events;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeChordPlayEventType(Chord* c, PlayEventType pet)

--- a/src/engraving/editing/editpart.cpp
+++ b/src/engraving/editing/editpart.cpp
@@ -53,12 +53,12 @@ InsertPart::InsertPart(Part* p, size_t targetPartIdx)
     m_targetPartIdx = targetPartIdx;
 }
 
-void InsertPart::undo(EditData*)
+void InsertPart::undo()
 {
     m_part->score()->removePart(m_part);
 }
 
-void InsertPart::redo(EditData*)
+void InsertPart::redo()
 {
     m_part->score()->insertPart(m_part, m_targetPartIdx);
 }
@@ -85,12 +85,12 @@ RemovePart::RemovePart(Part* p, size_t partIdx)
     }
 }
 
-void RemovePart::undo(EditData*)
+void RemovePart::undo()
 {
     m_part->score()->insertPart(m_part, m_partIdx);
 }
 
-void RemovePart::redo(EditData*)
+void RemovePart::redo()
 {
     m_part->score()->removePart(m_part);
 }
@@ -113,12 +113,12 @@ SetSoloist::SetSoloist(Part* p, bool b)
     soloist  = b;
 }
 
-void SetSoloist::undo(EditData*)
+void SetSoloist::undo()
 {
     part->setSoloist(!soloist);
 }
 
-void SetSoloist::redo(EditData*)
+void SetSoloist::redo()
 {
     part->setSoloist(soloist);
 }
@@ -133,7 +133,7 @@ ChangePart::ChangePart(Part* _part, Instrument* i)
     part       = _part;
 }
 
-void ChangePart::flip(EditData*)
+void ChangePart::flip()
 {
     Instrument* oi = part->instrument(); //tick?
     part->setInstrument(instrument);
@@ -167,7 +167,7 @@ ChangeInstrumentLong::ChangeInstrumentLong(const Fraction& _tick, Part* p, const
 {
 }
 
-void ChangeInstrumentLong::flip(EditData*)
+void ChangeInstrumentLong::flip()
 {
     String s = part->longName(tick);
     part->setLongName(longName, tick);
@@ -184,7 +184,7 @@ ChangeInstrumentShort::ChangeInstrumentShort(const Fraction& _tick, Part* p, con
 {
 }
 
-void ChangeInstrumentShort::flip(EditData*)
+void ChangeInstrumentShort::flip()
 {
     String s = part->shortName(tick);
     part->setShortName(shortName, tick);
@@ -202,7 +202,7 @@ ChangeInstrumentGroupOptions::ChangeInstrumentGroupOptions(const Fraction& _tick
 {
 }
 
-void ChangeInstrumentGroupOptions::flip(EditData*)
+void ChangeInstrumentGroupOptions::flip()
 {
     InstrumentLabel& label = part->instrument(tick)->instrumentLabel();
 
@@ -226,7 +226,7 @@ ChangeInstrumentNumber::ChangeInstrumentNumber(const Fraction& _tick, Part* p, i
 {
 }
 
-void ChangeInstrumentNumber::flip(EditData*)
+void ChangeInstrumentNumber::flip()
 {
     int v = part->number(tick);
     part->setNumber(number, tick);
@@ -238,7 +238,7 @@ void ChangeInstrumentNumber::flip(EditData*)
 //   ChangeDrumset
 //---------------------------------------------------------
 
-void ChangeDrumset::flip(EditData*)
+void ChangeDrumset::flip()
 {
     Drumset d = instrument->drumset() ? *instrument->drumset() : Drumset();
     instrument->setDrumset(&drumset);
@@ -253,7 +253,7 @@ void ChangeDrumset::flip(EditData*)
 //   ChangeStringData
 //---------------------------------------------------------
 
-void ChangeStringData::flip(EditData*)
+void ChangeStringData::flip()
 {
     const StringData* stringData =  m_stringTunings ? m_stringTunings->stringData() : m_instrument->stringData();
     int frets = stringData->frets();
@@ -272,7 +272,7 @@ void ChangeStringData::flip(EditData*)
 //   ChangePatch
 //---------------------------------------------------------
 
-void ChangePatch::flip(EditData*)
+void ChangePatch::flip()
 {
     MidiPatch op;
     op.prog          = channel->program();
@@ -318,7 +318,7 @@ void ChangePatch::flip(EditData*)
 //   SetUserBankController
 //---------------------------------------------------------
 
-void SetUserBankController::flip(EditData*)
+void SetUserBankController::flip()
 {
     bool oldVal = channel->userBankController();
     channel->setUserBankController(val);

--- a/src/engraving/editing/editpart.h
+++ b/src/engraving/editing/editpart.h
@@ -40,8 +40,8 @@ class InsertPart : public UndoableCommand
 
 public:
     InsertPart(Part* p, size_t targetPartIdx);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool) override;
 
     UNDO_TYPE(CommandType::InsertPart)
@@ -58,8 +58,8 @@ class RemovePart : public UndoableCommand
 
 public:
     RemovePart(Part*, size_t partIdx);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool) override;
 
     UNDO_TYPE(CommandType::RemovePart)
@@ -76,8 +76,8 @@ class SetSoloist : public UndoableCommand
 
 public:
     SetSoloist(Part* p, bool b);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::SetSoloist)
     UNDO_NAME("SetSoloist")
@@ -91,7 +91,7 @@ class ChangePart : public UndoableCommand
     Part* part = nullptr;
     Instrument* instrument = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangePart(Part*, Instrument*);
@@ -110,7 +110,7 @@ class ChangeInstrumentLong : public UndoableCommand
     Fraction tick;
     String longName;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeInstrumentLong(const Fraction&, Part*, const String&);
@@ -128,7 +128,7 @@ class ChangeInstrumentShort : public UndoableCommand
     Fraction tick;
     String shortName;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeInstrumentShort(const Fraction&, Part*, const String&);
@@ -148,7 +148,7 @@ class ChangeInstrumentGroupOptions : public UndoableCommand
     String longName;
     String shortName;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeInstrumentGroupOptions(const Fraction&, Part*, bool, const String&, const String&);
@@ -166,7 +166,7 @@ class ChangeInstrumentNumber : public UndoableCommand
     Fraction tick;
     int number;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeInstrumentNumber(const Fraction&, Part*, int v);
@@ -184,7 +184,7 @@ class ChangeDrumset : public UndoableCommand
     Drumset drumset;
     Part* part = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeDrumset(Instrument* i, const Drumset& d, Part* p)
@@ -206,7 +206,7 @@ public:
     ChangeStringData(Instrument* instrument, const StringData& stringData)
         : m_instrument(instrument), m_stringData(stringData) {}
 
-    void flip(EditData*) override;
+    void flip() override;
     UNDO_NAME("ChangeStringData")
 };
 
@@ -218,7 +218,7 @@ class ChangePatch : public UndoableCommand
     InstrChannel* channel = nullptr;
     MidiPatch patch;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangePatch(Score* s, InstrChannel* c, const MidiPatch& pt)
@@ -234,7 +234,7 @@ class SetUserBankController : public UndoableCommand
     InstrChannel* channel = nullptr;
     bool val = false;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     SetUserBankController(InstrChannel* c, bool v)

--- a/src/engraving/editing/editproperty.cpp
+++ b/src/engraving/editing/editproperty.cpp
@@ -36,7 +36,7 @@ using namespace mu::engraving;
 //   ChangeProperty::flip
 //---------------------------------------------------------
 
-void ChangeProperty::flip(EditData*)
+void ChangeProperty::flip()
 {
     LOG_UNDO() << element->typeName() << int(id) << "(" << propertyName(id) << ")" << element->getProperty(id) << "->" << property;
 
@@ -59,14 +59,14 @@ std::vector<EngravingObject*> ChangeProperty::objectItems() const
 //   ChangeBracketProperty::flip
 //---------------------------------------------------------
 
-void ChangeBracketProperty::flip(EditData* ed)
+void ChangeBracketProperty::flip()
 {
     if (!staff) {
         return;
     }
 
     element = staff->brackets()[level];
-    ChangeProperty::flip(ed);
+    ChangeProperty::flip();
     level = toBracketItem(element)->column();
 }
 
@@ -74,9 +74,9 @@ void ChangeBracketProperty::flip(EditData* ed)
 //   ChangeTextLineProperty::flip
 //---------------------------------------------------------
 
-void ChangeTextLineProperty::flip(EditData* ed)
+void ChangeTextLineProperty::flip()
 {
-    ChangeProperty::flip(ed);
+    ChangeProperty::flip();
     if (element->isTextLine()) {
         toTextLine(element)->initStyle();
     }

--- a/src/engraving/editing/editproperty.h
+++ b/src/engraving/editing/editproperty.h
@@ -36,7 +36,7 @@ protected:
     PropertyValue property;
     PropertyFlags flags;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeProperty(EngravingObject* e, Pid i, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
@@ -64,7 +64,7 @@ class ChangeBracketProperty : public ChangeProperty
     Staff* staff = nullptr;
     size_t level = 0;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeBracketProperty(Staff* s, size_t l, Pid i, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
@@ -77,7 +77,7 @@ class ChangeTextLineProperty : public ChangeProperty
 {
     OBJECT_ALLOCATOR(engraving, ChangeTextLineProperty)
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeTextLineProperty(EngravingObject* e, PropertyValue v)

--- a/src/engraving/editing/editscoreproperties.cpp
+++ b/src/engraving/editing/editscoreproperties.cpp
@@ -31,7 +31,7 @@ using namespace mu::engraving;
 //   ChangeMetaTags
 //---------------------------------------------------------
 
-void ChangeMetaTags::flip(EditData*)
+void ChangeMetaTags::flip()
 {
     std::map<String, String> t = score->metaTags();
     score->setMetaTags(metaTags);
@@ -43,7 +43,7 @@ void ChangeMetaTags::flip(EditData*)
 //   ChangeMetaText
 //---------------------------------------------------------
 
-void ChangeMetaText::flip(EditData*)
+void ChangeMetaText::flip()
 {
     String s = score->metaTag(id);
     score->setMetaTag(id, text);
@@ -55,7 +55,7 @@ void ChangeMetaText::flip(EditData*)
 //   ChangeScoreOrder
 //---------------------------------------------------------
 
-void ChangeScoreOrder::flip(EditData*)
+void ChangeScoreOrder::flip()
 {
     ScoreOrder s = score->scoreOrder();
     score->setScoreOrder(order);
@@ -66,7 +66,7 @@ void ChangeScoreOrder::flip(EditData*)
 //   ChangePageNumberOffset
 //---------------------------------------------------------
 
-void ChangePageNumberOffset::flip(EditData*)
+void ChangePageNumberOffset::flip()
 {
     int po = score->pageNumberOffset();
 

--- a/src/engraving/editing/editscoreproperties.h
+++ b/src/engraving/editing/editscoreproperties.h
@@ -34,7 +34,7 @@ class ChangeMetaTags : public UndoableCommand
     Score* score = nullptr;
     std::map<String, String> metaTags;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMetaTags(Score* s, const std::map<String, String>& m)
@@ -53,7 +53,7 @@ class ChangeMetaText : public UndoableCommand
     String id;
     String text;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMetaText(Score* s, const String& i, const String& t)
@@ -70,7 +70,7 @@ class ChangeScoreOrder : public UndoableCommand
 
     Score* score = nullptr;
     ScoreOrder order;
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeScoreOrder(Score* sc, ScoreOrder so)
@@ -88,7 +88,7 @@ class ChangePageNumberOffset : public UndoableCommand
     Score* score = nullptr;
     int pageOffset = 0;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangePageNumberOffset(Score* s, int po)

--- a/src/engraving/editing/editsoundflag.cpp
+++ b/src/engraving/editing/editsoundflag.cpp
@@ -30,7 +30,7 @@ using namespace mu::engraving;
 //   ChangeSoundFlag
 //---------------------------------------------------------
 
-void ChangeSoundFlag::flip(EditData*)
+void ChangeSoundFlag::flip()
 {
     IF_ASSERT_FAILED(m_soundFlag) {
         return;

--- a/src/engraving/editing/editsoundflag.h
+++ b/src/engraving/editing/editsoundflag.h
@@ -37,7 +37,7 @@ public:
     ChangeSoundFlag(SoundFlag* soundFlag, const SoundFlag::PresetCodes& presets, const SoundFlag::PlayingTechniqueCode& technique)
         : m_soundFlag(soundFlag), m_presets(presets), m_playingTechnique(technique) {}
 
-    void flip(EditData*) override;
+    void flip() override;
     UNDO_NAME("ChangeSoundFlag")
     UNDO_CHANGED_OBJECTS({ m_soundFlag })
 };

--- a/src/engraving/editing/editspanner.cpp
+++ b/src/engraving/editing/editspanner.cpp
@@ -34,7 +34,7 @@ using namespace mu::engraving;
 //   ChangeSpannerElements
 //---------------------------------------------------------
 
-void ChangeSpannerElements::flip(EditData*)
+void ChangeSpannerElements::flip()
 {
     EngravingItem* oldStartElement   = spanner->startElement();
     EngravingItem* oldEndElement     = spanner->endElement();
@@ -84,7 +84,7 @@ void ChangeSpannerElements::flip(EditData*)
 //   ChangeStartEndSpanner
 //---------------------------------------------------------
 
-void ChangeStartEndSpanner::flip(EditData*)
+void ChangeStartEndSpanner::flip()
 {
     EngravingItem* s = spanner->startElement();
     EngravingItem* e = spanner->endElement();

--- a/src/engraving/editing/editspanner.h
+++ b/src/engraving/editing/editspanner.h
@@ -35,7 +35,7 @@ class ChangeSpannerElements : public UndoableCommand
     EngravingItem* startElement = nullptr;
     EngravingItem* endElement = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeSpannerElements(Spanner* s, EngravingItem* se, EngravingItem* ee)
@@ -54,7 +54,7 @@ class ChangeStartEndSpanner : public UndoableCommand
     EngravingItem* start = nullptr;
     EngravingItem* end = nullptr;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeStartEndSpanner(Spanner* sp, EngravingItem* s, EngravingItem* e)

--- a/src/engraving/editing/editstaff.cpp
+++ b/src/engraving/editing/editstaff.cpp
@@ -42,12 +42,12 @@ InsertStaff::InsertStaff(Staff* p, staff_idx_t _ridx)
     ridx  = _ridx;
 }
 
-void InsertStaff::undo(EditData*)
+void InsertStaff::undo()
 {
     staff->score()->removeStaff(staff);
 }
 
-void InsertStaff::redo(EditData*)
+void InsertStaff::redo()
 {
     staff->score()->insertStaff(staff, ridx);
 }
@@ -71,7 +71,7 @@ RemoveStaff::RemoveStaff(Staff* p)
     wasSystemObjectStaff = staff->isSystemObjectStaff();
 }
 
-void RemoveStaff::undo(EditData*)
+void RemoveStaff::undo()
 {
     staff->score()->insertStaff(staff, ridx);
     if (wasSystemObjectStaff) {
@@ -79,7 +79,7 @@ void RemoveStaff::undo(EditData*)
     }
 }
 
-void RemoveStaff::redo(EditData*)
+void RemoveStaff::redo()
 {
     staff->score()->removeStaff(staff);
     if (wasSystemObjectStaff) {
@@ -104,12 +104,12 @@ AddSystemObjectStaff::AddSystemObjectStaff(Staff* s)
 {
 }
 
-void AddSystemObjectStaff::undo(EditData*)
+void AddSystemObjectStaff::undo()
 {
     staff->score()->removeSystemObjectStaff(staff);
 }
 
-void AddSystemObjectStaff::redo(EditData*)
+void AddSystemObjectStaff::redo()
 {
     staff->score()->addSystemObjectStaff(staff);
 }
@@ -123,12 +123,12 @@ RemoveSystemObjectStaff::RemoveSystemObjectStaff(Staff* s)
 {
 }
 
-void RemoveSystemObjectStaff::undo(EditData*)
+void RemoveSystemObjectStaff::undo()
 {
     staff->score()->addSystemObjectStaff(staff);
 }
 
-void RemoveSystemObjectStaff::redo(EditData*)
+void RemoveSystemObjectStaff::redo()
 {
     staff->score()->removeSystemObjectStaff(staff);
 }
@@ -144,12 +144,12 @@ InsertMStaff::InsertMStaff(Measure* m, MStaff* ms, staff_idx_t i)
     idx     = i;
 }
 
-void InsertMStaff::undo(EditData*)
+void InsertMStaff::undo()
 {
     measure->removeMStaff(mstaff, idx);
 }
 
-void InsertMStaff::redo(EditData*)
+void InsertMStaff::redo()
 {
     measure->insertMStaff(mstaff, idx);
 }
@@ -165,12 +165,12 @@ RemoveMStaff::RemoveMStaff(Measure* m, MStaff* ms, int i)
     idx     = i;
 }
 
-void RemoveMStaff::undo(EditData*)
+void RemoveMStaff::undo()
 {
     measure->insertMStaff(mstaff, idx);
 }
 
-void RemoveMStaff::redo(EditData*)
+void RemoveMStaff::redo()
 {
     measure->removeMStaff(mstaff, idx);
 }
@@ -186,12 +186,12 @@ InsertStaves::InsertStaves(Measure* m, staff_idx_t _a, staff_idx_t _b)
     b       = _b;
 }
 
-void InsertStaves::undo(EditData*)
+void InsertStaves::undo()
 {
     measure->removeStaves(a, b);
 }
 
-void InsertStaves::redo(EditData*)
+void InsertStaves::redo()
 {
     measure->insertStaves(a, b);
 }
@@ -207,12 +207,12 @@ RemoveStaves::RemoveStaves(Measure* m, staff_idx_t _a, staff_idx_t _b)
     b       = _b;
 }
 
-void RemoveStaves::undo(EditData*)
+void RemoveStaves::undo()
 {
     measure->insertStaves(a, b);
 }
 
-void RemoveStaves::redo(EditData*)
+void RemoveStaves::redo()
 {
     measure->removeStaves(a, b);
 }
@@ -231,12 +231,12 @@ SortStaves::SortStaves(Score* s, const std::vector<staff_idx_t>& l)
     list  = l;
 }
 
-void SortStaves::redo(EditData*)
+void SortStaves::redo()
 {
     score->sortStaves(list);
 }
 
-void SortStaves::undo(EditData*)
+void SortStaves::undo()
 {
     score->sortStaves(rlist);
 }
@@ -274,7 +274,7 @@ ChangeStaff::ChangeStaff(Staff* _staff, bool _visible, ClefTypeList _clefType, S
 //   flip
 //---------------------------------------------------------
 
-void ChangeStaff::flip(EditData*)
+void ChangeStaff::flip()
 {
     bool oldVisible = staff->visible();
     ClefTypeList oldClefType = staff->defaultClefType();
@@ -308,7 +308,7 @@ void ChangeStaff::flip(EditData*)
 //   ChangeStaffType::flip
 //---------------------------------------------------------
 
-void ChangeStaffType::flip(EditData*)
+void ChangeStaffType::flip()
 {
     StaffType oldStaffType = *staff->staffType(tick);
 
@@ -343,7 +343,7 @@ ChangeMStaffProperties::ChangeMStaffProperties(Measure* m, staff_idx_t i, bool v
 {
 }
 
-void ChangeMStaffProperties::flip(EditData*)
+void ChangeMStaffProperties::flip()
 {
     bool v = measure->visible(staffIdx);
     bool s = measure->stemless(staffIdx);
@@ -362,7 +362,7 @@ ChangeMStaffHideIfEmpty::ChangeMStaffHideIfEmpty(Measure* m, staff_idx_t i, Auto
 {
 }
 
-void ChangeMStaffHideIfEmpty::flip(EditData*)
+void ChangeMStaffHideIfEmpty::flip()
 {
     AutoOnOff h = measure->hideStaffIfEmpty(staffIdx);
     measure->setHideStaffIfEmpty(staffIdx, hideIfEmpty);

--- a/src/engraving/editing/editstaff.h
+++ b/src/engraving/editing/editstaff.h
@@ -38,8 +38,8 @@ class InsertStaff : public UndoableCommand
 
 public:
     InsertStaff(Staff*, staff_idx_t idx);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool) override;
 
     UNDO_TYPE(CommandType::InsertStaff)
@@ -57,8 +57,8 @@ class RemoveStaff : public UndoableCommand
 
 public:
     RemoveStaff(Staff*);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
     void cleanup(bool) override;
 
     UNDO_TYPE(CommandType::RemoveStaff)
@@ -74,8 +74,8 @@ class AddSystemObjectStaff : public UndoableCommand
 
 public:
     AddSystemObjectStaff(Staff*);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::AddSystemObjectStaff)
     UNDO_NAME("AddSystemObjectStaff")
@@ -90,8 +90,8 @@ class RemoveSystemObjectStaff : public UndoableCommand
 
 public:
     RemoveSystemObjectStaff(Staff*);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::RemoveSystemObjectStaff)
     UNDO_NAME("RemoveSystemObjectStaff")
@@ -108,8 +108,8 @@ class InsertMStaff : public UndoableCommand
 
 public:
     InsertMStaff(Measure*, MStaff*, staff_idx_t);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::InsertMStaff)
     UNDO_NAME("InsertMStaff")
@@ -126,8 +126,8 @@ class RemoveMStaff : public UndoableCommand
 
 public:
     RemoveMStaff(Measure*, MStaff*, int);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::RemoveMStaff)
     UNDO_NAME("RemoveMStaff")
@@ -144,8 +144,8 @@ class InsertStaves : public UndoableCommand
 
 public:
     InsertStaves(Measure*, staff_idx_t, staff_idx_t);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::InsertStaves)
     UNDO_NAME("InsertStaves")
@@ -162,8 +162,8 @@ class RemoveStaves : public UndoableCommand
 
 public:
     RemoveStaves(Measure*, staff_idx_t, staff_idx_t);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::RemoveStaves)
     UNDO_NAME("RemoveStaves")
@@ -180,8 +180,8 @@ class SortStaves : public UndoableCommand
 
 public:
     SortStaves(Score*, const std::vector<staff_idx_t>&);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
     UNDO_TYPE(CommandType::SortStaves)
     UNDO_NAME("SortStaves")
@@ -206,7 +206,7 @@ class ChangeStaff : public UndoableCommand
     AutoOnOff mergeMatchingRests = AutoOnOff::AUTO;
     bool reflectTranspositionInLinkedTab = false;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeStaff(Staff*);
@@ -231,7 +231,7 @@ class ChangeStaffType : public UndoableCommand
     StaffType staffType;
     Fraction tick;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeStaffType(Staff* s, const StaffType& t, Fraction tick = Fraction(0, 1))
@@ -251,7 +251,7 @@ class ChangeMStaffProperties : public UndoableCommand
     bool visible = false;
     bool stemless = false;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMStaffProperties(Measure*, staff_idx_t staffIdx, bool visible, bool stemless);
@@ -269,7 +269,7 @@ class ChangeMStaffHideIfEmpty : public UndoableCommand
     staff_idx_t staffIdx = 0;
     AutoOnOff hideIfEmpty = AutoOnOff::AUTO;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeMStaffHideIfEmpty(Measure*, staff_idx_t staffIdx, AutoOnOff hideIfEmpty);

--- a/src/engraving/editing/editstavesharing.cpp
+++ b/src/engraving/editing/editstavesharing.cpp
@@ -50,12 +50,12 @@ public:
     ConnectSharedPart(SharedPart* s, Part* o)
         : sharedPart(s), originPart(o) {}
 
-    void undo(EditData*) override
+    void undo() override
     {
         sharedPart->removeOriginPart(originPart);
     }
 
-    void redo(EditData*) override
+    void redo() override
     {
         sharedPart->addOriginPart(originPart);
     }
@@ -75,12 +75,12 @@ public:
     DisconnectSharedPart(SharedPart* s, Part* o)
         : sharedPart(s), originPart(o) {}
 
-    void undo(EditData*) override
+    void undo() override
     {
         sharedPart->addOriginPart(originPart);
     }
 
-    void redo(EditData*) override
+    void redo() override
     {
         sharedPart->removeOriginPart(originPart);
     }

--- a/src/engraving/editing/editstyle.cpp
+++ b/src/engraving/editing/editstyle.cpp
@@ -73,7 +73,7 @@ StyleIdSet ChangeStyle::changedIds() const
     return result;
 }
 
-void ChangeStyle::flip(EditData*)
+void ChangeStyle::flip()
 {
     MStyle tmp = score->style();
 
@@ -93,10 +93,10 @@ void ChangeStyle::flip(EditData*)
     style = tmp;
 }
 
-void ChangeStyle::undo(EditData* ed)
+void ChangeStyle::undo()
 {
     overlap = false;
-    UndoableCommand::undo(ed);
+    UndoableCommand::undo();
 }
 
 //---------------------------------------------------------
@@ -135,7 +135,7 @@ static void changeStyleValue(Score* score, Sid idx, const PropertyValue& oldValu
     }
 }
 
-void ChangeStyleValues::flip(EditData*)
+void ChangeStyleValues::flip()
 {
     if (!m_score) {
         return;

--- a/src/engraving/editing/editstyle.h
+++ b/src/engraving/editing/editstyle.h
@@ -35,8 +35,8 @@ class ChangeStyle : public UndoableCommand
     MStyle style;
     bool overlap = false;
 
-    void flip(EditData*) override;
-    void undo(EditData*) override;
+    void flip() override;
+    void undo() override;
 
 public:
     ChangeStyle(Score*, const MStyle&, const bool overlapOnly = false);
@@ -63,7 +63,7 @@ public:
     UNDO_CHANGED_OBJECTS({ m_score })
 
 private:
-    void flip(EditData*) override;
+    void flip() override;
 
     Score* m_score = nullptr;
     std::unordered_map<Sid, PropertyValue> m_values;

--- a/src/engraving/editing/editsystemlocks.cpp
+++ b/src/engraving/editing/editsystemlocks.cpp
@@ -45,13 +45,13 @@ public:
     AddSystemLock(const SystemLock* systemLock)
         : m_systemLock(systemLock) {}
 
-    void undo(EditData*) override
+    void undo() override
     {
         Score* score = m_systemLock->startMB()->score();
         score->removeSystemLock(m_systemLock);
     }
 
-    void redo(EditData*) override
+    void redo() override
     {
         Score* score = m_systemLock->startMB()->score();
         score->addSystemLock(m_systemLock);
@@ -86,13 +86,13 @@ public:
     RemoveSystemLock(const SystemLock* systemLock)
         : m_systemLock(systemLock) {}
 
-    void undo(EditData*) override
+    void undo() override
     {
         Score* score = m_systemLock->startMB()->score();
         score->addSystemLock(m_systemLock);
     }
 
-    void redo(EditData*) override
+    void redo() override
     {
         Score* score = m_systemLock->startMB()->score();
         score->removeSystemLock(m_systemLock);

--- a/src/engraving/editing/edittie.cpp
+++ b/src/engraving/editing/edittie.cpp
@@ -31,7 +31,7 @@ using namespace mu::engraving;
 //   ChangeTieJumpPointActive
 //---------------------------------------------------------
 
-void ChangeTieJumpPointActive::flip(EditData*)
+void ChangeTieJumpPointActive::flip()
 {
     TieJumpPoint* jumpPoint = m_jumpPointList->findJumpPoint(m_id);
     if (!jumpPoint) {

--- a/src/engraving/editing/edittie.h
+++ b/src/engraving/editing/edittie.h
@@ -38,7 +38,7 @@ class ChangeTieJumpPointActive : public UndoableCommand
     muse::String m_id;
     bool m_active = false;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     ChangeTieJumpPointActive(TieJumpPointList* jumpPointList, muse::String id, bool active)

--- a/src/engraving/editing/edittremolo.cpp
+++ b/src/engraving/editing/edittremolo.cpp
@@ -33,7 +33,7 @@ using namespace mu::engraving;
 //   MoveTremolo
 //---------------------------------------------------------
 
-void MoveTremolo::redo(EditData*)
+void MoveTremolo::redo()
 {
     // Find new tremolo chords
     Measure* m1 = score->tick2measure(chord1Tick);
@@ -90,7 +90,7 @@ void MoveTremolo::redo(EditData*)
     }
 }
 
-void MoveTremolo::undo(EditData*)
+void MoveTremolo::undo()
 {
     // Move tremolo to old position
     trem->chord1()->setTremoloTwoChord(nullptr);

--- a/src/engraving/editing/edittremolo.h
+++ b/src/engraving/editing/edittremolo.h
@@ -40,8 +40,8 @@ class MoveTremolo : public UndoableCommand
     Chord* oldC1 = nullptr;
     Chord* oldC2 = nullptr;
 
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
 public:
     MoveTremolo(Score* s, Fraction c1, Fraction c2, TremoloTwoChord* tr, track_idx_t t)

--- a/src/engraving/editing/exchangevoices.cpp
+++ b/src/engraving/editing/exchangevoices.cpp
@@ -44,12 +44,12 @@ public:
     ExchangeVoicesInMeasure(Measure* measure, track_idx_t srcTrack, track_idx_t dstTrack, staff_idx_t staff)
         : m_measure(measure), m_srcTrack(srcTrack), m_dstTrack(dstTrack), m_staff(staff) {}
 
-    void undo(EditData*) override
+    void undo() override
     {
         doExchange(m_dstTrack, m_srcTrack);
     }
 
-    void redo(EditData*) override
+    void redo() override
     {
         doExchange(m_srcTrack, m_dstTrack);
     }

--- a/src/engraving/editing/inserttime.cpp
+++ b/src/engraving/editing/inserttime.cpp
@@ -33,12 +33,12 @@ using namespace mu::engraving;
 //   InsertTime
 //---------------------------------------------------------
 
-void InsertTime::redo(EditData*)
+void InsertTime::redo()
 {
     score->insertTime(tick, len);
 }
 
-void InsertTime::undo(EditData*)
+void InsertTime::undo()
 {
     score->insertTime(tick, -len);
 }
@@ -47,7 +47,7 @@ void InsertTime::undo(EditData*)
 //   InsertTimeUnmanagedSpanner
 //---------------------------------------------------------
 
-void InsertTimeUnmanagedSpanner::flip(EditData*)
+void InsertTimeUnmanagedSpanner::flip()
 {
     for (Score* s : score->scoreList()) {
         std::set<Spanner*> spannersCopy = s->unmanagedSpanners();

--- a/src/engraving/editing/inserttime.h
+++ b/src/engraving/editing/inserttime.h
@@ -35,8 +35,8 @@ class InsertTime : public UndoableCommand
     Fraction tick;
     Fraction len;
 
-    void redo(EditData*) override;
-    void undo(EditData*) override;
+    void redo() override;
+    void undo() override;
 
 public:
     InsertTime(Score* _score, const Fraction& _tick, const Fraction& _len)
@@ -55,7 +55,7 @@ class InsertTimeUnmanagedSpanner : public UndoableCommand
     Fraction tick;
     Fraction len;
 
-    void flip(EditData*) override;
+    void flip() override;
 
 public:
     InsertTimeUnmanagedSpanner(Score* s, const Fraction& _tick, const Fraction& _len)

--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -53,19 +53,6 @@ TextEditData::~TextEditData()
 }
 
 //---------------------------------------------------------
-//   cursor
-//---------------------------------------------------------
-
-TextCursor* TextEditData::cursor() const
-{
-    IF_ASSERT_FAILED(m_textBase) {
-        return nullptr;
-    }
-
-    return m_textBase->cursor();
-}
-
-//---------------------------------------------------------
 //   editInsertText
 //---------------------------------------------------------
 
@@ -110,7 +97,7 @@ void TextBase::startEdit(EditData& ed)
 {
     std::shared_ptr<TextEditData> ted = std::make_shared<TextEditData>(this);
     ted->e = this;
-    ted->cursor()->startEdit();
+    cursor()->startEdit();
 
     assert(!score()->undoStack()->hasActiveTransaction());
 
@@ -123,7 +110,7 @@ void TextBase::startEdit(EditData& ed)
     }
 
     //! NOTE: startMove will be null if we didn't use the mouse (e.g. we added a lyric with the spacebar)
-    if (!ed.startMove.isNull() && !ted->cursor()->set(ed.startMove)) {
+    if (!ed.startMove.isNull() && !cursor()->set(ed.startMove)) {
         resetFormatting();
     }
     double _spatium = spatium();
@@ -139,11 +126,11 @@ void TextBase::startEdit(EditData& ed)
 void TextBase::endEdit(EditData& ed)
 {
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    IF_ASSERT_FAILED(ted && ted->cursor()) {
+    IF_ASSERT_FAILED(ted) {
         return;
     }
 
-    ted->cursor()->endEdit();
+    cursor()->endEdit();
 
     UndoStack* undo = score()->undoStack();
     IF_ASSERT_FAILED(undo) {
@@ -267,26 +254,21 @@ void TextBase::commitText()
 //   insertSym
 //---------------------------------------------------------
 
-void TextBase::insertSym(EditData& ed, SymId id)
+void TextBase::insertSym(SymId id)
 {
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-
-    deleteSelectedText(ed);
+    deleteSelectedText();
     String s = score()->engravingFont()->toString(id);
-    cursor->format()->setFontFamily(u"ScoreText");
-    score()->undo(new InsertText(cursor, s), &ed);
+    cursor()->format()->setFontFamily(u"ScoreText");
+    score()->undo(new InsertText(cursor(), s));
 }
 
 //---------------------------------------------------------
 //   insertText
 //---------------------------------------------------------
 
-void TextBase::insertText(EditData& ed, const String& s)
+void TextBase::insertText(const String& s)
 {
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-    score()->undo(new InsertText(cursor, s), &ed);
+    score()->undo(new InsertText(cursor(), s));
 }
 
 bool TextBase::isEditAllowed(EditData& ed) const
@@ -425,7 +407,7 @@ bool TextBase::edit(EditData& ed)
     if (!ted) {
         return false;
     }
-    TextCursor* cursor = ted->cursor();
+    TextCursor* cursor = this->cursor();
     CharFormat* currentFormat = cursor->format();
 
     String s         = ed.s;
@@ -480,8 +462,8 @@ bool TextBase::edit(EditData& ed)
         switch (ed.key) {
         case Key_Enter:
         case Key_Return:
-            deleteSelectedText(ed);
-            score()->undo(new SplitText(cursor), &ed);
+            deleteSelectedText();
+            score()->undo(new SplitText(cursor));
 
             notifyAboutTextCursorChanged();
 
@@ -498,23 +480,23 @@ bool TextBase::edit(EditData& ed)
 
                 s.clear();
 
-                if (deleteSelectedText(ed)) {
+                if (deleteSelectedText()) {
                     notifyAboutTextRemoved(startPosition, endPosition, text);
                 }
             } else {
                 String text = cursor->selectedText();
 
-                if (!deleteSelectedText(ed)) {
+                if (!deleteSelectedText()) {
                     // if you are on the end of the line, delete the newline char
                     if (cursor->column() == cursor->columns()) {
                         size_t cursorRow = cursor->row();
                         cursor->movePosition(TextCursor::MoveOperation::Down);
                         if (cursor->row() != cursorRow) {
                             cursor->movePosition(TextCursor::MoveOperation::StartOfLine);
-                            score()->undo(new JoinText(cursor), &ed);
+                            score()->undo(new JoinText(cursor));
                         }
                     } else {
-                        score()->undo(new RemoveText(cursor, String(cursor->currentCharacter())), &ed);
+                        score()->undo(new RemoveText(cursor, String(cursor->currentCharacter())));
                     }
                 } else {
                     notifyAboutTextRemoved(startPosition + 1, startPosition, text);
@@ -534,20 +516,20 @@ bool TextBase::edit(EditData& ed)
 
                 s.clear();
 
-                if (deleteSelectedText(ed)) {
+                if (deleteSelectedText()) {
                     notifyAboutTextRemoved(startPosition, endPosition, text);
                 }
             } else {
                 String text = cursor->selectedText();
 
-                if (!deleteSelectedText(ed)) {
+                if (!deleteSelectedText()) {
                     if (cursor->column() == 0 && m_cursor->row() != 0) {
-                        score()->undo(new JoinText(cursor), &ed);
+                        score()->undo(new JoinText(cursor));
                     } else {
                         if (!cursor->movePosition(TextCursor::MoveOperation::Left)) {
                             return false;
                         }
-                        score()->undo(new RemoveText(cursor, String(cursor->currentCharacter())), &ed);
+                        score()->undo(new RemoveText(cursor, String(cursor->currentCharacter())));
                     }
                 } else {
                     notifyAboutTextRemoved(startPosition, startPosition - 1, text);
@@ -704,47 +686,47 @@ bool TextBase::edit(EditData& ed)
                 s = u"\u266e";               // Unicode natural
                 break;
             case Key_Space:
-                insertSym(ed, SymId::space);
+                insertSym(SymId::space);
                 return true;
             case Key_F:
-                insertSym(ed, SymId::dynamicForte);
+                insertSym(SymId::dynamicForte);
                 return true;
             case Key_M:
-                insertSym(ed, SymId::dynamicMezzo);
+                insertSym(SymId::dynamicMezzo);
                 return true;
             case Key_N:
-                insertSym(ed, SymId::dynamicNiente);
+                insertSym(SymId::dynamicNiente);
                 return true;
             case Key_P:
-                insertSym(ed, SymId::dynamicPiano);
+                insertSym(SymId::dynamicPiano);
                 return true;
             case Key_S:
-                insertSym(ed, SymId::dynamicSforzando);
+                insertSym(SymId::dynamicSforzando);
                 return true;
             case Key_R:
-                insertSym(ed, SymId::dynamicRinforzando);
+                insertSym(SymId::dynamicRinforzando);
                 return true;
             case Key_Z:
                 // Ctrl+Z is normally "undo"
                 // but this code gets hit even if you are also holding Shift
                 // so Shift+Ctrl+Z works
-                insertSym(ed, SymId::dynamicZ);
+                insertSym(SymId::dynamicZ);
                 return true;
             }
         }
         if (ctrlPressed && altPressed) {
             if (ed.key == Key_Minus || ed.key == Key_Underscore) {
-                insertSym(ed, SymId::lyricsElision);
+                insertSym(SymId::lyricsElision);
                 return true;
             }
         }
     }
     if (!s.isEmpty()) {
-        deleteSelectedText(ed);
+        deleteSelectedText();
         if (currentFormat->fontFamily() == u"ScoreText") {
             currentFormat->setFontFamily(propertyDefault(Pid::FONT_FACE).value<String>());
         }
-        score()->undo(new InsertText(m_cursor, s), &ed);
+        score()->undo(new InsertText(m_cursor, s));
 
         int startPosition = cursor->currentPosition();
         notifyAboutTextInserted(startPosition, startPosition + static_cast<int>(s.size()), s);
@@ -756,11 +738,9 @@ bool TextBase::edit(EditData& ed)
 //   movePosition
 //---------------------------------------------------------
 
-void TextBase::movePosition(EditData& ed, TextCursor::MoveOperation op)
+void TextBase::movePosition(TextCursor::MoveOperation op)
 {
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
-    cursor->movePosition(op);
+    cursor()->movePosition(op);
     score()->addRefresh(canvasBoundingRect());
     score()->update();
 }
@@ -769,22 +749,19 @@ void TextBase::movePosition(EditData& ed, TextCursor::MoveOperation op)
 //  ChangeText::insertText
 //---------------------------------------------------------
 
-void ChangeText::insertText(EditData* ed)
+void ChangeText::insertText()
 {
     TextCursor tc = m_cursor;
     tc.setFormat(m_format);                              // To undo TextCursor::updateCursorFormat()
     tc.text()->editInsertText(&tc, m_s);
-    if (ed) {
-        TextCursor* ttc = tc.text()->cursorFromEditData(*ed);
-        *ttc = tc;
-    }
+    *tc.text()->cursor() = tc;
 }
 
 //---------------------------------------------------------
 //  ChangeText::removeText
 //---------------------------------------------------------
 
-void ChangeText::removeText(EditData* ed)
+void ChangeText::removeText()
 {
     TextCursor tc = m_cursor;
     TextBlock& l  = m_cursor.curLine();
@@ -795,9 +772,7 @@ void ChangeText::removeText(EditData* ed)
         l.remove(static_cast<int>(column), &m_cursor);
     }
     m_cursor.text()->triggerLayout();
-    if (ed) {
-        *m_cursor.text()->cursorFromEditData(*ed) = tc;
-    }
+    *m_cursor.text()->cursor() = tc;
     m_cursor.text()->setTextInvalid();
 }
 
@@ -805,7 +780,7 @@ void ChangeText::removeText(EditData* ed)
 //   SplitJoinText
 //---------------------------------------------------------
 
-void SplitJoinText::join(EditData* ed)
+void SplitJoinText::join()
 {
     TextBase* t   = m_cursor.text();
     size_t line   = m_cursor.row();
@@ -831,13 +806,11 @@ void SplitJoinText::join(EditData* ed)
     m_cursor.setFormat(*charFmt);             // restore orig. format at new line
     m_cursor.clearSelection();
 
-    if (ed) {
-        *t->cursorFromEditData(*ed) = m_cursor;
-    }
-    m_cursor.text()->setTextInvalid();
+    *t->cursor() = m_cursor;
+    t->setTextInvalid();
 }
 
-void SplitJoinText::split(EditData* ed)
+void SplitJoinText::split()
 {
     TextBase* t   = m_cursor.text();
     size_t line   = m_cursor.row();
@@ -848,7 +821,7 @@ void SplitJoinText::split(EditData* ed)
     TextBase::LayoutData* ldata = t->mutldata();
     CharFormat* charFmt = m_cursor.format();           // take current format
     ldata->blocks.insert(ldata->blocks.begin() + line + 1,
-                         m_cursor.curLine().split(static_cast<int>(m_cursor.column()), t->cursorFromEditData(*ed)));
+                         m_cursor.curLine().split(static_cast<int>(m_cursor.column()), t->cursor()));
     m_cursor.curLine().setEol(true);
 
     m_cursor.setRow(line + 1);
@@ -857,10 +830,8 @@ void SplitJoinText::split(EditData* ed)
     m_cursor.setFormat(*charFmt);               // restore orig. format at new line
     m_cursor.clearSelection();
 
-    if (ed) {
-        *t->cursorFromEditData(*ed) = m_cursor;
-    }
-    m_cursor.text()->setTextInvalid();
+    *t->cursor() = m_cursor;
+    t->setTextInvalid();
 }
 
 //---------------------------------------------------------
@@ -869,7 +840,7 @@ void SplitJoinText::split(EditData* ed)
 
 EngravingItem* TextBase::drop(EditData& ed)
 {
-    TextCursor* cursor = cursorFromEditData(ed);
+    TextCursor* cursor = this->cursor();
 
     EngravingItem* e = ed.dropElement;
 
@@ -879,7 +850,7 @@ EngravingItem* TextBase::drop(EditData& ed)
         SymId id = toSymbol(e)->sym();
         delete e;
 
-        insertSym(ed, id);
+        insertSym(id);
     }
     break;
 
@@ -893,8 +864,8 @@ EngravingItem* TextBase::drop(EditData& ed)
             currentFormat->setFontFamily(propertyDefault(Pid::FONT_FACE).value<String>());
         }
 
-        deleteSelectedText(ed);
-        score()->undo(new InsertText(cursor, s), &ed);
+        deleteSelectedText();
+        score()->undo(new InsertText(cursor, s));
     }
     break;
 
@@ -909,7 +880,7 @@ EngravingItem* TextBase::drop(EditData& ed)
 //   paste
 //---------------------------------------------------------
 
-void TextBase::paste(EditData& ed, const String& txt)
+void TextBase::paste(const String& txt)
 {
     if (MScore::debugMode) {
         LOGD("<%s>", muPrintable(txt));
@@ -919,7 +890,7 @@ void TextBase::paste(EditData& ed, const String& txt)
     String token;
     String sym;
     bool symState = false;
-    CharFormat format = *static_cast<TextEditData*>(ed.getData(this).get())->cursor()->format();
+    CharFormat format = *cursor()->format();
 
     score()->startCmd(TranslatableString("undoableAction", "Paste text"));
     for (size_t i = 0; i < txt.size(); i++) {
@@ -935,22 +906,20 @@ void TextBase::paste(EditData& ed, const String& txt)
                 if (symState) {
                     sym += c;
                 } else {
-                    deleteSelectedText(ed);
-                    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-                    TextCursor* cursor = ted->cursor();
-                    cursor->setFormat(format);
+                    deleteSelectedText();
+                    cursor()->setFormat(format);
                     if (c.isHighSurrogate()) {
                         Char highSurrogate = c;
                         assert(i + 1 < txt.size());
                         i++;
                         Char lowSurrogate = txt.at(i);
-                        insertText(ed, String::fromUcs4(Char::surrogateToUcs4(highSurrogate, lowSurrogate)));
+                        insertText(String::fromUcs4(Char::surrogateToUcs4(highSurrogate, lowSurrogate)));
                     } else if (c == '\r') {
                         continue;
                     } else if (c == '\n') {
-                        score()->undo(new SplitText(cursor), &ed);
+                        score()->undo(new SplitText(cursor()));
                     } else {
-                        insertText(ed, String(c));
+                        insertText(String(c));
                     }
                 }
             }
@@ -962,8 +931,8 @@ void TextBase::paste(EditData& ed, const String& txt)
                     sym.clear();
                 } else if (token == "/sym") {
                     symState = false;
-                    static_cast<TextEditData*>(ed.getData(this).get())->cursor()->setFormat(format);
-                    insertSym(ed, SymNames::symIdByName(sym));
+                    cursor()->setFormat(format);
+                    insertSym(SymNames::symIdByName(sym));
                 } else {
                     prepareFormat(token, format);
                 }
@@ -974,29 +943,29 @@ void TextBase::paste(EditData& ed, const String& txt)
             if (c == ';') {
                 state = 0;
                 if (token == "lt") {
-                    insertText(ed, u"<");
+                    insertText(u"<");
                 } else if (token == "gt") {
-                    insertText(ed, u">");
+                    insertText(u">");
                 } else if (token == "amp") {
-                    insertText(ed, u"&");
+                    insertText(u"&");
                 } else if (token == "quot") {
-                    insertText(ed, u"\"");
+                    insertText(u"\"");
                 } else {
-                    insertSym(ed, SymNames::symIdByName(token));
+                    insertSym(SymNames::symIdByName(token));
                 }
             } else if (!c.isLetter()) {
                 state = 0;
-                insertText(ed, u"&");
-                insertText(ed, token);
-                insertText(ed, c);
+                insertText(u"&");
+                insertText(token);
+                insertText(c);
             } else {
                 token += c;
             }
         }
     }
     if (state == 2) {
-        insertText(ed, u"&");
-        insertText(ed, token);
+        insertText(u"&");
+        insertText(token);
     }
     score()->endCmd();
 }
@@ -1005,10 +974,9 @@ void TextBase::paste(EditData& ed, const String& txt)
 //   endHexState
 //---------------------------------------------------------
 
-void TextBase::endHexState(EditData& ed)
+void TextBase::endHexState()
 {
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
-    TextCursor* cursor = ted->cursor();
+    TextCursor* cursor = this->cursor();
 
     if (m_hexState >= 0) {
         if (m_hexState > 0) {
@@ -1036,9 +1004,9 @@ void TextBase::endHexState(EditData& ed)
 //   deleteSelectedText
 //---------------------------------------------------------
 
-bool TextBase::deleteSelectedText(EditData& ed)
+bool TextBase::deleteSelectedText()
 {
-    TextCursor* cursor = cursorFromEditData(ed);
+    TextCursor* cursor = this->cursor();
 
     if (!cursor->hasSelection()) {
         return false;
@@ -1061,14 +1029,14 @@ bool TextBase::deleteSelectedText(EditData& ed)
             break;
         }
         if (cursor->column() == 0 && cursor->row() != 0) {
-            score()->undo(new JoinText(cursor), &ed);
+            score()->undo(new JoinText(cursor));
         } else {
             // move cursor left:
             if (!m_cursor->movePosition(TextCursor::MoveOperation::Left)) {
                 break;
             }
             TextCursor undoCursor(*m_cursor);
-            score()->undo(new RemoveText(&undoCursor, String(m_cursor->currentCharacter())), &ed);
+            score()->undo(new RemoveText(&undoCursor, String(m_cursor->currentCharacter())));
         }
     }
     return true;
@@ -1098,7 +1066,7 @@ ChangeTextProperties::ChangeTextProperties(const TextCursor* tc, Pid propId, con
     }
 }
 
-void ChangeTextProperties::undo(EditData*)
+void ChangeTextProperties::undo()
 {
     cursor().text()->resetFormatting();
     cursor().text()->setXmlText(m_xmlText);
@@ -1106,7 +1074,7 @@ void ChangeTextProperties::undo(EditData*)
     cursor().text()->renderer()->layoutText1(cursor().text());
 }
 
-void ChangeTextProperties::redo(EditData*)
+void ChangeTextProperties::redo()
 {
     m_xmlText = cursor().text()->xmlText();
     restoreSelection();

--- a/src/engraving/editing/textedit.h
+++ b/src/engraving/editing/textedit.h
@@ -39,8 +39,6 @@ public:
     String oldXmlText;
     size_t startUndoIdx = 0;
 
-    TextCursor* cursor() const;
-
     bool deleteText = false;
 
     String selectedText;
@@ -99,8 +97,8 @@ class ChangeTextProperties : public TextEditUndoableCommand
 
 public:
     ChangeTextProperties(const TextCursor* tc, Pid propId, const PropertyValue& propVal, PropertyFlags flags);
-    void undo(EditData*) override;
-    void redo(EditData*) override;
+    void undo() override;
+    void redo() override;
 
 private:
 
@@ -124,13 +122,13 @@ class ChangeText : public TextEditUndoableCommand
 public:
     ChangeText(const TextCursor* tc, const String& t)
         : TextEditUndoableCommand(*tc), m_s(t), m_format(*tc->format()) {}
-    virtual void undo(EditData*) override = 0;
-    virtual void redo(EditData*) override = 0;
+    virtual void undo() override = 0;
+    virtual void redo() override = 0;
     const String& string() const { return m_s; }
 
 protected:
-    void insertText(EditData*);
-    void removeText(EditData*);
+    void insertText();
+    void removeText();
 
 private:
 
@@ -148,8 +146,8 @@ class InsertText : public ChangeText
 public:
     InsertText(const TextCursor* tc, const String& t)
         : ChangeText(tc, t) {}
-    virtual void redo(EditData* ed) override { insertText(ed); }
-    virtual void undo(EditData* ed) override { removeText(ed); }
+    virtual void redo() override { insertText(); }
+    virtual void undo() override { removeText(); }
     UNDO_NAME("InsertText")
 };
 
@@ -163,8 +161,8 @@ class RemoveText : public ChangeText
 public:
     RemoveText(const TextCursor* tc, const String& t)
         : ChangeText(tc, t) {}
-    virtual void redo(EditData* ed) override { removeText(ed); }
-    virtual void undo(EditData* ed) override { insertText(ed); }
+    virtual void redo() override { removeText(); }
+    virtual void undo() override { insertText(); }
     UNDO_NAME("RemoveText")
 };
 
@@ -176,8 +174,8 @@ class SplitJoinText : public TextEditUndoableCommand
 {
     OBJECT_ALLOCATOR(engraving, SplitJoinText)
 protected:
-    virtual void split(EditData*);
-    virtual void join(EditData*);
+    virtual void split();
+    virtual void join();
 
 public:
     SplitJoinText(const TextCursor* tc)
@@ -192,8 +190,8 @@ class SplitText : public SplitJoinText
 {
     OBJECT_ALLOCATOR(engraving, SplitText)
 
-    virtual void undo(EditData* data) override { join(data); }
-    virtual void redo(EditData* data) override { split(data); }
+    virtual void undo() override { join(); }
+    virtual void redo() override { split(); }
 
 public:
     SplitText(const TextCursor* tc)
@@ -209,8 +207,8 @@ class JoinText : public SplitJoinText
 {
     OBJECT_ALLOCATOR(engraving, JoinText)
 
-    virtual void undo(EditData* data) override { split(data); }
-    virtual void redo(EditData* data) override { join(data); }
+    virtual void undo() override { split(); }
+    virtual void redo() override { join(); }
 
 public:
     JoinText(const TextCursor* tc)

--- a/src/engraving/editing/transaction/transaction.cpp
+++ b/src/engraving/editing/transaction/transaction.cpp
@@ -77,10 +77,10 @@ Transaction& Transaction::dummy()
     return dummyTransaction;
 }
 
-void Transaction::push(UndoableCommand* cmd, EditData* editData)
+void Transaction::push(UndoableCommand* cmd)
 {
     if (m_isDummy) {
-        cmd->redo(editData);
+        cmd->redo();
         delete cmd;
         return;
     }
@@ -89,7 +89,7 @@ void Transaction::push(UndoableCommand* cmd, EditData* editData)
     // may themselves push further commands; those must end up _after_ this
     // command in the transaction, so that undo reverses them first.
     m_undoableTransaction->appendCommand(cmd);
-    cmd->redo(editData);
+    cmd->redo();
 }
 
 void Transaction::pushWithoutPerforming(UndoableCommand* cmd)
@@ -246,7 +246,7 @@ void TransactionManager::undoRedo(bool undo, EditData* editData)
         changes = stack->last()->changesInfo(true);
         stack->undo(editData);
     } else {
-        stack->redo(editData);
+        stack->redo();
         changes = stack->last()->changesInfo(false);
     }
 

--- a/src/engraving/editing/transaction/transaction.h
+++ b/src/engraving/editing/transaction/transaction.h
@@ -110,7 +110,7 @@ public:
     Transaction(Transaction&&) = default;
     Transaction& operator=(Transaction&&) = default;
 
-    void push(UndoableCommand* cmd, EditData* editData = nullptr);
+    void push(UndoableCommand* cmd);
     void pushWithoutPerforming(UndoableCommand* cmd);
 
 private:

--- a/src/engraving/editing/transaction/undoablecommand.cpp
+++ b/src/engraving/editing/transaction/undoablecommand.cpp
@@ -57,12 +57,12 @@ std::vector<EngravingObject*> mu::engraving::compoundObjects(EngravingObject* ob
     return objects;
 }
 
-void UndoableCommand::undo(EditData* ed)
+void UndoableCommand::undo()
 {
-    flip(ed);
+    flip();
 }
 
-void UndoableCommand::redo(EditData* ed)
+void UndoableCommand::redo()
 {
-    flip(ed);
+    flip();
 }

--- a/src/engraving/editing/transaction/undoablecommand.h
+++ b/src/engraving/editing/transaction/undoablecommand.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 namespace mu::engraving {
-class EditData;
 class EngravingItem;
 class EngravingObject;
 
@@ -172,8 +171,8 @@ class UndoableCommand
 public:
     virtual ~UndoableCommand() = default;
 
-    virtual void undo(EditData*);
-    virtual void redo(EditData*);
+    virtual void undo();
+    virtual void redo();
 
     virtual void cleanup(bool /*wasDone*/) {}
 
@@ -184,7 +183,7 @@ public:
     virtual bool matchesFilter(UndoableCommandFilter, const EngravingItem* /* target */) const { return false; }
 
 protected:
-    virtual void flip(EditData*) {}
+    virtual void flip() {}
 };
 
 std::vector<EngravingObject*> compoundObjects(EngravingObject* object);

--- a/src/engraving/editing/transaction/undostack.cpp
+++ b/src/engraving/editing/transaction/undostack.cpp
@@ -224,15 +224,15 @@ void UndoStack::undo(EditData* ed)
     if (m_currentIndex) {
         --m_currentIndex;
         assert(m_currentIndex < m_transactions.size());
-        m_transactions[m_currentIndex]->undo(ed);
+        m_transactions[m_currentIndex]->undo();
     }
 }
 
-void UndoStack::redo(EditData* ed)
+void UndoStack::redo()
 {
     LOG_UNDO() << "called";
     if (canRedo()) {
-        m_transactions[m_currentIndex++]->redo(ed);
+        m_transactions[m_currentIndex++]->redo();
     }
 }
 
@@ -265,7 +265,7 @@ void UndoableTransaction::unwind()
     while (!m_commands.empty()) {
         UndoableCommand* command = muse::takeLast(m_commands);
         LOG_UNDO() << "unwind: " << command->name();
-        command->undo(nullptr);
+        command->undo();
         command->cleanup(false);
         delete command;
     }
@@ -363,7 +363,7 @@ void UndoableTransaction::applySelectionInfo(const SelectionInfo& info, Selectio
     }
 }
 
-void UndoableTransaction::undo(EditData* ed)
+void UndoableTransaction::undo()
 {
     m_redoInputState = m_score->inputState();
     fillSelectionInfo(m_redoSelectionInfo, m_score->selection());
@@ -371,7 +371,7 @@ void UndoableTransaction::undo(EditData* ed)
 
     for (auto it = m_commands.rbegin(); it != m_commands.rend(); ++it) {
         LOG_UNDO() << "<" << (*it)->name() << ">";
-        (*it)->undo(ed);
+        (*it)->undo();
     }
 
     m_score->setInputState(m_undoInputState);
@@ -381,7 +381,7 @@ void UndoableTransaction::undo(EditData* ed)
     }
 }
 
-void UndoableTransaction::redo(EditData* ed)
+void UndoableTransaction::redo()
 {
     m_undoInputState = m_score->inputState();
     fillSelectionInfo(m_undoSelectionInfo, m_score->selection());
@@ -389,7 +389,7 @@ void UndoableTransaction::redo(EditData* ed)
 
     for (UndoableCommand* command : m_commands) {
         LOG_UNDO() << "<" << command->name() << ">";
-        command->redo(ed);
+        command->redo();
     }
 
     m_score->setInputState(m_redoInputState);

--- a/src/engraving/editing/transaction/undostack.h
+++ b/src/engraving/editing/transaction/undostack.h
@@ -46,8 +46,8 @@ public:
     UndoableTransaction(Score* s, const muse::TranslatableString& actionName);
     ~UndoableTransaction();
 
-    void undo(EditData*);
-    void redo(EditData*);
+    void undo();
+    void redo();
 
     void appendCommand(UndoableCommand* cmd) { m_commands.push_back(cmd); }
     void append(UndoableTransaction&& other);
@@ -145,7 +145,7 @@ public:
     }
 
     void undo(EditData*);
-    void redo(EditData*);
+    void redo();
     void reopen();
 
     void mergeTransactions(size_t startIdx);

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -754,7 +754,7 @@ public:
     UNDO_CHANGED_OBJECTS({ m_harmony })
 
 private:
-    void flip(EditData*) override;
+    void flip() override;
 
     Harmony* m_harmony = nullptr;
 
@@ -763,7 +763,7 @@ private:
 };
 }
 
-void TransposeHarmony::flip(EditData*)
+void TransposeHarmony::flip()
 {
     m_harmony->realizedHarmony().setDirty(true);   // harmony should be re-realized after transposition
 
@@ -805,7 +805,7 @@ public:
     UNDO_CHANGED_OBJECTS({ m_harmony })
 
 private:
-    void flip(EditData*) override;
+    void flip() override;
 
     Harmony* m_harmony = nullptr;
     int m_interval = 0;
@@ -814,7 +814,7 @@ private:
 };
 }
 
-void TransposeHarmonyDiatonic::flip(EditData*)
+void TransposeHarmonyDiatonic::flip()
 {
     m_harmony->realizedHarmony().setDirty(true);   // harmony should be re-realized after transposition
 

--- a/src/engraving/rendering/editmode/editmoderenderer.cpp
+++ b/src/engraving/rendering/editmode/editmoderenderer.cpp
@@ -28,7 +28,6 @@
 #include "dom/dynamic.h"
 #include "dom/slurtie.h"
 #include "dom/textbase.h"
-#include "editing/textedit.h"
 #include "rendering/score/tdraw.h"
 
 using namespace mu::engraving::rendering::editmode;
@@ -43,64 +42,64 @@ void EditModeRenderer::drawItem(const EngravingItem* item, muse::draw::Painter* 
         drawBarline(item_cast<const BarLine*>(item), painter, ed, currentViewScaling, opt);
         break;
     case ElementType::CAPO:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::DYNAMIC:
         drawDynamic(item_cast<const Dynamic*>(item), painter, ed, currentViewScaling, opt);
         break;
     case ElementType::EXPRESSION:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::FIGURED_BASS:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::FINGERING:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::GUITAR_BEND_TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::HARMONY:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::HARP_DIAGRAM:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::INSTRUMENT_CHANGE:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::INSTRUMENT_NAME:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::JUMP:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::LAISSEZ_VIB_SEGMENT:
         drawSlurTieSegment(item_cast<const SlurTieSegment*>(item), painter, ed, currentViewScaling, opt);
         break;
     case ElementType::LYRICS:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::MMREST_RANGE:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::MARKER:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::MEASURE_NUMBER:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::PARTIAL_TIE_SEGMENT:
         drawSlurTieSegment(item_cast<const SlurTieSegment*>(item), painter, ed, currentViewScaling, opt);
         break;
     case ElementType::PLAY_COUNT_TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::PLAYTECH_ANNOTATION:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::REHEARSAL_MARK:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::SLUR_SEGMENT:
     case ElementType::TIE_SEGMENT:
@@ -109,25 +108,25 @@ void EditModeRenderer::drawItem(const EngravingItem* item, muse::draw::Painter* 
         drawSlurTieSegment(item_cast<const SlurTieSegment*>(item), painter, ed, currentViewScaling, opt);
         break;
     case ElementType::STAFF_TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::STICKING:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::STRING_TUNINGS:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::SYSTEM_TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::TEMPO_TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::TEXT:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     case ElementType::TRIPLET_FEEL:
-        drawTextBase(item_cast<const TextBase*>(item), painter, ed, currentViewScaling, opt);
+        drawTextBase(item_cast<const TextBase*>(item), painter, currentViewScaling, opt);
         break;
     default:
         drawEngravingItem(item, painter, ed, currentViewScaling, opt);
@@ -176,7 +175,7 @@ void EditModeRenderer::drawDynamic(const Dynamic* item, muse::draw::Painter* pai
                                    const PaintOptions& opt)
 {
     if (item->cursor() && item->cursor()->editing()) {
-        drawTextBase(item, painter, ed, currentViewScaling, opt);
+        drawTextBase(item, painter, currentViewScaling, opt);
         return;
     }
 
@@ -211,19 +210,13 @@ static void drawTextBaseSelection(const TextBase* item, muse::draw::Painter* pai
     painter->restore();
 }
 
-void EditModeRenderer::drawTextBase(const TextBase* item, muse::draw::Painter* painter, const EditData& ed, double currentViewScaling,
+void EditModeRenderer::drawTextBase(const TextBase* item, muse::draw::Painter* painter, double currentViewScaling,
                                     const PaintOptions& opt)
 {
     PointF pos(item->canvasPos());
     painter->translate(pos);
 
-    TextEditData* ted = static_cast<TextEditData*>(ed.getData(item).get());
-    if (!ted) {
-        LOGD("ted not found");
-        return;
-    }
-    TextCursor* cursor = ted->cursor();
-
+    const TextCursor* cursor = item->cursor();
     const TextBase::LayoutData* ldata = item->ldata();
     IF_ASSERT_FAILED(ldata) {
         return;

--- a/src/engraving/rendering/editmode/editmoderenderer.h
+++ b/src/engraving/rendering/editmode/editmoderenderer.h
@@ -62,8 +62,7 @@ private:
     static void drawSlurTieSegment(const SlurTieSegment* item, muse::draw::Painter* painter, const EditData& ed, double currentViewScaling,
                                    const PaintOptions& opt);
 
-    static void drawTextBase(const TextBase* item, muse::draw::Painter* painter, const EditData& ed, double currentViewScaling,
-                             const PaintOptions& opt);
+    static void drawTextBase(const TextBase* item, muse::draw::Painter* painter, double currentViewScaling, const PaintOptions& opt);
     static void draw(const TextBlock& textBlock, const TextBase* item, muse::draw::Painter* painter);
     static void draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter);
 };

--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -456,12 +456,12 @@ void DomAccessor::undoRemoveElement(EngravingItem* item)
     score()->undoRemoveElement(item);
 }
 
-void DomAccessor::undo(UndoableCommand* cmd, EditData* ed) const
+void DomAccessor::undo(UndoableCommand* cmd) const
 {
     IF_ASSERT_FAILED(score()) {
         return;
     }
-    score()->undo(cmd, ed);
+    score()->undo(cmd);
 }
 
 void DomAccessor::addElement(EngravingItem* item)

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -202,7 +202,7 @@ public:
     void undoAddElement(EngravingItem* item, bool addToLinkedStaves = true, bool ctrlModifier = false);
     void doUndoRemoveElement(EngravingItem* item);
     void undoRemoveElement(EngravingItem* item);
-    void undo(UndoableCommand* cmd, EditData* ed = nullptr) const;
+    void undo(UndoableCommand* cmd) const;
     void addElement(EngravingItem* item);
     void removeElement(EngravingItem* item);
     void updateSystemLocksOnCreateMMRest(Measure* first, Measure* last);

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -72,7 +72,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextBefore)
     EditData ed;
     dynamic->startEdit(ed);
     score->startCmd(TranslatableString::untranslatable("Edit dynamic text (test)"));
-    score->undo(new InsertText(dynamic->cursor(), String(u"poco ")), &ed);
+    score->undo(new InsertText(dynamic->cursor(), String(u"poco ")));
     score->endCmd();
     dynamic->endEdit(ed);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"dynamicAddTextBefore.mscx", TEXTBASE_DATA_DIR + u"dynamicAddTextBefore-ref.mscx"));
@@ -101,7 +101,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextNoItalic)
     dynamic->startEdit(ed);
     score->startCmd(TranslatableString::untranslatable("Edit dynamic text (test)"));
     dynamic->setProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0));
-    score->undo(new InsertText(dynamic->cursor(), String(u"moderately ")), &ed);
+    score->undo(new InsertText(dynamic->cursor(), String(u"moderately ")));
     score->endCmd();
     dynamic->endEdit(ed);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"dynamicAddTextNoItalic.mscx", TEXTBASE_DATA_DIR + u"dynamicAddTextNoItalic-ref.mscx"));
@@ -123,9 +123,9 @@ TEST_F(Engraving_TextBaseTests, getFontStyleProperty)
     StaffText* staffText = addStaffText(score);
     EditData ed;
     staffText->startEdit(ed);
-    score->undo(new InsertText(staffText->cursor(), String(u"normal ")), &ed);
+    score->undo(new InsertText(staffText->cursor(), String(u"normal ")));
     staffText->setProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
-    score->undo(new InsertText(staffText->cursor(), String(u"bold")), &ed);
+    score->undo(new InsertText(staffText->cursor(), String(u"bold")));
     staffText->cursor()->moveCursorToStart();
     EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::NextWord, TextCursor::MoveMode::KeepAnchor);
@@ -158,7 +158,7 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     EditData ed;
     score->undoStack()->undo(&ed);
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
-    score->undoStack()->redo(&ed);
+    score->undoStack()->redo();
     EXPECT_EQ(staffText->xmlText(), u"<b>normal bold <u>underline</u> <i>italic</i></b>");
     score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(
@@ -202,7 +202,7 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontSizeEmptyLines)   // Testcase for 
     LOGD(" 2.: Text is now : %s", muPrintable(staffText->xmlText().replace(u"\n", u"\\n")));
     EXPECT_EQ(staffText->xmlText(), originalText);
 
-    score->undoStack()->redo(&ed);
+    score->undoStack()->redo();
     LOGD(" 3.: Text is now : %s", muPrintable(staffText->xmlText().replace(u"\n", u"\\n")));
     EXPECT_EQ(staffText->xmlText(), expectedText);
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1111,8 +1111,7 @@ void NotationInteraction::selectAndStartEditIfNeeded(EngravingItem* element)
 void NotationInteraction::selectAll()
 {
     if (isTextEditingStarted()) {
-        auto textBase = toTextBase(m_editData.element);
-        textBase->selectAll(textBase->cursorFromEditData(m_editData));
+        toTextBase(m_editData.element)->selectAll();
     } else {
         score()->cmdSelectAll();
     }
@@ -4443,7 +4442,7 @@ void NotationInteraction::editText(QInputMethodEvent* event)
 
     if (!event->commitString().isEmpty()) {
         score()->startCmd(TranslatableString("undoableAction", "Edit text"));
-        text->insertText(m_editData, event->commitString());
+        text->insertText(event->commitString());
         score()->endCmd();
         preeditString.clear();
     } else {
@@ -4589,11 +4588,7 @@ bool NotationInteraction::doTextEdit(QKeyEvent* event, TextBase* tb)
         return true;
     }
 
-    TextEditData* ted = static_cast<TextEditData*>(m_editData.getData(tb).get());
-    TextCursor* cursor = ted ? ted->cursor() : nullptr;
-    IF_ASSERT_FAILED(cursor) {
-        return true;
-    }
+    TextCursor* cursor = tb->cursor();
 
     bool useCloseQuote = false; // Use close if there's a non-space before the newly inputted quote
 
@@ -4608,7 +4603,7 @@ bool NotationInteraction::doTextEdit(QKeyEvent* event, TextBase* tb)
     startEdit(TranslatableString("undoableAction", "Keystroke edit"));
 
     cursor->movePosition(TextCursor::MoveOperation::Left);
-    score()->undo(new RemoveText(cursor, event->text()), &m_editData);
+    score()->undo(new RemoveText(cursor, event->text()));
 
     //: Single open quotation mark
     const String singleOpenQuote = muse::mtrc("notation", u"‘");
@@ -4623,7 +4618,7 @@ bool NotationInteraction::doTextEdit(QKeyEvent* event, TextBase* tb)
                                ? (useCloseQuote ? singleCloseQuote : singleOpenQuote)
                                : (useCloseQuote ? doubleCloseQuote : doubleOpenQuote);
 
-    tb->insertText(m_editData, replacement);
+    tb->insertText(replacement);
     apply();
 
     return true;
@@ -4733,7 +4728,7 @@ void NotationInteraction::changeTextCursorPosition(const PointF& newCursorPos)
     textEl->mousePress(m_editData);
     if (m_editData.buttons == mu::engraving::MiddleButton) {
         QString txt = QGuiApplication::clipboard()->text();
-        textEl->paste(m_editData, txt);
+        textEl->paste(txt);
     }
 
     notifyAboutTextEditingChanged();
@@ -4746,8 +4741,8 @@ void NotationInteraction::selectText(mu::engraving::SelectTextType type)
     }
 
     mu::engraving::TextBase* text = mu::engraving::toTextBase(m_editData.element);
-    text->select(m_editData, type);
-    text->endHexState(m_editData);
+    text->select(type);
+    text->endHexState();
     text->setPrimed(false);
 
     notifyAboutTextEditingChanged();
@@ -5487,7 +5482,7 @@ void NotationInteraction::pasteIntoTextEdit()
     const QMimeData* mimeData = QApplication::clipboard()->mimeData();
     if (mimeData->hasFormat(TextEditData::mimeRichTextFormat)) {
         const QString txt = QString::fromUtf8(mimeData->data(TextEditData::mimeRichTextFormat));
-        toTextBase(m_editData.element)->paste(m_editData, txt);
+        toTextBase(m_editData.element)->paste(txt);
         notifyAboutTextEditingChanged();
         return;
     }
@@ -5498,7 +5493,7 @@ void NotationInteraction::pasteIntoTextEdit()
         textForPaste = extractSyllable(clipboardText);
     }
 
-    toTextBase(m_editData.element)->paste(m_editData, textForPaste);
+    toTextBase(m_editData.element)->paste(textForPaste);
     notifyAboutTextEditingChanged();
 
     if (textForPaste.isEmpty() || !m_editData.element->isLyrics()) {
@@ -5546,7 +5541,7 @@ void NotationInteraction::deleteSelection()
 
     if (isTextEditingStarted()) {
         mu::engraving::TextBase* textBase = toTextBase(m_editData.element);
-        if (!textBase->deleteSelectedText(m_editData)) {
+        if (!textBase->deleteSelectedText()) {
             m_editData.key = Qt::Key_Backspace;
             m_editData.modifiers = {};
             if (textBase->edit(m_editData)) {
@@ -6946,10 +6941,10 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
 
     startEditText(nextLyrics, PointF());
 
-    mu::engraving::TextCursor* cursor = nextLyrics->cursor();
     if (end) {
-        nextLyrics->selectAll(cursor);
+        nextLyrics->selectAll();
     } else if (!newLyrics) {
+        mu::engraving::TextCursor* cursor = nextLyrics->cursor();
         cursor->movePosition(mu::engraving::TextCursor::MoveOperation::End, mu::engraving::TextCursor::MoveMode::MoveAnchor);
         cursor->movePosition(mu::engraving::TextCursor::MoveOperation::Start, mu::engraving::TextCursor::MoveMode::KeepAnchor);
     }
@@ -7087,7 +7082,7 @@ void NotationInteraction::navigateToNextSyllable()
             score()->select(toLyrics, SelectType::SINGLE, 0);
             score()->setLayoutAll();
             startEditText(toLyrics, PointF());
-            toLyrics->selectAll(toLyrics->cursor());
+            toLyrics->selectAll();
             showItem(toLyrics);
 
             return;
@@ -7213,7 +7208,7 @@ void NotationInteraction::navigateToNextSyllable()
 
     startEditText(toLyrics, PointF());
 
-    toLyrics->selectAll(toLyrics->cursor());
+    toLyrics->selectAll();
     showItem(toLyrics);
 }
 
@@ -7273,7 +7268,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
     score()->setLayoutAll();
     score()->update();
 
-    lyrics->selectAll(lyrics->cursor());
+    lyrics->selectAll();
     showItem(lyrics);
 }
 
@@ -7809,7 +7804,7 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
 
         if (text) {
             startEditText(text);
-            text->selectAll(text->cursor());
+            text->selectAll();
             showItem(text);
         }
     } else {
@@ -8056,7 +8051,7 @@ void NotationInteraction::addMelisma()
     score()->select(toLyrics, SelectType::SINGLE, 0);
     startEditText(toLyrics, PointF());
 
-    toLyrics->selectAll(toLyrics->cursor());
+    toLyrics->selectAll();
 }
 
 //! NOTE: Copied from ScoreView::lyricsReturn


### PR DESCRIPTION
It was only used by some text editing UndoableCommands. See this as finishing what https://github.com/musescore/MuseScore/commit/70745ef6874a82a26adb283e79666ff420bb69d7 started: making TextCursor exclusively owned by TextBase. 

(I’m actually not completely convinced that that is the direction we’ll ultimately want to go, but anything is better than the current half-baked state.)