### PR TITLE
uicomponents: fix StyledDropdown navigation/label/dropIcon resolving to null

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
@@ -50,10 +50,10 @@ Item {
 
     property int popupItemsCount: 18
 
-    property alias dropIcon: mainItem.dropIcon
-    property alias label: mainItem.label
+    property alias dropIcon: dropIconItem
+    property alias label: labelItem
 
-    property alias navigation: mainItem.navigation
+    property alias navigation: navCtrl
 
     property alias isOpened: dropdownLoader.isOpened
     property alias dropdown: dropdownLoader.dropdown


### PR DESCRIPTION
StyledDropdown exposed these three properties as aliases into an alias declared on its internal mainItem (e.g. `property alias navigation: mainItem.navigation`, where mainItem itself has `property alias navigation: navCtrl`). With Qt 6.11, this two-hop alias chain resolves to null whenever the StyledDropdown instance is created dynamically (Qt.createComponent().createObject(), a Loader, or a ListView delegate), which is how most dialogs including "New score" are built. The null grouped-property writes this caused were severe enough to abort construction of the whole enclosing dynamically-created object tree.

Point the properties directly at the leaf items instead, bypassing the broken two-hop resolution.

Resolves: #34091

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


- [x] I signed the [CLA](https://musescore.org/en/cla) as [doronbehar](https://musescore.org/en/user/1684064).
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
