### PR TITLE
Automation - fix assertion when opening empty score page

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -359,6 +359,7 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     });
 
     // FIXME: only un-/re-subscribe when master notation changes
+    m_notationAutomationController->init();
     notationAutomation()->automationModeEnabledChanged().onNotify(this, [this]() {
         scheduleRedraw();
         emit automationModeChanged();
@@ -762,8 +763,6 @@ void AbstractNotationPaintView::onNotationSetup()
     TRACEFUNC;
     onCurrentNotationChanged();
     onPlayingChanged();
-
-    m_notationAutomationController->init();
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onCurrentNotationChanged();

--- a/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
@@ -72,10 +72,10 @@ void NotationAutomationController::init()
 
     automation()->automationModeEnabledChanged().onNotify(this, [this]() {
         updatePolylinesGeometry();
-    });
+    }, Asyncable::Mode::SetReplace /* FIXME */);
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onCurrentNotationChanged();
-    });
+    }, Asyncable::Mode::SetReplace /* FIXME */);
 }
 
 NotationAutomationController::SysStaffToPolylinesMap NotationAutomationController::createPolylinesForSystem(const System* system)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/33960#discussion_r3498779032

Take 2 (after #33975) - `onNotationSetup` runs even if no score is loaded, so the assert persisted. This PR moves the `init` call to `onLoadNotation` which fundamentally relies on a score being present.

As hinted at by the pre-existing comment there's still work to be done in this area since were subscribing and initing whenever the notation changes - in reality we should only do this when the master notation has changed. Disconnect and deinit calls should also used whenever the master notation us unloaded.