### PR TITLE
fixed #34043: WAV/FLAC export from command line broken

### DIFF
--- a/src/importexport/audioexport/iaudioexportconfiguration.h
+++ b/src/importexport/audioexport/iaudioexportconfiguration.h
@@ -47,12 +47,15 @@ public:
 
     virtual muse::audio::samples_t exportBufferSize() const = 0;
 
-    virtual muse::audio::AudioSampleFormat exportSampleFormat() const = 0;
-    virtual void setExportSampleFormat(muse::audio::AudioSampleFormat format) = 0;
-    virtual void setExportSampleFormat(const QString& extension, muse::audio::AudioSampleFormat format) = 0;
-    virtual const std::vector<muse::audio::AudioSampleFormat>& availableSampleFormats(const QString& extension) const = 0;
+    virtual muse::audio::AudioSampleFormat exportWavSampleFormat() const = 0;
+    virtual void setExportWavSampleFormat(muse::audio::AudioSampleFormat format) = 0;
+
+    virtual muse::audio::AudioSampleFormat exportFlacSampleFormat() const = 0;
+    virtual void setExportFlacSampleFormat(muse::audio::AudioSampleFormat format) = 0;
+
+    virtual const std::vector<muse::audio::AudioSampleFormat>& availableWavSampleFormats() const = 0;
+    virtual const std::vector<muse::audio::AudioSampleFormat>& availableFlacSampleFormats() const = 0;
     virtual QString sampleFormatToString(muse::audio::AudioSampleFormat format) const = 0;
-    virtual void loadSampleFormatSetting(const QString& extension) = 0;
 };
 }
 

--- a/src/importexport/audioexport/internal/audioexportconfiguration.cpp
+++ b/src/importexport/audioexport/internal/audioexportconfiguration.cpp
@@ -85,54 +85,43 @@ samples_t AudioExportConfiguration::exportBufferSize() const
     return 4096;
 }
 
-AudioSampleFormat AudioExportConfiguration::exportSampleFormat() const
+AudioSampleFormat AudioExportConfiguration::exportWavSampleFormat() const
 {
-    return m_exportSampleFormat;
+    return static_cast<AudioSampleFormat>(settings()->value(EXPORT_WAV_SAMPLE_FORMAT_KEY).toInt());
 }
 
-void AudioExportConfiguration::setExportSampleFormat(AudioSampleFormat format)
+void AudioExportConfiguration::setExportWavSampleFormat(AudioSampleFormat format)
 {
-    m_exportSampleFormat = format;
+    settings()->setSharedValue(EXPORT_WAV_SAMPLE_FORMAT_KEY, Val(static_cast<int>(format)));
 }
 
-void AudioExportConfiguration::setExportSampleFormat(const QString& extension, AudioSampleFormat format)
+AudioSampleFormat AudioExportConfiguration::exportFlacSampleFormat() const
 {
-    m_exportSampleFormat = format;
-    if (extension == QLatin1String("wav")) {
-        settings()->setSharedValue(EXPORT_WAV_SAMPLE_FORMAT_KEY, Val(static_cast<int>(format)));
-    } else if (extension == QLatin1String("flac")) {
-        settings()->setSharedValue(EXPORT_FLAC_SAMPLE_FORMAT_KEY, Val(static_cast<int>(format)));
-    }
+    return static_cast<AudioSampleFormat>(settings()->value(EXPORT_FLAC_SAMPLE_FORMAT_KEY).toInt());
 }
 
-const std::vector<AudioSampleFormat>& AudioExportConfiguration::availableSampleFormats(const QString& extension) const
+void AudioExportConfiguration::setExportFlacSampleFormat(AudioSampleFormat format)
 {
-    if (extension == QLatin1String("wav")) {
-        static const std::vector<muse::audio::AudioSampleFormat> wavSampleFormats {
-            AudioSampleFormat::Int16,
-            AudioSampleFormat::Int24,
-            AudioSampleFormat::Float32,
-        };
-        return wavSampleFormats;
-    }
-    if (extension == QLatin1String("flac")) {
-        static const std::vector<muse::audio::AudioSampleFormat> flacSampleFormats {
-            AudioSampleFormat::Int16,
-            AudioSampleFormat::Int24,
-        };
-        return flacSampleFormats;
-    }
-    static const std::vector<muse::audio::AudioSampleFormat> emptySampleFormats {};
-    return emptySampleFormats;
+    settings()->setSharedValue(EXPORT_FLAC_SAMPLE_FORMAT_KEY, Val(static_cast<int>(format)));
 }
 
