### PR TITLE
transform notation actions to commands

### DIFF
--- a/src/app/configs/data/shortcuts.json
+++ b/src/app/configs/data/shortcuts.json
@@ -1,5 +1,73 @@
 {
-    "PROJECT_PAGE": [
+    "NAVIGATION": [
+        {
+            "command": "command://navigation/escape",
+            "sequences": ["Escape"]
+        },
+        {
+            "command": "command://navigation/next-section",
+            "sequences": ["F6", "`"]
+        },
+        {
+            "command": "command://navigation/prev-section",
+            "sequences": ["Shift+F6", "Shift+`"]
+        },
+        {
+            "command": "command://navigation/next-panel",
+            "sequences": ["Tab"]
+        },
+        {
+            "command": "command://navigation/prev-panel",
+            "sequences": ["Shift+Tab"]
+        },
+
+        {
+            "command": "command://navigation/next-tab",
+            "sequences": ["Ctrl+Tab"]
+        },
+        {
+            "command": "command://navigation/prev-tab",
+            "sequences": ["Ctrl+Shift+Tab"]
+        },
+        {
+            "command": "command://navigation/right",
+            "sequences": ["Right"]
+        },
+        {
+            "command": "command://navigation/left",
+            "sequences": ["Left"]
+        },
+        {
+            "command": "command://navigation/up",
+            "sequences": ["Up"]
+        },
+        {
+            "command": "command://navigation/down",
+            "sequences": ["Down"]
+        },
+        {
+            "command": "command://navigation/first-control",
+            "sequences": ["Home"]
+        },
+        {
+            "command": "command://navigation/last-control",
+            "sequences": ["End"]
+        },
+        {
+            "command": "command://navigation/next-row-control",
+            "sequences": ["PgDown"]
+        },
+        {
+            "command": "command://navigation/prev-row-control",
+            "sequences": ["PgUp"]
+        },
+        {
+            "command": "command://navigation/trigger-control",
+            "sequences": ["Return", "Enter", "Space"],
+            "autorepeat": 0
+        }
+    ],
+    "PLAYBACK": [
         {
             "command": "command://playback/play-toggle",
             "sequences": ["Space"],
@@ -27,6 +95,54 @@
             "command": "command://playback/metronome-toggle",
             "sequences": [],
             "autorepeat": 0
+        }
+    ],
+    "NOTATION": [
+        {
+            "command": "command://notation/move-right",
+            "sequences": ["Right"]
+        },
+        {
+            "command": "command://notation/move-right-quickly",
+            "sequences": ["Ctrl+Right"]
+        },
+        {
+            "command": "command://notation/move-left",
+            "sequences": ["Left"]
+        },
+        {
+            "command": "command://notation/move-left-quickly",
+            "sequences": ["Ctrl+Left"]
+        },
+        {
+            "command": "command://notation/pitch-up",
+            "sequences": ["Up"]
+        },
+        {
+            "command": "command://notation/pitch-down",
+            "sequences": ["Down"]
+        },
+        {
+            "command": "command://notation/pitch-up-octave",
+            "sequences": ["Ctrl+Up"]
+        },
+        {
+            "command": "command://notation/pitch-down-octave",
+            "sequences": ["Ctrl+Down"]
+        }
+    ],
+    "NOTATION_TEXT_EDITING": [
+        {
+            "command": "command://notation/edit-next-word",
+            "sequences": ["Space"]
+        },
+        {
+            "command": "command://notation/edit-next-text-element",
+            "sequences": ["Right"]
+        },
+        {
+            "command": "command://notation/edit-prev-text-element",
+            "sequences": ["Left", "Shift+Space", "Backspace"]
         }
     ]
 }

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -931,20 +931,6 @@
     <autorepeat>0</autorepeat>
     </SC>
   <SC>
-    <key>next-word</key>
-    <seq>Space</seq>
-    </SC>
-  <SC>
-    <key>next-text-element</key>
-    <seq>Right</seq>
-    </SC>
-  <SC>
-    <key>prev-text-element</key>
-    <seq>Shift+Space</seq>
-    <seq>Left</seq>
-    <seq>Backspace</seq>
-    </SC>
-  <SC>
     <key>next-syllable</key>
     <seq>-</seq>
     <seq>Num+-</seq>

--- a/src/app/refs/nav_panels.txt
+++ b/src/app/refs/nav_panels.txt
@@ -1,2 +1,0 @@
-GLOBAL - global (any page, any panel)
-PROJECT_PAGE - project page 

--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -34,4 +34,6 @@ target_sources(context PRIVATE
     internal/playbackstate.h
     internal/uicontextresolver.cpp
     internal/uicontextresolver.h
+    internal/shortcutresolver.cpp 
+    internal/shortcutresolver.h
 )

--- a/src/context/contextmodule.cpp
+++ b/src/context/contextmodule.cpp
@@ -25,6 +25,7 @@
 #include "internal/globalcontext.h"
 #include "internal/uicontextresolver.h"
 #include "shortcutcontext.h"
+#include "internal/shortcutresolver.h"
 
 using namespace mu::context;
 using namespace muse::modularity;
@@ -50,6 +51,7 @@ void ContextModuleContext::registerExports()
     ioc()->registerExport<IGlobalContext>(mname, m_globalContext);
     ioc()->registerExport<IUiContextResolver>(mname, m_uicontextResolver);
     ioc()->registerExport<IShortcutContextPriority>(mname, new ShortcutContextPriority());
+    ioc()->registerExport<IShortcutsResolver>(mname, new ShortcutResolver(iocContext()));
 }
 
 void ContextModuleContext::onInit(const muse::IApplication::RunMode& mode)

