### PR TITLE
CI. Backend. Package fix

### DIFF
--- a/buildscripts/ci/backend/build_docker.sh
+++ b/buildscripts/ci/backend/build_docker.sh
@@ -57,7 +57,7 @@ docker buildx create --use >/dev/null 2>&1 || true
 
 docker buildx build \
     --platform linux/amd64\
-    -t ghcr.io/musescore/converter_4:${MU_VERSION} \
+    -t ghcr.io/musescore/converter_5:${MU_VERSION} \
     --load .
 
 cd $ORIGIN_DIR

--- a/buildscripts/ci/backend/build_docker.sh
+++ b/buildscripts/ci/backend/build_docker.sh
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 echo "Build Docker MuseScore"
+trap 'echo Build Docker failed; exit 1' ERR
 
 HERE="$(dirname ${BASH_SOURCE[0]})"
 ORIGIN_DIR=${PWD}

--- a/buildscripts/ci/backend/check_update_config_on_s3.sh
+++ b/buildscripts/ci/backend/check_update_config_on_s3.sh
@@ -51,10 +51,10 @@ echo "Login Docker"
 echo $ACCESS_TOKEN | docker login ghcr.io -u $ACCESS_USER --password-stdin
 
 echo "Pull Docker"
-docker pull ghcr.io/musescore/converter_4:${MU_VERSION}
+docker pull ghcr.io/musescore/converter_5:${MU_VERSION}
 
 echo "Check version..."
-docker run ghcr.io/musescore/converter_4:${MU_VERSION} /musescore/convertor -v > $ARTIFACTS_DIR/conv_output.txt
+docker run ghcr.io/musescore/converter_5:${MU_VERSION} /musescore/convertor -v > $ARTIFACTS_DIR/conv_output.txt
 
 APP_VERSION=$(echo "$MU_VERSION" | cut -d '.' -f 1,2,3)
 CONV_OUT=$(cat $ARTIFACTS_DIR/conv_output.txt)
@@ -84,7 +84,7 @@ CONFIGURE_FILE_PATH="$ARTIFACTS_DIR/${CONFIGURE_FILE}"
 s3cmd get "$S3_URL/$CONFIGURE_FILE" "$CONFIGURE_FILE_PATH"
 
 NEW_DISTR=$ARTIFACT_NAME
-NEW_IMAGE_URL="ghcr.io/musescore/converter_4:${MU_VERSION}"
+NEW_IMAGE_URL="ghcr.io/musescore/converter_5:${MU_VERSION}"
 NEW_STAGE=$STAGE
 
 if jq -e "has(\"$MU_VERSION_MAJOR_MINOR\")" "$CONFIGURE_FILE_PATH" > /dev/null; then

--- a/buildscripts/ci/backend/docker/Dockerfile
+++ b/buildscripts/ci/backend/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/ubuntu:22.04
+FROM library/ubuntu:24.04
 ENV TZ=Etc/UTC DEBIAN_FRONTEND=noninteractive
 COPY setup.sh /setup.sh
 COPY install_mu.sh /install_mu.sh

--- a/buildscripts/ci/backend/docker/setup.sh
+++ b/buildscripts/ci/backend/docker/setup.sh
@@ -103,7 +103,7 @@ cd fonts-main
 
 echo "Installing Google Fonts..."
 mkdir -p "$FONTS_DIR"
-find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -print0 | xargs -0 -r mv -n -t "$FONTS_DIR"
+find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -print0 | xargs -0 -r mv --update=none -t "$FONTS_DIR"
 
 echo "Installing Fonts Cache..."
 fc-cache -f -v

--- a/buildscripts/ci/backend/docker/setup.sh
+++ b/buildscripts/ci/backend/docker/setup.sh
@@ -51,7 +51,7 @@ apt_packages_runtime=(
   libcups2
   libdbus-1-3
   libegl1-mesa-dev
-  libodbc1
+  libodbc2
   libpq-dev
   libxcomposite-dev
   libxcursor-dev

--- a/buildscripts/ci/backend/package.sh
+++ b/buildscripts/ci/backend/package.sh
@@ -81,8 +81,11 @@ mv squashfs-root "$APP_DIR"
 cp $HERE/convertor.in $APP_DIR/convertor
 chmod 775 $APP_DIR/convertor
 
+# Remove the build-time "usr -> ." symlink, 7z refuses to extract it
+rm -f "$APP_DIR/usr"
+
 # Pack to 7z
-7z a "$ARTIFACT_NAME.7z" "$APP_DIR/*"
+7z a -snl "$ARTIFACT_NAME.7z" "$APP_DIR/*"
 chmod a+rw "$ARTIFACT_NAME.7z"
 
 # Clean up

--- a/buildscripts/ci/backend/publish_to_registry.sh
+++ b/buildscripts/ci/backend/publish_to_registry.sh
@@ -46,7 +46,7 @@ echo "Login Docker"
 echo $ACCESS_TOKEN | docker login ghcr.io -u $ACCESS_USER --password-stdin
 
 echo "Push Docker"
-docker push ghcr.io/musescore/converter_4:${MU_VERSION}
+docker push ghcr.io/musescore/converter_5:${MU_VERSION}
 
 echo "Done!!"
 

--- a/buildscripts/ci/backend/publish_to_registry.sh
+++ b/buildscripts/ci/backend/publish_to_registry.sh
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 echo "Publish Docker MuseScore"
+trap 'echo Publish Docker failed; exit 1' ERR
 
 ARTIFACTS_DIR=build.artifacts
 MU_VERSION=""


### PR DESCRIPTION
Fixed symbolic link errors 
```
./MuseScore-5.0.0.260716035/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/usr/share/man/man1/musescore4portable.1.gz : errno=40 : Too many levels of symbolic links
```

After that there was a mismatch between the CI runner version and the Docker version being built for the backend. I updated the Docker version to Ubuntu 24.04
```
#10 50.50 /musescore/bin/mscore4portable: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /musescore/bin/mscore4portable)
```

And then there was a problem with installing fonts on Ubuntu 24
```
#10 204.2 mv: not replacing '/root/.local/share/fonts/NotoSansNKo-Regular.ttf'
```

Green build here https://github.com/musescore/MuseScore/actions/runs/29637083388