### PR TITLE
Add Ctrl+, shortcut for Preferences on Windows and Linux

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -757,6 +757,11 @@
     <autorepeat>0</autorepeat>
     </SC>
   <SC>
+    <key>preference-dialog</key>
+    <seq>Ctrl+,</seq>
+    <autorepeat>0</autorepeat>
+  </SC>
+  <SC>
     <key>toggle-mixer</key>
     <seq>F10</seq>
     <autorepeat>0</autorepeat>


### PR DESCRIPTION
## Summary
Adds Ctrl+, as the default shortcut for opening Preferences on Windows and Linux.

## Issue
Fixes #23530

## Testing
- Confirmed the shortcut entry uses the existing `preference-dialog` action.
- Ran `git diff --check` with no errors.