### PR TITLE
[MusicXML] improve handling of alter values

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -4276,25 +4276,11 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
     xml.startElement(useDrumset ? "unpitched" : "pitch");
     xml.tag(useDrumset ? "display-step" : "step", step);
     // Check for microtonal accidentals and overwrite "alter" tag
-    const Accidental* acc = note->accidental();
-    double microtonalAlter = 0.0;
-    if (acc) {
-        switch (acc->accidentalType()) {
-        case AccidentalType::MIRRORED_FLAT:  microtonalAlter = -0.5;
-            break;
-        case AccidentalType::SHARP_SLASH:    microtonalAlter = 0.5;
-            break;
-        case AccidentalType::MIRRORED_FLAT2: microtonalAlter = -1.5;
-            break;
-        case AccidentalType::SHARP_SLASH4:   microtonalAlter = 1.5;
-            break;
-        default:                                             break;
-        }
-    }
-    // Override accidental with explicit note tuning
+    double microtonalAlter = note->centOffset() / 100.0;
+    // Explicit note tuning
     double tuning = note->tuning();
     if (!muse::RealIsNull(tuning)) {
-        microtonalAlter = tuning / 100.0;
+        microtonalAlter += tuning / 100.0;
     }
     if (alter || microtonalAlter) {
         xml.tag("alter", alter + microtonalAlter);

--- a/src/importexport/musicxml/internal/import/importmusicxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlnotepitch.cpp
@@ -138,7 +138,7 @@ void MusicXmlNotePitch::pitch(muse::XmlStreamReader& e)
         if (e.name() == "alter") {
             const String alter = e.readText();
             bool ok;
-            m_alter = MusicXmlSupport::stringToInt(alter, &ok);             // fractions not supported by mscore
+            m_alter = MusicXmlSupport::stringToInt(alter, &ok);
             if (!ok || m_alter < -3 || m_alter > 3) {
                 m_logger->logError(String(u"invalid alter '%1'").arg(alter), &e);
                 bool ok2;

--- a/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
@@ -28,6 +28,7 @@
 #include "global/serialization/xmlstreamreader.h"
 
 #include "translation.h"
+#include "engraving/dom/accidental.h"
 #include "engraving/dom/chordlist.h"
 #include "engraving/dom/harmony.h"
 #include "engraving/dom/score.h"
@@ -646,9 +647,17 @@ AccidentalType microtonalGuess(double val)
         return AccidentalType::SHARP_SLASH4;
     } else if (isAppr(val, 2, eps)) {
         return AccidentalType::SHARP2;
-    } else {
-        LOGD("Guess for microtonal accidental corresponding to value %f failed.", val);
     }
+
+    for (int i = 1; i < static_cast<int>(AccidentalType::END); ++i) {
+        AccidentalType type = static_cast<AccidentalType>(i);
+        double altVal = static_cast<int>(Accidental::subtype2value(type)) + Accidental::subtype2centOffset(type) / 100.0;
+        if (isAppr(val, altVal, eps)) {
+            return type;
+        }
+    }
+
+    LOGD("Guess for microtonal accidental corresponding to value %f failed.", val);
     // default
     return AccidentalType::NONE;
 }

--- a/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
@@ -609,7 +609,6 @@ String musicXmlAccidentalTextToChar(const String mxmlName)
 
 /**
  Convert a MusicXML alter tag into a microtonal accidental in MuseScore enum AccidentalType.
- Works only for quarter tone, half tone, three-quarters tone and whole tone accidentals.
  */
 
 AccidentalType microtonalGuess(double val)

--- a/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
@@ -613,24 +613,14 @@ String musicXmlAccidentalTextToChar(const String mxmlName)
 
 AccidentalType microtonalGuess(double val)
 {
-    if (muse::RealIsEqual(val, -2)) {
-        return AccidentalType::FLAT2;
-    } else if (muse::RealIsEqual(val, -1.5)) {
+    if (muse::RealIsEqual(val, -1.5)) {
         return AccidentalType::MIRRORED_FLAT2;
-    } else if (muse::RealIsEqual(val, -1)) {
-        return AccidentalType::FLAT;
     } else if (muse::RealIsEqual(val, -0.5)) {
         return AccidentalType::MIRRORED_FLAT;
-    } else if (muse::RealIsEqual(val, 0)) {
-        return AccidentalType::NATURAL;
     } else if (muse::RealIsEqual(val, 0.5)) {
         return AccidentalType::SHARP_SLASH;
-    } else if (muse::RealIsEqual(val, 1)) {
-        return AccidentalType::SHARP;
     } else if (muse::RealIsEqual(val, 1.5)) {
         return AccidentalType::SHARP_SLASH4;
-    } else if (muse::RealIsEqual(val, 2)) {
-        return AccidentalType::SHARP2;
     }
 
     for (int i = 1; i < static_cast<int>(AccidentalType::END); ++i) {

--- a/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/shared/musicxmlsupport.cpp
@@ -604,20 +604,6 @@ String musicXmlAccidentalTextToChar(const String mxmlName)
 }
 
 //---------------------------------------------------------
-//   isAppr
-//---------------------------------------------------------
-
-/**
- Check if v approximately equals ref.
- Used to prevent floating point comparison for equality from failing
- */
-
-static bool isAppr(const double v, const double ref, const double epsilon)
-{
-    return v > ref - epsilon && v < ref + epsilon;
-}
-
-//---------------------------------------------------------
 //   microtonalGuess
 //---------------------------------------------------------
 
@@ -628,31 +614,30 @@ static bool isAppr(const double v, const double ref, const double epsilon)
 
 AccidentalType microtonalGuess(double val)
 {
-    const double eps = 0.001;
-    if (isAppr(val, -2, eps)) {
+    if (muse::RealIsEqual(val, -2)) {
         return AccidentalType::FLAT2;
-    } else if (isAppr(val, -1.5, eps)) {
+    } else if (muse::RealIsEqual(val, -1.5)) {
         return AccidentalType::MIRRORED_FLAT2;
-    } else if (isAppr(val, -1, eps)) {
+    } else if (muse::RealIsEqual(val, -1)) {
         return AccidentalType::FLAT;
-    } else if (isAppr(val, -0.5, eps)) {
+    } else if (muse::RealIsEqual(val, -0.5)) {
         return AccidentalType::MIRRORED_FLAT;
-    } else if (isAppr(val, 0, eps)) {
+    } else if (muse::RealIsEqual(val, 0)) {
         return AccidentalType::NATURAL;
-    } else if (isAppr(val, 0.5, eps)) {
+    } else if (muse::RealIsEqual(val, 0.5)) {
         return AccidentalType::SHARP_SLASH;
-    } else if (isAppr(val, 1, eps)) {
+    } else if (muse::RealIsEqual(val, 1)) {
         return AccidentalType::SHARP;
-    } else if (isAppr(val, 1.5, eps)) {
+    } else if (muse::RealIsEqual(val, 1.5)) {
         return AccidentalType::SHARP_SLASH4;
-    } else if (isAppr(val, 2, eps)) {
+    } else if (muse::RealIsEqual(val, 2)) {
         return AccidentalType::SHARP2;
     }
 
     for (int i = 1; i < static_cast<int>(AccidentalType::END); ++i) {
         AccidentalType type = static_cast<AccidentalType>(i);
         double altVal = static_cast<int>(Accidental::subtype2value(type)) + Accidental::subtype2centOffset(type) / 100.0;
-        if (isAppr(val, altVal, eps)) {
+        if (muse::RealIsEqual(val, altVal)) {
             return type;
         }
     }


### PR DESCRIPTION
This switches to an generic approach for writing the alter values on MusicXML export to include all microtonal accidentals. 
It also improves the matching for microtonal accidental types during import.
