### PR TITLE
Linux: condense mime-type definitions

### DIFF
--- a/buildscripts/packaging/Linux+BSD/musescore.xml.in
+++ b/buildscripts/packaging/Linux+BSD/musescore.xml.in
@@ -6,6 +6,7 @@
     <mime-type type="application/x-musescore">
         <comment>MuseScore File</comment>
         <glob pattern="*.mscz"/>
+        <glob pattern="*.mscz~"/>
         <sub-class-of type="application/zip"/>
         <icon name="application-x-musescore@MUSE_APP_INSTALL_SUFFIX@"/>
     </mime-type>
@@ -13,20 +14,6 @@
     <mime-type type="application/x-musescore+xml">
         <comment>MuseScore Uncompressed File</comment>
         <glob pattern="*.mscx"/>
-        <sub-class-of type="application/xml"/>
-        <root-XML namespaceURI="" localName="museScore"/>
-        <icon name="application-x-musescore@MUSE_APP_INSTALL_SUFFIX@+xml"/>
-        <magic>
-            <match type="string" value="&lt;?xml" offset="0">
-                <match type="string" value="&lt;museScore" offset="0:128">
-                    <match type="string" value="&lt;Score" offset="0:512"/>
-                </match>
-            </match>
-        </magic>
-    </mime-type>
-
-    <mime-type type="application/x-musescore+xml">
-        <comment>MuseScore Uncompressed File</comment>
         <glob pattern="*.mscsx"/>
         <sub-class-of type="application/xml"/>
         <root-XML namespaceURI="" localName="museScore"/>
@@ -38,13 +25,6 @@
                 </match>
             </match>
         </magic>
-    </mime-type>
-
-    <mime-type type="application/x-musescore">
-        <comment>MuseScore compressed backup score</comment>
-        <glob pattern="*.mscz~"/>
-        <sub-class-of type="application/zip"/>
-        <icon name="application-x-musescore@MUSE_APP_INSTALL_SUFFIX@"/>
     </mime-type>
 
     <!-- MuseScore URL Protocol -->

--- a/buildscripts/packaging/Linux+BSD/musescore.xml.in
+++ b/buildscripts/packaging/Linux+BSD/musescore.xml.in
@@ -14,7 +14,7 @@
     <mime-type type="application/x-musescore+xml">
         <comment>MuseScore Uncompressed File</comment>
         <glob pattern="*.mscx"/>
-        <glob pattern="*.mscsx"/>
+        <glob pattern="*.mscs"/>
         <sub-class-of type="application/xml"/>
         <root-XML namespaceURI="" localName="museScore"/>
         <icon name="application-x-musescore@MUSE_APP_INSTALL_SUFFIX@+xml"/>


### PR DESCRIPTION
Resolves: #15922

Condenses Linux mime-type definitions
- Removes duplicate `application/x-musescore+xml` declaration, moving both globs under a single `mime-type`
- Removes duplicate `application/x-musescore` for backup files, putting both `*.mscz` and `*.mscz~` globs under one `mime-type`
- Fixes file extension typo, correcting `mscsx` to `mscs`

**NOTE:** this removes the "MuseScore compressed backup score" label from Linux file managers for `.mscz~` files and replaces it with the regular "MuseScore File".

Because backup files are the same format as standard score files, I don't think they should have a separate mime-type. If the behavior of opening them needs to be different, I think that should be handled at the application layer.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [grantmk](https://musescore.org/en/user/6662937): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).