### PR TITLE
Fix #26105: Copy slurs to existing parts during Implode

### DIFF
--- a/src/engraving/editing/clonevoice.cpp
+++ b/src/engraving/editing/clonevoice.cpp
@@ -311,7 +311,11 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
                     }
                 }
             }
-            destScore->doUndoAddElement(ns);
+            if (link) {
+                destScore->doUndoAddElement(ns);
+            } else {
+                destScore->undoAddElement(ns);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves: #26105  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
When copying spanners during Implode, use the linked-aware `undoAddElement()` path when `link == false`, matching the behavior used for ChordRests and annotations.

https://github.com/user-attachments/assets/ae2498f8-54ba-4574-80ec-cf96cd83acc1

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).