### PR TITLE
Section break repeat fix

### DIFF
--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -236,6 +236,11 @@ void RepeatList::updateTempo()
         return;
     }
 
+    // Collect the end-ticks of all segments that carry a section-break pause.
+    // tick2time() always includes the pause at the queried tick, so for repeated
+    // sections every segment ending at a section break would accumulate the pause
+    // once per iteration.  We subtract it from non-final segments so that it is
+    // counted only once (in the last segment, where s->pause > 0.0).
     std::set<int> sectionBreakEndTicks;
     for (RepeatSegment* s : *this) {
         if (s->pause > 0.0) {
@@ -254,6 +259,8 @@ void RepeatList::updateTempo()
         int len       = s->len();
         utick        += len;
         double delta  = tl->tick2time(s->tick + len) - ct;
+        // For a non-final segment that ends at a section break, remove the
+        // section-break pause from the delta so the pause is not double-counted.
         if (s->pause == 0.0 && sectionBreakEndTicks.count(s->tick + len)) {
             delta -= tl->pauseSecs(s->tick + len);
         }

--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -23,6 +23,7 @@
 #include "repeatlist.h"
 
 #include <list>
+#include <set>
 #include <utility> // std::pair
 
 #include "jump.h"
@@ -235,6 +236,13 @@ void RepeatList::updateTempo()
         return;
     }
 
+    std::set<int> sectionBreakEndTicks;
+    for (RepeatSegment* s : *this) {
+        if (s->pause > 0.0) {
+            sectionBreakEndTicks.insert(s->tick + s->len());
+        }
+    }
+
     int utick = 0;
     double t  = 0;
 
@@ -245,7 +253,11 @@ void RepeatList::updateTempo()
         s->timeOffset = t - ct;
         int len       = s->len();
         utick        += len;
-        t            += tl->tick2time(s->tick + len) - ct;
+        double delta  = tl->tick2time(s->tick + len) - ct;
+        if (s->pause == 0.0 && sectionBreakEndTicks.count(s->tick + len)) {
+            delta -= tl->pauseSecs(s->tick + len);
+        }
+        t            += delta;
     }
 }
 

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -41,10 +41,34 @@ inline int timestampToTick(const Score* score, const muse::mpe::timestamp_t time
     return score->repeatList().utime2utick(timestamp / 1000000.f);
 }
 
-inline muse::mpe::duration_t pauseUs(const Score* score, const int tick)
+inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const int noteStartTick,
+                                     const int tickPositionOffset)
 {
     double secs = score->tempomap()->pauseSecs(tick);
-    return muse::RealIsNull(secs) ? 0 : secs* 1000000;
+    if (muse::RealIsNull(secs)) {
+        return 0;
+    }
+
+    bool isSectionBreak = false;
+    for (const RepeatSegment* s : score->repeatList()) {
+        if (s->pause > 0.0 && s->tick + s->len() == tick) {
+            isSectionBreak = true;
+            break;
+        }
+    }
+
+    if (!isSectionBreak) {
+        return secs * 1000000;
+    }
+
+    int utick = noteStartTick + tickPositionOffset;
+    for (const RepeatSegment* s : score->repeatList()) {
+        if (utick >= s->utick && utick < s->utick + s->len()) {
+            return s->pause > 0.0 ? secs * 1000000 : 0;
+        }
+    }
+
+    return 0;
 }
 
 inline muse::mpe::duration_t durationFromStartAndEndTick(const Score* score, const int startTick, const int endTick,
@@ -52,7 +76,7 @@ inline muse::mpe::duration_t durationFromStartAndEndTick(const Score* score, con
 {
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTick + tickPositionOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, endTick + tickPositionOffset);
-    muse::mpe::duration_t pause = pauseUs(score, endTick);
+    muse::mpe::duration_t pause = pauseUs(score, endTick, startTick, tickPositionOffset);
 
     return endTimestamp - startTimestamp - pause;
 }
@@ -70,7 +94,7 @@ inline muse::mpe::TimestampAndDuration timestampAndDurationFromStartAndDurationT
     int startTickWithOffset = startTick + tickPositionOffset;
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTickWithOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, startTickWithOffset + durationTicks);
-    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks);
+    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks, startTick, tickPositionOffset);
     muse::mpe::duration_t duration = endTimestamp - startTimestamp - pause;
 
     return { startTimestamp, duration };

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -41,6 +41,14 @@ inline int timestampToTick(const Score* score, const muse::mpe::timestamp_t time
     return score->repeatList().utime2utick(timestamp / 1000000.f);
 }
 
