### PR TITLE
Fix stale pointer entries in EID register when items are deleted

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -385,6 +385,8 @@ void Score::onElementDestruction(EngravingItem* e)
         onBracketItemDestruction(score, toBracketItem(e));
     }
 
+    score->masterScore()->eidRegister()->onItemDestroyed(e);
+
     score->selection().remove(e);
     score->cmdState().unsetElement(e);
     score->elementDestroyed().send(e);

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -376,16 +376,26 @@ void Score::onElementDestruction(EngravingItem* e)
 {
     Score* score = e->EngravingObject::score();
 
-    if (!score || Score::validScores.find(score) == Score::validScores.end()) {
-        // No score or the score is already deleted
+    if (!score) {
+        return;
+    }
+
+    // The EID register lives on the master score, so unregister the item even when
+    // its own score is being deleted (e.g. when an excerpt is removed), as long as
+    // the master score, and with it the register, is still alive
+    MasterScore* masterScore = score->masterScore();
+    if (masterScore && Score::validScores.find(masterScore) != Score::validScores.end()) {
+        masterScore->eidRegister()->onItemDestroyed(e);
+    }
+
+    if (Score::validScores.find(score) == Score::validScores.end()) {
+        // The score is already deleted
         return;
     }
 
     if (e->isBracketItem()) {
         onBracketItemDestruction(score, toBracketItem(e));
     }
-
-    score->masterScore()->eidRegister()->onItemDestroyed(e);
 
     score->selection().remove(e);
     score->cmdState().unsetElement(e);

--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -80,6 +80,22 @@ void EIDRegister::removeItem(const EngravingObject* item)
     m_eidToItem.erase(eidIter);
 }
 
+void EIDRegister::onItemDestroyed(const EngravingObject* item)
+{
+    std::lock_guard lock(m_mutex);
+    // NOTE: most items never get an EID assigned, so a missing entry is the normal case.
+    // Items that do have one must be unregistered here: a later allocation can reuse
+    // the freed address, and a stale entry would corrupt the register.
+
+    auto itemIter = m_itemToEid.find(const_cast<EngravingObject*>(item));
+    if (itemIter == m_itemToEid.end()) {
+        return;
+    }
+
+    m_eidToItem.erase(itemIter->second);
+    m_itemToEid.erase(itemIter);
+}
+
 EngravingObject* EIDRegister::itemFromEID(const EID& eid) const
 {
     std::shared_lock lock(m_mutex);

--- a/src/engraving/infrastructure/eidregister.h
+++ b/src/engraving/infrastructure/eidregister.h
@@ -39,6 +39,7 @@ public:
     EID newEIDForItem(const EngravingObject* item);
     void registerItemEID(const EID& eid, const EngravingObject* item);
     void removeItem(const EngravingObject* item);
+    void onItemDestroyed(const EngravingObject* item);
 
     EngravingObject* itemFromEID(const EID& eid) const;
     EID EIDFromItem(const EngravingObject* item) const;

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -22,8 +22,11 @@
 
 #include <gtest/gtest.h>
 
+#include "engraving/dom/dynamic.h"
 #include "engraving/dom/engravingitem.h"
+#include "engraving/dom/masterscore.h"
 
+#include "engraving/compat/scoreaccess.h"
 #include "utils/scorerw.h"
 
 using namespace mu::engraving;
@@ -53,5 +56,45 @@ TEST_F(Engraving_EIDTests, testRegisteredItems)
         checkRegister(mb);
     }
 
+    delete score;
+}
+
+TEST_F(Engraving_EIDTests, deletedItemIsUnregistered)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    EngravingItem* item = new Dynamic(score->dummy()->segment());
+    EID eid = item->assignNewEID();
+    EXPECT_TRUE(eid.isValid());
+    EXPECT_EQ(score->eidRegister()->itemFromEID(eid), item);
+
+    delete item;
+
+    // The register must not keep a stale entry for the deleted item; a later
+    // allocation could reuse the same address and collide with the stale entry
+    EXPECT_FALSE(score->eidRegister()->EIDFromItem(item).isValid());
+
+    delete score;
+}
+
+TEST_F(Engraving_EIDTests, writeReadElementDoesNotLeakRegisterEntries)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
+
+    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
+    dynamic->setDynamicType(DynamicType(1));
+
+    // writeReadElement round trips through clipboard write and paste read,
+    // which assigns a new EID to the newly created element
+    Dynamic* d = toDynamic(ScoreRW::writeReadElement(dynamic));
+    EID eid = d->eid();
+    EXPECT_TRUE(eid.isValid());
+    EXPECT_EQ(score->eidRegister()->itemFromEID(eid), d);
+
+    delete d;
+
+    EXPECT_FALSE(score->eidRegister()->EIDFromItem(d).isValid());
+
+    delete dynamic;
     delete score;
 }

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -92,10 +92,11 @@ TEST_F(Engraving_EIDTests, deletedExcerptScoreItemsAreUnregistered)
     EXPECT_EQ(master->eidRegister()->itemFromEID(eid), measure);
 
     // Deleting the part score (as when an excerpt is removed) must unregister
