### PR TITLE
[4.7] StaffTextPropertiesDialog: fix disabling swing checkbox not persisted

### DIFF
--- a/src/notationscene/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notationscene/widgets/stafftextpropertiesdialog.cpp
@@ -134,6 +134,8 @@ void StaffTextPropertiesDialog::saveValues()
             m_staffText->setSwingParameters(Constants::DIVISION / 4, swingBox->value());
             swingBox->setEnabled(true);
         }
+    } else {
+        m_staffText->setSwing(false);
     }
 
     INotationUndoStackPtr stack = undoStack();


### PR DESCRIPTION
Changing the swing value to Off worked fine, but disabling the main swing change checkbox did not.

Resolves: https://github.com/musescore/MuseScore/issues/12687
Ports: https://github.com/musescore/MuseScore/pull/34353
