### PR TITLE
Support "Add dynamic" when hairpin selected. Fixes #34200.

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -223,7 +223,7 @@ public:
 
     virtual void autoFlipHairpinsType(engraving::Dynamic* selDyn) = 0;
 
-    virtual void toggleDynamicPopup() = 0;
+    virtual void toggleDynamicPopup(bool allowAnyGrip=false) = 0;
     virtual bool toggleLayoutBreakAvailable() const = 0;
     virtual void toggleLayoutBreak(LayoutBreakType breakType) = 0;
     virtual void moveMeasureToPrevSystem() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -223,7 +223,7 @@ public:
 
     virtual void autoFlipHairpinsType(engraving::Dynamic* selDyn) = 0;
 
-    virtual void toggleDynamicPopup(bool allowAnyGrip=false) = 0;
+    virtual void toggleDynamicPopup(bool allowAnyGrip = false) = 0;
     virtual bool toggleLayoutBreakAvailable() const = 0;
     virtual void toggleLayoutBreak(LayoutBreakType breakType) = 0;
     virtual void moveMeasureToPrevSystem() = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5687,7 +5687,7 @@ void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
     apply();
 }
 
-void NotationInteraction::toggleDynamicPopup()
+void NotationInteraction::toggleDynamicPopup(bool allowAnyGrip)
 {
     EngravingItem* el = selection()->element();
     if (!el) {
@@ -5710,9 +5710,7 @@ void NotationInteraction::toggleDynamicPopup()
             apply();
             startEditText(dynamic);
         };
-
-        switch (m_editData.curGrip) {
-        case Grip::START:
+        if (m_editData.curGrip == Grip::START || (m_editData.curGrip == Grip::APERTURE && hairpin->isDecrescendo())) {
             if (EngravingItem* startDynOrExp = hairpinSeg->findElementToSnapBefore()) {
                 // If there is already a dynamic, select it instead of opening an empty popup
                 select({ startDynOrExp });
@@ -5722,8 +5720,7 @@ void NotationInteraction::toggleDynamicPopup()
             } else {
                 addDynamic(hairpin->tick(), hairpin->track(), hairpin->voiceAssignment());
             }
-            break;
-        case Grip::END:
+        } else if (m_editData.curGrip == Grip::END || allowAnyGrip) {
             if (EngravingItem* endDynOrExp = hairpinSeg->findElementToSnapAfter()) {
                 // If there is already a dynamic, select it instead of opening an empty popup
                 select({ endDynOrExp });
@@ -5733,13 +5730,9 @@ void NotationInteraction::toggleDynamicPopup()
             } else {
                 addDynamic(hairpin->tick2(), hairpin->track2(), hairpin->voiceAssignment());
             }
-            break;
-        default:
-            break;
-        }
+        } // if repositioning hairpin by mouse drag, do nothing
         return;
     }
-
     addTextToItem(TextStyleType::DYNAMICS, el);
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -242,7 +242,7 @@ public:
 
     void autoFlipHairpinsType(engraving::Dynamic* selDyn) override;
 
-    void toggleDynamicPopup(bool allowAnyGrip=false) override;
+    void toggleDynamicPopup(bool allowAnyGrip = false) override;
     bool toggleLayoutBreakAvailable() const override;
     void toggleLayoutBreak(LayoutBreakType breakType) override;
     void moveMeasureToPrevSystem() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -242,7 +242,7 @@ public:
 
     void autoFlipHairpinsType(engraving::Dynamic* selDyn) override;
 
-    void toggleDynamicPopup() override;
+    void toggleDynamicPopup(bool allowAnyGrip=false) override;
     bool toggleLayoutBreakAvailable() const override;
     void toggleLayoutBreak(LayoutBreakType breakType) override;
     void moveMeasureToPrevSystem() override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -177,7 +177,7 @@ public:
 
     MOCK_METHOD(void, autoFlipHairpinsType, (engraving::Dynamic * selDyn), (override));
 
-    MOCK_METHOD(void, toggleDynamicPopup, (), (override));
+    MOCK_METHOD(void, toggleDynamicPopup, (bool allowAnyGrip), (override));
     MOCK_METHOD(bool, toggleLayoutBreakAvailable, (), (const, override));
     MOCK_METHOD(void, toggleLayoutBreak, (LayoutBreakType), (override));
     MOCK_METHOD(void, moveMeasureToPrevSystem, (), (override));

