### PR TITLE
Extend tremolos to complete SMuFL range

### DIFF
--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2823,10 +2823,14 @@ QString Braille::brailleTremolo(Chord* chord)
     case TremoloType::R16: return BRAILLE_TREMOLO_16THS;
     case TremoloType::R32: return BRAILLE_TREMOLO_32NDS;
     case TremoloType::R64: return BRAILLE_TREMOLO_64THS;
+    case TremoloType::R128:
+    case TremoloType::R256: return BRAILLE_TREMOLO_128THS;
     case TremoloType::C8:  return BRAILLE_TREMOLO_8THS_ALT;
     case TremoloType::C16: return BRAILLE_TREMOLO_16THS_ALT;
     case TremoloType::C32: return BRAILLE_TREMOLO_32NDS_ALT;
     case TremoloType::C64: return BRAILLE_TREMOLO_64THS_ALT;
+    case TremoloType::C128:
+    case TremoloType::C256: return BRAILLE_TREMOLO_128THS_ALT;
     case TremoloType::BUZZ_ROLL: return QString();     //TODO
     case TremoloType::INVALID_TREMOLO: return QString();
     }

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -2823,14 +2823,14 @@ QString Braille::brailleTremolo(Chord* chord)
     case TremoloType::R16: return BRAILLE_TREMOLO_16THS;
     case TremoloType::R32: return BRAILLE_TREMOLO_32NDS;
     case TremoloType::R64: return BRAILLE_TREMOLO_64THS;
-    case TremoloType::R128:
-    case TremoloType::R256: return BRAILLE_TREMOLO_128THS;
+    case TremoloType::R128: return BRAILLE_TREMOLO_128THS;
+    case TremoloType::R256: return QString(); // unsupported in braille
     case TremoloType::C8:  return BRAILLE_TREMOLO_8THS_ALT;
     case TremoloType::C16: return BRAILLE_TREMOLO_16THS_ALT;
     case TremoloType::C32: return BRAILLE_TREMOLO_32NDS_ALT;
     case TremoloType::C64: return BRAILLE_TREMOLO_64THS_ALT;
-    case TremoloType::C128:
-    case TremoloType::C256: return BRAILLE_TREMOLO_128THS_ALT;
+    case TremoloType::C128: return BRAILLE_TREMOLO_128THS_ALT;
+    case TremoloType::C256: return QString(); // unsupported in braille
     case TremoloType::BUZZ_ROLL: return QString();     //TODO
     case TremoloType::INVALID_TREMOLO: return QString();
     }

--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -1391,13 +1391,17 @@ enum class TremoloType {
     R16       = int(mu::engraving::TremoloType::R16),
     R32       = int(mu::engraving::TremoloType::R32),
     R64       = int(mu::engraving::TremoloType::R64),
+    R128      = int(mu::engraving::TremoloType::R128),
+    R256      = int(mu::engraving::TremoloType::R256),
     BUZZ_ROLL = int(mu::engraving::TremoloType::BUZZ_ROLL),
 
     /// two-chord tremolos
-    C8  = int(mu::engraving::TremoloType::C8),
-    C16 = int(mu::engraving::TremoloType::C16),
-    C32 = int(mu::engraving::TremoloType::C32),
-    C64 = int(mu::engraving::TremoloType::C64),
+    C8   = int(mu::engraving::TremoloType::C8),
+    C16  = int(mu::engraving::TremoloType::C16),
+    C32  = int(mu::engraving::TremoloType::C32),
+    C64  = int(mu::engraving::TremoloType::C64),
+    C128 = int(mu::engraving::TremoloType::C128),
+    C256 = int(mu::engraving::TremoloType::C256),
 };
 Q_ENUM_NS(TremoloType);
 

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -118,7 +118,7 @@ bool Stem::acceptDrop(EditData& data) const
     const EngravingItem* e = data.dropElement;
     switch (e->type()) {
     case ElementType::TREMOLO_SINGLECHORD:
-        return item_cast<const TremoloSingleChord*>(e)->tremoloType() <= TremoloType::R64;
+        return item_cast<const TremoloSingleChord*>(e)->tremoloType() <= TremoloType::R256;
     default:
         break;
     }

--- a/src/engraving/dom/tremolosinglechord.cpp
+++ b/src/engraving/dom/tremolosinglechord.cpp
@@ -106,6 +106,14 @@ void TremoloSingleChord::setTremoloType(TremoloType t)
     case TremoloType::C64:
         m_lines = 4;
         break;
+    case TremoloType::R128:
+    case TremoloType::C128:
+        m_lines = 5;
+        break;
+    case TremoloType::R256:
+    case TremoloType::C256:
+        m_lines = 6;
+        break;
     default:
         m_lines = 1;
         break;
