### PR TITLE
StaffTextPropertiesDialog: fix disabling swing checkbox not persisted

### DIFF
--- a/src/notationscene/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notationscene/widgets/stafftextpropertiesdialog.cpp
@@ -142,6 +142,8 @@ void StaffTextPropertiesDialog::saveValues()
             m_staffText->setSwingParameters(Constants::DIVISION / 4, swingBox->value());
             swingBox->setEnabled(true);
         }
+    } else {
+        m_staffText->setSwing(false);
     }
 
     INotationUndoStackPtr stack = undoStack();


### PR DESCRIPTION
Changing the swing value to Off worked fine, but disabling the main swing change checkbox did not.
<img width="1066" height="732" alt="Scherm­afbeelding 2026-07-26 om 23 35 06" src="https://github.com/user-attachments/assets/244a64e8-6bf0-4b3c-86d3-8ffbf980f53f" />

Resolves: https://github.com/musescore/MuseScore/issues/12687

Perhaps also nice to have in 4.7.5.