### PR TITLE
[4.7.5] Eliminate `xxd` and w3c dependencies.

### DIFF
--- a/SetupConfigure.cmake
+++ b/SetupConfigure.cmake
@@ -370,14 +370,6 @@ if (MUSE_MODULE_NETWORK_WEBSOCKET)
     set(QT_ADD_WEBSOCKET ON)
 endif()
 
-if (MUE_BUILD_IMPEXP_MNX_MODULE)
-    find_program(XXD_PROGRAM xxd QUIET)
-    if (NOT XXD_PROGRAM)
-        message(WARNING "xxd not found, disabling MNX import/export module")
-        set(MUE_BUILD_IMPEXP_MNX_MODULE OFF)
-    endif()
-endif()
-
 ###########################################
 # Unit tests
 ###########################################

--- a/src/importexport/mnx/CMakeLists.txt
+++ b/src/importexport/mnx/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
     FetchContent_Declare(
         mnxdom
         GIT_REPOSITORY https://github.com/rpatters1/mnxdom.git
-        GIT_TAG        e7c947bf768caccf315426dcae0dfac02caf738b
+        GIT_TAG        488aa8757ec602c20ff8cf599a2c6857339d8e93
     )
     FetchContent_MakeAvailable(mnxdom)
     set(MNXDOM_LIB mnxdom)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34107

This pull request updates mnx importexport to use a new version of mnxdom that eliminates the following troublesome dependencies.

- The `xxd` utility is no longer required at build time.
- The w3c mnx GitHub repo is no longer fetched at build time.

The change in `mnxdom` is a narrow patch to version 3.0 (called 3.0.1) that refactors the build but leaves the rest of the code unchanged. PR #33958 incorporates this cmake change for the `main` branch along with many updates to `mnxdom` for later mnx schemas, so this PR should **not** be merged back to the `main` branch.

Hopefully this eliminates the need to exclude mnx from dev or production builds on any platform.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).