### PR TITLE
MusicXML import: tighten the assumption of grace-after notes based on slurs

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -7382,7 +7382,7 @@ Note* MusicXmlParserPass2::note(const String& partId,
     }
 
     // handle grace after state: remember current grace list size
-    if (grace && notations.mustStopGraceAFter()) {
+    if (grace && notations.mustStopGraceAfter()) {
         gac = gcl.size();
     }
 

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -7002,6 +7002,8 @@ Note* MusicXmlParserPass2::note(const String& partId,
     String noteheadFilled;
     int velocity = round(m_e.doubleAttribute("dynamics") * 0.9);
     bool graceSlash = false;
+    double graceStealFollowing = -1.0;
+    double graceStealPrevious  = -1.0;
     bool printObject = m_e.asciiAttribute("print-object") != "no";
     bool printLyric = (printObject && m_e.asciiAttribute("print-lyric") != "no") || m_e.asciiAttribute("print-lyric") == "yes";
     bool isSingleDrumset = false;
@@ -7037,6 +7039,8 @@ Note* MusicXmlParserPass2::note(const String& partId,
         } else if (m_e.name() == "grace") {
             grace = true;
             graceSlash = m_e.asciiAttribute("slash") == "yes";
+            graceStealFollowing = m_e.doubleAttribute("steal-time-following", -1.0);
+            graceStealPrevious  = m_e.doubleAttribute("steal-time-previous", -1.0);
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "instrument") {
             instrumentId = m_e.attribute("id");
@@ -7381,9 +7385,12 @@ Note* MusicXmlParserPass2::note(const String& partId,
         }
     }
 
-    // handle grace after state: remember current grace list size
-    if (grace && notations.mustStopGraceAfter()) {
-        gac = gcl.size();
+    if (grace) {
+        const bool afterByStealTime = graceStealPrevious >= 0.0 && c && c->noteType() != NoteType::ACCIACCATURA;
+        if (graceStealFollowing < 0.0 && (afterByStealTime || notations.mustStopGraceAfter())) {
+            // handle grace after state: remember current grace list size
+            gac = gcl.size();
+        }
     }
 
     // handle tremolo before handling tuplet (two note tremolos modify timeMod)

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.h
@@ -355,7 +355,7 @@ public:
     muse::String tremoloSmufl() const { return m_tremoloSmufl; }
     engraving::Color tremoloColor() const { return m_tremoloColor; }
     int tremoloNr() const { return m_tremoloNr; }
-    bool mustStopGraceAFter() const { return m_slurStop || m_wavyLineStop; }
+    bool mustStopGraceAfter() const { return (m_slurStop && !m_slurStart) || m_wavyLineStop; }
 private:
     void addError(const muse::String& error);      // Add an error to be shown in the GUI
     void addNotation(const Notation& notation, engraving::ChordRest* const cr, engraving::Note* const note);


### PR DESCRIPTION
Resolves: #34140

We currently assume that grace notes are grace-after based on whether they have a slur stop in them. We seem to have some cases where grace notes are slurred both backwards and forwards in the XML. In these cases, I have constrained the slur check to choose grace-before by default, and leave the grace-after assumption for notes that _only_ have a slur stop (but no slur start).

Also includes added constraints using the `steal-time-` attributes of the musicXML `grace` element.