### PR TITLE
Force whole measures in multi-voice explode for #16896

### DIFF
--- a/src/engraving/editing/implodeexplode.cpp
+++ b/src/engraving/editing/implodeexplode.cpp
@@ -69,13 +69,13 @@ bool ImplodeExplode::explode(Score* score)
             break;
         }
     }
+    // force complete measures
+    score->deselectAll();
+    score->select(startMeasure, SelectType::RANGE, srcStaff);
+    score->select(endMeasure, SelectType::RANGE, srcStaff);
+    startSegment = score->selection().startSegment();
+    endSegment = score->selection().endSegment();
     if (!voice) {
-        // force complete measures
-        score->deselectAll();
-        score->select(startMeasure, SelectType::RANGE, srcStaff);
-        score->select(endMeasure, SelectType::RANGE, srcStaff);
-        startSegment = score->selection().startSegment();
-        endSegment = score->selection().endSegment();
         if (srcStaff == lastStaff - 1) {
             // only one staff was selected up front - determine number of staves
             // loop through all chords looking for maximum number of notes


### PR DESCRIPTION
[replacement for #34347, which clashed with #34332. Also see https://github.com/musescore/MuseScore/pull/34347#issuecomment-5098231672 for workaround as explode feature currently inoperative.]


Addresses: #16896 

(It's hard to say it resolves it, but it fixes the specific repro case)

The specific case occurs when a range selection is less than a full bar. So, invoking the behaviour of the single-voice branch and forcing full measures seems justified. (This makes #34299 worse, but avoiding corruption is more important...)

- [x] I signed the [CLA](https://musescore.org/en/cla) as [stevage](https://musescore.com/user/107931127):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes. (Well, I included a separate commit that renames some variables in this area which makes this code path a bit more understandable).

- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

(I would need assistance to do so).