### PR TITLE
Fix Pedal properties in twrite to write TextLineBase properties before SLine's

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2720,22 +2720,7 @@ void TWrite::write(const Pedal* item, XmlWriter& xml, WriteContext& ctx)
         return;
     }
     xml.startElement(item);
-
-    for (auto i : {
-        Pid::END_HOOK_TYPE,
-        Pid::LINE_VISIBLE,
-        Pid::BEGIN_HOOK_TYPE,
-        Pid::BEGIN_TEXT_OFFSET,
-        Pid::CONTINUE_TEXT_OFFSET,
-        Pid::END_TEXT_OFFSET
-    }) {
-        writeProperty(item, xml, i);
-    }
-    for (const StyledProperty& spp : *item->styledProperties()) {
-        writeProperty(item, xml, spp.pid);
-    }
-
-    writeProperties(static_cast<const SLine*>(item), xml, ctx);
+    writeProperties(static_cast<const TextLineBase*>(item), xml, ctx);
     xml.endElement();
 }
 

--- a/src/engraving/tests/compat114_data/pedal-ref.mscx
+++ b/src/engraving/tests/compat114_data/pedal-ref.mscx
@@ -105,8 +105,9 @@
             </TimeSig>
           <Spanner type="Pedal">
             <Pedal>
-              <continueText>&lt;font size=&quot;11&quot;/&gt;</continueText>
               <endHookHeight>1.5</endHookHeight>
+              <continueText>&lt;font size=&quot;11&quot;/&gt;</continueText>
+              <endTextPlace>auto</endTextPlace>
               <eid>J_J</eid>
               </Pedal>
             <next>

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -580,6 +580,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>BB_BB</eid>
               </Pedal>
             <next>

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -122,6 +122,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>C_C</eid>
               </Pedal>
             <next>
@@ -509,6 +511,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>5_5</eid>
               </Pedal>
             <next>
@@ -931,6 +935,8 @@
             <Spanner type="Pedal">
               <Pedal>
                 <endHookType>1</endHookType>
+                <continueTextPlace>auto</continueTextPlace>
+                <endTextPlace>auto</endTextPlace>
                 <eid>DC_DC</eid>
                 <linkedTo>C_C</linkedTo>
                 </Pedal>
@@ -1370,6 +1376,8 @@
             <Spanner type="Pedal">
               <Pedal>
                 <endHookType>1</endHookType>
+                <continueTextPlace>auto</continueTextPlace>
+                <endTextPlace>auto</endTextPlace>
                 <eid>+C_+C</eid>
                 <linkedTo>5_5</linkedTo>
                 </Pedal>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter9-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter9-base-ref.xml
@@ -5,6 +5,8 @@
       <Pedal>
         <beginText>&lt;sym&gt;keyboardPedalPed&lt;sym&gt;</beginText>
         <continueText></continueText>
+        <continueTextPlace>auto</continueTextPlace>
+        <endTextPlace>auto</endTextPlace>
         <ticks_f>3/4</ticks_f>
         <eid>B_B</eid>
         </Pedal>

--- a/src/engraving/tests/spanners_data/linecolor01-ref.mscx
+++ b/src/engraving/tests/spanners_data/linecolor01-ref.mscx
@@ -96,8 +96,10 @@
             </TimeSig>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>1</endHookType>
               <beginHookType>1</beginHookType>
+              <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>G_G</eid>
               <color r="255" g="0" b="0" a="255"/>
               <Segment>

--- a/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
+++ b/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
@@ -97,8 +97,10 @@
             </TimeSig>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>1</endHookType>
               <beginHookType>1</beginHookType>
+              <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>G_G</eid>
               <Segment>
                 <subtype>0</subtype>

--- a/src/importexport/mei/tests/data/color-01.mscx
+++ b/src/importexport/mei/tests/data/color-01.mscx
@@ -449,6 +449,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>JB_JB</eid>
               <color r="148" g="33" b="146" a="255"/>
               </Pedal>

--- a/src/importexport/mei/tests/data/pedal-01.mscx
+++ b/src/importexport/mei/tests/data/pedal-01.mscx
@@ -186,6 +186,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <lineVisible>0</lineVisible>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>e_e</eid>
               </Pedal>
             <next>
@@ -250,6 +252,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>n_n</eid>
               </Pedal>
             <next>
@@ -313,8 +317,10 @@
         <voice>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>1</endHookType>
               <beginHookType>1</beginHookType>
+              <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>w_w</eid>
               </Pedal>
             <next>
@@ -380,6 +386,8 @@
             <Pedal>
               <lineVisible>0</lineVisible>
               <beginText>&lt;sym&gt;keyboardPedalSost&lt;/sym&gt;</beginText>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>5_5</eid>
               </Pedal>
             <next>

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -2158,6 +2158,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>hF_hF</eid>
               </Pedal>
             <next>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -152,6 +152,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>L_L</eid>
               </Pedal>
             <next>
@@ -235,6 +237,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>Z_Z</eid>
               </Pedal>
             <next>
@@ -325,6 +329,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>2</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>o_o</eid>
               </Pedal>
             <next>
@@ -362,8 +368,10 @@
             </Spanner>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>2</endHookType>
               <beginHookType>2</beginHookType>
+              <endHookType>2</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>t_t</eid>
               </Pedal>
             <next>
@@ -408,8 +416,10 @@
             </Spanner>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>1</endHookType>
               <beginHookType>2</beginHookType>
+              <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>z_z</eid>
               </Pedal>
             <next>

--- a/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
@@ -1447,8 +1447,10 @@
         <voice>
           <Spanner type="Pedal">
             <Pedal>
-              <endHookType>1</endHookType>
               <beginHookType>1</beginHookType>
+              <endHookType>1</endHookType>
+              <continueTextPlace>auto</continueTextPlace>
+              <endTextPlace>auto</endTextPlace>
               <eid>BE_BE</eid>
               </Pedal>
             <next>


### PR DESCRIPTION
Resolves: #34168

Ported from: #34192