--- a/src/context/internal/shortcutresolver.cpp
+++ b/src/context/internal/shortcutresolver.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "shortcutresolver.h"
+
+#include <functional>
+
+#include "global/containers.h"
+
+#include "log.h"
+
+using namespace muse::shortcuts;
+using namespace mu::context;
+
+static const std::string NAVIGATION_SCOPE = "NAVIGATION";
+static const std::string PLAYBACK_SCOPE = "PLAYBACK";
+static const std::string NOTATION_SCOPE = "NOTATION";
+static const std::string NOTATION_TEXT_EDITING_SCOPE = "NOTATION_TEXT_EDITING";
+
+static const QString NOTATION_PANEL_NAME("ScoreView");
+
+int ShortcutResolver::scopePriority(const std::string& scope) const
+{
+    if (m_scopePriorityMap.empty()) {
+        m_scopePriorityMap = {
+            { NAVIGATION_SCOPE, []() { return 1; } },
+            { PLAYBACK_SCOPE, []() { return 2; } },
+            { NOTATION_SCOPE, [this]() { return isNotationFocused() ? 3 : -1; } },
+            { NOTATION_TEXT_EDITING_SCOPE, [this]() { return isNotationFocused() ? 4 : -1; } },
+        };
+    }
+
+    auto priority = muse::value(m_scopePriorityMap, scope, nullptr);
+    if (priority) {
+        return priority();
+    }
+    return 0;
+}
+
+bool ShortcutResolver::isNotationFocused() const
+{
+    auto activePanel = navigationController()->activePanel();
+    return activePanel && activePanel->name() == NOTATION_PANEL_NAME;
+}
+
+Shortcut ShortcutResolver::selectOne(const ShortcutList& list) const
+{
+    IF_ASSERT_FAILED(list.size() > 0) {
+        return Shortcut();
+    }
+
+    LOGD() << "selectOne: " << list.size();
+    for (const Shortcut& shortcut : list) {
+        LOGD() << "shortcut: " << shortcut.command;
+    }
+
+    ShortcutList sorted = list;
+    sorted.sort([this](const Shortcut& a, const Shortcut& b) {
+        return scopePriority(a.scope) > scopePriority(b.scope);
+    });
+
+    return sorted.front();
+}

--- a/src/context/internal/shortcutresolver.h
+++ b/src/context/internal/shortcutresolver.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <map>
+#include <functional>
+
+#include "shortcuts/ishortcutsresolver.h"
+
+#include "modularity/ioc.h"
+#include "ui/inavigationcontroller.h"
+
+namespace mu::context {
+class ShortcutResolver : public muse::shortcuts::IShortcutsResolver, public muse::Contextable
+{
+    muse::ContextInject<muse::ui::INavigationController> navigationController = { this };
+
+public:
+    ShortcutResolver(const muse::modularity::ContextPtr& iocCtx)
+        : muse::Contextable(iocCtx) {}
+
+    muse::shortcuts::Shortcut selectOne(const muse::shortcuts::ShortcutList& list) const override;
+
+private:
+    int scopePriority(const std::string& scope) const;
+
+    bool isNotationFocused() const;
+
+    mutable std::map<std::string, std::function<int()> > m_scopePriorityMap;
+};
+}

