### PR TITLE
[MusicXml] Fix line-end="up" on <bracket> renders as a downward hook (and vice versa)

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -5849,7 +5849,7 @@ void ExportMusicXml::textLine(TextLineBase const* const tl, staff_idx_t staff, c
     String lineEnd;
     switch (hookType) {
     case HookType::HOOK_90:
-        lineEnd = (hookHeight < 0.0) ? u"up" : u"down";
+        lineEnd = (tl->placement() == PlacementV::BELOW) ? u"up" : u"down";
         rest += String(u" end-length=\"%1\"").arg(std::abs(hookHeight * 10));
         break;
     case HookType::HOOK_90T:

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -5131,6 +5131,7 @@ void MusicXmlParserDirection::bracket(const String& type, const int number,
             if (!endLength.empty()) {
                 double length = endLength.toDouble();
                 textLine->setBeginHookHeight(Spatium(lineEnd == "both" ? length / 20 : length / 10));
+                textLine->setPropertyFlags(Pid::BEGIN_HOOK_HEIGHT, PropertyFlags::UNSTYLED);
             }
             if (lineEnd == "up") {
                 textLine->setBeginHookType(HookType::HOOK_90);
@@ -5192,6 +5193,7 @@ void MusicXmlParserDirection::bracket(const String& type, const int number,
             if (!endLength.empty()) {
                 double length = endLength.toDouble();
                 textLine->setEndHookHeight(Spatium(lineEnd == "both" ? length / 20 : length / 10));
+                textLine->setPropertyFlags(Pid::END_HOOK_HEIGHT, PropertyFlags::UNSTYLED);
             }
             if (lineEnd == "up") {
                 textLine->setEndHookType(HookType::HOOK_90);

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -5134,9 +5134,9 @@ void MusicXmlParserDirection::bracket(const String& type, const int number,
             }
             if (lineEnd == "up") {
                 textLine->setBeginHookType(HookType::HOOK_90);
-                textLine->setBeginHookHeight(-1 * textLine->beginHookHeight());
             } else if (lineEnd == "down") {
                 textLine->setBeginHookType(HookType::HOOK_90);
+                textLine->setBeginHookHeight(-1 * textLine->beginHookHeight());
             } else if (lineEnd == "both") {
                 textLine->setBeginHookType(HookType::HOOK_90T);
             } else if (lineEnd == "arrow") {
@@ -5195,9 +5195,9 @@ void MusicXmlParserDirection::bracket(const String& type, const int number,
             }
             if (lineEnd == "up") {
                 textLine->setEndHookType(HookType::HOOK_90);
-                textLine->setEndHookHeight(-1 * textLine->endHookHeight());
             } else if (lineEnd == "down") {
                 textLine->setEndHookType(HookType::HOOK_90);
+                textLine->setEndHookHeight(-1 * textLine->endHookHeight());
             } else if (lineEnd == "both") {
                 textLine->setEndHookType(HookType::HOOK_90T);
             } else if (lineEnd == "arrow") {


### PR DESCRIPTION
Resolves: #34164
See #34201 for 4.7