### PR TITLE
fix: nullptr deref in LyricsLayout::lyricsLineEndX

### DIFF
--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -777,6 +777,9 @@ double LyricsLayout::lyricsLineEndX(const LyricsLineSegment* item, const Lyrics*
     const System* system = item->system();
     const LyricsLine* lyricsLine = item->lyricsLine();
     const ChordRest* endChordRest = toChordRest(lyricsLine->endElement());
+    if (!endChordRest) {
+        return system->endingXForOpenEndedLines();
+    }
     const double systemPageX = system->pageX();
     const MStyle& style = item->style();
     const bool melisma = lyricsLine->isEndMelisma();


### PR DESCRIPTION
This check exist on line 796 later, but nullptr dereference is possible before line 796