--- a/src/notationscene/CMakeLists.txt
+++ b/src/notationscene/CMakeLists.txt
@@ -25,7 +25,10 @@ target_sources(notationscene PRIVATE
     notationscenemodule.h
 
     inotationsceneconfiguration.h
+    inotationcommandscontroller.h
     iselectinstrumentscenario.h
+
+    notationcommands.h
 
     internal/notationsceneconfiguration.cpp
     internal/notationsceneconfiguration.h
@@ -37,6 +40,10 @@ target_sources(notationscene PRIVATE
     internal/notationuiactions.h
     internal/notationactionsshortcutsmigrator.cpp
     internal/notationactionsshortcutsmigrator.h
+    internal/notationcommandsregister.cpp
+    internal/notationcommandsregister.h
+    internal/notationcommandsstate.cpp
+    internal/notationcommandsstate.h
 
     utilities/engravingitempreviewpainter.cpp
     utilities/engravingitempreviewpainter.h

--- a/src/notationscene/inotationcommandscontroller.h
+++ b/src/notationscene/inotationcommandscontroller.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+
+#include "global/async/channel.h"
+
+namespace mu::notation {
+class INotationCommandsController : MODULE_CONTEXT_INTERFACE
+{
+    INTERFACE_ID(INotationCommandsController)
+public:
+    virtual ~INotationCommandsController() = default;
+
+    virtual bool isTextEditing() const = 0;
+    virtual muse::async::Channel<bool> textEditingChanged() const = 0;
+};
+}

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -21,7 +21,10 @@
  */
 #include "notationactioncontroller.h"
 
-#include "io/file.h"
+#include <QGuiApplication>
+
+#include "global/io/file.h"
+#include "global/translation.h"
 
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/note.h"
@@ -34,10 +37,10 @@
 
 #include "qml/MuseScore/NotationScene/abstractelementpopupmodel.h"
 
-#include "translation.h"
-#include "log.h"
+#include "../notationcommands.h"
 
-#include <QGuiApplication>
+#include "log.h"
+#include "types/ret.h"
 
 using namespace mu;
 using namespace muse;
@@ -151,9 +154,6 @@ void NotationActionController::init()
     registerNoteAction("insert-a", NoteName::A, NoteAddingMode::InsertChord);
     registerNoteAction("insert-b", NoteName::B, NoteAddingMode::InsertChord);
 
-    registerAction("next-text-element", &Controller::nextTextElement, &Controller::textNavigationAvailable);
-    registerAction("prev-text-element", &Controller::prevTextElement, &Controller::textNavigationAvailable);
-    registerAction("next-word", &Controller::nextWord, &Controller::textNavigationAvailable);
     registerAction("next-beat-TEXT", &Controller::nextBeatTextElement, &Controller::textNavigationByBeatsAvailable);
     registerAction("prev-beat-TEXT", &Controller::prevBeatTextElement, &Controller::textNavigationByBeatsAvailable);
 
@@ -211,14 +211,6 @@ void NotationActionController::init()
     registerMoveSelectionAction("next-system", MoveSelectionType::System, MoveDirection::Right);
     registerMoveSelectionAction("prev-system", MoveSelectionType::System, MoveDirection::Left);
 
-    registerAction("notation-move-right", &Controller::move, MoveDirection::Right, false, &Controller::isNotEditingOrHasPopup);
-    registerAction("notation-move-left", &Controller::move, MoveDirection::Left, false, &Controller::isNotEditingOrHasPopup);
-    registerAction("notation-move-right-quickly", &Controller::move, MoveDirection::Right, true, &Controller::measureNavigationAvailable);
-    registerAction("notation-move-left-quickly", &Controller::move, MoveDirection::Left, true, &Controller::measureNavigationAvailable);
-    registerAction("pitch-up", &Controller::move, MoveDirection::Up, false, &Controller::isNotEditingOrHasPopup);
-    registerAction("pitch-down", &Controller::move, MoveDirection::Down, false, &Controller::isNotEditingOrHasPopup);
-    registerAction("pitch-up-octave", &Controller::move, MoveDirection::Up, true, &Controller::isNotEditingOrHasPopup);
-    registerAction("pitch-down-octave", &Controller::move, MoveDirection::Down, true, &Controller::isNotEditingOrHasPopup);
     registerAction("up-chord", [this]() { moveWithinChord(MoveDirection::Up); }, &Controller::hasSelection);
     registerAction("down-chord", [this]() { moveWithinChord(MoveDirection::Down); }, &Controller::hasSelection);
 
@@ -562,11 +554,20 @@ void NotationActionController::init()
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         auto notation = globalContext()->currentNotation();
         if (notation) {
-            notation->interaction()->noteInput()->stateChanged().onNotify(this, [this]() {
+            auto interaction = notation->interaction();
+            interaction->noteInput()->stateChanged().onNotify(this, [this]() {
                 m_currentNotationNoteInputChanged.notify();
+            }, Asyncable::Mode::SetReplace);
+
+            interaction->textEditingStarted().onNotify(this, [this]() {
+                m_textEditingChanged.send(true);
+            }, Asyncable::Mode::SetReplace);
+            interaction->textEditingEnded().onReceive(this, [this](TextBase*) {
+                m_textEditingChanged.send(false);
             }, Asyncable::Mode::SetReplace);
         }
         m_currentNotationNoteInputChanged.notify();
+        m_textEditingChanged.send(isTextEditing());
     });
 
     // Register engraving debugging options actions
@@ -582,6 +583,25 @@ void NotationActionController::init()
         });
     }
     dispatcher()->reg(this, "check-for-score-corruptions", [this] { checkForScoreCorruptions(); });