--- a/src/notationscene/inotationcommandscontroller.h
+++ b/src/notationscene/inotationcommandscontroller.h
@@ -66,6 +66,7 @@ public:
 
     virtual bool isNoteInputActionAllowed() const = 0;
     virtual bool isNoteOrRestSelected() const = 0;
+    virtual bool isHairpinSelected() const = 0;
     virtual bool isMoveSelectionAvailable(MoveSelectionType type) const = 0;
 
     virtual bool isToggleLayoutBreakAvailable() const = 0;

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -305,7 +305,7 @@ void NotationActionController::init()
     registerCommand(ADD_OTTAVA_8VA_COMMAND, &Interaction::addOttavaToSelection, OttavaType::OTTAVA_8VA);
     registerCommand(ADD_OTTAVA_8VB_COMMAND, &Interaction::addOttavaToSelection, OttavaType::OTTAVA_8VB);
 
-    registerCommand(ADD_DYNAMIC_COMMAND, &Interaction::toggleDynamicPopup);
+    registerCommand(ADD_DYNAMIC_COMMAND, [this]() { addDynamic(); });
     registerCommand(ADD_HAIRPIN_COMMAND, &Interaction::addHairpinsToSelection, HairpinType::CRESC_HAIRPIN);
     registerCommand(ADD_HAIRPIN_REVERSE_COMMAND, &Interaction::addHairpinsToSelection, HairpinType::DIM_HAIRPIN);
     registerCommand(ADD_NOTELINE_COMMAND, &Interaction::addAnchoredLineToSelectedNotes);
@@ -2266,6 +2266,15 @@ void NotationActionController::addText(TextStyleType type)
     interaction->addTextToItem(type, item);
 }
 
+void NotationActionController::addDynamic()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+    interaction->toggleDynamicPopup(true);
+}
+
 void NotationActionController::addImage()
 {
     auto interaction = currentNotationInteraction();
@@ -2976,6 +2985,12 @@ bool NotationActionController::isNoteOrRestSelected() const
 
     INotationSelectionPtr selection = currentNotationInteraction() ? currentNotationInteraction()->selection() : nullptr;
     return selection && selection->elementsSelected(NOTE_REST_TYPES);
+}
+
+bool NotationActionController::isHairpinSelected() const
+{
+    INotationSelectionPtr selection = currentNotationInteraction() ? currentNotationInteraction()->selection() : nullptr;
+    return selection && selection->element() && selection->element()->isHairpinSegment();
 }
 
 const mu::engraving::Harmony* NotationActionController::editedChordSymbol() const

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -99,6 +99,7 @@ public:
 
     bool isNoteInputActionAllowed() const override;
     bool isNoteOrRestSelected() const override;
+    bool isHairpinSelected() const override;
     bool isMoveSelectionAvailable(MoveSelectionType type) const override;
 
     bool isToggleLayoutBreakAvailable() const override;
@@ -171,6 +172,7 @@ private:
     void insertClef(mu::engraving::ClefType type);
 
     void addText(TextStyleType type);
+    void addDynamic();
     void addImage();
     void addFiguredBass();
     void addGuitarBend(GuitarBendType bendType);

--- a/src/notationscene/internal/notationcommandsstate.cpp
+++ b/src/notationscene/internal/notationcommandsstate.cpp
@@ -414,6 +414,10 @@ CommandState NotationCommandsState::doCommandState(const Command& command) const
         return CommandState(true, controller()->currentVoice() == VOICE_COMMANDS.at(command));
     }
 
+    if (command == ADD_DYNAMIC_COMMAND) {
+        return CommandState(controller()->isNoteOrRestSelected() || controller()->isHairpinSelected(), false);
+    }
+
     if (muse::contains(NOTE_OR_REST_SELECTED_COMMANDS, command)) {
         return CommandState(controller()->isNoteOrRestSelected(), false);
     }


### PR DESCRIPTION
Resolves: #34200 

Makes "Add dynamic" (Ctrl+D) work when a hairpin is selected.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [stevage](https://musescore.com/user/107931127):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.

- [] I created a unit test or vtest to verify the changes I made (if applicable).

I have not. I would need assistance to do so.