-    // its items from the master score's register, which stays alive
+    // its items from the master score's register, which stays alive.
+    // itemFromEID() asserts on a missing entry, so query by item instead.
     delete partScore;
 
-    EXPECT_EQ(master->eidRegister()->itemFromEID(eid), nullptr);
+    EXPECT_FALSE(master->eidRegister()->EIDFromItem(measure).isValid());
 
     delete master;
 }

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -24,7 +24,9 @@
 
 #include "engraving/dom/dynamic.h"
 #include "engraving/dom/engravingitem.h"
+#include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/measure.h"
 
 #include "engraving/compat/scoreaccess.h"
 #include "utils/scorerw.h"
@@ -75,6 +77,27 @@ TEST_F(Engraving_EIDTests, deletedItemIsUnregistered)
     EXPECT_FALSE(score->eidRegister()->EIDFromItem(item).isValid());
 
     delete score;
+}
+
+TEST_F(Engraving_EIDTests, deletedExcerptScoreItemsAreUnregistered)
+{
+    MasterScore* master = compat::ScoreAccess::createMasterScore(nullptr);
+    Score* partScore = master->createScore();
+
+    Measure* measure = Factory::createMeasure(partScore->dummy()->system());
+    partScore->measures()->append(measure);
+
+    EID eid = measure->assignNewEID();
+    EXPECT_TRUE(eid.isValid());
+    EXPECT_EQ(master->eidRegister()->itemFromEID(eid), measure);
+
+    // Deleting the part score (as when an excerpt is removed) must unregister
+    // its items from the master score's register, which stays alive
+    delete partScore;
+
+    EXPECT_FALSE(master->eidRegister()->EIDFromItem(measure).isValid());
+
+    delete master;
 }
 
 TEST_F(Engraving_EIDTests, writeReadElementDoesNotLeakRegisterEntries)

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -95,7 +95,7 @@ TEST_F(Engraving_EIDTests, deletedExcerptScoreItemsAreUnregistered)
     // its items from the master score's register, which stays alive
     delete partScore;
 
-    EXPECT_FALSE(master->eidRegister()->EIDFromItem(measure).isValid());
+    EXPECT_EQ(master->eidRegister()->itemFromEID(eid), nullptr);
 
     delete master;
 }


### PR DESCRIPTION
Resolves: #34167

The EID register maps raw pointers, and deleting an item did not remove its entry. A later allocation could reuse the freed address and collide with the stale entry, corrupting the register and asserting in Debug builds when elements are read in paste mode. See the issue for the full analysis.

The fix unregisters items in `Score::onElementDestruction`, which already guards against scores under destruction. The two new regression tests fail deterministically on all platforms without the fix, making the problem visible in CI even though the crash itself only manifested on macOS.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
