### PR TITLE
Introduce configurable pedal release gap for VST and MIDI engines

### DIFF
--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -58,6 +58,7 @@
 #include "dom/segment.h"
 #include "dom/staff.h"
 #include "dom/stafftextbase.h"
+#include "dom/tempo.h"
 #include "dom/swing.h"
 #include "dom/tie.h"
 #include "dom/trill.h"
@@ -1468,6 +1469,8 @@ void CompatMidiRendererInternal::doRenderSpanners(EventsHolder& events, Spanner*
     if (s->isPedal()) {
         PedalEvent lastEvent;
 
+        // TODO: pedalEventList is always empty here, so consecutive-pedal gap checks below never fire.
+        // The list should likely be accumulated across spanners.
         if (!pedalEventList.empty()) {
             lastEvent = pedalEventList.back();
         } else {
@@ -1476,14 +1479,20 @@ void CompatMidiRendererInternal::doRenderSpanners(EventsHolder& events, Spanner*
 
         int st = s->tick().ticks();
 
+        int gapTicks = 1;
+        if (MScore::pedalReleaseGapMs > 0) {
+            double bps = score->tempomap()->multipliedTempo(st).val;
+            gapTicks = std::max(1, static_cast<int>((MScore::pedalReleaseGapMs* bps* Constants::DIVISION) / 1000.0));
+        }
+
         if (!lastEvent.on && lastEvent.tick >= (st + 2)) {
             pedalEventList.emplace(pedalEventList.cend() - 1,
-                                   st + (2 - MScore::pedalEventsMinTicks), false, staffIdx);
+                                   st + (2 - gapTicks), false, staffIdx);
         }
         int a = st + 2;
         pedalEventList.emplace_back(a, true, staffIdx);
 
-        int t = s->tick2().ticks() + (2 - MScore::pedalEventsMinTicks);
+        int t = std::max(a + 1, s->tick2().ticks() + (2 - gapTicks));
         if (!score->repeatList().empty()) {
             const RepeatSegment& lastRepeat = *score->repeatList().back();
             if (t > lastRepeat.utick + lastRepeat.len()) {

--- a/src/engraving/dom/mscore.cpp
+++ b/src/engraving/dom/mscore.cpp
@@ -50,7 +50,7 @@ double MScore::horizontalPageGapOdd = 3.5 * DPMM;
 
 bool MScore::warnPitchRange;
 bool MScore::warnGuitarBends;
-int MScore::pedalEventsMinTicks;
+int MScore::pedalReleaseGapMs;
 
 double MScore::nudgeStep;
 double MScore::nudgeStep10;

--- a/src/engraving/dom/mscore.h
+++ b/src/engraving/dom/mscore.h
@@ -196,7 +196,7 @@ public:
 
     static bool warnPitchRange;
     static bool warnGuitarBends;
-    static int pedalEventsMinTicks;
+    static int pedalReleaseGapMs;
 
     static double nudgeStep;
     static double nudgeStep10;

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -252,7 +252,7 @@ void EngravingModule::onInit(const IApplication::RunMode&)
 
     MScore::warnPitchRange      = true;
     MScore::warnGuitarBends     = true;
-    MScore::pedalEventsMinTicks = 1;
+    MScore::pedalReleaseGapMs = 0;
 
     Drumset::initDrumset();
     FiguredBass::readConfigFile(String());

--- a/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
@@ -30,7 +30,9 @@
 #include "dom/tempo.h"
 
 #include "playback/utils/pitchutils.h"
+#include "playback/utils/arrangementutils.h"
 #include "playback/filters/spannerfilter.h"
+#include "dom/mscore.h"
 
 using namespace mu::engraving;
 using namespace muse;
@@ -142,6 +144,16 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
         return;
     }
 
+    int durationTicks = overallDurationTicks;
+
+    if (spanner->type() == ElementType::PEDAL) {
+        int gapTicks = 0;
+        if (MScore::pedalReleaseGapMs > 0) {
+            gapTicks = std::max(1, ticksFromTempoAndDuration(spannerCtx.beatsPerSecond.val, MScore::pedalReleaseGapMs * 1000));
+        }
+        durationTicks = std::max(1, overallDurationTicks - gapTicks);
+    }
+
     mpe::ArticulationMeta articulationMeta;
     articulationMeta.type = type;
     articulationMeta.pattern = pattern;
@@ -150,7 +162,7 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
     articulationMeta.overallDynamicChangesRange = overallDynamicRange;
     articulationMeta.overallDuration = durationFromStartAndTicks(spannerCtx.score,
                                                                  spannerCtx.nominalPositionStartTick,
-                                                                 overallDurationTicks,
+                                                                 durationTicks,
                                                                  spannerCtx.positionTickOffset);
 
     appendArticulationData(std::move(articulationMeta), result);

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -207,6 +207,10 @@ public:
     virtual void setNotePlayDurationMilliseconds(int durationMs) = 0;
     virtual muse::async::Channel<int> notePlayDurationMillisecondsChanged() const = 0;
 
+    virtual int pedalReleaseGapMs() const = 0;
+    virtual void setPedalReleaseGapMs(int ms) = 0;
+    virtual muse::async::Channel<int> pedalReleaseGapMsChanged() const = 0;
+
     virtual void setTemplateModeEnabled(std::optional<bool> enabled) = 0;
     virtual void setTestModeEnabled(std::optional<bool> enabled) = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -92,6 +92,7 @@ static const Settings::Key IS_CANVAS_ORIENTATION_VERTICAL_KEY(module_name, "ui/c
 static const Settings::Key COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE(module_name, "score/note/warnPitchRange");
 static const Settings::Key WARN_GUITAR_BENDS(module_name, "score/note/warnGuitarBends");
 static const Settings::Key REALTIME_DELAY(module_name, "io/midi/realtimeDelay");
+static const Settings::Key PEDAL_RELEASE_GAP_MS(module_name, "application/playback/pedalReleaseGapMs");
 static const Settings::Key USE_MIDI_VELOCITY_AND_DURATION_DURING_NOTE_INPUT(module_name,
                                                                             "io/midi/useMidiVelocityAndDurationDuringNoteInput");
 static const Settings::Key NOTE_DEFAULT_PLAY_DURATION(module_name, "score/note/defaultPlayDuration");
@@ -309,6 +310,14 @@ void NotationConfiguration::init()
         m_delayBetweenNotesInRealTimeModeMillisecondsChanged.send(val.toInt());
     });
 
+    settings()->setDefaultValue(PEDAL_RELEASE_GAP_MS, Val(0));
+    settings()->setDescription(PEDAL_RELEASE_GAP_MS, muse::trc("notation", "Pedal release gap for playback (in milliseconds)"));
+    settings()->setCanBeManuallyEdited(PEDAL_RELEASE_GAP_MS, true, Val(0));
+    settings()->valueChanged(PEDAL_RELEASE_GAP_MS).onReceive(this, [this](const Val& val) {
+        mu::engraving::MScore::pedalReleaseGapMs = val.toInt();
+        m_pedalReleaseGapMsChanged.send(val.toInt());
+    });
+
     settings()->setDefaultValue(USE_MIDI_VELOCITY_AND_DURATION_DURING_NOTE_INPUT, Val(true));
     settings()->valueChanged(USE_MIDI_VELOCITY_AND_DURATION_DURING_NOTE_INPUT).onReceive(this, [this](const Val& val) {
         m_useMidiVelocityAndDurationDuringNoteInputChanged.send(val.toBool());
@@ -340,6 +349,7 @@ void NotationConfiguration::init()
 
     mu::engraving::MScore::warnPitchRange = colorNotesOutsideOfUsablePitchRange();
     mu::engraving::MScore::warnGuitarBends = warnGuitarBends();
+    mu::engraving::MScore::pedalReleaseGapMs = settings()->value(PEDAL_RELEASE_GAP_MS).toInt();
 
     // Restore stored grid size values
     mu::engraving::MScore::setHRaster(settings()->value(HORIZONTAL_GRID_SIZE_KEY).toInt());
@@ -985,6 +995,21 @@ void NotationConfiguration::setDelayBetweenNotesInRealTimeModeMilliseconds(int d
 async::Channel<int> NotationConfiguration::delayBetweenNotesInRealTimeModeMillisecondsChanged() const
 {
     return m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
+}
+
+int NotationConfiguration::pedalReleaseGapMs() const
+{
+    return settings()->value(PEDAL_RELEASE_GAP_MS).toInt();
+}
+
+void NotationConfiguration::setPedalReleaseGapMs(int ms)
+{
+    settings()->setSharedValue(PEDAL_RELEASE_GAP_MS, Val(ms));
+}
+
+async::Channel<int> NotationConfiguration::pedalReleaseGapMsChanged() const
+{
+    return m_pedalReleaseGapMsChanged;
 }
 
 bool NotationConfiguration::useMidiVelocityAndDurationDuringNoteInput() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -209,6 +209,10 @@ public:
     void setNotePlayDurationMilliseconds(int durationMs) override;
     muse::async::Channel<int> notePlayDurationMillisecondsChanged() const override;
 
+    int pedalReleaseGapMs() const override;
+    void setPedalReleaseGapMs(int ms) override;
+    muse::async::Channel<int> pedalReleaseGapMsChanged() const override;
+
     void setTemplateModeEnabled(std::optional<bool> enabled) override;
     void setTestModeEnabled(std::optional<bool> enabled) override;
 
@@ -261,6 +265,7 @@ private:
     muse::async::Channel<bool> m_warnGuitarBendsChanged;
     muse::async::Channel<int> m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
     muse::async::Channel<int> m_notePlayDurationMillisecondsChanged;
+    muse::async::Channel<int> m_pedalReleaseGapMsChanged;
     muse::async::Channel<bool> m_useMidiVelocityAndDurationDuringNoteInputChanged;
     muse::async::Channel<std::string> m_styleFileImportPathChanged;
     muse::async::Notification m_isPlayRepeatsChanged;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -115,6 +115,10 @@ void NotationPlayback::init()
         }
     });
 
+    configuration()->pedalReleaseGapMsChanged().onReceive(this, [this](int) {
+        m_playbackModel.reload();
+    });
+
     score()->loopBoundaryTickChanged().onReceive(this, [this](LoopBoundaryType, unsigned) {
         updateLoopBoundaries();
     });

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -195,6 +195,10 @@ public:
     MOCK_METHOD(void, setNotePlayDurationMilliseconds, (int), (override));
     MOCK_METHOD((muse::async::Channel<int>), notePlayDurationMillisecondsChanged, (), (const, override));
 
+    MOCK_METHOD(int, pedalReleaseGapMs, (), (const, override));
+    MOCK_METHOD(void, setPedalReleaseGapMs, (int), (override));
+    MOCK_METHOD((muse::async::Channel<int>), pedalReleaseGapMsChanged, (), (const, override));
+
     MOCK_METHOD(void, setTemplateModeEnabled, (std::optional<bool>), (override));
     MOCK_METHOD(void, setTestModeEnabled, (std::optional<bool>), (override));
 

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -638,6 +638,21 @@ muse::async::Channel<int> NotationConfigurationStub::notePlayDurationMillisecond
     return ch;
 }
 
+int NotationConfigurationStub::pedalReleaseGapMs() const
+{
+    return 0;
+}
+
+void NotationConfigurationStub::setPedalReleaseGapMs(int)
+{
+}
+
+muse::async::Channel<int> NotationConfigurationStub::pedalReleaseGapMsChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
+}
+
 void NotationConfigurationStub::setTemplateModeEnabled(std::optional<bool>)
 {
 }

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -209,6 +209,10 @@ public:
     void setNotePlayDurationMilliseconds(int durationMs)  override;
     muse::async::Channel<int> notePlayDurationMillisecondsChanged() const override;
 
+    int pedalReleaseGapMs() const override;
+    void setPedalReleaseGapMs(int ms) override;
+    muse::async::Channel<int> pedalReleaseGapMsChanged() const override;
+
     void setTemplateModeEnabled(std::optional<bool> enabled) override;
     void setTestModeEnabled(std::optional<bool> enabled) override;
 


### PR DESCRIPTION
Resolves: #22910
Resolves: #26399

<!-- Add a short description of and motivation for the changes here -->

Pianoteq (and possibly other VSTs) fails to process sustain pedal releases because the MIDI events are sent too quickly, leading to muddy sounds. A previous fix #5788 added an advanced preference `pedalEventsMinTicks` to shorten the duration of the spanner. In recent versions, the setting is no longer available and the variable in the code is hardcoded to 1 tick.

I replaced `pedalEventsMinTicks` with `pedalReleaseGapMs` and added the "Pedal release gap for playback (in milliseconds)" setting to the Advanced tab in Preferences. The default value is set to 0, which does not impact existing playback.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [rmcat](https://musescore.org/en/user/6621726): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).