### PR TITLE
Notation Page. Hide extensions toolbar by default

### DIFF
--- a/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/MuseScore/AppShell/NotationPage/NotationPage.qml
@@ -180,6 +180,9 @@ DockPage {
             contentBottomPadding: floating ? 8 : 2
             contentTopPadding: floating ? 8 : 0
 
+            //! NOTE: Opened by page model when there are extensions with toolbar actions
+            visible: false
+
             dropDestinations: [
                 { "dock": notationToolBar, "dropLocation": Location.Right },
                 { "dock": playbackToolBar, "dropLocation": Location.Right }


### PR DESCRIPTION
Opened by the page model when there are extensions with toolbar actions