### PR TITLE
Add shortcut to adjust dynamics. Fixes #34082

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -601,6 +601,14 @@
     <seq>Shift+.</seq>
     </SC>
   <SC>
+    <key>increase-dynamic</key>
+    <seq>Alt+.</seq>
+    </SC>
+  <SC>
+  <key>decrease-dynamic</key>
+  <seq>Alt+,</seq>
+    </SC>
+  <SC>
     <key>time-delete</key>
     <seq>Ctrl+Del</seq>
     <seq>Ctrl+Backspace</seq>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -604,6 +604,14 @@
     <key>add-hairpin-reverse</key>
     <seq>Shift+.</seq>
     </SC>
+      <SC>
+    <key>increase-dynamic</key>
+    <seq>Alt+.</seq>
+    </SC>
+  <SC>
+    <key>decrease-dynamic</key>
+    <seq>Alt+,</seq>
+    </SC>
   <SC>
     <key>time-delete</key>
     <seq>Ctrl+Del</seq>

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -224,6 +224,8 @@ public:
     virtual void autoFlipHairpinsType(engraving::Dynamic* selDyn) = 0;
 
     virtual void toggleDynamicPopup() = 0;
+    virtual void increaseDecreaseDynamicsForSelection(int delta) = 0;
+
     virtual bool toggleLayoutBreakAvailable() const = 0;
     virtual void toggleLayoutBreak(LayoutBreakType breakType) = 0;
     virtual void moveMeasureToPrevSystem() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -224,6 +224,7 @@ public:
     virtual void autoFlipHairpinsType(engraving::Dynamic* selDyn) = 0;
 
     virtual void toggleDynamicPopup() = 0;
+    virtual void increaseDecreaseDynamic(engraving::Dynamic* dynamic, int delta) = 0;
     virtual void increaseDecreaseDynamicsForSelection(int delta) = 0;
 
     virtual bool toggleLayoutBreakAvailable() const = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5764,33 +5764,78 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
     }
 }
 
