### PR TITLE
Fix use-after-free/double-free crash when leaving an empty lyrics syllable

### DIFF
--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -161,12 +161,16 @@ void TextBase::endEdit(EditData& ed)
     }
 
     const bool newlyAdded = ted->oldXmlText.isEmpty();
+    bool rollbackWillDeleteThis = false;
     if (newlyAdded) {
         const UndoableTransaction* transaction = textWasEdited ? undo->prev() : undo->last();
         if (transaction && transaction->hasCommandsMatchingFilter(UndoableCommandFilter::AddElement, this)) {
             // We have just added this element to a score.
             // Combine undo records of text creation with text editing.
             undo->mergeTransactions(ted->startUndoIdx - 1);
+            // The merged transaction now contains the "add element" command for `this`,
+            // so rolling it back below will synchronously delete `this` (see AddElement::cleanup()).
+            rollbackWillDeleteThis = true;
         }
     }
 
@@ -184,6 +188,14 @@ void TextBase::endEdit(EditData& ed)
         undo->reopen();
         if (newlyAdded) {
             score()->endCmd(true); // rollback the "add element" command
+
+            if (rollbackWillDeleteThis) {
+                // `this` (and therefore `ted`, which points to it) was just deleted by the
+                // rollback above. Any further use of them would be a use-after-free, so bail
+                // out immediately instead of falling through to the code below.
+                return;
+            }
+
             ted->deleteText = true;
         } else {
             score()->undoRemoveElement(this);


### PR DESCRIPTION
Fixes #34131

## Problem

MuseScore Studio crashes when, while editing lyrics, the user navigates to
a note/rest that has no lyrics yet (which auto-creates an empty `Lyrics`
syllable) and then leaves that syllable **without typing anything into
it** — e.g. by pressing `Shift+Space` to go back to the previous syllable.

### Steps to reproduce

1. Select a note and start editing lyrics (`Ctrl+L`).
2. Type a syllable, then press `Space` (or `-`) to move to the next
   note. This creates a new, empty `Lyrics` element on that note and
   places the cursor in it.
3. Without typing anything, press `Shift+Space` to navigate back to
   the previous syllable.
4. Crash.

### Backtrace (Debug build)

```
Thread 1 "main" received signal SIGSEGV, Segmentation fault.
0x000055555a68f9a6 in mu::engraving::deletePostponed (cmdState=...)
    at src/engraving/editing/cmd.cpp:289
289         delete e;
#0  mu::engraving::deletePostponed (cmdState=...) at src/engraving/editing/cmd.cpp:289
#1  mu::engraving::MasterScore::update (this=..., resetCmdState=false, layoutAllParts=false)
    at src/engraving/editing/cmd.cpp:378
```

## Root cause

In `TextBase::endEdit()` (`src/engraving/editing/textedit.cpp`), when the
text being edited is empty **and** was newly added in the current undo
transaction, the code rolls back the "add element" command:

```cpp
undo->reopen();
if (newlyAdded) {
    score()->endCmd(true); // rollback the "add element" command
    ted->deleteText = true;
    ...
```

`score()->endCmd(true)` rolls back via `UndoableTransaction::unwind()`
(`src/engraving/editing/transaction/undostack.cpp`), which now calls
`command->cleanup(false)` on every undone command. For the `AddElement`
command that created this `Lyrics`, `AddElement::cleanup()`
(`src/engraving/editing/addremoveelement.cpp`) does:

```cpp
void AddElement::cleanup(bool wasDone)
{
    if (!wasDone) {
        delete element;   // synchronously deletes the Lyrics object
        element = nullptr;
    }
}
```

This **synchronously deletes** the very `Lyrics` object that
`TextBase::endEdit()` is still executing on (`this`). Execution then
returns to `endEdit()`, which keeps using the now-dangling `this`/`ted`
(`ted->deleteText = true;`, `isLyrics()`, `toLyrics(this)`, ...) — a
use-after-free.

Because `ted->deleteText` gets set, `TextEditData`'s destructor later
schedules a **second** deletion of the same, already-freed object via
`deleteLater()`:

```cpp
TextEditData::~TextEditData()
{
    if (deleteText) {
        for (EngravingObject* se : m_textBase->linkList()) { // UAF: m_textBase already deleted
            toTextBase(se)->deleteLater();
        }
    }
}
```

The corrupted pointer(s) end up in `MasterScore`'s postponed-deletion
list, and the next `MasterScore::update()` crashes trying to `delete`
them a second time (`deletePostponed`, `cmd.cpp:289`) — the observed
crash.

### Bisected culprit

I bisected this to 67b5fa12a479e179931c2ab3143a27ba9e13a681 ("Don't leak
items owned by UndoableCommand deleted in `unwind`"), which added the
synchronous `command->cleanup(false)` call to `unwind()`. Before that
commit, `unwind()` only deleted the undo *command*, not the element it
referred to, so the element stayed alive for the separate
`deleteText`/`deleteLater()` cleanup path introduced in
1f0c8cc5abc926098198e848902cf3ae937afdf1 ("Don't leak
newly-added-but-removed-because-empty text objects"), itself built on
top of 9c178a6f0e52fcf8408ed1f18280eb665b772fed which introduced the
`score()->endCmd(true)` rollback for this case.

So this is a case of two independent, previously-correct leak fixes that
now conflict: `67b5fa12a4` made `unwind()` delete elements
synchronously, without accounting for the fact that
`TextBase::endEdit()`'s `newlyAdded` branch already relies on a
*separate*, deferred deletion mechanism for the same object.

## Fix

Detect ahead of time whether the upcoming rollback will delete `this`
(i.e. whether the "add element" command for `this` is part of the
transaction being rolled back — the same condition already checked a
few lines above, when merging transactions), and if so, return
immediately after `endCmd(true)` without touching `this`/`ted` again.

## Note on issue #31986

While investigating, I compared this crash against the older, still-open
issue #31986 ("Crash if lyrics text is empty or contains line breaks"),
since GitHub suggested it as a possible duplicate. They are **not** the
same bug:

- #31986 predates the culprit commit above (`67b5fa12a4`, several months
  later than #31986's last activity), so it cannot share this root
  cause.
- Reproducing #31986's steps (paste multi-line text into a lyrics,
  save/reload, then repeatedly press `-`/Space on another lyrics) still
  crashes on `main` even with this fix applied, but with a **different**
  backtrace:

  ```
  #0 mu::engraving::EngravingItem::ldata()          engravingitem.cpp:2753
  #1 mu::engraving::EngravingItem::addToSkyline()    engravingitem.h:432
  #2 mu::engraving::rendering::score::ChordLayout::chordRestShape() chordlayout.cpp:3370
  ```

  That crash is a dangling `Lyrics*` left inside `ChordRest::lyrics()`
  (dereferenced later during layout in `chordRestShape`,
  `src/engraving/rendering/score/chordlayout.cpp:3367-3371`), which is a
  distinct use-after-free unrelated to the undo/rollback path fixed
  here. I'll leave a comment on #31986 with these findings; it will need
  a separate fix.

## Testing

- Built `engraving` + `MuseScoreStudio` (Debug) and confirmed under
  `gdb` that the original repro steps no longer crash with this fix.
- Confirmed that reverting this fix reproduces the original crash with
  the exact backtrace above, isolating the regression to `67b5fa12a4`.