### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -960,29 +960,10 @@ MeasureBase* MeasureBaseList::firstMeasureBaseAtTick(int tick) const
 
     auto it = m_tickIndex.upper_bound(tick);
 
-    if (it == m_tickIndex.begin()) {
-        MeasureBase* mb = it->second;
-
-        return mb;
+    if (it != m_tickIndex.begin()) {
+        --it;
     }
-
-    --it;
-    for (;; --it) {
-        if (it == m_tickIndex.begin()) {
-            MeasureBase* mb = it->second;
-
-            return mb;
-        }
-
-        MeasureBase* mb = it->second;
-        if (!mb) {
-            break;
-        }
-
-        return mb;
-    }
-
-    return nullptr;
+    return it->second;
 }
 
 std::vector<MeasureBase*> MeasureBaseList::measureBasesAtTick(int tick) const

--- a/src/engraving/dom/scoreorder.cpp
+++ b/src/engraving/dom/scoreorder.cpp
@@ -408,7 +408,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
 
         staff_idx_t staffIdx { 0 };
         const bool isMultiStaffInstrument = instrTemplate->staffCount > 1;
-        const int partStaffCount = part->nstaves();
+        const size_t partStaffCount = part->nstaves();
 
         const int templateBracketSpan = std::accumulate(instrTemplate->bracketSpan, instrTemplate->bracketSpan + MAX_STAVES, 0);
         const bool bracketSpansAllStaves = templateBracketSpan == (int)instrTemplate->staffCount;
@@ -430,7 +430,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
             // The number of staves could differ from the template
             // Use template spans if span doesn't cover whole set of staves (eg. organ), otherwise cover all staves
             if (partStaffCount > 1) {
-                int bracketSpan = bracketSpansAllStaves ? partStaffCount : instrTemplate->bracketSpan[staffIdx];
+                size_t bracketSpan = bracketSpansAllStaves ? partStaffCount : instrTemplate->bracketSpan[staffIdx];
                 EditStaffBrackets::undoAddBracket(score, staff, 0, instrTemplate->bracket[staffIdx], bracketSpan);
 
                 int barlineSpan = instrTemplate->barlineSpan[barlineSpansAllStaves - 1 ? 0 : staffIdx];

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2336,12 +2336,10 @@ void NotationInteraction::applyPaletteElementToList(EngravingItem* element, mu::
         const ActionIcon* icon = toActionIcon(element);
         switch (icon->actionType()) {
         case ActionIconType::SYSTEM_LOCK: {
-            engraving::Transaction& tx = score->transactionManager()->currentOrDummyTransaction();
             EditSystemLocks::toggleSystemLock(tx, score, score->selection().selectedSystems());
             return;
         }
         case ActionIconType::PAGE_LOCK: {
-            engraving::Transaction& tx = score->transactionManager()->currentOrDummyTransaction();
             EditPageLocks::togglePageLock(tx, score, score->selection().pagesContainingSelection());
             return;
         }


### PR DESCRIPTION
* reg.: declaration of 'tx' hides previous local declaration (C4456)
* reg.: unreachable code (C4702)
* reg.: 'initializing': conversion from 'size_t' to '(const) int', possible loss of data (C4267)