+void NotationInteraction::increaseDecreaseDynamic(Dynamic* dynamic, int delta)
+{
+    const DynamicType currentType = dynamic->dynamicType();
+    auto inRange = [](DynamicType type) {
+        return type >= DynamicType::PPPPP && type <= DynamicType::FFFFF;
+    };
+    if (!inRange(currentType)) {
+        return;
+    }
+    DynamicType newType = static_cast<DynamicType>(static_cast<int>(currentType) + delta);
+    if (!inRange(newType)) {
+        return;
+    }
+
+    dynamic->undoChangeProperty(Pid::DYNAMIC_TYPE, newType);
+    dynamic->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(newType));
+    autoFlipHairpinsTypeImpl(dynamic);
+}
+
+std::vector<Dynamic*> findDynamicsForElement(const EngravingItem* element)
+{
+    const ChordRest* cr = nullptr;
+
+    if (element->isChordRest()) {
+        cr = toChordRest(element);
+    } else if (element->isNote()) {
+        auto parent = element->parent();
+        if (parent && parent->isChordRest()) {
+            cr = toChordRest(parent);
+        }
+    }
+
+    if (!cr) {
+        return {};
+    }
+
+    Segment* segment = cr->segment();
+
+    std::vector<Dynamic*> dynamics;
+    for (EngravingItem* item : segment->annotations()) {
+        if (!item->isDynamic()) {
+            continue;
+        }
+
+        Dynamic* dynamic = toDynamic(item);
+        if (dynamic->elementAppliesToTrack(cr->track())
+            && (dynamic->staffIdx() == cr->staffIdx() || dynamic->appliesToAllVoicesInInstrument())) {
+            dynamics.push_back(dynamic);
+        }
+    }
+
+    return dynamics;
+}
+
 void NotationInteraction::increaseDecreaseDynamicsForSelection(int delta)
 {
     if (selection()->isNone()) {
         return;
     }
     startEdit(TranslatableString("undoableAction", delta > 0 ? "Increase dynamics" : "Decrease dynamics"));
-
-    for (EngravingItem* item : selection()->elements()) {
-        if (!item->isDynamic()) {
-            continue;
+    if (selection()->element() && !selection()->element()->isDynamic()) {
+        std::vector<Dynamic*> dynamics = findDynamicsForElement(selection()->element());
+        for (Dynamic* dynamic : dynamics) {
+            increaseDecreaseDynamic(dynamic, delta);
         }
-        Dynamic* dynamic = toDynamic(item);
-        const DynamicType currentType = dynamic->dynamicType();
-        auto inRange = [](DynamicType type) {
-            return type >= DynamicType::PPPPP && type <= DynamicType::FFFFF;
-        };
-        if (!inRange(currentType)) {
-            continue;
+    } else {
+        for (EngravingItem* item : selection()->elements()) {
+            if (!item->isDynamic()) {
+                continue;
+            }
+            increaseDecreaseDynamic(toDynamic(item), delta);
         }
-        DynamicType newType = static_cast<DynamicType>(static_cast<int>(currentType) + delta);
-        if (!inRange(newType)) {
-            continue;
-        }
-
-        dynamic->undoChangeProperty(Pid::DYNAMIC_TYPE, newType);
-        dynamic->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(newType));
-        autoFlipHairpinsTypeImpl(dynamic);
     }
     apply();
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5776,14 +5776,18 @@ void NotationInteraction::increaseDecreaseDynamicsForSelection(int delta)
             continue;
         }
         Dynamic* dynamic = toDynamic(item);
-        DynamicType newType;
-        if (delta > 0 && dynamic->dynamicType() <= DynamicType::FFFF) {
-            newType = static_cast<DynamicType>(static_cast<int>(dynamic->dynamicType()) + 1);
-        } else if (delta < 0 && dynamic->dynamicType() >= DynamicType::PPPPP) {
-            newType = static_cast<DynamicType>(static_cast<int>(dynamic->dynamicType()) - 1);
-        } else {
+        const DynamicType currentType = dynamic->dynamicType();
+        auto inRange = [](DynamicType type) {
+            return type >= DynamicType::PPPPP && type <= DynamicType::FFFFF;
+        };
+        if (!inRange(currentType)) {
             continue;
         }
+        DynamicType newType = static_cast<DynamicType>(static_cast<int>(currentType) + delta);
+        if (!inRange(newType)) {
+            continue;
+        }
+
         dynamic->undoChangeProperty(Pid::DYNAMIC_TYPE, newType);
         dynamic->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(newType));
         autoFlipHairpinsTypeImpl(dynamic);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5762,7 +5762,7 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
         select({ segment });
         startEditGrip(segment, mu::engraving::Grip::END);
     }
-};
+}
 
 void NotationInteraction::increaseDecreaseDynamicsForSelection(int delta)
 {
@@ -6057,7 +6057,8 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
     notifyAboutNotationChanged();
 }
 
-void NotationInteraction::autoFlipHairpinsTypeImpl(Dynamic* selDyn) {
+void NotationInteraction::autoFlipHairpinsTypeImpl(Dynamic* selDyn)
+{
     selDyn->findAdjacentHairpins();
 
     if (Hairpin* leftHp = selDyn->leftHairpin()) {
@@ -6085,7 +6086,6 @@ void NotationInteraction::autoFlipHairpinsTypeImpl(Dynamic* selDyn) {
             }
         }
     }
-
 }
 
 void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5762,6 +5762,33 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
         select({ segment });
         startEditGrip(segment, mu::engraving::Grip::END);
     }
+};
+
+void NotationInteraction::increaseDecreaseDynamicsForSelection(int delta)
+{
+    if (selection()->isNone()) {
+        return;
+    }
+    startEdit(TranslatableString("undoableAction", delta > 0 ? "Increase dynamics" : "Decrease dynamics"));
+
+    for (EngravingItem* item : selection()->elements()) {
+        if (!item->isDynamic()) {
+            continue;
+        }
+        Dynamic* dynamic = toDynamic(item);
+        DynamicType newType;
+        if (delta > 0 && dynamic->dynamicType() <= DynamicType::FFFF) {
+            newType = static_cast<DynamicType>(static_cast<int>(dynamic->dynamicType()) + 1);
+        } else if (delta < 0 && dynamic->dynamicType() >= DynamicType::PPPPP) {
+            newType = static_cast<DynamicType>(static_cast<int>(dynamic->dynamicType()) - 1);
+        } else {
+            continue;
+        }
+        dynamic->undoChangeProperty(Pid::DYNAMIC_TYPE, newType);
+        dynamic->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(newType));
+        autoFlipHairpinsTypeImpl(dynamic);
+    }
+    apply();
 }
 
 void NotationInteraction::putRestToSelection()
