### PR TITLE
[4.7.5] Fix crash on dragging items owned by measure to MMRest

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -845,7 +845,7 @@ PointF EngravingItem::canvasPos() const
             Page* page = system ? system->page() : nullptr;
             p.ry() += measureStaffY(measure, idx) + systemStaffY(system, idx) + pageY(page);
         } else if (parent->isMeasure()) {
-            Measure* measure = toMeasure(parent);
+            Measure* measure = toMeasure(parent)->coveringMMRestOrThis();
             System* system = measure->system();
             Page* page = system->page();
             p.ry() += measureStaffY(measure, idx) + systemStaffY(system, idx) + pageY(page);


### PR DESCRIPTION
Resolves: #34352 