+
+    // commands
+    {
+        auto d = commandDispatcher();
+
+        d->onRequest(this, MOVE_RIGHT_COMMAND, [this]() { return moveWithRet(MoveDirection::Right, false); });
+        d->onRequest(this, MOVE_LEFT_COMMAND, [this]() { return moveWithRet(MoveDirection::Left, false); });
+        d->onRequest(this, MOVE_RIGHT_QUICKLY_COMMAND, [this]() { return moveWithRet(MoveDirection::Right, true); });
+        d->onRequest(this, MOVE_LEFT_QUICKLY_COMMAND, [this]() { return moveWithRet(MoveDirection::Left, true); });
+
+        d->onRequest(this, PITCH_UP_COMMAND, [this]() { return moveWithRet(MoveDirection::Up, false); });
+        d->onRequest(this, PITCH_DOWN_COMMAND, [this]() { return moveWithRet(MoveDirection::Down, false); });
+        d->onRequest(this, PITCH_UP_OCTAVE_COMMAND, [this]() { return moveWithRet(MoveDirection::Up, true); });
+        d->onRequest(this, PITCH_DOWN_OCTAVE_COMMAND, [this]() { return moveWithRet(MoveDirection::Down, true); });
+
+        d->onRequest(this, EDIT_NEXT_WORD_COMMAND, [this]() { return nextWord(); });
+        d->onRequest(this, EDIT_NEXT_TEXT_ELEMENT_COMMAND, [this]() { return nextTextElement(); });
+        d->onRequest(this, EDIT_PREV_TEXT_ELEMENT_COMMAND, [this]() { return prevTextElement(); });
+    }
 }
 
 bool NotationActionController::canReceiveAction(const ActionCode& code) const
@@ -1105,12 +1125,12 @@ void NotationActionController::moveSelection(MoveSelectionType type, MoveDirecti
     seekSelectedElement();
 }
 
-void NotationActionController::move(MoveDirection direction, bool quickly)
+muse::Ret NotationActionController::moveWithRet(MoveDirection direction, bool quickly)
 {
     TRACEFUNC;
     auto interaction = currentNotationInteraction();
     if (!interaction) {
-        return;
+        return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
     const NoteInputState& state = interaction->noteInput()->state();
@@ -1119,7 +1139,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         // Try to restore the previous selection...
         interaction->moveSelection(direction, MoveSelectionType::EngravingItem);
         seekAndPlaySelectedElement(true);
-        return;
+        return muse::make_ok();
     }
 
     const EngravingItem* selectedElement = interaction->selection()->element();
@@ -1137,13 +1157,13 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             interaction->nudgeAnchors(direction);
         } else if (noteInput->isNoteInputMode() && noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)) {
             moveInputNotes(direction == MoveDirection::Up, quickly ? PitchMode::OCTAVE : PitchMode::DIATONIC);
-            return;
+            return muse::make_ok();
         } else if (noteInput->isNoteInputMode() && noteInput->state().staffGroup() == mu::engraving::StaffGroup::TAB) {
             if (quickly) {
                 interaction->movePitch(direction, PitchMode::OCTAVE);
             }
             interaction->moveSelection(direction, MoveSelectionType::String);
-            return;
+            return muse::make_ok();
         } else if (interaction->selection()->isNone() && !state.beyondScore()) {
             interaction->selectFirstElement(false);
         } else {
@@ -1182,12 +1202,12 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             }
 
             playbackController()->seekBeat(targetMeasureIdx, targetBeatIdx);
-            return;
+            return muse::make_ok();
         }
 
         if (interaction->isTextEditingStarted() && textNavigationAvailable()) {
             navigateToTextElementInNearMeasure(direction);
-            return;
+            return muse::make_ok();
         }
 
         if (selectedElement && selectedElement->isTextBase()) {
@@ -1207,6 +1227,13 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
     }
 
     seekAndPlaySelectedElement(playChord);
+
+    return muse::make_ok();
+}
+
+void NotationActionController::move(MoveDirection direction, bool quickly)
+{
+    moveWithRet(direction, quickly);
 }
 
 void NotationActionController::moveInputNotes(bool up, PitchMode mode)
@@ -1967,6 +1994,21 @@ bool NotationActionController::toggleLayoutBreakAvailable() const
     return interaction && interaction->toggleLayoutBreakAvailable();
 }
 
