### PR TITLE
Avoid transitively including all notation headers via inotation.h

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
@@ -21,6 +21,7 @@
  */
 #include "appmenumodel.h"
 
+#include "log.h"
 #include "types/translatablestring.h"
 
 #include "muse_framework_config.h"
@@ -29,7 +30,7 @@
 #include "workspace/qml/Muse/Workspace/workspacesmenumodel.h"
 #endif
 
-#include "log.h"
+#include "notation/inotationundostack.h"
 
 using namespace muse;
 using namespace mu::appshell;

--- a/src/appshell/qml/MuseScore/AppShell/notationpagemodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/notationpagemodel.cpp
@@ -26,6 +26,11 @@
 
 #include "async/async.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationselection.h"
+
 #include "log.h"
 
 using namespace mu::appshell;

--- a/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/notationstatusbarmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "notationstatusbarmodel.h"
 
+#include "defer.h"
+#include "log.h"
 #include "types/translatablestring.h"
 
 #include "muse_framework_config.h"
@@ -30,8 +32,10 @@
 #include "workspace/qml/Muse/Workspace/workspacesmenumodel.h"
 #endif
 
-#include "defer.h"
-#include "log.h"
+#include "notation/inotationaccessibility.h"
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+#include "notation/inotationviewstate.h" // IWYU pragma: keep
 
 using namespace mu::appshell;
 using namespace mu::notation;

--- a/src/braille/internal/braillewriter.cpp
+++ b/src/braille/internal/braillewriter.cpp
@@ -24,6 +24,8 @@
 
 #include <QBuffer>
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "braille.h"
 
 using namespace mu::project;

--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -28,11 +28,14 @@
 #include "engraving/dom/measure.h"
 #include "engraving/dom/segment.h"
 #include "engraving/dom/slur.h"
-#include "engraving/dom/spanner.h"
 #include "engraving/dom/staff.h"
 #include "engraving/dom/tie.h"
 
 #include "engraving/editing/noteinput.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
 
 #include "braille.h"
 #include "braillecode.h"

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -19,11 +19,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "uicontextresolver.h"
 
 #include <QTimer>
 
 #include "diagnostics/diagnosticutils.h"
+
+#include "notation/inotation.h"
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+#include "notation/inotationselection.h" // IWYU pragma: keep
 
 #include "shortcutcontext.h"
 

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -37,6 +37,9 @@
 #include "engraving/rw/mscsaver.h"
 #include "engraving/types/typesconv.h"
 
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "internal/converterutils.h"
 
 #include "backendjsonwriter.h"

--- a/src/converter/internal/compat/notationmeta.cpp
+++ b/src/converter/internal/compat/notationmeta.cpp
@@ -27,13 +27,14 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 
+#include "audio/common/audioutils.h"
+#include "audio/common/audiotypes.h"
+
 #include "engraving/dom/tempotext.h"
 #include "engraving/dom/text.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
 #include "project/inotationproject.h"
-
-#include "audio/common/audioutils.h"
-#include "audio/common/audiotypes.h"
 
 #include "log.h"
 

--- a/src/converter/internal/compat/notationmeta.h
+++ b/src/converter/internal/compat/notationmeta.h
@@ -22,7 +22,9 @@
 
 #pragma once
 
-#include "notation/inotation.h"
+#include "types/retval.h"
+
+#include "notation/inotation_fwd.h"
 
 namespace mu::engraving {
 class Score;

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -34,6 +34,11 @@
 #include "engraving/dom/masterscore.h"
 #include "engraving/infrastructure/mscio.h"
 
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselectionfilter.h" // IWYU pragma: keep
+
 #include "convertercodes.h"
 #include "compat/backendapi.h"
 #include "compat/notationmeta.h"

--- a/src/converter/internal/converterutils.cpp
+++ b/src/converter/internal/converterutils.cpp
@@ -26,6 +26,9 @@
 
 #include "async/notifylist.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationparts.h"
+
 #include "convertercodes.h"
 
 using namespace muse;

--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -31,6 +31,9 @@
 #include "engraving/dom/masterscore.h"
 #include "engraving/types/types.h"
 
+#include "notation/inotation.h"
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 // api
 #include "engravingapiv1.h"
 #include "score.h"
@@ -498,8 +501,8 @@ void PluginAPI::quit()
 
 mu::engraving::Score* PluginAPI::currentScore() const
 {
-    if (context()->currentNotation()) {
-        return context()->currentNotation()->elements()->msScore();
+    if (notation::INotationPtr notation = context()->currentNotation()) {
+        return notation->elements()->msScore();
     }
 
     return nullptr;

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -39,6 +39,9 @@
 #include "editing/transaction/transaction.h"
 #include "types/typesconv.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h"
+
 // api
 #include "apistructs.h"
 #include "cursor.h"

--- a/src/engraving/qml/MuseScore/Engraving/devtools/corruptscoredevtoolsmodel.cpp
+++ b/src/engraving/qml/MuseScore/Engraving/devtools/corruptscoredevtoolsmodel.cpp
@@ -25,6 +25,9 @@
 #include "engraving/dom/measurebase.h"
 #include "engraving/dom/score.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 using namespace mu::engraving;
 
 CorruptScoreDevToolsModel::CorruptScoreDevToolsModel(QObject* parent)
@@ -60,6 +63,4 @@ void CorruptScoreDevToolsModel::corruptOpenScore()
             }
         }
     });
-
-    notation->undoStack()->commitChanges();
 }

--- a/src/engraving/qml/MuseScore/Engraving/devtools/engravingstylemodel.cpp
+++ b/src/engraving/qml/MuseScore/Engraving/devtools/engravingstylemodel.cpp
@@ -22,7 +22,8 @@
 #include "engravingstylemodel.h"
 
 #include "notation/inotation.h"
-#include "notation/inotationstyle.h"
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
 
 #include "global/types/string.h"
 

--- a/src/engraving/qml/MuseScore/Engraving/devtools/engravingundostackmodel.cpp
+++ b/src/engraving/qml/MuseScore/Engraving/devtools/engravingundostackmodel.cpp
@@ -19,12 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "engravingundostackmodel.h"
 
 #include "notation/inotation.h"
 
 #include "engraving/editing/transaction/undoablecommand.h"
 #include "engraving/editing/transaction/undostack.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
 
 #include "log.h"
 

--- a/src/engraving/rendering/layoutoptions.h
+++ b/src/engraving/rendering/layoutoptions.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_LAYOUTOPTIONS_H
-#define MU_ENGRAVING_LAYOUTOPTIONS_H
+
+#pragma once
 
 namespace mu::engraving {
 //---------------------------------------------------------
@@ -46,5 +46,3 @@ struct LayoutOptions
     bool isLinearMode() const { return mode == LayoutMode::LINE || mode == LayoutMode::HORIZONTAL_FIXED; }
 };
 }
-
-#endif // MU_ENGRAVING_LAYOUTOPTIONS_H

--- a/src/importexport/imagesexport/internal/pdfwriter.cpp
+++ b/src/importexport/imagesexport/internal/pdfwriter.cpp
@@ -22,10 +22,10 @@
 
 #include "pdfwriter.h"
 
-#include <QPdfWriter>
 #include <QBuffer>
+#include <QPdfWriter>
 
-#include "engraving/dom/masterscore.h"
+#include "notation/inotationpainting.h"
 
 #include "log.h"
 

--- a/src/importexport/imagesexport/internal/pngwriter.cpp
+++ b/src/importexport/imagesexport/internal/pngwriter.cpp
@@ -26,6 +26,10 @@
 #include <QImage>
 #include <QBuffer>
 
+#include "engraving/dom/mscore.h"
+
+#include "notation/inotationpainting.h"
+
 #include "log.h"
 
 using namespace mu::iex::imagesexport;

--- a/src/importexport/imagesexport/internal/svgwriter.cpp
+++ b/src/importexport/imagesexport/internal/svgwriter.cpp
@@ -34,6 +34,8 @@
 #include "engraving/dom/system.h"
 #include "engraving/dom/repeatlist.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "svggenerator.h"
 
 #include "log.h"
