### PR TITLE
Fix "sticky selection" of lines [4.7.4]

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -456,13 +456,12 @@ void Selection::clear()
     }
 
     for (EngravingItem* e : m_el) {
+        e->score()->addRefresh(changeSelection(e, false));
         if (e->isSpanner()) {       // TODO: only visible elements should be selectable?
             Spanner* sp = toSpanner(e);
             for (auto s : sp->spannerSegments()) {
                 e->score()->addRefresh(changeSelection(s, false));
             }
-        } else {
-            e->score()->addRefresh(changeSelection(e, false));
         }
     }
     m_el.clear();


### PR DESCRIPTION
Resolves comment: https://github.com/musescore/MuseScore/issues/33982#issuecomment-4855841019

The line isn't actually selected - we're just failing to refresh the score since the spanner has no segments.