### PR TITLE
Fix crash on startup in converter mode

### DIFF
--- a/src/notationscene/internal/notationcommandsstate.cpp
+++ b/src/notationscene/internal/notationcommandsstate.cpp
@@ -199,9 +199,12 @@ void NotationCommandsState::init()
         updateCommandStates();
     });
 
-    interactive()->opened().onReceive(this, [this](const muse::Uri&) {
-        updateCommandStates();
-    });
+    //! NOTE: IInteractive is not available in console mode
+    if (interactive()) {
+        interactive()->opened().onReceive(this, [this](const muse::Uri&) {
+            updateCommandStates();
+        });
+    }
 
     controller()->selectionChanged().onNotify(this, [this]() {
         updateCommandStates(HAS_SELECTION_REQUIRED_COMMANDS);
@@ -244,7 +247,9 @@ void NotationCommandsState::init()
 void NotationCommandsState::deinit()
 {
     globalContext()->currentProjectChanged().disconnect(this);
-    interactive()->opened().disconnect(this);
+    if (interactive()) {
+        interactive()->opened().disconnect(this);
+    }
     controller()->selectionChanged().disconnect(this);
     controller()->stackChanged().disconnect(this);
     controller()->textEditingChanged().disconnect(this);
@@ -366,7 +371,8 @@ bool NotationCommandsState::isProjectOpened() const
         return false;
     }
 
-    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+    //! NOTE: IInteractive is not available in console mode; in that case there is no page to check
+    if (interactive() && !interactive()->isOpened(PROJECT_PAGE_URI).val) {
         return false;
     }
 

--- a/src/playback/internal/playbackcommandsstate.cpp
+++ b/src/playback/internal/playbackcommandsstate.cpp
@@ -60,9 +60,12 @@ void PlaybackCommandsState::init()
         }, Asyncable::Mode::SetReplace);
     });
 
-    interactive()->opened().onReceive(this, [this](const muse::Uri&) {
-        updateCommandStates();
-    });
+    //! NOTE: IInteractive is not available in console mode
+    if (interactive()) {
+        interactive()->opened().onReceive(this, [this](const muse::Uri&) {
+            updateCommandStates();
+        });
+    }
 
     playbackController()->isPlayAllowedChanged().onReceive(this, [this](bool) {
         updateCommandStates();
@@ -124,7 +127,9 @@ void PlaybackCommandsState::deinit()
 {
     globalContext()->currentProjectChanged().disconnect(this);
     globalContext()->currentNotationChanged().disconnect(this);
-    interactive()->opened().disconnect(this);
+    if (interactive()) {
+        interactive()->opened().disconnect(this);
+    }
     playbackController()->isPlayAllowedChanged().disconnect(this);
     playbackController()->isPlayingChanged().disconnect(this);
     playbackController()->loopEnabledChanged().disconnect(this);
@@ -211,7 +216,8 @@ bool PlaybackCommandsState::isProjectOpened() const
         return false;
     }
 
-    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+    //! NOTE: IInteractive is not available in console mode; in that case there is no page to check
+    if (interactive() && !interactive()->isOpened(PROJECT_PAGE_URI).val) {
         return false;
     }
 


### PR DESCRIPTION
PlaybackCommandsState and NotationCommandsState dereferenced the
IInteractive context inject unconditionally, but InteractiveModule is
not added for console apps, so IInteractive is never registered there
and any console/converter run crashed with SIGSEGV during context
setup, before reading a score.

Guard the interactive() usages; when IInteractive is absent there is no
notation page, so isProjectOpened() skips the page check to keep
command states functional in console mode.

---

This is an AI-generated patch, but I wonder whether PlaybackCommandsState and NotationCommandsState should be active at all in converter mode. The only thing that *might* make them relevant, is plugins/extensions that want to call commands, but even then, I’d think those don’t depend on command *states*. @igorkorsukov what do you think?