### PR TITLE
[MusicXML] Do not export accidentals on tablature

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -4439,7 +4439,9 @@ void ExportMusicXml::chord(Chord* chord, staff_idx_t staff, const std::vector<Ly
             dotTag += elementPosition(this, dot);
             m_xml.tagRaw(dotTag);
         }
-        writeAccidental(m_xml, u"accidental", note->accidental());
+        if (note->staff() && !note->staff()->isTabStaff(Fraction(0, 1))) {
+            writeAccidental(m_xml, u"accidental", note->accidental());
+        }
         writeTimeModification(m_xml, note->chord()->tuplet(), tremoloCorrection(note));
 
         // no stem for whole notes and beyond

--- a/src/importexport/musicxml/tests/data/testTapping.xml
+++ b/src/importexport/musicxml/tests/data/testTapping.xml
@@ -331,7 +331,6 @@
         <duration>1</duration>
         <voice>5</voice>
         <type>eighth</type>
-        <accidental>sharp</accidental>
         <stem>none</stem>
         <staff>2</staff>
         <notations>
@@ -369,7 +368,6 @@
         <duration>1</duration>
         <voice>5</voice>
         <type>eighth</type>
-        <accidental>flat</accidental>
         <stem>none</stem>
         <staff>2</staff>
         <notations>
@@ -632,7 +630,6 @@
         <duration>1</duration>
         <voice>5</voice>
         <type>eighth</type>
-        <accidental>sharp</accidental>
         <stem>none</stem>
         <staff>2</staff>
         <notations>
@@ -670,7 +667,6 @@
         <duration>1</duration>
         <voice>5</voice>
         <type>eighth</type>
-        <accidental>flat</accidental>
         <stem>none</stem>
         <staff>2</staff>
         <notations>


### PR DESCRIPTION
As tablatures do not show accidentals, they should not be exported, as seen e.g. on <https://www.w3.org/2021/06/musicxml40/tutorial/tablature/>.