-void AudioExportConfiguration::loadSampleFormatSetting(const QString& extension)
+const std::vector<AudioSampleFormat>& AudioExportConfiguration::availableWavSampleFormats() const
 {
-    if (extension == QLatin1String("wav")) {
-        setExportSampleFormat(static_cast<AudioSampleFormat>(settings()->value(EXPORT_WAV_SAMPLE_FORMAT_KEY).toInt()));
-    } else if (extension == QLatin1String("flac")) {
-        setExportSampleFormat(static_cast<AudioSampleFormat>(settings()->value(EXPORT_FLAC_SAMPLE_FORMAT_KEY).toInt()));
-    }
+    static const std::vector<AudioSampleFormat> formats {
+        AudioSampleFormat::Int16,
+        AudioSampleFormat::Int24,
+        AudioSampleFormat::Float32,
+    };
+    return formats;
+}
+
+const std::vector<AudioSampleFormat>& AudioExportConfiguration::availableFlacSampleFormats() const
+{
+    static const std::vector<AudioSampleFormat> formats {
+        AudioSampleFormat::Int16,
+        AudioSampleFormat::Int24,
+    };
+    return formats;
 }
 
 QString AudioExportConfiguration::sampleFormatToString(AudioSampleFormat format) const

--- a/src/importexport/audioexport/internal/audioexportconfiguration.h
+++ b/src/importexport/audioexport/internal/audioexportconfiguration.h
@@ -41,16 +41,18 @@ public:
 
     muse::audio::samples_t exportBufferSize() const override;
 
-    muse::audio::AudioSampleFormat exportSampleFormat() const override;
-    void setExportSampleFormat(muse::audio::AudioSampleFormat format) override;
-    void setExportSampleFormat(const QString& extension, muse::audio::AudioSampleFormat format) override;
-    const std::vector<muse::audio::AudioSampleFormat>& availableSampleFormats(const QString& extension) const override;
+    muse::audio::AudioSampleFormat exportWavSampleFormat() const override;
+    void setExportWavSampleFormat(muse::audio::AudioSampleFormat format) override;
+
+    muse::audio::AudioSampleFormat exportFlacSampleFormat() const override;
+    void setExportFlacSampleFormat(muse::audio::AudioSampleFormat format) override;
+
+    const std::vector<muse::audio::AudioSampleFormat>& availableWavSampleFormats() const override;
+    const std::vector<muse::audio::AudioSampleFormat>& availableFlacSampleFormats() const override;
     QString sampleFormatToString(muse::audio::AudioSampleFormat format) const override;
-    void loadSampleFormatSetting(const QString& extension) override;
 
 private:
     std::optional<int> m_exportMp3BitrateOverride = std::nullopt;
-    muse::audio::AudioSampleFormat m_exportSampleFormat;
 };
 }
 

--- a/src/importexport/audioexport/internal/flacwriter.cpp
+++ b/src/importexport/audioexport/internal/flacwriter.cpp
@@ -37,7 +37,7 @@ muse::Ret FlacWriter::write(notation::INotationPtr notation, muse::io::IODevice&
             configuration()->exportBufferSize(),
             2 /* audioChannelsNumber */
         },
-        configuration()->exportSampleFormat(),
+        configuration()->exportFlacSampleFormat(),
         0 /* bitRate */
     };
 

--- a/src/importexport/audioexport/internal/wavewriter.cpp
+++ b/src/importexport/audioexport/internal/wavewriter.cpp
@@ -37,7 +37,7 @@ Ret WaveWriter::write(notation::INotationPtr notation, io::IODevice& destination
             configuration()->exportBufferSize(),
             2 /* audioChannelsNumber */
         },
-        configuration()->exportSampleFormat(),
+        configuration()->exportWavSampleFormat(),
         0 /* bitRate */
     };
 

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -290,6 +290,15 @@ bool ExportDialogModel::isIndexValid(int index) const
     return index >= 0 && index < m_notations.size();
 }
 
