### PR TITLE
Fix crash when selecting MM rest measure

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -379,7 +379,11 @@ MeasureBase* Selection::startMeasureBase() const
         return nullptr;
     }
 
-    return m_score->tick2measureBase(tickStart());
+    MeasureBase* mb = m_score->tick2measureBase(tickStart());
+    if (mb && mb->isMeasure()) {
+        mb = toMeasure(mb)->coveringMMRestOrThis();
+    }
+    return mb;
 }
 
 MeasureBase* Selection::endMeasureBase() const
@@ -399,7 +403,11 @@ MeasureBase* Selection::endMeasureBase() const
         return nullptr;
     }
 
-    return m_score->tick2measureBase(tickEnd() - Fraction::eps());
+    MeasureBase* mb = m_score->tick2measureBase(tickEnd() - Fraction::eps());
+    if (mb && mb->isMeasure()) {
+        mb = toMeasure(mb)->coveringMMRestOrThis();
+    }
+    return mb;
 }
 
 std::vector<System*> Selection::selectedSystems() const
@@ -417,8 +425,14 @@ std::vector<System*> Selection::selectedSystems() const
 
     std::vector<System*> systems;
     for (const MeasureBase* mb = startMB; mb && mb->isBeforeOrEqual(endMB); mb = mb->nextMM()) {
+        if (!mb->isMeasure() && !mb->isHBox()) {
+            continue;
+        }
         System* sys = mb->system();
-        if ((mb->isMeasure() || mb->isHBox()) && (systems.empty() || sys != systems.back())) {
+        IF_ASSERT_FAILED(sys) {
+            continue;
+        }
+        if (systems.empty() || sys != systems.back()) {
             systems.push_back(sys);
         }
     }


### PR DESCRIPTION
`startMeasureBase()` and `endMeasureBase()` returned the real measure (instead of MM rest measure). This underlying measure, when covered by a MM rest, does not have a parent system (the MM rest does).

This was causing crashes in multiple places where these functions were used, when MM rests were present and we attempted to access their parent systems.

I encountered this from a crash that happened when a MM rest measure was selected, the MM rest was not the first measure of the score, and the Properties Panel was enabled (in `SystemLayoutSettingsModel::loadProperties()`=>`updateAllSystemsAreLocked`, because `Selection::selectedSystems()` was returning a `NULL` system which was later de-referenced):

https://github.com/user-attachments/assets/c9d9b2e0-3109-48fd-86db-133cbaecd332

But there were other problems caused by the same:

* Move measure to the next system => crash:

https://github.com/user-attachments/assets/8088c88a-1fc1-4efc-9c41-33584999a982

* Move measure to the previous system => assert fail in Debug, or ignored in Release:

https://github.com/user-attachments/assets/af6abddd-7a2d-4cd9-91de-2c8c91a6aacf

* System lock when the MM rest is selected => crash:

https://github.com/user-attachments/assets/b3633d92-865c-4103-8f6a-bb66e915dfcc

This PR updates `startMeasureBase()` and `endMeasureBase()` so that they will return the MM rest measure, if any, and adds an assert to `Selection::selectedSystems()` to ensure we don't get more crashes due to a non-existing system.

