### PR TITLE
Avoid unnecessary calls to text layout

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -468,8 +468,8 @@ void TextCursor::setFormat(FormatId id, FormatValue val)
         }
     }
     format()->setFormatValue(id, val);
-    changeSelectionFormat(id, val);
     if (hasSelection()) {
+        changeSelectionFormat(id, val);
         text()->setTextInvalid();
     }
     if (!editing()) {

--- a/src/engraving/rendering/score/textlayout.cpp
+++ b/src/engraving/rendering/score/textlayout.cpp
@@ -53,6 +53,8 @@ void TextLayout::layoutBaseTextBase(TextBase* item, LayoutContext&)
 
 void TextLayout::layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* ldata)
 {
+    TRACEFUNC;
+
     if (item->explicitParent() && item->layoutToParentWidth()) {
         LD_CONDITION(item->parentItem()->ldata()->isSetBbox());
     }

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -574,7 +574,6 @@
                 </Channel>
               </Instrument>
             <eid>AB_AB</eid>
-            <autoplace>0</autoplace>
             <text>Instrument</text>
             </InstrumentChange>
           <Spanner type="Pedal">

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -3968,6 +3968,7 @@ Text* MusicXmlParserDirection::addTextToHeader(const TextStyleType textStyleType
 {
     Text* t = Factory::createText(m_score->dummy(), textStyleType);
     t->setXmlText(m_wordsText.trimmed());
+    t->renderer()->layoutText1(t);
     MeasureBase* const firstMeasure = m_score->measures()->first();
     VBox* vbox
         = firstMeasure->isVBox() ? toVBox(firstMeasure) : MusicXmlParserPass1::createAndAddVBoxForCreditWords(m_score, Fraction(0, 1));

--- a/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
@@ -119,7 +119,7 @@ the video game: a tone poem</metaTag>
       </Part>
     <Staff id="1">
       <VBox>
-        <height>11.7828</height>
+        <height>13.9828</height>
         <eid>E_E</eid>
         <Text>
           <eid>F_F</eid>

--- a/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
@@ -121,7 +121,7 @@ Words &amp; Music by also Henry Ives (and ampersands)
       </Part>
     <Staff id="1">
       <VBox>
-        <height>11.0385</height>
+        <height>11.3305</height>
         <eid>E_E</eid>
         <Text>
           <eid>F_F</eid>

--- a/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.mscx
@@ -485,7 +485,7 @@
               <Fingering>
                 <eid>WB_WB</eid>
                 <italic>1</italic>
-                <text><i>2</i></text>
+                <text>2</text>
                 </Fingering>
               <pitch>64</pitch>
               <tpc>18</tpc>


### PR DESCRIPTION
This layout call only makes sense if the text is being edited. Otherwise, this function gets called every time we set any font property, including during text creation via initElementStyle.

On the Beethoven 9, the total number of calls to text layout went down from 415.000 to approx 50.000. Most of these unnecessary calls run on empty text so they aren't very expensive, but I still get a 5-6% improvement in the total layout time.