### PR TITLE
Fix musicXML imports containing start-end repeat barlines from Noteflight

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -5663,7 +5663,8 @@ String MusicXmlParserDirection::metronome(double& r)
 //---------------------------------------------------------
 
 static bool determineBarLineType(const String& barStyle, const String& repeat,
-                                 BarLineType& type, bool& visible)
+                                 BarLineType& type, bool& visible,
+                                 const MusicXmlExporterSoftware& exporter)
 {
     // set defaults
     type = BarLineType::NORMAL;
@@ -5672,6 +5673,8 @@ static bool determineBarLineType(const String& barStyle, const String& repeat,
     if (barStyle == u"light-heavy" && repeat == u"backward") {
         type = BarLineType::END_REPEAT;
     } else if (barStyle == u"heavy-light" && repeat == u"forward") {
+        type = BarLineType::START_REPEAT;
+    } else if (barStyle == u"light-heavy" && repeat == u"forward" && exporter == MusicXmlExporterSoftware::NOTEFLIGHT) {
         type = BarLineType::START_REPEAT;
     } else if (barStyle == u"light-heavy" && repeat.empty()) {
         type = BarLineType::END;
@@ -5807,7 +5810,7 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
 
     BarLineType type = BarLineType::NORMAL;
     bool visible = true;
-    if (determineBarLineType(barStyle, repeat, type, visible)) {
+    if (determineBarLineType(barStyle, repeat, type, visible, m_pass1.exporterSoftware())) {
         const track_idx_t track = m_pass1.trackForPart(partId);
         if (type & BarLineType::START_REPEAT) {
             // combine start_repeat flag with current state initialized during measure parsing

--- a/src/importexport/musicxml/tests/data/testNoteflightStartRepeatBarline.xml
+++ b/src/importexport/musicxml/tests/data/testNoteflightStartRepeatBarline.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="2.0">
+  <work>
+    <work-title>Untitled score</work-title>
+  </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>Noteflight version 0.4</software>
+      <encoding-date>2026-07-06</encoding-date>
+      <supports attribute="new-system" element="print" type="no" value="no"></supports>
+      <supports attribute="new-page" element="print" type="no" value="no"></supports>
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>1.411111112</millimeters>
+      <tenths>10</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1980</page-height>
+      <page-width>1530</page-width>
+      <page-margins type="both">
+        <left-margin>89.375</left-margin>
+        <right-margin>85</right-margin>
+        <top-margin>145</top-margin>
+        <bottom-margin>120</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>89.375</left-margin>
+        <right-margin>40</right-margin>
+      </system-margins>
+      <system-distance>130</system-distance>
+      <top-system-distance>210</top-system-distance>
+    </system-layout>
+    <staff-layout>
+      <staff-distance>65</staff-distance>
+    </staff-layout>
+  </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="765" default-y="1870" font-size="24" justify="right" valign="top">
+      Untitled score
+    </credit-words>
+  </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1377" default-y="1870" font-size="12" justify="right" valign="top">
+      Composer / arranger
+    </credit-words>
+  </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Violin</part-name>
+      <part-abbreviation>Vln.</part-abbreviation>
+      <score-instrument id="P1I1">
+        <instrument-name>Violin</instrument-name>
+        <instrument-sound>strings.violin</instrument-sound>
+      </score-instrument>
+      <midi-instrument id="P1I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>41</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>64</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time print-object="yes">
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <repeat direction="backward"></repeat>
+      </barline>
+    </measure>
+    <measure number="2">
+      <print new-system="no"></print>
+      <barline location="left">
+        <bar-style>light-heavy</bar-style>
+        <repeat direction="forward"></repeat>
+      </barline>
+      <attributes></attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <repeat direction="backward"></repeat>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/src/importexport/musicxml/tests/data/testNoteflightStartRepeatBarline_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNoteflightStartRepeatBarline_ref.mscx
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.70">
+  <Score>
+    <eid>B_B</eid>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.5</pageWidth>
+      <pageHeight>11</pageHeight>
+      <pagePrintableWidth>7.53125</pagePrintableWidth>
+      <pageEvenLeftMargin>0.496528</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.496528</pageOddLeftMargin>
+      <pageEvenTopMargin>0.805556</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.666667</pageEvenBottomMargin>
+      <pageOddTopMargin>0.805556</pageOddTopMargin>
+      <pageOddBottomMargin>0.666667</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
+      <minSystemDistance>13</minSystemDistance>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>
+      <spatium>1.41111</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Violin</trackName>
+      <Instrument id="violin">
+        <longName>Violin</longName>
+        <shortName>Vln.</shortName>
+        <trackName>Violin</trackName>
+        <minPitchP>55</minPitchP>
+        <maxPitchP>103</maxPitchP>
+        <minPitchA>55</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <instrumentId>strings.violin</instrumentId>
+        <glissandoStyle>portamento</glissandoStyle>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="arco">
+          <program value="40"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="45"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>D_D</eid>
+        <Text>
+          <eid>E_E</eid>
+          <style>title</style>
+          <text><font size="24"/><br/>      Untitled score</text>
+          </Text>
+        <Text>
+          <eid>F_F</eid>
+          <style>composer</style>
+          <text><font size="12"/><br/>      Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <eid>G_G</eid>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            <eid>H_H</eid>
+            </Clef>
+          <TimeSig>
+            <eid>I_I</eid>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>J_J</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>K_K</eid>
+              <Events>
+                <Event>
+                  <len>15</len>
+                  </Event>
+                </Events>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>L_L</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>M_M</eid>
+              <Events>
+                <Event>
+                  <len>15</len>
+                  </Event>
+                </Events>
+              <pitch>79</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>N_N</eid>
+        <startRepeat/>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <Chord>
+            <eid>O_O</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>P_P</eid>
+              <Events>
+                <Event>
+                  <len>15</len>
+                  </Event>
+                </Events>
+              <pitch>81</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>Q_Q</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>R_R</eid>
+              <Events>
+                <Event>
+                  <len>15</len>
+                  </Event>
+                </Events>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -399,6 +399,9 @@ TEST_F(MusicXml_Tests, backupRoundingError) {
 TEST_F(MusicXml_Tests, barlineLoc) {
     musicXmlImportTestRef("testBarlineLoc");
 }
+TEST_F(MusicXml_Tests, noteflightStartRepeatBarline) {
+    musicXmlImportTestRef("testNoteflightStartRepeatBarline");
+}
 TEST_F(MusicXml_Tests, barlineSpan) {
     musicXmlIoTest("testBarlineSpan");
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34139

When combined start-end repeat barlines are present (:||:), scores exported from Noteflight seem to contain barline elements that have both light-heavy bar-style, together with forward repeat direction, to signify the start repeat. This was not being recognised as a valid barline type. This PR adds a specific handling for this case.

Ported from: https://github.com/musescore/MuseScore/pull/34187