### PR TITLE
Fix property changes of courtesy key signatures at system breaks

### DIFF
--- a/src/engraving/dom/keysig.cpp
+++ b/src/engraving/dom/keysig.cpp
@@ -193,7 +193,6 @@ EngravingObject* KeySig::propertyDelegate(Pid propertyId) const
     case Pid::KEY_CONCERT:
     case Pid::SHOW_COURTESY:
     case Pid::KEYSIG_MODE:
-    case Pid::IS_COURTESY:
     {
         Segment* thisSeg = segment();
         Segment* nextKSSeg = thisSeg ? thisSeg->next1(SegmentType::KeySig) : nullptr;
@@ -290,8 +289,11 @@ bool KeySig::setProperty(Pid propertyId, const PropertyValue& v)
 void KeySig::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps)
 {
     if (EngravingObject* e = propertyDelegate(id)) {
-        // If this is a courtesy, we must change the property of the _real_ key signature
+        /* If this is a courtesy, we must change the property of the _real_ key signature,
+         * and we want to avoid EngravingObject::undoChangeProperty unsetting GENERATED
+         * unless something really has changed about the courtesy itself: */
         e->undoChangeProperty(id, v, ps);
+        // If removing the courtesy, deselect it first:
         if (id == Pid::SHOW_COURTESY && _isCourtesy && !v.toBool() && selected() && e->isKeySig()) {
             score()->deselect(this);
             score()->select(toEngravingItem(e), SelectType::ADD, staffIdx());

--- a/src/engraving/dom/keysig.cpp
+++ b/src/engraving/dom/keysig.cpp
@@ -284,6 +284,24 @@ bool KeySig::setProperty(Pid propertyId, const PropertyValue& v)
 }
 
 //---------------------------------------------------------
+//   undoChangeProperty
+//---------------------------------------------------------
+
+void KeySig::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps)
+{
+    if (EngravingObject* e = propertyDelegate(id)) {
+        // If this is a courtesy, we must change the property of the _real_ key signature
+        e->undoChangeProperty(id, v, ps);
+        if (id == Pid::SHOW_COURTESY && _isCourtesy && !v.toBool() && selected() && e->isKeySig()) {
+            score()->deselect(this);
+            score()->select(toEngravingItem(e), SelectType::ADD, staffIdx());
+        }
+        return;
+    }
+    EngravingItem::undoChangeProperty(id, v, ps);
+}
+
+//---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 

--- a/src/engraving/dom/keysig.h
+++ b/src/engraving/dom/keysig.h
@@ -81,6 +81,8 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+    void undoChangeProperty(Pid id, const PropertyValue& v) { EngravingObject::undoChangeProperty(id, v); }
+    void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps) override;
     PropertyValue propertyDefault(Pid id) const override;
     EngravingObject* propertyDelegate(Pid) const override;
 

--- a/src/engraving/dom/keysig.h
+++ b/src/engraving/dom/keysig.h
@@ -81,7 +81,7 @@ public:
 
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
-    void undoChangeProperty(Pid id, const PropertyValue& v) { EngravingObject::undoChangeProperty(id, v); }
+    using EngravingItem::undoChangeProperty;
     void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps) override;
     PropertyValue propertyDefault(Pid id) const override;
     EngravingObject* propertyDelegate(Pid) const override;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -785,13 +785,13 @@ void Segment::add(EngravingItem* el)
         assert(m_segmentType & SegmentType::KeySigTypes);
         checkElement(el, track);
         m_elist[track] = el;
-        if (!el->generated()) {
+        if (m_segmentType & SegmentType::CourtesyKeySigTypes) {
+            toKeySig(el)->setIsCourtesy(true);
+        }
+        if (!el->generated() && !toKeySig(el)->isCourtesy()) {
             el->staff()->setKey(tick(), toKeySig(el)->keySigEvent());
         }
         setEmpty(false);
-        if (m_segmentType == SegmentType::CourtesyKeySigTypes) {
-            toKeySig(el)->setIsCourtesy(true);
-        }
         break;
 
     case ElementType::CHORD:
@@ -963,7 +963,7 @@ void Segment::remove(EngravingItem* el)
 
     case ElementType::KEYSIG:
         m_elist[track] = 0;
-        if (!el->generated()) {
+        if (!el->generated() && !toKeySig(el)->isCourtesy()) {
             el->staff()->removeKey(tick());
         }
         break;

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1855,9 +1855,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             bool courtesySig = (curTick == m->endTick());
             segment = m->getSegment(courtesySig ? SegmentType::KeySigAnnounce : SegmentType::KeySig, curTick);
             segment->add(ks);
-            if (!courtesySig) {
-                staff->setKey(curTick, ks->keySigEvent());
-            }
+            staff->setKey(curTick, ks->keySigEvent());
         } else if (tag == "Lyrics") {
             Lyrics* l = Factory::createLyrics(ctx.dummy()->chord());
             l->setTrack(ctx.track());

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3013,9 +3013,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             bool courtesySig = (curTick == m->endTick());
             segment = m->getSegment(courtesySig ? SegmentType::KeySigAnnounce : SegmentType::KeySig, curTick);
             segment->add(ks);
-            if (!courtesySig) {
-                staff->setKey(curTick, ks->keySigEvent());
-            }
+            staff->setKey(curTick, ks->keySigEvent());
         } else if (tag == "Text" || tag == "StaffText") {
             // MuseScore 3 has different types for system text and
             // staff text while MuseScore 2 didn't.

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/notation/keysignatures/keysignaturesettingsmodel.cpp
@@ -23,6 +23,7 @@
 
 #include "engraving/dom/layoutbreak.h"
 #include "engraving/dom/measure.h"
+#include "engraving/dom/keysig.h"
 
 #include "translation.h"
 
@@ -58,7 +59,7 @@ void KeySignatureSettingsModel::loadProperties()
     bool enableCourtesy = true;
 
     for (const mu::engraving::EngravingItem* element : m_elementList) {
-        if (element->generated()) {
+        if (element->generated() || toKeySig(element)->isCourtesy()) {
             enableMode = false;
         }
 


### PR DESCRIPTION
Resolves: #32386

This PR updates `Segment::add` (and `remove`) to make sure that courtesy key signatures are not added to the `Staff`'s `KeyList` even if they are no longer `GENERATED` (e.g. because the user changed something about it, such as auto-placement or visibility), which would replace the real key sig in the map. This was causing the bug described in #32386 .

It also adds an overload of `undoChangeProperty` to `KeySig`, so that when the key signature is a courtesy one,  the delegated properties will be changed for the _real_ key signature without changing the `GENERATED` flag for the courtesy itself.

Lastly, it fixes a couple of related bugs:
* stop delegating the `KeySig`'s `IS_COURTESY` property, which makes no sense
* fix a mis-labelling of courtesy key signatures due to `Segment::add` checking the segment type with `==` instead of binary `&`.
    * Note: this required a compatibility update in `read114` and `read206` because scores created with these versions' mscx files not always contained the _real_ signature, but only the courtesy at the end of the previous system, which served as the key change (e.g. if the change was to C key). This was working before because the courtesy check in `Segment::add` was broken, so they were being added to the `KeyList` as normal key signatures, but after my changes they were not added so they just disappeared. I have forced the read functions to add the key signatures to the `KeyList` in every case - worst case scenario, if they'd already been added during `Segment::add`, this is a harmless redundant call (plus the redundancy was already there before for non-courtesy signatures).