### PR TITLE
Always delay adding inferred sticking on XML import

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -3550,15 +3550,13 @@ void MusicXmlParserDirection::direction(const String& partId,
             sticking->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED);
         }
 
-        if (hasTotalY()) {
-            // Add element to score later, after collecting all the others and sorting by default-y
-            // This allows default-y to be at least respected by the order of elements
-            MusicXmlDelayedDirectionElement* delayedDirection = new MusicXmlDelayedDirectionElement(
-                totalY(), sticking, m_track, placement(), measure, tick + m_offset);
-            delayedDirections.push_back(delayedDirection);
-        } else {
-            m_pass2.addElemOffset(sticking, m_track, placement(), measure, tick + m_offset);
-        }
+        // Add element to score later, after collecting all the others and sorting by default-y
+        // This allows default-y to be at least respected by the order of elements
+        // We also need to check whether the chord at the current tick has a grace note. Directions can appear
+        // before the note they apply to, so this may not have been read yet
+        MusicXmlDelayedDirectionElement* delayedDirection = new MusicXmlDelayedDirectionElement(
+            totalY(), sticking, m_track, placement(), measure, tick + m_offset);
+        delayedDirections.push_back(delayedDirection);
     } else if (isLikelyDynamicRange()) {
         isDynamicRange = true;
     } else if (!m_wordsText.empty() || !m_rehearsalText.empty() || !m_metroText.empty()) {


### PR DESCRIPTION
Resolves: 
<img width="425" height="385" alt="Screenshot 2026-07-29 at 11 36 43" src="https://github.com/user-attachments/assets/162654dd-91a0-4b4d-837e-f6b58b205611" />
In situations where a `words` direction which will be converted to a sticking appears before the note:
```XML
<direction placement="above">
  <direction-type>
    <words font-style="italic" relative-x="-20" relative-y="102">L</words>
  </direction-type>
</direction>
...
<note>
  <grace></grace>
  <unpitched>
    <display-step>C</display-step>
    <display-octave>5</display-octave>
  </unpitched>
  ...
</note>
```