### PR TITLE
[4.7.4] fix #34026: prevent unlimited memory for image via maxScaledImageDim

### DIFF
--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -144,5 +144,8 @@ public:
     virtual bool specificSlursLayoutWorkaround() const = 0;
     virtual bool preferSameStringForTranspose() const = 0;
     virtual void setPreferSameStringForTranspose(bool preferSameString) = 0;
+
+    virtual int maxScaledImageDim() const = 0;
+    virtual void setMaxScaledImageDim(int maxDim) = 0;
 };
 }

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -488,3 +488,13 @@ bool EngravingConfiguration::preferSameStringForTranspose() const
 void EngravingConfiguration::setPreferSameStringForTranspose(bool /*preferSameString*/)
 {
 }
+
+int EngravingConfiguration::maxScaledImageDim() const
+{
+    return m_maxScaledImageDim;
+}
+
+void EngravingConfiguration::setMaxScaledImageDim(int maxDim)
+{
+    m_maxScaledImageDim = maxDim;
+}

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -124,7 +124,11 @@ public:
     bool preferSameStringForTranspose() const override;
     void setPreferSameStringForTranspose(bool preferSameString) override;
 
+    int maxScaledImageDim() const override;
+    void setMaxScaledImageDim(int maxDim) override;
+
 private:
+    int m_maxScaledImageDim = 4096;
     muse::async::Channel<voice_idx_t, Color> m_voiceColorChanged;
     muse::async::Channel<bool> m_dynamicsApplyToAllVoicesChanged;
     muse::async::Channel<bool> m_fretboardDiagramsAutoUpdateChanged;

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2038,13 +2038,16 @@ void TDraw::draw(const Image* item, Painter* painter, const PaintOptions& opt)
             } else {
                 s = item->size() * DPMM;
             }
-            if (opt.isPrinting && !MScore::svgPrinting) {
-                // use original image size for printing, but not for svg for reasonable file size.
+            Transform t = painter->worldTransform();
+            muse::Size ss = muse::Size(s.width() * t.m11(), s.height() * t.m22());
+            int maxDim = item->configuration()->maxScaledImageDim();
+            bool useDirectDraw = (opt.isPrinting && !MScore::svgPrinting)
+                                 || (maxDim > 0 && std::max(ss.width(), ss.height()) > maxDim);
+
+            if (useDirectDraw) {
                 painter->scale(s.width() / item->rasterImage()->width(), s.height() / item->rasterImage()->height());
                 painter->drawPixmap(PointF(0, 0), *item->rasterImage());
             } else {
-                Transform t = painter->worldTransform();
-                muse::Size ss = muse::Size(s.width() * t.m11(), s.height() * t.m22());
                 t.setMatrix(1.0, t.m12(), t.m13(), t.m21(), 1.0, t.m23(), t.m31(), t.m32(), t.m33());
                 painter->setWorldTransform(t);
                 if ((item->buffer().size() != ss || item->dirty()) && item->rasterImage() && !item->rasterImage()->isNull()) {

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -107,5 +107,8 @@ public:
     MOCK_METHOD(bool, specificSlursLayoutWorkaround, (), (const, override));
     MOCK_METHOD(bool, preferSameStringForTranspose, (), (const, override));
     MOCK_METHOD(void, setPreferSameStringForTranspose, (bool), (override));
+
+    MOCK_METHOD(int, maxScaledImageDim, (), (const, override));
+    MOCK_METHOD(void, setMaxScaledImageDim, (int), (override));
 };
 }


### PR DESCRIPTION
Resolves: #34026
Backport of #34038 