@@ -141,7 +143,7 @@ Ret SvgWriter::write(INotationPtr notation, io::IODevice& destinationDevice, con
             mu::engraving::StaffLines* concatenatedSL = nullptr;
             mu::engraving::Shape concatenatedShape;
             mu::engraving::Shape concatenatedMask;
-            StaffType* prevStaffType = nullptr;
+            mu::engraving::StaffType* prevStaffType = nullptr;
             for (mu::engraving::MeasureBase* measure = firstMeasure; measure; measure = system->nextMeasure(measure)) {
                 if (!measure->isMeasure()) {
                     if (concatenatedSL != nullptr) {

--- a/src/importexport/lyricsexport/internal/lrcwriter.cpp
+++ b/src/importexport/lyricsexport/internal/lrcwriter.cpp
@@ -32,6 +32,8 @@
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/repeatlist.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 using namespace Qt::Literals;
 
 using namespace muse;

--- a/src/importexport/lyricsexport/internal/lrcwriter.h
+++ b/src/importexport/lyricsexport/internal/lrcwriter.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "engraving/types/types.h"
+
 #include "project/inotationwriter.h"
 
 #include "../ilyricsexportconfiguration.h"

--- a/src/importexport/mei/internal/meiwriter.cpp
+++ b/src/importexport/mei/internal/meiwriter.cpp
@@ -30,6 +30,8 @@
 #include "engraving/engravingerrors.h"
 #include "engraving/dom/score.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 using namespace mu;
 using namespace muse;
 using namespace mu::iex::mei;

--- a/src/importexport/mei/internal/meiwriter.h
+++ b/src/importexport/mei/internal/meiwriter.h
@@ -24,6 +24,10 @@
 #include "project/inotationwriter.h"
 #include "engraving/engravingerrors.h"
 
+namespace mu::engraving {
+class Score;
+}
+
 namespace mu::iex::mei {
 class MeiWriter : public project::INotationWriter
 {

--- a/src/importexport/midi/internal/notationmidiwriter.cpp
+++ b/src/importexport/midi/internal/notationmidiwriter.cpp
@@ -24,6 +24,8 @@
 
 #include <QBuffer>
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "midiexport/exportmidi.h"
 
 #include "log.h"

--- a/src/importexport/mnx/internal/notationmnxwriter.cpp
+++ b/src/importexport/mnx/internal/notationmnxwriter.cpp
@@ -26,6 +26,9 @@
 #include "notationmnxwriter.h"
 
 #include "engraving/dom/score.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu::iex::mnxio;

--- a/src/importexport/musicxml/internal/musicxmlwriter.cpp
+++ b/src/importexport/musicxml/internal/musicxmlwriter.cpp
@@ -25,6 +25,8 @@
 #include "engraving/dom/score.h"
 #include "export/exportmusicxml.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu::iex::musicxml;

--- a/src/importexport/musicxml/internal/mxlwriter.cpp
+++ b/src/importexport/musicxml/internal/mxlwriter.cpp
@@ -22,6 +22,8 @@
 
 #include "mxlwriter.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "export/exportmusicxml.h"
 
 #include "log.h"

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -30,12 +30,16 @@
 #include "global/io/filestream.h"
 
 #include "draw/fontmetrics.h"
+#include "draw/painter.h"
 #include "draw/types/drawtypes.h"
 
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/page.h"
 #include "engraving/dom/repeatlist.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationpainting.h"
+#include "notation/inotationplayback.h"
 #include "notation/notationtypes.h"
 
 #include "notationscene/qml/MuseScore/NotationScene/playbackcursor.h"

--- a/src/instrumentsscene/internal/instrumentsactionscontroller.cpp
+++ b/src/instrumentsscene/internal/instrumentsactionscontroller.cpp
@@ -24,6 +24,10 @@
 
 #include "engraving/dom/instrchange.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationparts.h" // IWYU pragma: keep
+#include "notation/inotationselection.h" // IWYU pragma: keep
+
 using namespace mu::instrumentsscene;
 using namespace mu::notation;
 using namespace muse;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/abstractlayoutpaneltreeitem.h
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/abstractlayoutpaneltreeitem.h
@@ -27,7 +27,10 @@
 #include <QList>
 #include <qqmlintegration.h>
 
+#include "types/id.h"
+
 #include "notation/imasternotation.h"
+#include "notation/inotationparts.h"
 
 #include "layoutpanelitemtype.h"
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentsettingsmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentsettingsmodel.cpp
@@ -23,6 +23,9 @@
 
 #include "engraving/types/types.h"
 
+#include "notation/inotationparts.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 using namespace muse;
 using namespace mu::instrumentsscene;
 using namespace mu::notation;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentsonscorelistmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/instrumentsonscorelistmodel.cpp
@@ -26,6 +26,8 @@
 
 #include "log.h"
 
+#include "notation/inotationparts.h"
+
 using namespace muse;
 using namespace muse::uicomponents;
 using namespace muse::async;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpanelcontextmenumodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpanelcontextmenumodel.cpp
@@ -27,6 +27,8 @@
 
 #include "log.h"
 
+#include "notation/inotationparts.h" // IWYU pragma: keep
+
 using namespace mu::context;
 using namespace mu::instrumentsscene;
 using namespace mu::notation;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/layoutpaneltreemodel.cpp
@@ -27,6 +27,12 @@
 #include "async/notifylist.h"
 
 #include "translation.h"
+
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationselection.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 #include "roottreeitem.h"
 #include "parttreeitem.h"
 #include "sharedparttreeitem.h"

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/parttreeitem.cpp
@@ -23,6 +23,9 @@
 
 #include "async/notifylist.h"
 
+#include "notation/inotation.h"
+#include "notation/inotationparts.h"
+
 #include "log.h"
 
 using namespace mu::instrumentsscene;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/sharedparttreeitem.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/sharedparttreeitem.cpp
@@ -21,9 +21,7 @@
  */
 #include "sharedparttreeitem.h"
 
-#include "async/notifylist.h"
-
-#include "log.h"
+#include "notation/inotation.h"
 
 using namespace mu::instrumentsscene;
 using namespace mu::notation;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/staffsettingsmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/staffsettingsmodel.cpp
@@ -19,9 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "staffsettingsmodel.h"
 
 #include "engraving/types/types.h"
+
+#include "notation/inotationparts.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
 
 using namespace mu::instrumentsscene;
 using namespace mu::notation;

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/systemobjectslayersettingsmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/systemobjectslayersettingsmodel.cpp
@@ -24,6 +24,9 @@
 
 #include "layoutpanelutils.h"
 
+#include "notation/inotationparts.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h"
+
 using namespace mu::instrumentsscene;
 using namespace mu::notation;
 

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -24,9 +24,10 @@ target_sources(notation PRIVATE
     notationmodule.cpp
     notationmodule.h
 
+    inotation_fwd.h
+    inotation.h
     imasternotation.h
     iexcerptnotation.h
-    inotation.h
     inotationpainting.h
     inotationviewstate.h
     inotationsolomutestate.h
@@ -40,7 +41,6 @@ target_sources(notation PRIVATE
     inotationundostack.h
     inotationaccessibility.h
     inotationmidiinput.h
-    notationtypes.h
     inotationconfiguration.h
     inotationcontextconfiguration.h
     notationerrors.h
@@ -48,6 +48,10 @@ target_sources(notation PRIVATE
     inotationelements.h
     inotationparts.h
     iinstrumentsrepository.h
+
+    notationtypes.h
+    types/viewmode.h
+    types/zoomtype.h
 
     internal/excerptnotation.cpp
     internal/excerptnotation.h

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -33,9 +33,11 @@ target_sources(notation PRIVATE
     inotationnoteinput.h
     inotationselection.h
     inotationselectionfilter.h
+    inotationselectionrange.h
     inotationautomation.h
     inotationinteraction.h
     inotationstyle.h
+    inotationundostack.h
     inotationaccessibility.h
     inotationmidiinput.h
     notationtypes.h
@@ -47,11 +49,9 @@ target_sources(notation PRIVATE
     inotationparts.h
     iinstrumentsrepository.h
 
-    internal/inotationundostack.h
     internal/excerptnotation.cpp
     internal/excerptnotation.h
     internal/igetscore.h
-    internal/inotationselectionrange.h
     internal/instrumentsrepository.cpp
     internal/instrumentsrepository.h
     internal/masternotation.cpp

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -20,15 +20,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_NOTATION_IEXCERPTNOTATION_H
-#define MU_NOTATION_IEXCERPTNOTATION_H
+#pragma once
 
-#include "inotation.h"
+#include "async/notification.h"
+#include "types/string.h"
+
+#include "inotation_fwd.h"
 
 namespace mu::notation {
-class IExcerptNotation;
-using IExcerptNotationPtr = std::shared_ptr<IExcerptNotation>;
-
 class IExcerptNotation
 {
 public:
@@ -50,5 +49,3 @@ public:
     virtual IExcerptNotationPtr clone() const = 0;
 };
 }
-
-#endif // MU_NOTATION_IEXCERPTNOTATION_H

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -24,17 +24,18 @@
 #include "async/notification.h"
 #include "types/ret.h"
 
-#include "inotation.h"
-#include "iexcerptnotation.h"
-#include "inotationplayback.h"
-#include "inotationautomation.h"
+#include "inotation_fwd.h"
+
+namespace mu::engraving {
+class MasterScore;
+}
 
 namespace mu::project {
 class INotationProject;
 }
 
 namespace mu::notation {
-using ExcerptNotationList = std::vector<IExcerptNotationPtr>;
+struct ScoreCreateOptions;
 
 class IMasterNotation
 {
@@ -58,7 +59,7 @@ public:
 
     virtual void initExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void setExcerpts(const ExcerptNotationList& excerpts) = 0;
-    virtual void resetExcerpt(IExcerptNotationPtr excerpt) = 0;
+    virtual void resetExcerpt(IExcerptNotationPtr& excerpt) = 0;
     virtual void sortExcerpts(ExcerptNotationList& excerpts) = 0;
 
     virtual void setExcerptIsOpen(const INotationPtr excerptNotation, bool opened) = 0;

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -32,7 +32,7 @@
 #include "inotationsolomutestate.h"
 #include "inotationstyle.h"
 #include "inotationviewstate.h"
-#include "internal/inotationundostack.h"
+#include "inotationundostack.h"
 #include "notationtypes.h"
 
 class QString;

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -19,21 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
+#include "async/channel.h"
 #include "async/notification.h"
+#include "draw/types/geometry.h"
+#include "modularity/ioc.h"
 
-#include "inotationaccessibility.h"
-#include "inotationelements.h"
-#include "inotationinteraction.h"
-#include "inotationmidiinput.h"
-#include "inotationpainting.h"
-#include "inotationparts.h"
-#include "inotationsolomutestate.h"
-#include "inotationstyle.h"
-#include "inotationviewstate.h"
-#include "inotationundostack.h"
-#include "notationtypes.h"
+#include "inotation_fwd.h" // IWYU pragma: export
+#include "types/viewmode.h"
 
 class QString;
 
@@ -42,14 +37,6 @@ class INotationProject;
 }
 
 namespace mu::notation {
-class INotation;
-using INotationPtr = std::shared_ptr<INotation>;
-using INotationWeakPtr = std::weak_ptr<INotation>;
-using INotationPtrList = std::vector<INotationPtr>;
-
-class IMasterNotation;
-using IMasterNotationPtr = std::shared_ptr<IMasterNotation>;
-
 class INotation
 {
 public:
@@ -116,4 +103,6 @@ public:
     // notify
     virtual muse::async::Channel<muse::RectF> notationChanged() const = 0;
 };
+
+using INotationPtr = std::shared_ptr<INotation>;
 }

--- a/src/notation/inotation_fwd.h
+++ b/src/notation/inotation_fwd.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace mu::notation {
+class INotation;
+using INotationPtr = std::shared_ptr<INotation>;
+using INotationWeakPtr = std::weak_ptr<INotation>;
+using INotationPtrList = std::vector<INotationPtr>;
+
+class IMasterNotation;
+using IMasterNotationPtr = std::shared_ptr<IMasterNotation>;
+
+class IExcerptNotation;
+using IExcerptNotationPtr = std::shared_ptr<IExcerptNotation>;
+using ExcerptNotationList = std::vector<IExcerptNotationPtr>;
+
+class INotationPainting;
+using INotationPaintingPtr = std::shared_ptr<INotationPainting>;
+
+class INotationViewState;
+using INotationViewStatePtr = std::shared_ptr<INotationViewState>;
+
+class INotationSoloMuteState;
+using INotationSoloMuteStatePtr = std::shared_ptr<INotationSoloMuteState>;
+
+class INotationInteraction;
+using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;
+
+class INotationSelection;
+using INotationSelectionPtr = std::shared_ptr<INotationSelection>;
+
+class INotationSelectionRange;
+using INotationSelectionRangePtr = std::shared_ptr<INotationSelectionRange>;
+
+class INotationSelectionFilter;
+using INotationSelectionFilterPtr = std::shared_ptr<INotationSelectionFilter>;
+
+class INotationNoteInput;
+using INotationNoteInputPtr = std::shared_ptr<INotationNoteInput>;
+
+class INotationMidiInput;
+using INotationMidiInputPtr = std::shared_ptr<INotationMidiInput>;
+
+class INotationUndoStack;
+using INotationUndoStackPtr = std::shared_ptr<INotationUndoStack>;
+
+class INotationStyle;
+using INotationStylePtr = std::shared_ptr<INotationStyle>;
+
+class INotationElements;
+using INotationElementsPtr = std::shared_ptr<INotationElements>;
+
+class INotationAccessibility;
+using INotationAccessibilityPtr = std::shared_ptr<INotationAccessibility>;
+
+class INotationParts;
+using INotationPartsPtr = std::shared_ptr<INotationParts>;
+
+class INotationPlayback;
+using INotationPlaybackPtr = std::shared_ptr<INotationPlayback>;
+
+class INotationAutomation;
+using INotationAutomationPtr = std::shared_ptr<INotationAutomation>;
+}

--- a/src/notation/inotationaccessibility.h
+++ b/src/notation/inotationaccessibility.h
@@ -20,11 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_NOTATION_INOTATIONACCESSIBILITY_H
-#define MU_NOTATION_INOTATIONACCESSIBILITY_H
+#pragma once
 
 #include "types/retval.h"
-#include "notationtypes.h"
 
 #include "engraving/accessibility/accessibleroot.h"
 
@@ -43,5 +41,3 @@ public:
 
 using INotationAccessibilityPtr = std::shared_ptr<INotationAccessibility>;
 }
-
-#endif // MU_NOTATION_INOTATIONACCESSIBILITY_H

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -29,8 +29,10 @@
 #include "async/channel.h"
 #include "types/retval.h"
 #include "io/path.h"
-#include "notationtypes.h"
 #include "global/globaltypes.h"
+
+#include "notationtypes.h"
+#include "types/zoomtype.h"
 
 namespace mu::notation {
 class INotationConfiguration : MODULE_GLOBAL_INTERFACE

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -19,16 +19,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include <functional>
 
 #include "async/notification.h"
 
+#include "inotation_fwd.h"
 #include "notationtypes.h"
-#include "inotationnoteinput.h"
-#include "inotationselection.h"
-#include "inotationselectionfilter.h"
 
 class QKeyEvent;
 class QInputMethodEvent;

--- a/src/notation/inotationmidiinput.h
+++ b/src/notation/inotationmidiinput.h
@@ -24,10 +24,12 @@
 
 #include "async/channel.h"
 
-#include "notationtypes.h"
-
 namespace muse::midi {
 struct Event;
+}
+
+namespace mu::engraving {
+class Note;
 }
 
 namespace mu::notation {
@@ -37,7 +39,7 @@ public:
     virtual ~INotationMidiInput() = default;
 
     virtual void onMidiEventReceived(const muse::midi::Event& event) = 0;
-    virtual muse::async::Channel<std::vector<const Note*> > notesReceived() const = 0;
+    virtual muse::async::Channel<std::vector<const engraving::Note*> > notesReceived() const = 0;
 
     virtual void onRealtimeAdvance() = 0;
 };

--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_INOTATIONNOTEINPUT_H
-#define MU_NOTATION_INOTATIONNOTEINPUT_H
+
+#pragma once
 
 #include "async/notification.h"
 #include "types/ret.h"
@@ -83,5 +83,3 @@ public:
 
 using INotationNoteInputPtr = std::shared_ptr<INotationNoteInput>;
 }
-
-#endif // MU_NOTATION_INOTATIONNOTEINPUT_H

--- a/src/notation/inotationpainting.h
+++ b/src/notation/inotationpainting.h
@@ -24,10 +24,12 @@
 
 #include <memory>
 
-#include "notationtypes.h"
+#include "async/notification.h"
 
 #include "draw/painter.h"
 #include "engraving/rendering/iscorerenderer.h"
+
+#include "types/viewmode.h"
 
 namespace mu::notation {
 class INotationPainting

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_INOTATIONPLAYBACK_H
-#define MU_NOTATION_INOTATIONPLAYBACK_H
+
+#pragma once
 
 #include "types/retval.h"
 #include "midi/miditypes.h"
@@ -97,5 +97,3 @@ public:
 
 using INotationPlaybackPtr = std::shared_ptr<INotationPlayback>;
 }
-
-#endif // MU_NOTATION_INOTATIONPLAYBACK_H

--- a/src/notation/inotationselection.h
+++ b/src/notation/inotationselection.h
@@ -23,10 +23,11 @@
 
 #include <vector>
 
-#include "notationtypes.h"
-#include "internal/inotationselectionrange.h"
 #include "types/bytearray.h"
 #include "types/ret.h"
+
+#include "inotationselectionrange.h"
+#include "notationtypes.h"
 
 class QMimeData;
 

--- a/src/notation/inotationselection.h
+++ b/src/notation/inotationselection.h
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include <vector>

--- a/src/notation/inotationselectionrange.h
+++ b/src/notation/inotationselectionrange.h
@@ -19,12 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_INOTATIONSELECTIONRANGE_H
-#define MU_NOTATION_INOTATIONSELECTIONRANGE_H
+
+#pragma once
 
 #include <vector>
 
-#include "../notationtypes.h"
+#include "notationtypes.h"
 
 namespace mu::notation {
 class INotationSelectionRange
@@ -58,5 +58,3 @@ public:
 
 using INotationSelectionRangePtr = std::shared_ptr<INotationSelectionRange>;
 }
-
-#endif // MU_NOTATION_INOTATIONSELECTIONRANGE_H

--- a/src/notation/inotationundostack.h
+++ b/src/notation/inotationundostack.h
@@ -25,7 +25,7 @@
 #include "async/notification.h"
 #include "async/channel.h"
 
-#include "../notationtypes.h"
+#include "notationtypes.h"
 
 namespace mu::engraving {
 class EditData;

--- a/src/notation/inotationviewstate.h
+++ b/src/notation/inotationviewstate.h
@@ -19,14 +19,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include <memory>
 
 #include "async/channel.h"
+#include "io/path.h"
 #include "types/retval.h"
 
-#include "notationtypes.h"
+#include "types/viewmode.h"
+#include "types/zoomtype.h"
 
 namespace muse::draw {
 class Transform;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -24,6 +24,9 @@
 
 #include "engraving/dom/excerpt.h"
 #include "engraving/editing/editexcerpt.h"
+#include "engraving/editing/transaction/transaction.h"
+
+#include "inotationundostack.h"
 
 using namespace mu::notation;
 
@@ -107,11 +110,10 @@ void ExcerptNotation::undoSetName(const QString& name)
     }
 
     //: Means: "edit the name of a part score"
-    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Rename part"));
+    undoStack()->transaction(muse::TranslatableString("undoableAction", "Rename part"), [&](engraving::Transaction& tx) {
+        tx.push(new engraving::ChangeExcerptTitle(m_excerpt, name));
+    });
 
-    score()->undo(new engraving::ChangeExcerptTitle(m_excerpt, name));
-
-    undoStack()->commitChanges();
     notifyAboutNotationChanged();
 }
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "masternotation.h"
 
 #include <QFileInfo>
@@ -45,6 +46,8 @@
 #include "engraving/editing/edittimesig.h"
 #include "engraving/editing/transaction/transaction.h"
 
+#include "inotationelements.h" // IWYU pragma: keep
+#include "inotationsolomutestate.h"
 #include "excerptnotation.h"
 #include "masternotationparts.h"
 #include "notationautomation.h"
@@ -532,7 +535,7 @@ void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
     doSetExcerpts(excerpts);
 }
 
-void MasterNotation::resetExcerpt(IExcerptNotationPtr excerptNotation)
+void MasterNotation::resetExcerpt(IExcerptNotationPtr& excerptNotation)
 {
     if (!excerptNotation || !excerptNotation->isInited()) {
         return;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -60,7 +60,7 @@ public:
 
     void initExcerpts(const ExcerptNotationList& excerpts) override;
     void setExcerpts(const ExcerptNotationList& excerpts) override;
-    void resetExcerpt(IExcerptNotationPtr excerptNotation) override;
+    void resetExcerpt(IExcerptNotationPtr& excerptNotation) override;
     void sortExcerpts(ExcerptNotationList& excerpts) override;
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -30,6 +30,9 @@
 #include "engraving/editing/transaction/transaction.h"
 #include "engraving/editing/transpose.h"
 
+#include "inotation.h"
+#include "iexcerptnotation.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace muse;

--- a/src/notation/internal/mscnotationwriter.cpp
+++ b/src/notation/internal/mscnotationwriter.cpp
@@ -22,8 +22,9 @@
 
 #include "mscnotationwriter.h"
 
-#include "io/buffer.h"
 #include "io/file.h"
+
+#include "inotationelements.h" // IWYU pragma: keep
 
 #include "engraving/engravingproject.h"
 #include "engraving/dom/masterscore.h"

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -27,6 +27,7 @@
 #include "engraving/dom/masterscore.h"
 
 #include "imasternotation.h"
+#include "inotationnoteinput.h" // IWYU pragma: keep
 
 #include "masternotation.h"
 #include "notationpainting.h"

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include "async/asyncable.h"

--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -19,12 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationaccessibility.h"
 
 #include "translation.h"
-
-#include "igetscore.h"
-#include "notation.h"
 
 #include "engraving/accessibility/accessibleroot.h"
 #include "engraving/dom/masterscore.h"
@@ -32,6 +30,10 @@
 #include "engraving/dom/part.h"
 #include "engraving/dom/segment.h"
 #include "engraving/dom/staff.h"
+
+#include "igetscore.h"
+#include "inotationinteraction.h" // IWYU pragma: keep
+#include "notation.h"
 
 using namespace mu::notation;
 using namespace muse::async;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationinteraction.h"
 
 #include "log.h"
@@ -69,7 +70,7 @@
 #include "engraving/dom/keysig.h"
 #include "engraving/dom/lasso.h"
 #include "engraving/dom/layoutbreak.h"
-#include "engraving/dom/linkedobjects.h"
+#include "engraving/dom/linkedobjects.h" // IWYU pragma: keep
 #include "engraving/dom/lyrics.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/measure.h"
@@ -124,6 +125,7 @@
 #include "engraving/rw/rwregister.h"
 #include "engraving/rw/xmlreader.h"
 
+#include "inotationviewstate.h"
 #include "notationerrors.h"
 #include "notation.h"
 #include "notationnoteinput.h"

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -28,13 +28,17 @@
 #include "defer.h"
 #include "log.h"
 
+#include "midi/miditypes.h"
+
 #include "engraving/dom/factory.h"
 #include "engraving/dom/note.h"
 #include "engraving/dom/score.h"
 #include "engraving/dom/segment.h"
-#include "engraving/dom/tie.h"
 #include "engraving/editing/noteinput.h"
 #include "engraving/editing/transaction/transaction.h"
+
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationselection.h" // IWYU pragma: keep
 
 #include "playback/playbackcommands.h"
 

--- a/src/notation/internal/notationmidiinput.h
+++ b/src/notation/internal/notationmidiinput.h
@@ -26,6 +26,8 @@
 
 #include <QTimer>
 
+#include "midi/midievent.h"
+
 #include "modularity/ioc.h"
 #include "playback/iplaybackcontroller.h"
 #include "inotationconfiguration.h"

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -21,25 +21,24 @@
  */
 #include "notationparts.h"
 
-#include "engraving/editing/transaction/transaction.h"
 #include "translation.h"
 
 #include "engraving/dom/barline.h"
 #include "engraving/dom/excerpt.h"
 #include "engraving/dom/factory.h"
-#include "engraving/dom/instrchange.h"
 #include "engraving/dom/instrument.h"
 #include "engraving/dom/page.h"
 #include "engraving/editing/addremoveelement.h"
 #include "engraving/editing/editexcerpt.h"
 #include "engraving/editing/editpart.h"
-#include "engraving/editing/editscoreproperties.h"
 #include "engraving/editing/editstaff.h"
 #include "engraving/editing/editstavesharing.h"
 #include "engraving/editing/editsystemlocks.h"
+#include "engraving/editing/transaction/transaction.h"
 #include "engraving/editing/transpose.h"
 
 #include "igetscore.h"
+#include "inotationnoteinput.h" // IWYU pragma: keep
 
 #include "log.h"
 

--- a/src/notation/internal/notationviewstate.h
+++ b/src/notation/internal/notationviewstate.h
@@ -19,10 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include "../inotationviewstate.h"
 #include "async/asyncable.h"
+
+#include "draw/types/transform.h"
 
 #include "modularity/ioc.h"
 #include "../inotationcontextconfiguration.h"

--- a/src/notation/internal/positionswriter.cpp
+++ b/src/notation/internal/positionswriter.cpp
@@ -34,6 +34,8 @@
 
 #include "engraving/types/types.h"
 
+#include "inotationelements.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu::project;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -59,8 +59,6 @@
 #include "engraving/dom/timesig.h"
 #include "engraving/dom/tuplet.h"
 
-#include "engraving/rendering/layoutoptions.h"
-
 namespace mu::notation {
 using Page = mu::engraving::Page;
 using System = mu::engraving::System;
@@ -75,7 +73,6 @@ using Duration = mu::engraving::TDuration;
 using SelectType = mu::engraving::SelectType;
 using SelectionState = mu::engraving::SelState;
 using Pad = mu::engraving::Pad;
-using ViewMode = engraving::LayoutMode;
 using PitchMode = mu::engraving::UpDownMode;
 using StyleId = mu::engraving::Sid;
 using StyleIdSet = mu::engraving::StyleIdSet;
@@ -254,25 +251,6 @@ enum class NoteFilter : unsigned char
     WithTie,
     WithSlur
 };
-
-enum class ZoomType : unsigned char {
-    Percentage,
-    PageWidth,
-    WholePage,
-    TwoPages
-};
-
-inline muse::TranslatableString zoomTypeTitle(ZoomType type)
-{
-    switch (type) {
-    case ZoomType::Percentage: return muse::TranslatableString("notation", "Percentage");
-    case ZoomType::PageWidth: return muse::TranslatableString("notation", "Page width");
-    case ZoomType::WholePage: return muse::TranslatableString("notation", "Whole page");
-    case ZoomType::TwoPages: return muse::TranslatableString("notation", "Two pages");
-    }
-
-    return {};
-}
 
 struct Tempo
 {

--- a/src/notation/tests/mocks/notationselectionrangemock.h
+++ b/src/notation/tests/mocks/notationselectionrangemock.h
@@ -24,7 +24,7 @@
 
 #include <gmock/gmock.h>
 
-#include "notation/internal/inotationselectionrange.h"
+#include "notation/inotationselectionrange.h"
 
 namespace mu::notation {
 class NotationSelectionRangeMock : public INotationSelectionRange

--- a/src/notation/types/viewmode.h
+++ b/src/notation/types/viewmode.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "engraving/rendering/layoutoptions.h"
+
+namespace mu::notation {
+using ViewMode = engraving::LayoutMode;
+}

--- a/src/notation/types/zoomtype.h
+++ b/src/notation/types/zoomtype.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types/translatablestring.h"
+
+namespace mu::notation {
+enum class ZoomType : unsigned char {
+    Percentage,
+    PageWidth,
+    WholePage,
+    TwoPages
+};
+
+inline muse::TranslatableString zoomTypeTitle(ZoomType type)
+{
+    switch (type) {
+    case ZoomType::Percentage: return muse::TranslatableString("notation", "Percentage");
+    case ZoomType::PageWidth: return muse::TranslatableString("notation", "Page width");
+    case ZoomType::WholePage: return muse::TranslatableString("notation", "Whole page");
+    case ZoomType::TwoPages: return muse::TranslatableString("notation", "Two pages");
+    }
+
+    return {};
+}
+}

--- a/src/notationscene/internal/midiinputoutputcontroller.cpp
+++ b/src/notationscene/internal/midiinputoutputcontroller.cpp
@@ -23,6 +23,8 @@
 
 #include "midi/miditypes.h"
 
+#include "notation/inotationmidiinput.h"
+
 #include "log.h"
 
 using namespace mu::notation;

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -33,7 +33,16 @@
 #include "engraving/dom/sig.h"
 #include "engraving/editing/noteinput.h"
 
+#include "notation/inotationautomation.h" // IWYU pragma: keep
+#include "notation/inotationelements.h"
+#include "notation/inotationmidiinput.h"
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationplayback.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationstyle.h"
+#include "notation/inotationundostack.h"
 #include "notation/notationtypes.h"
+#include "notation/inotationinteraction.h"
 
 #include "qml/MuseScore/NotationScene/abstractelementpopupmodel.h"
 

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -27,6 +27,12 @@
 #include "ui/view/iconcodes.h"
 #include "context/shortcutcontext.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationautomation.h" // IWYU pragma: keep
+
 using namespace mu;
 using namespace mu::notation;
 using namespace muse;

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.cpp
@@ -24,6 +24,11 @@
 
 #include "engraving/dom/property.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+#include "notation/inotationundostack.h"
+#include "notation/inotationviewstate.h"
+
 #include "elementpopups/partialtiepopupmodel.h"
 #include "elementpopups/shadownotepopupmodel.h"
 

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -26,10 +26,19 @@
 #include <QMimeData>
 
 #include "async/async.h"
+#include "log.h"
 
 #include "actions/actiontypes.h"
 #include "engraving/dom/shadownote.h"
-#include "log.h"
+
+#include "notation/inotationaccessibility.h" // IWYU pragma: keep
+#include "notation/inotationautomation.h"
+#include "notation/inotationelements.h"
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationpainting.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationstyle.h"
+#include "notation/inotationviewstate.h"
 
 using namespace mu;
 using namespace mu::notation;

--- a/src/notationscene/qml/MuseScore/NotationScene/continuouspanel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/continuouspanel.cpp
@@ -25,6 +25,8 @@
 
 #include "containers.h"
 
+#include "draw/painter.h"
+
 #include "engraving/dom/barline.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/instrument.h"
@@ -41,7 +43,7 @@
 #include "engraving/dom/timesig.h"
 #include "engraving/rendering/score/tlayout.h"
 
-#include "draw/painter.h"
+#include "notation/inotationelements.h" // IWYU pragma: keep
 
 #include "log.h"
 

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/dynamicpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/dynamicpopupmodel.cpp
@@ -29,6 +29,8 @@
 #include "engraving/types/symnames.h"
 #include "engraving/types/typesconv.h"
 
+#include "notation/inotationinteraction.h"
+
 #include "log.h"
 
 using namespace mu::notation;

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/partialtiepopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/partialtiepopupmodel.cpp
@@ -25,6 +25,9 @@
 #include "engraving/dom/partialtie.h"
 #include "engraving/dom/tie.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 using namespace mu::notation;
 using namespace mu::engraving;
 using namespace muse::uicomponents;

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/percussionnotepopupcontentmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/percussionnotepopupcontentmodel.cpp
@@ -25,6 +25,9 @@
 #include "engraving/dom/drumset.h"
 #include "engraving/dom/shadownote.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h"
+
 using namespace mu::notation;
 
 PercussionNotePopupContentModel::PercussionNotePopupContentModel(QObject* parent)

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/shadownotepopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/shadownotepopupmodel.cpp
@@ -21,7 +21,10 @@
  */
 
 #include "shadownotepopupmodel.h"
+
 #include "engraving/dom/shadownote.h"
+
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
 
 using namespace mu::notation;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
@@ -37,6 +37,9 @@
 #include "engraving/types/fraction.h"
 #include "engraving/types/types.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu::notation;

--- a/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/internal/undohistorymodel.cpp
@@ -22,6 +22,9 @@
 
 #include "undohistorymodel.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h"
+
 using namespace mu::notation;
 using namespace muse;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/internal/undoredotoolbarmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/internal/undoredotoolbarmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "undoredotoolbarmodel.h"
 
+#include "notation/inotationundostack.h"
+
 #include "uicomponents/qml/Muse/UiComponents/toolbaritem.h"
 
 using namespace mu::notation;
@@ -65,7 +67,7 @@ void UndoRedoToolbarModel::load()
 
 void UndoRedoToolbarModel::onActionsStateChanges(const muse::actions::ActionCodeList& codes)
 {
-    auto stack = undoStack();
+    INotationUndoStackPtr stack = undoStack();
 
     for (const actions::ActionCode& code : codes) {
         if (code == UNDO_ACTION_CODE) {
@@ -103,7 +105,7 @@ void UndoRedoToolbarModel::updateItems()
 
 void UndoRedoToolbarModel::subsribeOnUndoStackChanges()
 {
-    auto stack = undoStack();
+    INotationUndoStackPtr stack = undoStack();
     if (!stack) {
         return;
     }

--- a/src/notationscene/qml/MuseScore/NotationScene/loopmarker.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/loopmarker.cpp
@@ -21,8 +21,14 @@
  */
 
 #include "loopmarker.h"
+
+#include "draw/painter.h"
 #include "draw/types/pen.h"
+
 #include "engraving/iengravingfont.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h" // IWYU pragma: keep
 
 using namespace muse;
 using namespace mu;

--- a/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
@@ -23,8 +23,12 @@
 #include "notationautomationcontroller.h"
 
 #include "uicomponents/qml/Muse/UiComponents/polylineplot.h"
+
 #include "engraving/automation/iautomation.h"
 #include "engraving/dom/masterscore.h"
+
+#include "notation/inotationautomation.h"
+#include "notation/inotationelements.h"
 
 using namespace mu::notation;
 using namespace muse::uicomponents;

--- a/src/notationscene/qml/MuseScore/NotationScene/notationcontextmenumodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationcontextmenumodel.cpp
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationcontextmenumodel.h"
 
 #include "types/translatablestring.h"
@@ -29,6 +30,8 @@
 
 #include "engraving/dom/gradualtempochange.h"
 #include "engraving/dom/fret.h"
+
+#include "notation/inotationselection.h"
 
 using namespace mu::notation;
 using namespace muse;

--- a/src/notationscene/qml/MuseScore/NotationScene/notationcontextmenumodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationcontextmenumodel.h
@@ -26,6 +26,8 @@
 #include "context/iglobalcontext.h"
 
 #include "uicomponents/qml/Muse/UiComponents/abstractmenumodel.h"
+
+#include "notation/inotationinteraction.h"
 #include "notation/notationtypes.h"
 
 namespace mu::notation {

--- a/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationnavigator.cpp
@@ -19,9 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationnavigator.h"
 
 #include "log.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
 
 using namespace muse;
 using namespace mu::notation;

--- a/src/notationscene/qml/MuseScore/NotationScene/notationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationpaintview.cpp
@@ -19,7 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationpaintview.h"
+
+#include "notation/inotationviewstate.h"
 
 using namespace mu;
 using namespace muse::draw;

--- a/src/notationscene/qml/MuseScore/NotationScene/notationswitchlistmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationswitchlistmodel.cpp
@@ -24,6 +24,8 @@
 
 #include "log.h"
 
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+
 using namespace mu::notation;
 using namespace mu::project;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
@@ -39,6 +39,13 @@
 #include "engraving/dom/fret.h"
 #include "engraving/dom/shadownote.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationpainting.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationstyle.h"
+#include "notation/inotationviewstate.h" // IWYU pragma: keep
+
 using namespace mu;
 using namespace mu::notation;
 using namespace mu::engraving;

--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
@@ -24,6 +24,13 @@
 #include "types/translatablestring.h"
 
 #include "context/shortcutcontext.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationselection.h"
+#include "notation/inotationundostack.h"
+
 #include "internal/notationuiactions.h"
 
 using namespace mu;

--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputcursor.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputcursor.cpp
@@ -19,7 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "noteinputcursor.h"
+
+#include "draw/painter.h"
+
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationnoteinput.h"
 
 using namespace mu::notation;
 using namespace mu::engraving;

--- a/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
@@ -29,6 +29,8 @@
 
 #include "engraving/dom/utils.h"
 
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+
 using namespace mu::notation;
 using namespace muse;
 using namespace muse::uicomponents;

--- a/src/notationscene/qml/MuseScore/NotationScene/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/percussionpanel/percussionpanelmodel.cpp
@@ -34,6 +34,11 @@
 #include "engraving/dom/factory.h"
 #include "engraving/dom/utils.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h"
+#include "notation/inotationparts.h" // IWYU pragma: keep
+
 static const QString PAD_NAMES_CODE("percussion-pad-names");
 static const QString NOTATION_PREVIEW_CODE("percussion-notation-preview");
 static const QString SET_COLUMNS_CODE("percussion-set-columns");

--- a/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/pianokeyboard/pianokeyboardcontroller.cpp
@@ -22,7 +22,13 @@
 #include "pianokeyboardcontroller.h"
 
 #include "defer.h"
-#include "log.h"
+
+#include "midi/midievent.h"
+
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationmidiinput.h"
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+#include "notation/inotationselection.h" // IWYU pragma: keep
 
 using namespace mu::notation;
 using namespace muse::midi;

--- a/src/notationscene/qml/MuseScore/NotationScene/playbackcursor.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/playbackcursor.cpp
@@ -19,9 +19,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "playbackcursor.h"
 
+#include "draw/painter.h"
+
 #include "engraving/dom/system.h"
+
+#include "notation/inotation.h"
+#include "notation/inotationelements.h" // IWYU pragma: keep
 
 using namespace mu::engraving;
 using namespace mu::notation;

--- a/src/notationscene/qml/MuseScore/NotationScene/playbackcursor.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/playbackcursor.h
@@ -29,7 +29,7 @@
 #include "draw/types/geometry.h"
 #include "midi/miditypes.h"
 
-#include "notation/inotation.h"
+#include "notation/inotation_fwd.h"
 
 class QColor;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
@@ -21,6 +21,10 @@
  */
 #include "searchpopupmodel.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+
 using namespace mu::notation;
 
 SearchPopupModel::SearchPopupModel(QObject* parent)

--- a/src/notationscene/qml/MuseScore/NotationScene/selectionfilter/abstractselectionfiltermodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/selectionfilter/abstractselectionfiltermodel.cpp
@@ -24,6 +24,9 @@
 
 #include "log.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselectionfilter.h"
+
 using namespace mu::notation;
 
 AbstractSelectionFilterModel::AbstractSelectionFilterModel(QObject* parent)

--- a/src/notationscene/qml/MuseScore/NotationScene/selectionfilter/notesinchordselectionfiltermodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/selectionfilter/notesinchordselectionfiltermodel.cpp
@@ -22,6 +22,10 @@
 
 #include "notesinchordselectionfiltermodel.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationselectionfilter.h"
+
 #include "log.h"
 #include "translation.h"
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/stavesharingpagemodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/stavesharingpagemodel.cpp
@@ -19,7 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "stavesharingpagemodel.h"
+
+#include "notation/inotationparts.h" // IWYU pragma: keep
 
 using namespace mu::engraving;
 

--- a/src/notationscene/qml/MuseScore/NotationScene/timelineview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/timelineview.cpp
@@ -22,14 +22,15 @@
 
 #include "timelineview.h"
 
-#include "widgets/timeline.h"
-
 #include <QApplication>
 #include <QQuickWindow>
 #include <QSplitter>
 #include <QTimer>
 
-#include "log.h"
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
+#include "widgets/timeline.h"
 
 namespace mu::notation {
 class TimelineAdapter : public QSplitter, public muse::uicomponents::IDisplayableWidget

--- a/src/notationscene/widgets/breaksdialog.cpp
+++ b/src/notationscene/widgets/breaksdialog.cpp
@@ -22,6 +22,9 @@
 
 #include "breaksdialog.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+
 using namespace mu::notation;
 
 static constexpr int DEFAULT_INTERVAL = 4;

--- a/src/notationscene/widgets/editstaff.cpp
+++ b/src/notationscene/widgets/editstaff.cpp
@@ -45,6 +45,10 @@
 #include "engraving/dom/utils.h"
 #include "engraving/editing/transaction/undostack.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationparts.h"
+#include "notation/inotationselection.h"
+
 #include "log.h"
 
 using namespace mu::notation;

--- a/src/notationscene/widgets/editstringdata.cpp
+++ b/src/notationscene/widgets/editstringdata.cpp
@@ -33,6 +33,9 @@
 #include "engraving/dom/stringtunings.h"
 #include "engraving/editing/editpart.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+
 #include "ui/view/widgetstatestore.h"
 #include "ui/view/widgetnavigationfix.h"
 

--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -47,6 +47,11 @@
 #include "engraving/types/types.h"
 #include "engraving/types/typesconv.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+#include "notation/inotationviewstate.h" // IWYU pragma: keep
+
 #include "ui/view/widgetstatestore.h"
 #include "ui/view/widgetutils.h"
 

--- a/src/notationscene/widgets/editstyle.h
+++ b/src/notationscene/widgets/editstyle.h
@@ -27,6 +27,7 @@
 #include "ui_editstyle.h"
 
 #include "modularity/ioc.h"
+#include "accessibility/iaccessibilitycontroller.h"
 #include "context/iglobalcontext.h"
 #include "interactive/iinteractive.h"
 #include "ui/iuiconfiguration.h"

--- a/src/notationscene/widgets/measureproperties.cpp
+++ b/src/notationscene/widgets/measureproperties.cpp
@@ -33,7 +33,9 @@
 #include "engraving/dom/sig.h"
 #include "engraving/editing/editstaff.h"
 
-#include "notation/inotationelements.h"
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationundostack.h"
 
 #include "ui/view/widgetnavigationfix.h"
 #include "ui/view/widgetstatestore.h"

--- a/src/notationscene/widgets/pagesettings.cpp
+++ b/src/notationscene/widgets/pagesettings.cpp
@@ -30,6 +30,10 @@
 #include "engraving/dom/excerpt.h"
 #include "engraving/style/pagestyle.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 #include "ui/view/widgetstatestore.h"
 
 using namespace mu::notation;

--- a/src/notationscene/widgets/realizeharmonydialog.cpp
+++ b/src/notationscene/widgets/realizeharmonydialog.cpp
@@ -23,7 +23,9 @@
 #include "realizeharmonydialog.h"
 
 #include "engraving/dom/harmony.h"
-#include "engraving/dom/staff.h"
+
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h" // IWYU pragma: keep
 
 #include "translation.h"
 

--- a/src/notationscene/widgets/selectdialog.cpp
+++ b/src/notationscene/widgets/selectdialog.cpp
@@ -27,7 +27,12 @@
 */
 
 #include "engraving/dom/system.h"
+
+#include "notation/inotationelements.h"
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h" // IWYU pragma: keep
 #include "notation/notationtypes.h"
+
 #include "ui/view/widgetstatestore.h"
 
 using namespace mu::notation;

--- a/src/notationscene/widgets/selectnotedialog.cpp
+++ b/src/notationscene/widgets/selectnotedialog.cpp
@@ -38,6 +38,10 @@
 #include "engraving/dom/select.h"
 #include "engraving/dom/system.h"
 
+#include "notation/inotationelements.h"
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h" // IWYU pragma: keep
+
 #include "ui/view/widgetstatestore.h"
 
 #include "log.h"

--- a/src/notationscene/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notationscene/widgets/stafftextpropertiesdialog.cpp
@@ -19,12 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "stafftextpropertiesdialog.h"
 
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/score.h"
 #include "engraving/dom/staff.h"
 #include "engraving/dom/stafftextbase.h"
+
+#include "notation/inotationinteraction.h"
+#include "notation/inotationundostack.h"
 
 #include "ui/view/widgetstatestore.h"
 

--- a/src/notationscene/widgets/timeline.cpp
+++ b/src/notationscene/widgets/timeline.cpp
@@ -49,6 +49,11 @@
 #include "engraving/dom/timesig.h"
 #include "engraving/types/typesconv.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 #include "log.h"
 
 using namespace mu::notation;

--- a/src/notationscene/widgets/transposedialog.cpp
+++ b/src/notationscene/widgets/transposedialog.cpp
@@ -22,6 +22,9 @@
 
 #include "transposedialog.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+
 #include "ui/view/widgetstatestore.h"
 
 using namespace mu::notation;

--- a/src/notationscene/widgets/tupletdialog.cpp
+++ b/src/notationscene/widgets/tupletdialog.cpp
@@ -23,6 +23,8 @@
 
 #include "engraving/dom/tuplet.h"
 
+#include "notation/inotationstyle.h"
+
 #include "ui/view/widgetstatestore.h"
 
 using namespace mu::notation;

--- a/src/palette/internal/paletteactionscontroller.cpp
+++ b/src/palette/internal/paletteactionscontroller.cpp
@@ -22,6 +22,8 @@
 
 #include "paletteactionscontroller.h"
 
+#include "notation/inotationinteraction.h"
+
 using namespace mu::palette;
 using namespace muse;
 using namespace muse::ui;

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -31,6 +31,8 @@
 
 #include "engraving/dom/mscore.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+
 #include "palettecreator.h"
 
 #include "io/path.h"

--- a/src/palette/widgets/customizekitdialog.cpp
+++ b/src/palette/widgets/customizekitdialog.cpp
@@ -41,6 +41,10 @@
 #include "engraving/dom/score.h"
 #include "engraving/dom/utils.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+#include "notation/inotationparts.h" // IWYU pragma: keep
+
 #include "modularity/ioc.h"
 #include "notationscene/utilities/percussionutilities.h"
 

--- a/src/palette/widgets/palettewidget.cpp
+++ b/src/palette/widgets/palettewidget.cpp
@@ -60,6 +60,8 @@
 #include "engraving/style/defaultstyle.h"
 #include "engraving/style/style.h"
 
+#include "notation/inotationinteraction.h"
+
 #include "notationscene/utilities/engravingitempreviewpainter.h"
 
 #include "internal/palettecelliconengine.h"

--- a/src/palette/widgets/specialcharactersdialog.cpp
+++ b/src/palette/widgets/specialcharactersdialog.cpp
@@ -34,6 +34,8 @@
 #include "engraving/types/symnames.h"
 #include "engraving/infrastructure/smufl.h"
 
+#include "notation/inotationinteraction.h"
+
 #include "ui/view/widgetstatestore.h"
 
 static const QString SPECIAL_CHARACTERS_DIALOG_NAME("SpecialCharactersDialog");

--- a/src/palette/widgets/symboldialog.cpp
+++ b/src/palette/widgets/symboldialog.cpp
@@ -30,6 +30,8 @@
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/symbol.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "palettewidget.h"
 
 using namespace mu::engraving;

--- a/src/palette/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/widgets/timesignaturepropertiesdialog.cpp
@@ -30,6 +30,9 @@
 #include "engraving/dom/score.h"
 #include "engraving/dom/timesig.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 #include "ui/view/musicalsymbolcodes.h"
 #include "ui/view/widgetstatestore.h"
 

--- a/src/playback/internal/drumsetloader.cpp
+++ b/src/playback/internal/drumsetloader.cpp
@@ -22,6 +22,7 @@
 
 #include "drumsetloader.h"
 
+#include "notation/inotationparts.h"
 #include "notation/notationtypes.h"
 #include "notationscene/utilities/percussionutilities.h"
 
@@ -83,7 +84,8 @@ void DrumsetLoader::loadDrumset(INotationPtr notation, const InstrumentTrackId& 
 
 void DrumsetLoader::replaceDrumset(INotationPtr notation, const InstrumentTrackId& trackId, const Drumset& drumset)
 {
-    const Part* part = notation->parts()->part(trackId.partId);
+    INotationPartsPtr parts = notation->parts();
+    const Part* part = parts->part(trackId.partId);
     if (!part) {
         return;
     }
@@ -101,6 +103,6 @@ void DrumsetLoader::replaceDrumset(INotationPtr notation, const InstrumentTrackI
         instrumentKey.partId = trackId.partId;
         instrumentKey.tick = Fraction::fromTicks(it->first);
 
-        notation->parts()->replaceDrumset(instrumentKey, drumset, false /*undoable*/);
+        parts->replaceDrumset(instrumentKey, drumset, false /*undoable*/);
     }
 }

--- a/src/playback/internal/playbackcommandsstate.cpp
+++ b/src/playback/internal/playbackcommandsstate.cpp
@@ -22,6 +22,8 @@
 
 #include "playbackcommandsstate.h"
 
+#include "notation/inotationinteraction.h"
+
 #include "../playbackcommands.h"
 
 using namespace muse;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -22,24 +22,28 @@
 #include "playbackcontroller.h"
 
 #include "async/notifylist.h"
-
+#include "containers.h"
 #include "modularity/ioc.h"
-#include "onlinesoundscontroller.h"
-
-#include "engraving/dom/masterscore.h"
-#include "engraving/dom/stafftext.h"
-#include "engraving/dom/utils.h"
-#include "engraving/dom/factory.h"
+#include "log.h"
+#include "types/ret.h"
 
 #include "audio/common/audioutils.h"
 #include "audio/devtools/inputlag.h"
 
+#include "engraving/dom/factory.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/stafftext.h"
+#include "engraving/dom/utils.h"
+
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h" // IWYU pragma: keep
+#include "notation/inotationparts.h"
+#include "notation/inotationselection.h"
+
 #include "../playbacktypes.h"
 #include "../playbackcommands.h"
-
-#include "containers.h"
-#include "log.h"
-#include "types/ret.h"
+#include "onlinesoundscontroller.h"
 
 using namespace muse;
 using namespace muse::actions;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -22,16 +22,17 @@
 
 #pragma once
 
-#include "modularity/imoduleinterface.h"
-#include "async/notification.h"
-#include "async/channel.h"
-#include "async/promise.h"
-#include "global/progress.h"
-#include "notation/inotation.h"
-#include "notation/notationtypes.h"
-#include "audio/common/audiotypes.h"
 #include "actions/actiontypes.h"
-#include "midi/miditypes.h"
+#include "async/channel.h"
+#include "async/notification.h"
+#include "async/promise.h"
+#include "audio/common/audiotypes.h"
+#include "global/progress.h"
+#include "modularity/imoduleinterface.h"
+
+#include "notation/inotation_fwd.h"
+#include "notation/inotationsolomutestate.h"
+#include "notation/notationtypes.h"
 
 #include "playbacktypes.h"
 

--- a/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
@@ -26,6 +26,8 @@
 #include "translation.h"
 #include "log.h"
 
+#include "notation/inotationplayback.h"
+
 using namespace mu::playback;
 using namespace muse;
 using namespace muse::audio;

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -23,12 +23,12 @@
 #include "mixerpanelmodel.h"
 
 #include "async/notifylist.h"
-
 #include "defer.h"
-
 #include "log.h"
-#include "modularity/ioc.h"
 #include "translation.h"
+
+#include "notation/inotationparts.h"
+#include "notation/inotationplayback.h"
 
 using namespace muse;
 using namespace mu::playback;

--- a/src/playback/qml/MuseScore/Playback/notationregionsbeingprocessedmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/notationregionsbeingprocessedmodel.cpp
@@ -21,8 +21,12 @@
  */
 
 #include "notationregionsbeingprocessedmodel.h"
-#include <QtCore/qvariant.h>
-#include <QtGui/qtransform.h>
+
+#include <QVariant>
+#include <QTransform>
+
+#include "notation/inotationparts.h" // IWYU pragma: keep
+#include "notation/inotationplayback.h" // IWYU pragma: keep
 
 using namespace muse::audio;
 using namespace mu::playback;

--- a/src/playback/qml/MuseScore/Playback/onlinesoundsstatusmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/onlinesoundsstatusmodel.cpp
@@ -26,6 +26,7 @@
 #include "global/translation.h"
 
 #include "audio/common/audioerrors.h"
+#include "notation/inotationplayback.h" // IWYU pragma: keep
 #include "playback/playbackcommands.h"
 
 using namespace mu::notation;

--- a/src/playback/qml/MuseScore/Playback/soundflagsettingsmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/soundflagsettingsmodel.cpp
@@ -27,6 +27,8 @@
 #include "engraving/dom/stafftext.h"
 #include "engraving/dom/soundflag.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+
 #include "audio/common/audioutils.h"
 #include "actions/actiontypes.h"
 

--- a/src/playback/qml/MuseScore/Playback/soundprofilesmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/soundprofilesmodel.cpp
@@ -22,6 +22,7 @@
 
 #include "soundprofilesmodel.h"
 
+#include "notation/inotationplayback.h"
 #include "project/inotationproject.h"
 
 using namespace mu::playback;

--- a/src/print/internal/printprovider.cpp
+++ b/src/print/internal/printprovider.cpp
@@ -25,6 +25,10 @@
 #include <QPrintDialog>
 #include <QWindow>
 
+#include "draw/painter.h"
+
+#include "notation/inotationpainting.h"
+
 #include "log.h"
 
 using namespace muse;
@@ -43,7 +47,7 @@ Ret PrintProvider::printNotation(INotationPtr notation)
         return make_ret(Ret::Code::InternalError);
     }
 
-    auto painting = notation->painting();
+    INotationPaintingPtr painting = notation->painting();
 
     SizeF pageSizeInch = painting->pageSizeInch();
     QPrinter printerDev(QPrinter::HighResolution);

--- a/src/project/internal/engravingpluginapihelper.cpp
+++ b/src/project/internal/engravingpluginapihelper.cpp
@@ -21,6 +21,8 @@
  */
 #include "engravingpluginapihelper.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+
 #include "inotationwriter.h"
 #include "types/projecttypes.h"
 

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -28,6 +28,10 @@
 #include "defer.h"
 #include "log.h"
 
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationpainting.h" // IWYU pragma: keep
+
 using namespace muse;
 using namespace muse::io;
 using namespace mu::project;

--- a/src/project/internal/mscmetareader.h
+++ b/src/project/internal/mscmetareader.h
@@ -31,6 +31,10 @@ namespace muse {
 class XmlStreamReader;
 }
 
+namespace mu::engraving {
+class MscReader;
+}
+
 namespace mu::project {
 class MscMetaReader : public IMscMetaReader
 {

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -46,6 +46,9 @@
 #include "engraving/rw/write/writecontext.h"
 
 #include "iprojectautosaver.h"
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+#include "notation/inotationviewstate.h"
 #include "notation/internal/masternotation.h"
 #include "notation/notationerrors.h"
 #include "projectaudiosettings.h"

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -39,6 +39,9 @@
 #include "engraving/infrastructure/mscio.h"
 #include "engraving/engravingerrors.h"
 
+#include "notation/inotationinteraction.h"
+#include "notation/inotationselection.h"
+
 #include "projecterrors.h"
 #include "projectextensionpoints.h"
 

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "exportdialogmodel.h"
 
 #include <algorithm>
@@ -26,7 +27,8 @@
 #include <QItemSelectionModel>
 #include <QTimer>
 
-#include "async/async.h"
+#include "notation/iexcerptnotation.h" // IWYU pragma: keep
+
 #include "translation.h"
 #include "log.h"
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/emptystaves/emptystavesvisiblitysettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/emptystaves/emptystavesvisiblitysettingsmodel.cpp
@@ -26,6 +26,10 @@
 #include "engraving/dom/system.h"
 #include "engraving/rendering/score/systemlayout.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 using namespace mu::propertiespanel;
 using namespace mu::notation;
 using namespace mu::engraving;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
@@ -27,6 +27,8 @@
 #include "engraving/editing/editvisibility.h"
 #include "engraving/editing/transaction/transaction.h"
 
+#include "notation/inotationelements.h"
+
 #include "translation.h"
 
 using namespace mu::propertiespanel;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/measures/measuressettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/measures/measuressettingsmodel.cpp
@@ -23,6 +23,9 @@
 
 #include "engraving/dom/score.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+
 #include "translation.h"
 
 using namespace mu::propertiespanel;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/barlines/barlinesettingsmodel.cpp
@@ -22,8 +22,12 @@
 #include "barlinesettingsmodel.h"
 
 #include "translation.h"
-#include "types/barlinetypes.h"
+
 #include "engraving/dom/barline.h"
+
+#include "notation/inotationundostack.h"
+
+#include "types/barlinetypes.h"
 
 using namespace mu::propertiespanel;
 using namespace mu::engraving;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/chordsymbols/chordsymbolsettingsmodel.cpp
@@ -19,7 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "chordsymbolsettingsmodel.h"
+
+#include "notation/inotationstyle.h" // IWYU pragma: keep
 
 #include "translation.h"
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordlistmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/frames/fretframe/fretframechordlistmodel.cpp
@@ -24,9 +24,9 @@
 #include "engraving/dom/box.h"
 #include "engraving/dom/fret.h"
 
-#include "fretframechorditem.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
 
-#include "translation.h"
+#include "fretframechorditem.h"
 
 using namespace mu::propertiespanel;
 using namespace mu::engraving;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/internal/fretcanvas.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/fretdiagrams/internal/fretcanvas.cpp
@@ -26,6 +26,8 @@
 
 #include "engraving/dom/fret.h"
 
+#include "notation/inotationundostack.h" // IWYU pragma: keep
+
 using namespace mu::propertiespanel;
 
 FretCanvas::FretCanvas(QQuickItem* parent)

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/instrumentname/instrumentnamesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/instrumentname/instrumentnamesettingsmodel.cpp
@@ -24,6 +24,8 @@
 
 #include "engraving/dom/instrumentname.h"
 
+#include "notation/inotationselection.h" // IWYU pragma: keep
+
 using namespace mu::propertiespanel;
 using namespace muse::actions;
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/mmrests/mmrestsettingsmodel.cpp
@@ -23,6 +23,8 @@
 
 #include "engraving/dom/mmrest.h"
 
+#include "notation/inotationstyle.h"
+
 #include "translation.h"
 
 using namespace mu::propertiespanel;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/notesettingsproxymodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/notes/notesettingsproxymodel.cpp
@@ -19,7 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notesettingsproxymodel.h"
+
+#include "notation/inotationselection.h" // IWYU pragma: keep
 
 #include "propertiespanelmodelfactory.h"
 #include "translation.h"

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stringtunings/stringtuningssettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/stringtunings/stringtuningssettingsmodel.cpp
@@ -19,7 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "stringtuningssettingsmodel.h"
+
+#include "notation/inotationselection.h"
 
 #include "translation.h"
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanelabstractmodel.cpp
@@ -26,6 +26,10 @@
 #include "engraving/dom/property.h"
 #include "engraving/dom/tempotext.h"
 
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationstyle.h"
+#include "notation/inotationundostack.h"
+
 #include "modularity/ioc.h"
 #include "shortcuts/shortcutstypes.h"
 

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanellistmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/propertiespanellistmodel.cpp
@@ -19,7 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "propertiespanellistmodel.h"
+
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+#include "notation/inotationselection.h"
+#include "notation/inotationundostack.h" // IWYU pragma: keep
 
 #include "general/generalsettingsmodel.h"
 #include "measures/measuressettingsmodel.h"

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/score/scoredisplaysettingsmodel.cpp
@@ -19,9 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "scoredisplaysettingsmodel.h"
 
-#include "log.h"
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+
 #include "translation.h"
 
 using namespace mu::propertiespanel;

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textsettingsmodel.cpp
@@ -30,6 +30,9 @@
 #include "engraving/dom/textbase.h"
 #include "engraving/types/typesconv.h"
 
+#include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h" // IWYU pragma: keep
+
 #include "translation.h"
 #include "log.h"
 #include "realfn.h"

--- a/src/web/appshell/view/notationpagemodel.cpp
+++ b/src/web/appshell/view/notationpagemodel.cpp
@@ -19,12 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "notationpagemodel.h"
 
 #include "internal/applicationuiactions.h"
 #include "dockwindow/idockwindow.h"
 
 #include "async/async.h"
+
+#include "notation/inotationinteraction.h"
+#include "notation/inotationnoteinput.h"
 
 #include "log.h"
 
@@ -53,7 +57,7 @@ void NotationPageModel::init()
 
     for (const ActionCode& actionCode : ApplicationUiActions::toggleDockActions().keys()) {
         DockName dockName = ApplicationUiActions::toggleDockActions()[actionCode];
-        dispatcher()->reg(this, actionCode, [=]() { toggleDock(dockName); });
+        dispatcher()->reg(this, actionCode, [this, dockName]() { toggleDock(dockName); });
     }
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {

--- a/src/web/appshell/view/notationpagemodel.h
+++ b/src/web/appshell/view/notationpagemodel.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_APPSHELL_NOTATIONPAGEMODEL_H
-#define MU_APPSHELL_NOTATIONPAGEMODEL_H
+
+#pragma once
 
 #include <QQuickItem>
 
@@ -89,5 +89,3 @@ private:
     void updatePercussionPanelVisibility();
 };
 }
-
-#endif // MU_APPSHELL_NOTATIONPAGEMODEL_H


### PR DESCRIPTION
Together with the fact that notationtypes.h is now no longer included by inotation.h, this should reduce mass recompilations quite a bit.