### PR TITLE
Fix corruption after edit shared staves

### DIFF
--- a/src/engraving/rendering/score/stavesharinglayout.cpp
+++ b/src/engraving/rendering/score/stavesharinglayout.cpp
@@ -1318,6 +1318,8 @@ void StaveSharingLayout::cleanup(StaveSharingContext& ctx)
         }
     }
 
+    addMeasureRestsIfNeed(ctx);
+
     for (Spanner* spanner : ctx.overlappingSpanners) {
         if (!spanner->systemFlag() && spanner->track() >= range.startTrack && spanner->track() < range.endTrack
             && spanner->originItems().empty()) {
@@ -1328,6 +1330,29 @@ void StaveSharingLayout::cleanup(StaveSharingContext& ctx)
     for (StaveSharingLabel* oldLabel : ctx.oldStaveSharingLabels) {
         if (!muse::contains(ctx.updatedStaveSharingLabels, oldLabel)) {
             ctx.score->undoRemoveElement(oldLabel);
+        }
+    }
+}
+
+void StaveSharingLayout::addMeasureRestsIfNeed(StaveSharingContext& ctx)
+{
+    Measure* startMeas = ctx.segmentsToUpdate.front()->measure();
+    Measure* endMeas = ctx.segmentsToUpdate.back()->measure();
+
+    TrackRange trackRange = ctx.curSharedPart->trackRange();
+    staff_idx_t startStaff = track2staff(trackRange.startTrack);
+    staff_idx_t endStaff = track2staff(trackRange.endTrack);
+
+    for (Measure* measure = startMeas; measure && measure->isBeforeOrEqual(endMeas); measure = measure->nextMeasure()) {
+        for (staff_idx_t staffIdx = startStaff; staffIdx < endStaff; ++staffIdx) {
+            if (!measure->isEmpty(staffIdx)) {
+                continue;
+            }
+            if (ChordRest* firstCR = measure->firstChordRest(staffIdx * VOICES); firstCR && firstCR->isFullMeasureRest()) {
+                continue;
+            }
+
+            ctx.score->setRest(measure->tick(), staffIdx * VOICES, measure->ticks(), false, nullptr);
         }
     }
 }

--- a/src/engraving/rendering/score/stavesharinglayout.cpp
+++ b/src/engraving/rendering/score/stavesharinglayout.cpp
@@ -1044,12 +1044,12 @@ void StaveSharingLayout::makeStaveSharingLabels(StaveSharingContext& ctx)
     std::vector<EngravingItem*> updatedStaveSharingLabels;
 
     for (Note* unisonNote : ctx.sharedUnisonNotes) {
-        bool isForNewSystem = false;
-        if (!unisonNoteNeedsLabel(unisonNote, isForNewSystem, ctx)) {
+        bool needsRestateOnNewSystem = false;
+        if (!unisonNoteNeedsLabel(unisonNote, needsRestateOnNewSystem, ctx)) {
             continue;
         }
 
-        String text = formatUnisonLabel(unisonNote, trackMap, isForNewSystem, ctx);
+        String text = formatUnisonLabel(unisonNote, trackMap, needsRestateOnNewSystem, ctx);
         Segment* segment = unisonNote->chord()->segment();
 
         StaveSharingLabel* label = nullptr;
@@ -1082,9 +1082,8 @@ void StaveSharingLayout::makeStaveSharingLabels(StaveSharingContext& ctx)
     }
 }
 
-bool StaveSharingLayout::unisonNoteNeedsLabel(Note* unisonNote, bool& isForNewSystem, StaveSharingContext& ctx)
+bool StaveSharingLayout::unisonNoteNeedsLabel(Note* unisonNote, bool& needsRestateOnNewSystem, StaveSharingContext& ctx)
 {
-    bool restateOnNewSystem = ctx.style.styleV(Sid::unisonLabelRestateOnNewSystem).value<AutoOnOff>() != AutoOnOff::OFF;
     std::vector<track_idx_t> originTracksOfThisNote;
     for (EngravingItem* originNote : unisonNote->originItems()) {
         originTracksOfThisNote.push_back(originNote->track());
@@ -1094,10 +1093,6 @@ bool StaveSharingLayout::unisonNoteNeedsLabel(Note* unisonNote, bool& isForNewSy
     track_idx_t curTrack = unisonNote->track();
     Segment* curSegment = unisonNote->chord()->segment();
     for (Segment* seg = curSegment->prev1(SegmentType::ChordRest); seg; seg = seg->prev1(SegmentType::ChordRest)) {
-        if (seg->system() != curSegment->system() && restateOnNewSystem) {
-            isForNewSystem = true;
-            return true;
-        }
         if (EngravingItem* el = seg->element(curTrack); el && el->isChord()) {
             for (Note* note : toChord(el)->notes()) {
                 if (!note->originItems().empty()) {
@@ -1120,10 +1115,15 @@ bool StaveSharingLayout::unisonNoteNeedsLabel(Note* unisonNote, bool& isForNewSy
         originTracksOfPrevNote.push_back(originNote->track());
     }
 
-    return originTracksOfPrevNote != originTracksOfThisNote;
+    bool restateOnNewSystem = ctx.style.styleV(Sid::unisonLabelRestateOnNewSystem).value<AutoOnOff>() != AutoOnOff::OFF;
+    needsRestateOnNewSystem = restateOnNewSystem
+                              && unisonNote->chord()->segment()->system() != prevNote->chord()->segment()->system()
+                              && originTracksOfPrevNote == originTracksOfThisNote;
+
+    return originTracksOfPrevNote != originTracksOfThisNote || needsRestateOnNewSystem;
 }
 
-String StaveSharingLayout::formatUnisonLabel(Note* unisonNote, const SharedTrackMap& trackMap, bool isForNewSystem,
+String StaveSharingLayout::formatUnisonLabel(Note* unisonNote, const SharedTrackMap& trackMap, bool needsRestateOnNewSystem,
                                              const StaveSharingContext& ctx)
 {
     const MStyle& style = ctx.style;
@@ -1157,7 +1157,8 @@ String StaveSharingLayout::formatUnisonLabel(Note* unisonNote, const SharedTrack
         }
     }
 
-    bool addParenthesis = isForNewSystem && ctx.style.styleV(Sid::unisonLabelRestateOnNewSystem).value<AutoOnOff>() == AutoOnOff::AUTO;
+    bool addParenthesis = needsRestateOnNewSystem
+                          && ctx.style.styleV(Sid::unisonLabelRestateOnNewSystem).value<AutoOnOff>() == AutoOnOff::AUTO;
 
     if (tracksMappedToThisStave.size() <= originUnisonsCount) {
         if (addParenthesis) {

--- a/src/engraving/rendering/score/stavesharinglayout.h
+++ b/src/engraving/rendering/score/stavesharinglayout.h
@@ -97,5 +97,6 @@ private:
                                                           track_idx_t endOriginTrack, const SharedTrackMap& trackMap);
 
     static void cleanup(StaveSharingContext& ctx);
+    static void addMeasureRestsIfNeed(StaveSharingContext& ctx);
 };
 }


### PR DESCRIPTION
Resolves: #34364 
Resolves: #34362

The first commit resolves the linked issue (some measures were not filled with a full bar rest hence why they were being detected as corrupted with duration of 0/4).

The second commit resolves wrongly parenthesised unison labels get parenthesized.