### PR TITLE
Preserve text font style after XML text reset

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2273,6 +2273,7 @@ void TextBase::setXmlText(const String& s)
 {
     m_text = s;
     m_textInvalid = false;
+    mutldata()->blocks.clear();
     mutldata()->layoutInvalid = true;
 }
 


### PR DESCRIPTION
Resolves: #28652  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Preserve explicit font style overrides after replacing XML text.

When an Expression text item is added to a custom palette, it is written to MIME XML and read again. In that path, `<italic>0</italic>` was read correctly, but `setXmlText()` left cached text blocks in place while marking the layout invalid.

If `FONT_STYLE` was queried before layout was rebuilt, `selectedFragmentsFormat()` could fall back to the Expression default style, which is italic. Clearing the cached blocks keeps the layout cache consistent with the replaced XML text.


https://github.com/user-attachments/assets/a42391c1-10c9-4f2a-b7f0-246d623bfd38

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->9zu8co
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).