@@ -6026,19 +6053,8 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
     notifyAboutNotationChanged();
 }
 
-void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
-{
-    if (!selDyn) {
-        return;
-    }
-
-    if (selDyn->dynamicType() == DynamicType::OTHER || selDyn->dynamicType() >= DynamicType::FP) {
-        return;
-    }
-
+void NotationInteraction::autoFlipHairpinsTypeImpl(Dynamic* selDyn) {
     selDyn->findAdjacentHairpins();
-
-    startEdit(TranslatableString("undoableAction", "Change hairpin type"));
 
     if (Hairpin* leftHp = selDyn->leftHairpin()) {
         const Dynamic* startDyn = leftHp->dynamicSnappedBefore();
@@ -6065,6 +6081,21 @@ void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
             }
         }
     }
+
+}
+
+void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
+{
+    if (!selDyn) {
+        return;
+    }
+
+    if (selDyn->dynamicType() == DynamicType::OTHER || selDyn->dynamicType() >= DynamicType::FP) {
+        return;
+    }
+
+    startEdit(TranslatableString("undoableAction", "Change hairpin type"));
+    autoFlipHairpinsTypeImpl(selDyn);
 
     apply();
 }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -239,8 +239,11 @@ public:
     void increaseDecreaseDuration(int steps, bool stepByDots) override;
 
     void autoFlipHairpinsType(engraving::Dynamic* selDyn) override;
+    void autoFlipHairpinsTypeImpl(engraving::Dynamic* selDyn);
 
     void toggleDynamicPopup() override;
+    void increaseDecreaseDynamicsForSelection(int delta) override;
+
     bool toggleLayoutBreakAvailable() const override;
     void toggleLayoutBreak(LayoutBreakType breakType) override;
     void moveMeasureToPrevSystem() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -242,6 +242,7 @@ public:
     void autoFlipHairpinsTypeImpl(engraving::Dynamic* selDyn);
 
     void toggleDynamicPopup() override;
+    void increaseDecreaseDynamic(engraving::Dynamic* dynamic, int delta) override;
     void increaseDecreaseDynamicsForSelection(int delta) override;
 
     bool toggleLayoutBreakAvailable() const override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -185,6 +185,7 @@ public:
     MOCK_METHOD(void, autoFlipHairpinsType, (engraving::Dynamic * selDyn), (override));
 
     MOCK_METHOD(void, toggleDynamicPopup, (), (override));
+    MOCK_METHOD(void, increaseDecreaseDynamicsForSelection, (int), (override));
     MOCK_METHOD(bool, toggleLayoutBreakAvailable, (), (const, override));
     MOCK_METHOD(void, toggleLayoutBreak, (LayoutBreakType), (override));
     MOCK_METHOD(void, moveMeasureToPrevSystem, (), (override));

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -342,8 +342,14 @@ void NotationActionController::init()
     registerAction("add-hairpin-reverse", &Interaction::addHairpinsToSelection, HairpinType::DIM_HAIRPIN,
                    &Controller::noteOrRestSelected);
 