+bool NotationActionController::isTextEditing() const
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return false;
+    }
+
+    return interaction->isTextEditingStarted();
+}
+
+muse::async::Channel<bool> NotationActionController::textEditingChanged() const
+{
+    return m_textEditingChanged;
+}
+
 bool NotationActionController::textNavigationAvailable() const
 {
     return resolveTextNavigationAvailable(TextNavigationType::NearNoteOrRest);
@@ -2020,19 +2062,26 @@ bool NotationActionController::resolveTextNavigationAvailable(TextNavigationType
     return false;
 }
 
-void NotationActionController::nextTextElement()
+muse::Ret NotationActionController::nextTextElement()
 {
     navigateToTextElement(MoveDirection::Right, NEAR_NOTE_OR_REST);
+    return muse::make_ok();
 }
 
-void NotationActionController::prevTextElement()
+muse::Ret NotationActionController::prevTextElement()
 {
     navigateToTextElement(MoveDirection::Left, NEAR_NOTE_OR_REST);
+    return muse::make_ok();
 }
 
-void NotationActionController::nextWord()
+muse::Ret NotationActionController::nextWord()
 {
+    if (!textNavigationAvailable()) {
+        return muse::make_ret(Ret::Code::NotSupported);
+    }
+
     navigateToTextElement(MoveDirection::Right, NEAR_NOTE_OR_REST, false);
+    return muse::make_ok();
 }
 
 void NotationActionController::nextBeatTextElement()

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -21,13 +21,17 @@
  */
 #pragma once
 
+#include "../inotationcommandscontroller.h"
+
 #include "async/asyncable.h"
 #include "actions/actionable.h"
 #include "actions/actiontypes.h"
+#include "rcommand/commandable.h"
 
 #include "modularity/ioc.h"
 #include "interactive/iinteractive.h"
 #include "actions/iactionsdispatcher.h"
+#include "rcommand/icommanddispatcher.h"
 #include "ui/inavigationcontroller.h"
 #include "ui/iuiactionsregister.h"
 #include "context/iglobalcontext.h"
@@ -39,11 +43,13 @@
 #include "notation/inotation.h"
 
 namespace mu::notation {
-class NotationActionController : public muse::actions::Actionable, public muse::async::Asyncable, public muse::Contextable
+class NotationActionController : public INotationCommandsController, public muse::actions::Actionable, public muse::rcommand::Commandable,
+    public muse::async::Asyncable, public muse::Contextable
 {
     muse::GlobalInject<INotationConfiguration> configuration;
     muse::GlobalInject<engraving::IEngravingConfiguration> engravingConfiguration;
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher = { this };
+    muse::ContextInject<muse::rcommand::ICommandDispatcher> commandDispatcher = { this };
     muse::ContextInject<muse::ui::INavigationController> navigationController = { this };
     muse::ContextInject<muse::ui::IUiActionsRegister> actionRegister = { this };
     muse::ContextInject<context::IGlobalContext> globalContext = { this };
@@ -59,6 +65,9 @@ public:
     void init();
 
     bool canReceiveAction(const muse::actions::ActionCode& code) const override;
+
+    bool isTextEditing() const override;
+    muse::async::Channel<bool> textEditingChanged() const override;
 
     muse::async::Notification currentNotationChanged() const;
 
@@ -106,6 +115,7 @@ private:
 
     bool moveSelectionAvailable(MoveSelectionType type) const;
     void moveSelection(MoveSelectionType type, MoveDirection direction);
+    muse::Ret moveWithRet(MoveDirection direction, bool quickly = false);
     void move(MoveDirection direction, bool quickly = false);
     void moveInputNotes(bool up, PitchMode mode);
     void movePitchDiatonic(MoveDirection direction, bool);
@@ -203,11 +213,11 @@ private:
     bool textNavigationByFractionAvailable() const;
     bool resolveTextNavigationAvailable(TextNavigationType type = TextNavigationType::NearNoteOrRest) const;
 
-    void nextTextElement();
-    void prevTextElement();
+    muse::Ret nextTextElement();
+    muse::Ret prevTextElement();
+    muse::Ret nextWord();
     void nextBeatTextElement();
     void prevBeatTextElement();
-    void nextWord();
     void navigateToTextElement(MoveDirection direction, bool nearNoteOrRest = false, bool moveOnly = true);
     void navigateToTextElementByFraction(const Fraction& fraction);
     void navigateToTextElementInNearMeasure(MoveDirection direction);
@@ -279,6 +289,7 @@ private:
                         bool (NotationActionController::*)() const = &NotationActionController::isNotationPage);
 
     muse::async::Notification m_currentNotationNoteInputChanged;
+    muse::async::Channel<bool> m_textEditingChanged;
 
     using IsActionEnabledFunc = std::function<bool ()>;
     std::map<muse::actions::ActionCode, IsActionEnabledFunc> m_isEnabledMap;

--- a/src/notationscene/internal/notationcommandsregister.cpp
+++ b/src/notationscene/internal/notationcommandsregister.cpp
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "notationcommandsregister.h"
+
+#include "../notationcommands.h"
+
+using namespace muse;
+using namespace muse::rcommand;
+using namespace muse::ui;
+using namespace mu::notation;
+
+static const std::vector<CommandInfo> s_commandInfos = {
+    // navigation
+    CommandInfo{
+        MOVE_RIGHT_COMMAND,
+        TranslatableString("notation", "Move right"),
+        TranslatableString("notation", "Go to next notation element"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        MOVE_RIGHT_QUICKLY_COMMAND,
+        TranslatableString("notation", "Move right quickly"),
+        TranslatableString("notation", "Go to next notation element quickly"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        MOVE_LEFT_COMMAND,
+        TranslatableString("notation", "Move left"),
+        TranslatableString("notation", "Go to previous notation element"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        MOVE_LEFT_QUICKLY_COMMAND,
+        TranslatableString("notation", "Move left quickly"),
+        TranslatableString("notation", "Go to previous notation element quickly"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        PITCH_UP_COMMAND,
+        TranslatableString("notation", "Pitch up"),
+        TranslatableString("notation", "Pitch up the current note"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        PITCH_DOWN_COMMAND,
+        TranslatableString("notation", "Pitch down"),
+        TranslatableString("notation", "Pitch down the current note"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        PITCH_UP_OCTAVE_COMMAND,
+        TranslatableString("notation", "Pitch up octave"),
+        TranslatableString("notation", "Pitch up the current note by an octave"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        PITCH_DOWN_OCTAVE_COMMAND,
+        TranslatableString("notation", "Pitch down octave"),
+        TranslatableString("notation", "Pitch down the current note by an octave"),
+        InputSchema(),
+        Decoration()
+    },
+
+    // text editing
+    CommandInfo{
+        EDIT_NEXT_WORD_COMMAND,
+        TranslatableString("notation", "Edit next word"),
+        TranslatableString("notation", "Go to edit next notation word"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        EDIT_NEXT_TEXT_ELEMENT_COMMAND,
+        TranslatableString("notation", "Edit next text element"),
+        TranslatableString("notation", "Go to edit next notation text element"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        EDIT_PREV_TEXT_ELEMENT_COMMAND,
+        TranslatableString("notation", "Edit previous text element"),
+        TranslatableString("notation", "Go to edit previous notation text element"),
+        InputSchema(),
+        Decoration()
+    }
+};
+
+std::string NotationCommandsRegister::moduleName() const
+{
+    return "notation";
+}
+
+const std::vector<Command>& NotationCommandsRegister::commandList() const
+{
+    static std::vector<Command> commands;
+    if (commands.empty()) {
+        commands.reserve(s_commandInfos.size());
+        for (const auto& info : s_commandInfos) {
+            commands.push_back(info.command);
+        }
+    }
+    return commands;
+}
+
+const std::vector<CommandInfo>& NotationCommandsRegister::commandInfoList() const
+{
+    return s_commandInfos;
+}

--- a/src/notationscene/internal/notationcommandsregister.h
+++ b/src/notationscene/internal/notationcommandsregister.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "rcommand/imodulecommandsregister.h"
+
+namespace mu::notation {
+class NotationCommandsRegister : public muse::rcommand::IModuleCommandsRegister
+{
+public:
+    NotationCommandsRegister() = default;
+
+    std::string moduleName() const override;
+
+    const std::vector<muse::rcommand::Command>& commandList() const override;
+    const std::vector<muse::rcommand::CommandInfo>& commandInfoList() const override;
+};
+}

--- a/src/notationscene/internal/notationcommandsstate.cpp
+++ b/src/notationscene/internal/notationcommandsstate.cpp
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ #include "notationcommandsstate.h"
+
+ #include "global/containers.h"
+
+ #include "../notationcommands.h"
+
+using namespace muse;
+using namespace muse::rcommand;
+using namespace mu::notation;
+
+static const muse::Uri PROJECT_PAGE_URI("musescore://notation");
+
+static const std::vector<Command> TEXT_EDITING_COMMANDS = {
+    EDIT_NEXT_TEXT_ELEMENT_COMMAND,
+    EDIT_PREV_TEXT_ELEMENT_COMMAND,
+    EDIT_NEXT_WORD_COMMAND
+};
+
+std::string NotationCommandsState::moduleName() const
+{
+    return "notation";
+}
+
+void NotationCommandsState::init()
+{
+    m_moduleRegister = commandsRegister()->moduleRegister(moduleName());
+    IF_ASSERT_FAILED(m_moduleRegister) {
+        return;
+    }
+
+    globalContext()->currentProjectChanged().onNotify(this, [this]() {
+        updateCommandStates();
+    });
+
+    commandsController()->textEditingChanged().onReceive(this, [this](bool) {
+        updateCommandStates(TEXT_EDITING_COMMANDS);
+    });
+
+    updateCommandStates();
+}
+
+void NotationCommandsState::deinit()
+{
+    globalContext()->currentProjectChanged().disconnect(this);
+}
+
+void NotationCommandsState::updateCommandStates(const std::vector<Command>& commands)
+{
+    IF_ASSERT_FAILED(m_moduleRegister) {
+        return;
+    }
+
+    const auto& commandList = commands.empty() ? m_moduleRegister->commandList() : commands;
+
+    for (const auto& command : commandList) {
+        CommandState newState = commandState(command);
+        if (m_commandStates[command] != newState) {
+            m_commandStates[command] = newState;
+            m_commandStateChanged.send(command, newState);
+        }
+    }
+}
+
+CommandState NotationCommandsState::commandState(const Command& command) const
+{
+    if (!isProjectOpened()) {
+        return CommandState(false, false);
+    }
+
+    if (muse::contains(TEXT_EDITING_COMMANDS, command)) {
+        return CommandState(commandsController()->isTextEditing(), false);
+    }
+
+    return CommandState(true, false);
+}
+
+async::Channel<Command, CommandState> NotationCommandsState::commandStateChanged() const
+{
+    return m_commandStateChanged;
+}
+
+bool NotationCommandsState::isProjectOpened() const
+{
+    if (!globalContext()->currentProject()) {
+        return false;
+    }
+
+    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/notationscene/internal/notationcommandsstate.h
+++ b/src/notationscene/internal/notationcommandsstate.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ #pragma once
+
+ #include <map>
+
+ #include "rcommand/imodulecommandsstate.h"
+ #include "global/async/asyncable.h"
+
+ #include "global/modularity/ioc.h"
+ #include "interactive/iinteractive.h"
+#include "context/iglobalcontext.h"
+#include "rcommand/icommandsregister.h"
+#include "../inotationcommandscontroller.h"
+
+namespace mu::notation {
+class NotationCommandsState : public muse::rcommand::IModuleCommandsState, public muse::Contextable, public muse::async::Asyncable
+{
+    muse::GlobalInject<muse::rcommand::ICommandsRegister> commandsRegister;
+    muse::ContextInject<muse::IInteractive> interactive = { this };
+    muse::ContextInject<context::IGlobalContext> globalContext = { this };
+    muse::ContextInject<INotationCommandsController> commandsController = { this };
+public:
+    NotationCommandsState(const muse::modularity::ContextPtr& ctx)
+        : muse::Contextable(ctx) {}
+
+    std::string moduleName() const override;
+
+    void init() override;
+    void deinit() override;
+
+    muse::rcommand::CommandState commandState(const muse::rcommand::Command& command) const override;
+    muse::async::Channel<muse::rcommand::Command, muse::rcommand::CommandState> commandStateChanged() const override;
+
+private:
+
+    bool isProjectOpened() const;
+    void updateCommandStates(const std::vector<muse::rcommand::Command>& commands = {});
+
+    muse::rcommand::IModuleCommandsRegisterPtr m_moduleRegister;
+    std::map<muse::rcommand::Command, muse::rcommand::CommandState> m_commandStates;
+    muse::async::Channel<muse::rcommand::Command, muse::rcommand::CommandState> m_commandStateChanged;
+};
+}

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1711,24 +1711,6 @@ const UiActionList NotationUiActions::s_actions = {
              IconCode::Code::TUNING_FORK,
              Checkable::Yes
              ),
-    UiAction("next-word",
-             mu::context::UiCtxProjectFocused,
-             mu::context::CTX_NOTATION_TEXT_EDITING,
-             TranslatableString("action", "Next word"),
-             TranslatableString("action", "Go to next word")
-             ),
-    UiAction("next-text-element",
-             mu::context::UiCtxProjectFocused,
-             mu::context::CTX_NOTATION_TEXT_EDITING,
-             TranslatableString("action", "Next text element"),
-             TranslatableString("action", "Go to next text element")
-             ),
-    UiAction("prev-text-element",
-             mu::context::UiCtxProjectFocused,
-             mu::context::CTX_NOTATION_TEXT_EDITING,
-             TranslatableString("action", "Previous text element"),
-             TranslatableString("action", "Go to previous text element")
-             ),
     UiAction("next-beat-TEXT",
              mu::context::UiCtxProjectFocused,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notationscene/notationcommands.h
+++ b/src/notationscene/notationcommands.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ #pragma once
+
+ #include "rcommand/commandtypes.h"
+
+namespace mu::notation {
+inline static const muse::rcommand::Command MOVE_RIGHT_COMMAND("command://notation/move-right");
+inline static const muse::rcommand::Command MOVE_LEFT_COMMAND("command://notation/move-left");
+inline static const muse::rcommand::Command MOVE_RIGHT_QUICKLY_COMMAND("command://notation/move-right-quickly");
+inline static const muse::rcommand::Command MOVE_LEFT_QUICKLY_COMMAND("command://notation/move-left-quickly");
+
+inline static const muse::rcommand::Command PITCH_UP_COMMAND("command://notation/pitch-up");
+inline static const muse::rcommand::Command PITCH_DOWN_COMMAND("command://notation/pitch-down");
+inline static const muse::rcommand::Command PITCH_UP_OCTAVE_COMMAND("command://notation/pitch-up-octave");
+inline static const muse::rcommand::Command PITCH_DOWN_OCTAVE_COMMAND("command://notation/pitch-down-octave");
+
+inline static const muse::rcommand::Command EDIT_NEXT_WORD_COMMAND("command://notation/edit-next-word");
+inline static const muse::rcommand::Command EDIT_NEXT_TEXT_ELEMENT_COMMAND("command://notation/edit-next-text-element");
+inline static const muse::rcommand::Command EDIT_PREV_TEXT_ELEMENT_COMMAND("command://notation/edit-prev-text-element");
+}

--- a/src/notationscene/notationscenemodule.cpp
+++ b/src/notationscene/notationscenemodule.cpp
@@ -24,12 +24,17 @@
 #include "modularity/ioc.h"
 #include "interactive/iinteractiveuriregister.h"
 #include "ui/iuiactionsregister.h"
+#include "rcommand/icommandsregister.h"
+#include "rcommand/icommandsstate.h"
 
 #include "internal/notationsceneconfiguration.h"
 #include "internal/notationactioncontroller.h"
 #include "internal/midiinputoutputcontroller.h"
 #include "internal/notationuiactions.h"
 #include "internal/notationactionsshortcutsmigrator.h"
+#include "internal/notationcommandsregister.h"
+#include "internal/notationcommandsstate.h"
+#include "internal/notationactioncontroller.h"
 
 #include "widgets/breaksdialog.h"
 #include "widgets/editstaff.h"
@@ -85,6 +90,11 @@ void NotationSceneModule::resolveImports()
         ir->registerQmlUri(Uri("musescore://notation/percussionpanelpadswap"), "MuseScore.NotationScene", "PercussionPanelPadSwapDialog");
         ir->registerQmlUri(Uri("musescore://notation/editpercussionshortcut"), "MuseScore.NotationScene", "EditPercussionShortcutDialog");
     }
+
+    auto cr = globalIoc()->resolve<muse::rcommand::ICommandsRegister>(mname);
+    if (cr) {
+        cr->reg(std::make_shared<NotationCommandsRegister>());
+    }
 }
 
 void NotationSceneModule::onInit(const IApplication::RunMode&)
@@ -102,6 +112,8 @@ void NotationSceneContext::registerExports()
     m_actionController = std::make_shared<NotationActionController>(iocContext());
     m_notationUiActions = std::make_shared<NotationUiActions>(m_actionController, iocContext());
     m_midiInputOutputController = std::make_shared<MidiInputOutputController>(iocContext());
+
+    ioc()->registerExport<INotationCommandsController>(mname, m_actionController);
 }
 
 void NotationSceneContext::resolveImports()
@@ -109,6 +121,11 @@ void NotationSceneContext::resolveImports()
     auto ar = ioc()->resolve<muse::ui::IUiActionsRegister>("notationscene");
     if (ar) {
         ar->reg(m_notationUiActions);
+    }
+
+    auto cs = ioc()->resolve<muse::rcommand::ICommandsState>(mname);
+    if (cs) {
+        cs->reg(std::make_shared<NotationCommandsState>(iocContext()));
     }
 }
 

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -24,7 +24,6 @@
 
 #include "modularity/ioc.h"
 
-#include "ui/iuiactionsregister.h"
 #include "rcommand/icommandsregister.h"
 #include "rcommand/icommandsstate.h"
 #include "interactive/iinteractiveuriregister.h"


### PR DESCRIPTION
FW: https://github.com/musescore/muse_framework/pull/137

The outlines of a solution to the problem with shortcut conflicts are emerging.
How it works (close to how it was, but there are differences) 
* As before, commands (actions) have a flag indicating their availability (enabled)
* For example, there are commands "edit a next text element" - one is available if we are in text editing mode and is not available if we are not editing text. 
* In the shortcut configuration, we place shortcuts in scopes - essentially, these are arbitrary, virtual areas. 
* When we activate a keyboard shortcut, we get a list of shortcuts for this combination. 
* First, we filter this list by command availability; if a command is not available, then it definitely does not need to be sent. 
* If we have more than one command available, we call a shortcut resolver that determines which command to send. 
* Essentially, the shortcut resolver determines which scope has higher priority. 
* It does this based on a statically defined priority and current state (for example, it determines whether the main area of ​​the project is in focus) 

Some examples: 
1. We have Space set to play and move to the next edited word. 
* If we are not in text editing mode, then Play is available and the moving to the next edited word is not available - we call Play (one in the list of available ones)
* If we are in text editing mode, then there will be two commands in the list of available ones (we can execute play and go to the next word), then we call the resolver and there the "text editing" scope has a higher priority - we call the command to go to the next word

2. Navigation, for example, on the Right, navigation by the UI and navigation in the Notation are assigned (in the MSS, these are different things)
* When a project is open, these two commands are always available. That's why we call the resolver.
* If a notation is in focus, then the "notation" scope has high priority - the notation navigation command will be called
* If the notation is not in focus, then the "notation" scope has the lowest priority - the UI navigation command will be called 


As a result, we now have only two criteria, two places, determining what should be called: 
* Command Availability (enabled) - ModuleCommandState (this is where the hardest part is updating the state)
* Scope priority (which may change depending on the user's current action) - ShortcutResolver