### PR TITLE
Add more items to "Select similar"

### DIFF
--- a/src/engraving/dom/indicatoricon.cpp
+++ b/src/engraving/dom/indicatoricon.cpp
@@ -39,3 +39,8 @@ Font IndicatorIcon::font() const
     font.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE * magS());
     return font;
 }
+
+Fraction IndicatorIcon::tick() const
+{
+    return system() ? system()->endTick() : Fraction(0, 1);
+}

--- a/src/engraving/dom/indicatoricon.h
+++ b/src/engraving/dom/indicatoricon.h
@@ -44,6 +44,8 @@ public:
 
     muse::draw::Font font() const;
 
+    Fraction tick() const override;
+
     virtual char16_t iconCode() const { return 0x000; }
 
     void undoChangeProperty(Pid, const PropertyValue&, PropertyFlags) override { return; } // not editable

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1775,28 +1775,32 @@ int Score::utime2utick(double utime) const
 
 void Score::scanElementsInRange(std::function<void(EngravingItem*)> func)
 {
-    Segment* startSeg = m_selection.startSegment();
-    for (Segment* s = startSeg; s && s != m_selection.endSegment(); s = s->next1()) {
-        s->scanElements(func);
-        Measure* m = s->measure();
-        if (m && s == m->first()) {
-            Measure* mmr = m->mmRest();
-            if (mmr) {
-                mmr->scanElements(func);
-            }
+    const Fraction selectionStartTick = m_selection.startSegment() ? m_selection.startSegment()->tick() : Fraction(0, 1);
+    const Fraction selectionEndTick = m_selection.endSegment() ? m_selection.endSegment()->tick() : endTick();
+    auto doScanElement = [&](EngravingItem* e) {
+        if (e->tick() >= selectionStartTick && e->tick() < selectionEndTick) {
+            func(e);
         }
-    }
+    };
 
-    std::set<Spanner*> handledSpanners;
-    for (EngravingItem* e : m_selection.elements()) {
-        if (!e->isSpannerSegment()) {
-            continue;
+    System* lastSystem = nullptr;
+    // Inculde previous measure/system so we scan items at their end tick
+    // Filter anything else out in doScanElement
+    MeasureBase* startMb = m_selection.startMeasureBase();
+    if (startMb->prev()) {
+        startMb = startMb->prev();
+    }
+    for (MeasureBase* mb = startMb; mb && mb->tick() < selectionEndTick; mb = mb->next()) {
+        mb->scanElements(doScanElement);
+
+        if (mb->isMeasure() && toMeasure(mb)->mmRest()) {
+            Measure* mmr = toMeasure(mb)->mmRest();
+            mmr->scanElements(doScanElement);
         }
-        Spanner* spanner = toSpannerSegment(e)->spanner();
-        if (handledSpanners.insert(spanner).second) {
-            for (SpannerSegment* ss : spanner->spannerSegments()) {
-                ss->scanElements(func);
-            }
+        System* system = mb ? mb->system() : nullptr;
+        if (system && system != lastSystem) {
+            system->scanElements(doScanElement);
+            lastSystem = system;
         }
     }
 }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2151,7 +2151,7 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
                 return nme;
             } else if (nmb->isEndOfSystemLock()) {
                 System* system = nmb->system();
-                SystemLockIndicator* lockInd = system ? system->lockIndicators().front() : nullptr;
+                SystemLockIndicator* lockInd = system ? system->systemLockIndicators().front() : nullptr;
                 if (lockInd) {
                     return lockInd;
                 }
@@ -2363,7 +2363,7 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
                 return me;
             } else if (measure()->isEndOfSystemLock()) {
                 System* system = measure()->system();
-                SystemLockIndicator* lockInd = system ? system->lockIndicators().front() : nullptr;
+                SystemLockIndicator* lockInd = system ? system->systemLockIndicators().front() : nullptr;
                 if (lockInd) {
                     return lockInd;
                 }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2151,9 +2151,18 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
                 return nme;
             } else if (nmb->isEndOfSystemLock()) {
                 System* system = nmb->system();
-                SystemLockIndicator* lockInd = system ? system->systemLockIndicators().front() : nullptr;
-                if (lockInd) {
-                    return lockInd;
+                if (system) {
+                    for (SystemLockIndicator* lockInd : system->systemLockIndicators()) {
+                        if (nmb->systemLock() == lockInd->systemLock()) {
+                            return lockInd;
+                        }
+                    }
+                }
+            } else if (nmb->isEndOfPageLock()) {
+                System* system = nmb->system();
+                PageLockIndicator* pli = system ? system->pageLockIndicator() : nullptr;
+                if (pli) {
+                    return pli;
                 }
             } //TODO: StaffVisibilityIndicator handling
         }
@@ -2361,11 +2370,20 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
                 return me;
             } else if (me && me->isLayoutBreak() && e->staffIdx() == 0) {
                 return me;
+            } else if (measure()->isEndOfPageLock()) {
+                System* system = measure()->system();
+                PageLockIndicator* pli = system ? system->pageLockIndicator() : nullptr;
+                if (pli) {
+                    return pli;
+                }
             } else if (measure()->isEndOfSystemLock()) {
                 System* system = measure()->system();
-                SystemLockIndicator* lockInd = system ? system->systemLockIndicators().front() : nullptr;
-                if (lockInd) {
-                    return lockInd;
+                if (system) {
+                    for (SystemLockIndicator* lockInd : system->systemLockIndicators()) {
+                        if (measure()->systemLock() == lockInd->systemLock()) {
+                            return lockInd;
+                        }
+                    }
                 }
             } else if (psm != pmb) {
                 return pmb;

--- a/src/engraving/dom/system.cpp
+++ b/src/engraving/dom/system.cpp
@@ -159,7 +159,7 @@ System::~System()
     }
     muse::DeleteAll(m_staves);
     muse::DeleteAll(m_brackets);
-    muse::DeleteAll(m_lockIndicators);
+    muse::DeleteAll(m_systemLockIndicators);
     if (m_staffVisibilityIndicator) {
         delete m_staffVisibilityIndicator;
     }
@@ -326,16 +326,16 @@ const RangeLock* System::systemLock() const
     return m_ml.front()->systemLock();
 }
 
-void System::addLockIndicator(SystemLockIndicator* sli)
+void System::addSystemLockIndicator(SystemLockIndicator* sli)
 {
     assert(sli);
-    m_lockIndicators.push_back(sli);
+    m_systemLockIndicators.push_back(sli);
 }
 
-void System::deleteLockIndicators()
+void System::deleteSystemLockIndicators()
 {
-    muse::DeleteAll(m_lockIndicators);
-    m_lockIndicators.clear();
+    muse::DeleteAll(m_systemLockIndicators);
+    m_systemLockIndicators.clear();
 }
 
 void System::setPageLockIndicator(PageLockIndicator* pli)
@@ -746,7 +746,7 @@ void System::scanElements(std::function<void(EngravingItem*)> func)
         func(m_pageLockIndicator);
     }
 
-    for (auto i : m_lockIndicators) {
+    for (auto i : m_systemLockIndicators) {
         func(i);
     }
 

--- a/src/engraving/dom/system.h
+++ b/src/engraving/dom/system.h
@@ -216,9 +216,9 @@ public:
     bool isLocked() const;
     const RangeLock* systemLock() const;
 
-    const std::vector<SystemLockIndicator*> lockIndicators() const { return m_lockIndicators; }
-    void addLockIndicator(SystemLockIndicator* sli);
-    void deleteLockIndicators();
+    const std::vector<SystemLockIndicator*> systemLockIndicators() const { return m_systemLockIndicators; }
+    void addSystemLockIndicator(SystemLockIndicator* sli);
+    void deleteSystemLockIndicators();
 
     void setPageLockIndicator(PageLockIndicator* pli);
     void deletePageLockIndicator();
@@ -281,7 +281,7 @@ private:
     std::vector<SysStaff*> m_staves;
     std::vector<Bracket*> m_brackets;
     std::list<SpannerSegment*> m_spannerSegments;
-    std::vector<SystemLockIndicator*> m_lockIndicators;
+    std::vector<SystemLockIndicator*> m_systemLockIndicators;
     PageLockIndicator* m_pageLockIndicator = nullptr;
 
     StaffVisibilityIndicator* m_staffVisibilityIndicator = nullptr;

--- a/src/engraving/dom/system.h
+++ b/src/engraving/dom/system.h
@@ -220,6 +220,7 @@ public:
     void addSystemLockIndicator(SystemLockIndicator* sli);
     void deleteSystemLockIndicators();
 
+    PageLockIndicator* pageLockIndicator() const { return m_pageLockIndicator; }
     void setPageLockIndicator(PageLockIndicator* pli);
     void deletePageLockIndicator();
 

--- a/src/engraving/editing/navigation.cpp
+++ b/src/engraving/editing/navigation.cpp
@@ -924,7 +924,13 @@ EngravingItem* Score::nextElement()
         case ElementType::SYSTEM_LOCK_INDICATOR:
         {
             staffId = 0;
-            e = toSystemLockIndicator(e)->systemLock()->endMB();
+            SystemLockIndicator* sli = toSystemLockIndicator(e);
+            System* system = sli->system();
+            if (system && system->pageLockIndicator()) {
+                return system->pageLockIndicator();
+            } else {
+                e = toSystemLockIndicator(e)->systemLock()->endMB();
+            }
             continue;
         }
         case ElementType::PAGE_LOCK_INDICATOR:
@@ -1185,7 +1191,13 @@ EngravingItem* Score::prevElement()
         case ElementType::PAGE_LOCK_INDICATOR:
         {
             staffId = 0;
-            e = toPageLockIndicator(e)->pageLock()->endMB();
+            PageLockIndicator* pli = toPageLockIndicator(e);
+            System* system = pli->system();
+            if (system && !system->systemLockIndicators().empty()) {
+                return system->systemLockIndicators().front();
+            } else {
+                e = toPageLockIndicator(e)->pageLock()->endMB();
+            }
             continue;
         }
         case ElementType::HARMONY: {

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -258,13 +258,14 @@ void ScoreHorizontalViewLayout::layoutSystemLockIndicators(System* system)
 {
     // TODO: layout StaffVisibilityIndicator here
 
-    system->deleteLockIndicators();
+    system->deleteSystemLockIndicators();
 
     std::vector<const RangeLock*> systemLocks = system->score()->systemLocks()->allLocks();
     for (const RangeLock* lock : systemLocks) {
         SystemLockIndicator* lockIndicator = Factory::createSystemLockIndicator(system, lock);
+        lockIndicator->setTrack(0);
         lockIndicator->setParent(system);
-        system->addLockIndicator(lockIndicator);
+        system->addSystemLockIndicator(lockIndicator);
         TLayout::layoutIndicatorIcon(lockIndicator, lockIndicator->mutldata());
     }
 }

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -504,19 +504,20 @@ void SystemLayout::layoutSystemLockIndicators(System* system, LayoutContext& ctx
 {
     UNUSED(ctx);
 
-    const std::vector<SystemLockIndicator*> lockIndicators = system->lockIndicators();
+    const std::vector<SystemLockIndicator*> lockIndicators = system->systemLockIndicators();
     // In PAGE view, at most ONE lock indicator can exist per system.
     assert(lockIndicators.size() <= 1);
-    system->deleteLockIndicators();
+    system->deleteSystemLockIndicators();
 
     const RangeLock* lock = system->systemLock();
     if (!lock) {
         return;
     }
 
-    SystemLockIndicator* lockIndicator = new SystemLockIndicator(system, lock);
+    SystemLockIndicator* lockIndicator = Factory::createSystemLockIndicator(system, lock);
+    lockIndicator->setTrack(0);
     lockIndicator->setParent(system);
-    system->addLockIndicator(lockIndicator);
+    system->addSystemLockIndicator(lockIndicator);
 
     TLayout::layoutIndicatorIcon(lockIndicator, lockIndicator->mutldata());
 }
@@ -535,7 +536,8 @@ void SystemLayout::layoutPageLockIndicators(System* system)
         return;
     }
 
-    PageLockIndicator* lockIndicator = new PageLockIndicator(system, lock);
+    PageLockIndicator* lockIndicator = Factory::createPageLockIndicator(system, lock);
+    lockIndicator->setTrack(0);
     lockIndicator->setParent(system);
     system->setPageLockIndicator(lockIndicator);
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -3785,7 +3785,7 @@ void TLayout::layoutIndicatorIcon(const IndicatorIcon* item, IndicatorIcon::Layo
         }
     }
 
-    for (const SystemLockIndicator* sli : item->system()->lockIndicators()) {
+    for (const SystemLockIndicator* sli : item->system()->systemLockIndicators()) {
         if (sli != item) {
             // TODO: Rough spacing here
             xOffset -= (sli->ldata()->bbox().width() * 2) - spatium;


### PR DESCRIPTION
Resolves: #33074

Add items owned by `Measure` and `System` to selections

Also fixes system lock & page lock navigation