### PR TITLE
[4.7.5] Fix #34060: Crash after moving clef to 'After' position in Properties using range selection

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
@@ -113,8 +113,9 @@ void AbstractInspectorProxyModel::setModels(const QList<AbstractInspectorModel*>
 
         auto oldModel = m_models.take(model->modelType());
 
-        delete oldModel;
-        oldModel = nullptr;
+        //! NOTE: may run synchronously from a model's own property-change callback;
+        //! deleting immediately would destroy "this" mid-call, so defer it
+        oldModel->deleteLater();
     }
 
     for (AbstractInspectorModel* model : models) {

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
@@ -284,8 +284,9 @@ void InspectorListModel::removeUnusedModels(const ElementKeySet& newElementKeySe
 
         m_modelList.removeAt(index);
 
-        delete model;
-        model = nullptr;
+        //! NOTE: may run synchronously from a model's own property-change callback;
+        //! deleting immediately would destroy "this" mid-call, so defer it
+        model->deleteLater();
 
         endRemoveRows();
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34060