+// Returns the section-break pause at `tick` in microseconds, or 0.
+//
+// Section-break pauses should fire once — after the final repeat iteration —
+// but tick2time() includes the pause at every segment boundary.  To avoid
+// double-counting, we only return the pause for notes whose segment is the
+// one that carries it (i.e. the last segment in the repeat).
+//
+// Non-section-break pauses (caesuras, Fermata, etc.) are returned unconditionally.
 inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const int noteStartTick,
                                      const int tickPositionOffset)
 {
@@ -49,6 +57,7 @@ inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const i
         return 0;
     }
 
+    // Determine whether `tick` is a section-break boundary.
     bool isSectionBreak = false;
     for (const RepeatSegment* s : score->repeatList()) {
         if (s->pause > 0.0 && s->tick + s->len() == tick) {
@@ -61,6 +70,9 @@ inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const i
         return secs * 1000000;
     }
 
+    // Section break: only subtract the pause if the note lives in the segment
+    // that carries it.  Other segments had the pause already removed from their
+    // time delta in updateTempo(), so subtracting again would double-count.
     int utick = noteStartTick + tickPositionOffset;
     for (const RepeatSegment* s : score->repeatList()) {
         if (utick >= s->utick && utick < s->utick + s->len()) {

--- a/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
+++ b/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
@@ -2924,7 +2924,7 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
     timestamp_t fourthMeasureTime = thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION
                                     + 3000000 + QUARTER_NOTE_DURATION;
 
-    timestamp_t fifthMeasureTime = fourthMeasureTime + (WHOLE_NOTE_DURATION + 5000000) * 2; // repeat
+    timestamp_t fifthMeasureTime = fourthMeasureTime + WHOLE_NOTE_DURATION * 2 + 5000000; // repeat: only final iteration carries the section-break pause
 
     std::vector<TimestampAndDuration> expectedTnDList {
         // 1st measure (no notes)
@@ -2939,8 +2939,8 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
         { thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION + 3000000, QUARTER_NOTE_DURATION },
 
         // 4th measure (whole note inside repeat + section break)
-        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // + 5s pause (section break)
-        { fourthMeasureTime + WHOLE_NOTE_DURATION + 5000000, WHOLE_NOTE_DURATION }, // repeat
+        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // no extra pause (non-final segment)
+        { fourthMeasureTime + WHOLE_NOTE_DURATION, WHOLE_NOTE_DURATION }, // final iteration carries the 5s section-break pause
 
         // 5th measure
         { fifthMeasureTime, HALF_NOTE_DURATION },


### PR DESCRIPTION
Resolves: #14262 and similar (there are many issues detailing this problem)

Fix section break pause incorrectly applying during repeat playback.

When a section break is placed on a measure with a repeat end barline, the section break's pause was being included in the repeat, causing an unwanted pause when the playback jumps back to the repeat start. This fix ensures the pause only applies after the final repetition completes. Local tests were done verifying simply that I fixed the problem, but none were done to see if other features of MuseScore were broken because of the fix. There have been prior attempts to fix this issue, but none were successful.

- [x] I signed the CLA as Liam Smalley
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code follows the coding rules.
- [x] I understand all aspects of the code I'm contributing.
- [x] The code compiles and runs on my machine.
- [ ] No prior attempts exist, or I listed them in the description.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes (if applicable).