@@ -237,6 +245,10 @@ Fraction TremoloSingleChord::tremoloLen() const
     case 3: f.set(1, 32);
         break;
     case 4: f.set(1, 64);
+        break;
+    case 5: f.set(1, 128);
+        break;
+    case 6: f.set(1, 256);
         break;
     }
     return f;

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -146,7 +146,7 @@ RectF TremoloTwoChord::drag(EditData& ed)
 
 void TremoloTwoChord::setTremoloType(TremoloType t)
 {
-    IF_ASSERT_FAILED(t >= TremoloType::C8) {
+    IF_ASSERT_FAILED(isTremoloTwoChord(t)) {
         return;
     }
     m_tremoloType = t;
@@ -162,6 +162,14 @@ void TremoloTwoChord::setTremoloType(TremoloType t)
     case TremoloType::R64:
     case TremoloType::C64:
         m_lines = 4;
+        break;
+    case TremoloType::R128:
+    case TremoloType::C128:
+        m_lines = 5;
+        break;
+    case TremoloType::R256:
+    case TremoloType::C256:
+        m_lines = 6;
         break;
     default:
         m_lines = 1;
@@ -250,6 +258,10 @@ Fraction TremoloTwoChord::tremoloLen() const
     case 3: f.set(1, 32);
         break;
     case 4: f.set(1, 64);
+        break;
+    case 5: f.set(1, 128);
+        break;
+    case 6: f.set(1, 256);
         break;
     }
     return f;

--- a/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
@@ -46,6 +46,8 @@ static mpe::ArticulationType toArticulationType(TremoloType type)
         return mpe::ArticulationType::Tremolo32nd;
     case TremoloType::R64:
     case TremoloType::C64:
+    // Playback currently caps tremolo subdivisions at 64th; 128th and 256th
+    // tremolos intentionally reuse the 64th articulation pattern.
     case TremoloType::R128:
     case TremoloType::C128:
     case TremoloType::R256:

--- a/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
@@ -46,6 +46,10 @@ static mpe::ArticulationType toArticulationType(TremoloType type)
         return mpe::ArticulationType::Tremolo32nd;
     case TremoloType::R64:
     case TremoloType::C64:
+    case TremoloType::R128:
+    case TremoloType::C128:
+    case TremoloType::R256:
+    case TremoloType::C256:
         return mpe::ArticulationType::Tremolo64th;
     case TremoloType::BUZZ_ROLL:
         return mpe::ArticulationType::TremoloBuzz;

--- a/src/engraving/rendering/score/beamtremololayout.cpp
+++ b/src/engraving/rendering/score/beamtremololayout.cpp
@@ -88,8 +88,8 @@ void BeamTremoloLayout::setupLData(const BeamBase* item, BeamBase::LayoutData* l
 int BeamTremoloLayout::minStemLength(const ChordRest* cr, const BeamBase::LayoutData* ldata)
 {
     // min stem lengths in quarter spaces according to how many beams there are (starting with 1)
-    static constexpr int BEAMS_COUNT = 8;
-    static constexpr int minStemLengths[BEAMS_COUNT] = { 11, 13, 15, 18, 21, 24, 27, 30 };
+    static constexpr int BEAMS_COUNT = 9;
+    static constexpr int minStemLengths[BEAMS_COUNT] = { 11, 13, 15, 18, 21, 24, 27, 30, 33 };
     int beams = strokeCount(ldata, cr);
     if (beams > BEAMS_COUNT) {
         LOGE() << "Beam count " << beams << " out of range (" << BEAMS_COUNT - 1 << ")";
@@ -229,9 +229,19 @@ void BeamTremoloLayout::offsetBeamWithAnchorShortening(const BeamBase::LayoutDat
         return;
     }
     // min stem lengths according to how many beams there are (starting with 1)
-    static const int minStemLengths[] = { 11, 13, 15, 18, 21, 24, 27, 30 };
+    static constexpr int BEAMS_COUNT = 9;
+    static constexpr int minStemLengths[BEAMS_COUNT] = { 11, 13, 15, 18, 21, 24, 27, 30, 33 };
     int dictatorBeams = strokeCount(ldata, isStartDictator ? startChord : endChord);
     int pointerBeams = strokeCount(ldata, isStartDictator ? endChord : startChord);
+    if (dictatorBeams > BEAMS_COUNT) {
+        LOGE() << "Beam count " << dictatorBeams << " out of range (" << BEAMS_COUNT - 1 << ")";
+        dictatorBeams =  BEAMS_COUNT - 1;
+    }
+    if (pointerBeams > BEAMS_COUNT) {
+        LOGE() << "Beam count " << pointerBeams << " out of range (" << BEAMS_COUNT - 1 << ")";
+        pointerBeams =  BEAMS_COUNT - 1;
+    }
+
     int maxDictatorReduce = stemLengthDictator - minStemLengths[std::max(dictatorBeams - 1, 0)];
     maxDictatorReduce = std::min(std::abs(dictator - targetLine), maxDictatorReduce);
 

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -1155,8 +1155,8 @@ struct InstrumentTrackId {
 // Tremolo subtypes:
 enum class TremoloType : signed char {
     INVALID_TREMOLO = -1,
-    R8 = 0, R16, R32, R64, BUZZ_ROLL,    // one note tremolo (repeat)
-    C8, C16, C32, C64       // two note tremolo (change)
+    R8 = 0, R16, R32, R64, R128, R256, BUZZ_ROLL,     // one note tremolo (repeat)
+    C8, C16, C32, C64, C128, C256                     // two note tremolo (change)
 };
 
 inline bool isTremoloTwoChord(TremoloType type)

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2540,17 +2540,21 @@ BarLineType TConv::fromXml(const AsciiStringView& tag, BarLineType def)
     return def;
 }
 
-static const std::array<Item<TremoloType>, 10> TREMOLO_TYPES = { {
+static const std::array<Item<TremoloType>, 14> TREMOLO_TYPES = { {
     { TremoloType::INVALID_TREMOLO, "" },
     { TremoloType::R8,              "r8",       muse::TranslatableString("engraving/tremolotype", "Eighth through stem") },
     { TremoloType::R16,             "r16",      muse::TranslatableString("engraving/tremolotype", "16th through stem") },
     { TremoloType::R32,             "r32",      muse::TranslatableString("engraving/tremolotype", "32nd through stem") },
     { TremoloType::R64,             "r64",      muse::TranslatableString("engraving/tremolotype", "64th through stem") },
+    { TremoloType::R128,            "r128",     muse::TranslatableString("engraving/tremolotype", "128th through stem") },
+    { TremoloType::R256,            "r256",     muse::TranslatableString("engraving/tremolotype", "256th through stem") },
     { TremoloType::BUZZ_ROLL,       "buzzroll", muse::TranslatableString("engraving/tremolotype", "Buzz roll") },
     { TremoloType::C8,              "c8",       muse::TranslatableString("engraving/tremolotype", "Eighth between notes") },
     { TremoloType::C16,             "c16",      muse::TranslatableString("engraving/tremolotype", "16th between notes") },
     { TremoloType::C32,             "c32",      muse::TranslatableString("engraving/tremolotype", "32nd between notes") },
-    { TremoloType::C64,             "c64",      muse::TranslatableString("engraving/tremolotype", "64th between notes") }
+    { TremoloType::C64,             "c64",      muse::TranslatableString("engraving/tremolotype", "64th between notes") },
+    { TremoloType::C128,            "c128",     muse::TranslatableString("engraving/tremolotype", "128th between notes") },
+    { TremoloType::C256,            "c256",     muse::TranslatableString("engraving/tremolotype", "256th between notes") }
 } };
 
 const muse::TranslatableString& TConv::userName(TremoloType v)

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -3197,6 +3197,8 @@ engraving::TremoloType Convert::stemModFromMEI(const libmei::data_STEMMODIFIER m
     case (libmei::STEMMODIFIER_2slash): return engraving::TremoloType::R16;
     case (libmei::STEMMODIFIER_3slash): return engraving::TremoloType::R32;
     case (libmei::STEMMODIFIER_4slash): return engraving::TremoloType::R64;
+    case (libmei::STEMMODIFIER_5slash): return engraving::TremoloType::R128;
+    case (libmei::STEMMODIFIER_6slash): return engraving::TremoloType::R256;
     case (libmei::STEMMODIFIER_z): return engraving::TremoloType::BUZZ_ROLL;
     default:
         return engraving::TremoloType::INVALID_TREMOLO;
@@ -3210,6 +3212,8 @@ libmei::data_STEMMODIFIER Convert::stemModToMEI(const engraving::TremoloSingleCh
     case (engraving::TremoloType::R16): return libmei::STEMMODIFIER_2slash;
     case (engraving::TremoloType::R32): return libmei::STEMMODIFIER_3slash;
     case (engraving::TremoloType::R64): return libmei::STEMMODIFIER_4slash;
+    case (engraving::TremoloType::R128): return libmei::STEMMODIFIER_5slash;
+    case (engraving::TremoloType::R256): return libmei::STEMMODIFIER_6slash;
     case (engraving::TremoloType::BUZZ_ROLL): return libmei::STEMMODIFIER_z;
     default:
         return libmei::STEMMODIFIER_NONE;

--- a/src/importexport/mnx/internal/import/mnximportmarkings.cpp
+++ b/src/importexport/mnx/internal/import/mnximportmarkings.cpp
@@ -250,7 +250,7 @@ void MnxImporter::importTremolo(const mnx::sequence::SingleNoteTremolo& tremolo,
         return;
     }
     int tremoloTypeValue = int(TremoloType::R8) - 1 + marks;
-    tremoloTypeValue = std::clamp(tremoloTypeValue, int(TremoloType::R8), int(TremoloType::R64));
+    tremoloTypeValue = std::clamp(tremoloTypeValue, int(TremoloType::R8), int(TremoloType::R256));
     TremoloType type = TremoloType(tremoloTypeValue);
     if (type == TremoloType::INVALID_TREMOLO) {
         return;

--- a/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
+++ b/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
@@ -604,7 +604,7 @@ void MnxImporter::createTremolo(const mnx::sequence::MultiNoteTremolo& mnxTremol
         return;
     }
     int tremoloBeamsNum = int(TremoloType::C8) - 1 + mnxTremolo.marks();
-    tremoloBeamsNum = std::clamp(tremoloBeamsNum, int(TremoloType::C8), int(TremoloType::C64));
+    tremoloBeamsNum = std::clamp(tremoloBeamsNum, int(TremoloType::C8), int(TremoloType::C256));
     if (tremoloBeamsNum <= c1->durationType().hooks()) {
         return; // no tremolo is possible
     }

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -3046,6 +3046,10 @@ static void tremoloSingleStartStop(Chord* chord, Notations& notations, XmlWriter
                     break;
                 case TremoloType::R64: count = 4;
                     break;
+                case TremoloType::R128: count = 5;
+                    break;
+                case TremoloType::R256: count = 6;
+                    break;
                 default: LOGD("unknown tremolo single %d", int(st));
                     break;
                 }
@@ -3061,6 +3065,10 @@ static void tremoloSingleStartStop(Chord* chord, Notations& notations, XmlWriter
                 break;
             case TremoloType::C64: count = 4;
                 break;
+            case TremoloType::C128: count = 5;
+                break;
+            case TremoloType::C256: count = 6;
+                break;
             default: LOGD("unknown tremolo double %d", int(st));
                 break;
             }
@@ -3074,6 +3082,10 @@ static void tremoloSingleStartStop(Chord* chord, Notations& notations, XmlWriter
             case TremoloType::C32: count = 3;
                 break;
             case TremoloType::C64: count = 4;
+                break;
+            case TremoloType::C128: count = 5;
+                break;
+            case TremoloType::C256: count = 6;
                 break;
             default: LOGD("unknown tremolo double %d", int(st));
                 break;

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -6744,7 +6744,7 @@ static void addTremolo(ChordRest* cr, const int tremoloNr, const String& tremolo
     }
     if (tremoloNr) {
         //LOGD("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, muPrintable(tremoloType), ticks, _tremStart);
-        if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
+        if (tremoloNr >= 1 && tremoloNr <= 6) {
             if (tremoloType.empty() || tremoloType == u"single") {
                 TremoloType type = TremoloType::INVALID_TREMOLO;
                 switch (tremoloNr) {
@@ -6755,6 +6755,10 @@ static void addTremolo(ChordRest* cr, const int tremoloNr, const String& tremolo
                 case 3: type = TremoloType::R32;
                     break;
                 case 4: type = TremoloType::R64;
+                    break;
+                case 5: type = TremoloType::R128;
+                    break;
+                case 6: type = TremoloType::R256;
                     break;
                 }
 
@@ -6784,6 +6788,10 @@ static void addTremolo(ChordRest* cr, const int tremoloNr, const String& tremolo
                     case 3: type = TremoloType::C32;
                         break;
                     case 4: type = TremoloType::C64;
+                        break;
+                    case 5: type = TremoloType::C128;
+                        break;
+                    case 6: type = TremoloType::C256;
                         break;
                     }
 

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -643,7 +643,7 @@ PalettePtr PaletteCreator::newTremoloPalette()
         sp->appendElement(tremolo, tremolo->subtypeUserName());
     }
 
-    for (int i = int(TremoloType::C8); i <= int(TremoloType::C64); ++i) {
+    for (int i = int(TremoloType::C8); i <= int(TremoloType::C256); ++i) {
         auto tremolo = Factory::makeTremoloTwoChord(paletteScore()->dummy()->chord());
         tremolo->setTremoloType(TremoloType(i));
         sp->appendElement(tremolo, tremolo->subtypeUserName());


### PR DESCRIPTION
This adds tremolo types for 128ths and 256ths as specified in SMuFL and in MEI, MusicXML, and MNX.