-    registerAction("increase-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(1); }, &Controller::hasSelection);
-    registerAction("decrease-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(-1); }, &Controller::hasSelection);
+    registerAction("increase-dynamic", [this]() {
+        currentNotationInteraction()->increaseDecreaseDynamicsForSelection(
+            1);
+    }, &Controller::hasSelection);
+    registerAction("decrease-dynamic", [this]() {
+        currentNotationInteraction()->increaseDecreaseDynamicsForSelection(
+            -1);
+    }, &Controller::hasSelection);
 
     registerAction("add-noteline", &Interaction::addAnchoredLineToSelectedNotes);
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -341,8 +341,9 @@ void NotationActionController::init()
     registerAction("add-hairpin", &Interaction::addHairpinsToSelection, HairpinType::CRESC_HAIRPIN, &Controller::noteOrRestSelected);
     registerAction("add-hairpin-reverse", &Interaction::addHairpinsToSelection, HairpinType::DIM_HAIRPIN,
                    &Controller::noteOrRestSelected);
-    registerAction("increase-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(1); });
-    registerAction("decrease-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(-1); });
+
+    registerAction("increase-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(1); }, &Controller::hasSelection);
+    registerAction("decrease-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(-1); }, &Controller::hasSelection);
 
     registerAction("add-noteline", &Interaction::addAnchoredLineToSelectedNotes);
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -341,6 +341,9 @@ void NotationActionController::init()
     registerAction("add-hairpin", &Interaction::addHairpinsToSelection, HairpinType::CRESC_HAIRPIN, &Controller::noteOrRestSelected);
     registerAction("add-hairpin-reverse", &Interaction::addHairpinsToSelection, HairpinType::DIM_HAIRPIN,
                    &Controller::noteOrRestSelected);
+    registerAction("increase-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(1); });
+    registerAction("decrease-dynamic", [this]() { currentNotationInteraction()->increaseDecreaseDynamicsForSelection(-1); });
+
     registerAction("add-noteline", &Interaction::addAnchoredLineToSelectedNotes);
 
     registerAction("add-image", [this]() { addImage(); });

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1267,13 +1267,13 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Increase dynamics"),
-             TranslatableString("action", "Increase dynamics by one step")
+             TranslatableString("action", "Increase selected dynamics")
              ),
     UiAction("decrease-dynamic",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Decrease dynamics"),
-             TranslatableString("action", "Decrease dynamics by one step")
+             TranslatableString("action", "Decrease selected dynamics")
              ),
     UiAction("add-noteline",
              mu::context::UiCtxProjectOpened,

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1264,17 +1264,17 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Add hairpin: diminuendo")
              ),
     UiAction("increase-dynamic",
-        mu::context::UiCtxProjectOpened,
-        mu::context::CTX_NOTATION_OPENED,
-        TranslatableString("action", "Increase dynamics"),
-        TranslatableString("action", "Increase dynamics by one step")
-    ),
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Increase dynamics"),
+             TranslatableString("action", "Increase dynamics by one step")
+             ),
     UiAction("decrease-dynamic",
-        mu::context::UiCtxProjectOpened,
-        mu::context::CTX_NOTATION_OPENED,
-        TranslatableString("action", "Decrease dynamics"),
-        TranslatableString("action", "Decrease dynamics by one step")
-    ),
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Decrease dynamics"),
+             TranslatableString("action", "Decrease dynamics by one step")
+             ),
     UiAction("add-noteline",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1263,6 +1263,18 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "&Diminuendo"),
              TranslatableString("action", "Add hairpin: diminuendo")
              ),
+    UiAction("increase-dynamic",
+        mu::context::UiCtxProjectOpened,
+        mu::context::CTX_NOTATION_OPENED,
+        TranslatableString("action", "Increase dynamics"),
+        TranslatableString("action", "Increase dynamics by one step")
+    ),
+    UiAction("decrease-dynamic",
+        mu::context::UiCtxProjectOpened,
+        mu::context::CTX_NOTATION_OPENED,
+        TranslatableString("action", "Decrease dynamics"),
+        TranslatableString("action", "Decrease dynamics by one step")
+    ),
     UiAction("add-noteline",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,


### PR DESCRIPTION
Resolves: #34082 

Adds feature: shortcut key Alt+, and Alt+. decreases or increases every dynamic within the selection by one step, between ppppp and fffff. Pinned hairpins are adjusted if needed.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [stevage](https://musescore.com/user/107931127):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.

(well, I split out the body of `autoFlipHairpinsType()` in order to avoid excess calls to `startEdit()`, perhaps that was unecessary.

- [] I created a unit test or vtest to verify the changes I made (if applicable).

I have not - would appreciate guidance here.

https://github.com/user-attachments/assets/79d36e23-526b-4675-b9c5-bd99f1d86e90