+bool ExportDialogModel::isFormatSelected(const QString& formatSuffix) const
+{
+    IF_ASSERT_FAILED(!m_selectedExportType.suffixes.empty()) {
+        return false;
+    }
+
+    return m_selectedExportType.suffixes.contains(formatSuffix);
+}
+
 int ExportDialogModel::selectionLength() const
 {
     return m_selectionModel->selectedIndexes().size();
@@ -312,8 +321,6 @@ void ExportDialogModel::setExportType(const ExportType& type)
     }
 
     m_selectedExportType = type;
-
-    audioExportConfiguration()->loadSampleFormatSetting(type.suffixes[0]);
 
     emit selectedExportTypeChanged(type.toMap());
     emit availableSampleFormatsChanged();
@@ -432,7 +439,7 @@ bool ExportDialogModel::exportScores()
     if (m_exportPath != "" && filename != "") {
         defaultPath = io::absoluteDirpath(m_exportPath)
                       .appendingComponent(io::filename(filename, false))
-                      .appendingSuffix(m_selectedExportType.suffixes[0]);
+                      .appendingSuffix(m_selectedExportType.suffixes.front());
     }
 
     RetVal<muse::io::path_t> exportPath
@@ -941,7 +948,15 @@ void ExportDialogModel::updateExportInfo()
 
 QVariantList ExportDialogModel::availableSampleFormats() const
 {
-    const auto& formats = audioExportConfiguration()->availableSampleFormats(m_selectedExportType.suffixes[0]);
+    std::vector<muse::audio::AudioSampleFormat> formats;
+
+    if (isFormatSelected("wav")) {
+        formats = audioExportConfiguration()->availableWavSampleFormats();
+    }
+    if (isFormatSelected("flac")) {
+        formats = audioExportConfiguration()->availableFlacSampleFormats();
+    }
+
     QVariantList result;
     for (const auto& format : formats) {
         QVariantMap obj;
@@ -954,24 +969,38 @@ QVariantList ExportDialogModel::availableSampleFormats() const
 
 int ExportDialogModel::selectedSampleFormat() const
 {
-    return static_cast<int>(audioExportConfiguration()->exportSampleFormat());
+    if (isFormatSelected("wav")) {
+        return static_cast<int>(audioExportConfiguration()->exportWavSampleFormat());
+    }
+    if (isFormatSelected("flac")) {
+        return static_cast<int>(audioExportConfiguration()->exportFlacSampleFormat());
+    }
+    return static_cast<int>(muse::audio::AudioSampleFormat::Undefined);
 }
 
 void ExportDialogModel::setSelectedSampleFormat(int format)
 {
     const auto audioFormat = static_cast<muse::audio::AudioSampleFormat>(format);
-    if (audioFormat == audioExportConfiguration()->exportSampleFormat()) {
+    if (isFormatSelected("wav")) {
+        if (audioFormat == audioExportConfiguration()->exportWavSampleFormat()) {
+            return;
+        }
+        audioExportConfiguration()->setExportWavSampleFormat(audioFormat);
+    } else if (isFormatSelected("flac")) {
+        if (audioFormat == audioExportConfiguration()->exportFlacSampleFormat()) {
+            return;
+        }
+        audioExportConfiguration()->setExportFlacSampleFormat(audioFormat);
+    } else {
         return;
     }
-
-    audioExportConfiguration()->setExportSampleFormat(m_selectedExportType.suffixes[0], audioFormat);
     emit selectedSampleFormatChanged();
 }
 
 #ifdef MUE_BUILD_IMPEXP_VIDEOEXPORT_MODULE
 void ExportDialogModel::updateVideoExportSettingMode()
 {
-    videoEncoderResolver()->setIsSettingMode(m_selectedExportType.id == QLatin1String("mp4"));
+    videoEncoderResolver()->setIsSettingMode(isFormatSelected("mp4"));
 }
 
 void ExportDialogModel::disableVideoExportSettingMode()

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
@@ -300,6 +300,8 @@ private:
 
     bool isIndexValid(int index) const;
 
+    bool isFormatSelected(const QString& formatSuffix) const;
+
     bool isMainNotation(notation::INotationPtr notation) const;
     notation::IMasterNotationPtr masterNotation() const;
 


### PR DESCRIPTION
loadSampleFormatSetting was called only for the GUI, while the console app was running with an invalid sample format

Resolves: #34043