### PR TITLE
Follow-up: Fix chord bracket layout across visual staves

### DIFF
--- a/src/engraving/rendering/score/chordbracketlayout.cpp
+++ b/src/engraving/rendering/score/chordbracketlayout.cpp
@@ -1,0 +1,288 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "chordbracketlayout.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "dom/chord.h"
+#include "dom/chordbracket.h"
+#include "dom/engravingitem.h"
+#include "dom/note.h"
+#include "dom/part.h"
+#include "dom/segment.h"
+
+#include "chordlayout.h"
+#include "horizontalspacing.h"
+#include "tlayout.h"
+
+using namespace muse;
+using namespace mu::engraving;
+using namespace mu::engraving::rendering::score;
+
+namespace {
+struct BracketVisualSpan {
+    staff_idx_t topStaff = 0;
+    staff_idx_t bottomStaff = 0;
+
+    // Staff-local coordinates.
+    double topY = 0.0;
+    double bottomY = 0.0;
+};
+
+//---------------------------------------------------------
+//   chordBracketsInSegment
+//---------------------------------------------------------
+
+static std::vector<ChordBracket*> chordBracketsInSegment(const Segment* segment)
+{
+    std::vector<ChordBracket*> result;
+
+    if (!segment) {
+        return result;
+    }
+
+    for (EngravingItem* item : segment->elist()) {
+        if (!item || !item->isChord()) {
+            continue;
+        }
+
+        for (EngravingItem* child : toChord(item)->el()) {
+            if (child && child->isChordBracket()) {
+                result.push_back(toChordBracket(child));
+            }
+        }
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------
+//   bracketVisualSpan
+//---------------------------------------------------------
+
+static BracketVisualSpan bracketVisualSpan(const ChordBracket* bracket)
+{
+    const Chord* startChord = bracket->chord();
+    EngravingItem* endItem = startChord->segment()->element(bracket->endTrack());
+    const Chord* endChord = endItem && endItem->isChord() ? toChord(endItem) : startChord;
+
+    const auto topY = [](const Chord* chord) {
+        const Note* note = chord->upNote();
+        return chord->pos().y() + note->pos().y() + note->ldata()->bbox().top();
+    };
+
+    const auto bottomY = [](const Chord* chord) {
+        const Note* note = chord->downNote();
+        return chord->pos().y() + note->pos().y() + note->ldata()->bbox().bottom();
+    };
+
+    const staff_idx_t startStaff = startChord->vStaffIdx();
+    const staff_idx_t endStaff = endChord->vStaffIdx();
+
+    const double spatium = bracket->spatium();
+    const double lineWidth = bracket->style().styleAbsolute(Sid::chordBracketLineWidth);
+
+    // Match TLayout::layoutChordBracket() padding.
+    const double topPadding = bracket->userLen1() + 0.25 * spatium + 0.5 * lineWidth;
+    const double bottomPadding = bracket->userLen2() + 0.5 * spatium + 0.5 * lineWidth;
+
+    BracketVisualSpan result;
+    result.topStaff = std::min(startStaff, endStaff);
+    result.bottomStaff = std::max(startStaff, endStaff);
+
+    if (startStaff == endStaff) {
+        result.topY = std::min(topY(startChord), topY(endChord)) - topPadding;
+        result.bottomY = std::max(bottomY(startChord), bottomY(endChord)) + bottomPadding;
+    } else {
+        const Chord* upperAnchor = startStaff < endStaff ? startChord : endChord;
+        const Chord* lowerAnchor = startStaff < endStaff ? endChord : startChord;
+
+        result.topY = topY(upperAnchor) - topPadding;
+        result.bottomY = bottomY(lowerAnchor) + bottomPadding;
+    }
+
+    result.topY += bracket->offset().y();
+    result.bottomY += bracket->offset().y();
+
+    return result;
+}
+
+//---------------------------------------------------------
+//   bracketCollisionShape
+//---------------------------------------------------------
+
+static Shape bracketCollisionShape(const ChordBracket* bracket, const BracketVisualSpan& span, staff_idx_t staffIdx,
+                                   double x)
+{
+    if (staffIdx < span.topStaff || staffIdx > span.bottomStaff) {
+        return Shape();
+    }
+
+    double top = span.topY;
+    double bottom = span.bottomY;
+
+    // Final staff distances are not known during horizontal spacing.
+    // Approximate the bracket per staff: extend it toward the other endpoint on the endpoint staves
+    // and across the full height of intermediate staves.
+    static constexpr double CROSS_STAFF_COLLISION_EXTENT = 100000.0;
+
+    if (span.topStaff != span.bottomStaff) {
+        top = staffIdx == span.topStaff ? span.topY : -CROSS_STAFF_COLLISION_EXTENT;
+        bottom = staffIdx == span.bottomStaff ? span.bottomY : CROSS_STAFF_COLLISION_EXTENT;
+    }
+
+    if (bottom < top) {
+        std::swap(top, bottom);
+    }
+
+    return Shape(RectF(x, top, bracket->width(), bottom - top), bracket);
+}
+
+//---------------------------------------------------------
+//   layoutHorizontal
+//---------------------------------------------------------
+static void layoutHorizontal(ChordBracket* bracket)
+{
+    Chord* owner = bracket->chord();
+    Segment* segment = owner->segment();
+    const TrackRange range = bracket->part()->trackRange();
+    const BracketVisualSpan span = bracketVisualSpan(bracket);
+
+    double requiredDistance = 0.0;
+    const double baseX = owner->pos().x() + bracket->offset().x();
+
+    for (track_idx_t track = range.startTrack; track < range.endTrack; ++track) {
+        EngravingItem* item = segment->element(track);
+        if (!item || !item->isChord()) {
+            continue;
+        }
+
+        Chord* chord = toChord(item);
+        Shape chordShape = chord->shape();
+        chordShape.removeTypes({ ElementType::CHORD_BRACKET });
+        chordShape.translate(chord->pos());
+        if (chordShape.empty()) {
+            continue;
+        }
+
+        Shape bracketShape = bracketCollisionShape(bracket, span, chord->vStaffIdx(), baseX);
+        if (bracketShape.empty()) {
+            continue;
+        }
+
+        const double distance = bracket->rightSide()
+                                ? HorizontalSpacing::minHorizontalDistance(chordShape, bracketShape, bracket->spatium())
+                                : HorizontalSpacing::minHorizontalDistance(bracketShape, chordShape, bracket->spatium());
+        requiredDistance = std::max(requiredDistance, distance);
+    }
+
+    bracket->mutldata()->setPosX(bracket->rightSide() ? requiredDistance : -requiredDistance);
+}
+} // namespace
+
+//---------------------------------------------------------
+//   layoutSegment
+//---------------------------------------------------------
+
+void ChordBracketLayout::layoutSegment(Segment* segment, LayoutContext& ctx)
+{
+    if (!segment) {
+        return;
+    }
+
+    for (ChordBracket* bracket : chordBracketsInSegment(segment)) {
+        Chord* owner = bracket->chord();
+        if (!owner || owner->segment() != segment || !bracket->part() || owner->onTabStaff()) {
+            continue;
+        }
+
+        // Initialize the bracket's width, vertical geometry, and Shape.
+        // Replace the chord-local horizontal position with the segment-level result.
+        TLayout::layoutItem(bracket, ctx);
+        layoutHorizontal(bracket);
+
+        // Rebuild the owner Shape after moving the bracket.
+        ChordLayout::fillShape(owner, owner->mutldata());
+    }
+}
+
+//---------------------------------------------------------
+//   updateHorizontalSpacing
+//---------------------------------------------------------
+
+void ChordBracketLayout::updateHorizontalSpacing(const Segment* firstSegment, const Segment* secondSegment,
+                                                 staff_idx_t staffIdx, double squeezeFactor, double& minDistance)
+{
+    if (!firstSegment || !secondSegment) {
+        return;
+    }
+
+    auto updateForBrackets = [&](const Segment* segment, const Shape& otherShape, bool rightSide) {
+        for (ChordBracket* bracket : chordBracketsInSegment(segment)) {
+            if (bracket->chord()->onTabStaff() || !bracket->visible() || !bracket->addToSkyline() || bracket->rightSide() != rightSide) {
+                continue;
+            }
+
+            const BracketVisualSpan span = bracketVisualSpan(bracket);
+
+            if (span.topStaff == span.bottomStaff) {
+                continue;
+            }
+
+            const double x = bracket->chord()->pos().x() + bracket->pos().x();
+            const Shape bracketShape = bracketCollisionShape(bracket, span, staffIdx, x);
+
+            if (bracketShape.empty()) {
+                continue;
+            }
+
+            const double distance = rightSide
+                                    ? HorizontalSpacing::minHorizontalDistance(bracketShape, otherShape, bracket->spatium(), squeezeFactor)
+                                    : HorizontalSpacing::minHorizontalDistance(otherShape, bracketShape, bracket->spatium(), squeezeFactor);
+
+            minDistance = std::max(minDistance, distance);
+        }
+    };
+
+    // Check the brackets facing the gap between the two Segments:
+    // left-side brackets on the second Segment and right-side brackets on the first.
+    updateForBrackets(secondSegment, firstSegment->staffShape(staffIdx), /*rightSide=*/ false);
+    updateForBrackets(firstSegment, secondSegment->staffShape(staffIdx), /*rightSide=*/ true);
+}
+
+//---------------------------------------------------------
+//   updateVerticalGeometry
+//---------------------------------------------------------
+
+void ChordBracketLayout::updateVerticalGeometry(ChordBracket* bracket, LayoutContext& ctx)
+{
+    if (!bracket || !bracket->chord()) {
+        return;
+    }
+
+    // Re-layout the final height without changing the horizontal position.
+    const double x = bracket->ldata()->pos().x();
+    TLayout::layoutItem(bracket, ctx);
+    bracket->mutldata()->setPosX(x);
+}

--- a/src/engraving/rendering/score/chordbracketlayout.cpp
+++ b/src/engraving/rendering/score/chordbracketlayout.cpp
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2025 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,21 +40,11 @@ using namespace muse;
 using namespace mu::engraving;
 using namespace mu::engraving::rendering::score;
 
-namespace {
-struct BracketVisualSpan {
-    staff_idx_t topStaff = 0;
-    staff_idx_t bottomStaff = 0;
-
-    // Staff-local coordinates.
-    double topY = 0.0;
-    double bottomY = 0.0;
-};
-
 //---------------------------------------------------------
 //   chordBracketsInSegment
 //---------------------------------------------------------
 
-static std::vector<ChordBracket*> chordBracketsInSegment(const Segment* segment)
+std::vector<ChordBracket*> ChordBracketLayout::chordBracketsInSegment(const Segment* segment)
 {
     std::vector<ChordBracket*> result;
 
@@ -81,7 +71,7 @@ static std::vector<ChordBracket*> chordBracketsInSegment(const Segment* segment)
 //   bracketVisualSpan
 //---------------------------------------------------------
 
-static BracketVisualSpan bracketVisualSpan(const ChordBracket* bracket)
+ChordBracketLayout::BracketVisualSpan ChordBracketLayout::bracketVisualSpan(const ChordBracket* bracket)
 {
     const Chord* startChord = bracket->chord();
     EngravingItem* endItem = startChord->segment()->element(bracket->endTrack());
@@ -147,8 +137,8 @@ static BracketVisualSpan bracketVisualSpan(const ChordBracket* bracket)
 //   bracketCollisionShape
 //---------------------------------------------------------
 
-static Shape bracketCollisionShape(const ChordBracket* bracket, const BracketVisualSpan& span, staff_idx_t staffIdx,
-                                   double x)
+Shape ChordBracketLayout::bracketCollisionShape(const ChordBracket* bracket, const BracketVisualSpan& span, staff_idx_t staffIdx,
+                                                double x)
 {
     if (staffIdx < span.topStaff || staffIdx > span.bottomStaff) {
         return Shape();
@@ -177,7 +167,7 @@ static Shape bracketCollisionShape(const ChordBracket* bracket, const BracketVis
 //---------------------------------------------------------
 //   layoutHorizontal
 //---------------------------------------------------------
-static void layoutHorizontal(ChordBracket* bracket)
+void ChordBracketLayout::layoutHorizontal(ChordBracket* bracket)
 {
     Chord* owner = bracket->chord();
     Segment* segment = owner->segment();
@@ -214,7 +204,6 @@ static void layoutHorizontal(ChordBracket* bracket)
 
     bracket->mutldata()->setPosX(bracket->rightSide() ? requiredDistance : -requiredDistance);
 }
-} // namespace
 
 //---------------------------------------------------------
 //   layoutSegment

--- a/src/engraving/rendering/score/chordbracketlayout.cpp
+++ b/src/engraving/rendering/score/chordbracketlayout.cpp
@@ -240,7 +240,8 @@ void ChordBracketLayout::updateHorizontalSpacing(const Segment* firstSegment, co
 
     auto updateForBrackets = [&](const Segment* segment, const Shape& otherShape, bool rightSide) {
         for (ChordBracket* bracket : chordBracketsInSegment(segment)) {
-            if (bracket->chord()->onTabStaff() || !bracket->visible() || !bracket->addToSkyline() || bracket->rightSide() != rightSide) {
+            const Chord* owner = bracket->chord();
+            if (!owner || owner->onTabStaff() || !bracket->visible() || !bracket->addToSkyline() || bracket->rightSide() != rightSide) {
                 continue;
             }
 
@@ -250,7 +251,7 @@ void ChordBracketLayout::updateHorizontalSpacing(const Segment* firstSegment, co
                 continue;
             }
 
-            const double x = bracket->chord()->pos().x() + bracket->pos().x();
+            const double x = owner->pos().x() + bracket->pos().x();
             const Shape bracketShape = bracketCollisionShape(bracket, span, staffIdx, x);
 
             if (bracketShape.empty()) {

--- a/src/engraving/rendering/score/chordbracketlayout.cpp
+++ b/src/engraving/rendering/score/chordbracketlayout.cpp
@@ -114,6 +114,21 @@ static BracketVisualSpan bracketVisualSpan(const ChordBracket* bracket)
     if (startStaff == endStaff) {
         result.topY = std::min(topY(startChord), topY(endChord)) - topPadding;
         result.bottomY = std::max(bottomY(startChord), bottomY(endChord)) + bottomPadding;
+
+        // Enforce the minimum length using endpoint coordinates.
+        const double minLen = 2 * spatium;
+        const double diff = minLen - std::abs(result.bottomY - result.topY);
+
+        if (diff > 0.0) {
+            if (bracket->hookPos() == DirectionV::DOWN) {
+                result.topY -= diff;
+            } else if (bracket->hookPos() == DirectionV::AUTO) {
+                result.topY -= 0.5 * diff;
+                result.bottomY += 0.5 * diff;
+            } else {
+                result.bottomY += diff;
+            }
+        }
     } else {
         const Chord* upperAnchor = startStaff < endStaff ? startChord : endChord;
         const Chord* lowerAnchor = startStaff < endStaff ? endChord : startChord;

--- a/src/engraving/rendering/score/chordbracketlayout.cpp
+++ b/src/engraving/rendering/score/chordbracketlayout.cpp
@@ -293,7 +293,7 @@ void ChordBracketLayout::updateHorizontalSpacing(const Segment* firstSegment, co
 
 void ChordBracketLayout::updateVerticalGeometry(ChordBracket* bracket, LayoutContext& ctx)
 {
-    if (!bracket || !bracket->chord()) {
+    if (!bracket || !bracket->chord() || !bracket->chord()->segment()) {
         return;
     }
 
@@ -301,4 +301,14 @@ void ChordBracketLayout::updateVerticalGeometry(ChordBracket* bracket, LayoutCon
     const double x = bracket->ldata()->pos().x();
     TLayout::layoutItem(bracket, ctx);
     bracket->mutldata()->setPosX(x);
+
+    // Refresh cached shapes after restoring the segment-level position.
+    Chord* chord = bracket->chord();
+    Segment* segment = chord->segment();
+    ChordLayout::fillShape(chord, chord->mutldata());
+
+    const BracketVisualSpan span = bracketVisualSpan(bracket);
+    for (staff_idx_t staffIdx = span.topStaff; staffIdx <= span.bottomStaff; ++staffIdx) {
+        segment->createShape(staffIdx);
+    }
 }

--- a/src/engraving/rendering/score/chordbracketlayout.h
+++ b/src/engraving/rendering/score/chordbracketlayout.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "layoutcontext.h"
+
+namespace mu::engraving {
+class ChordBracket;
+class Segment;
+}
+
+namespace mu::engraving::rendering::score {
+class ChordBracketLayout
+{
+public:
+    static void layoutSegment(Segment* segment, LayoutContext& ctx);
+    static void updateHorizontalSpacing(const Segment* firstSegment, const Segment* secondSegment, staff_idx_t staffIdx,
+                                        double squeezeFactor, double& minDistance);
+    static void updateVerticalGeometry(ChordBracket* bracket, LayoutContext& ctx);
+};
+} // namespace mu::engraving::rendering::score

--- a/src/engraving/rendering/score/chordbracketlayout.h
+++ b/src/engraving/rendering/score/chordbracketlayout.h
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2025 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,11 +22,14 @@
 
 #pragma once
 
+#include <vector>
+
 #include "layoutcontext.h"
 
 namespace mu::engraving {
 class ChordBracket;
 class Segment;
+class Shape;
 }
 
 namespace mu::engraving::rendering::score {
@@ -37,5 +40,20 @@ public:
     static void updateHorizontalSpacing(const Segment* firstSegment, const Segment* secondSegment, staff_idx_t staffIdx,
                                         double squeezeFactor, double& minDistance);
     static void updateVerticalGeometry(ChordBracket* bracket, LayoutContext& ctx);
+
+private:
+    struct BracketVisualSpan {
+        staff_idx_t topStaff = 0;
+        staff_idx_t bottomStaff = 0;
+
+        // Staff-local coordinates.
+        double topY = 0.0;
+        double bottomY = 0.0;
+    };
+
+    static std::vector<ChordBracket*> chordBracketsInSegment(const Segment* segment);
+    static BracketVisualSpan bracketVisualSpan(const ChordBracket* bracket);
+    static Shape bracketCollisionShape(const ChordBracket* bracket, const BracketVisualSpan& span, staff_idx_t staffIdx, double x);
+    static void layoutHorizontal(ChordBracket* bracket);
 };
 } // namespace mu::engraving::rendering::score

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -336,12 +336,6 @@ void ChordLayout::layoutPitched(Chord* item, LayoutContext& ctx)
     createParenGroups(item);
     ParenthesisLayout::layoutChordParentheses(item, ctx);
 
-    for (EngravingItem* e : item->el()) {
-        if (e->isChordBracket()) {
-            TLayout::layoutItem(e, ctx);
-        }
-    }
-
     fillShape(item, item->mutldata(), ctx.conf());
 }
 
@@ -1656,26 +1650,6 @@ static void layoutSegmentElements(Segment* segment, track_idx_t startTrack, trac
     }
 }
 
-static void relayoutChordBracketsAfterSegmentLayout(const std::vector<Chord*>& chords, LayoutContext& ctx)
-{
-    for (Chord* chord : chords) {
-        bool hasChordBracket = false;
-
-        for (EngravingItem* e : chord->el()) {
-            if (!e->isChordBracket()) {
-                continue;
-            }
-
-            hasChordBracket = true;
-            TLayout::layoutItem(e, ctx);
-        }
-
-        if (hasChordBracket) {
-            ChordLayout::fillShape(chord, chord->mutldata(), ctx.conf());
-        }
-    }
-}
-
 void ChordLayout::skipAccidentals(Segment* segment, track_idx_t startTrack, track_idx_t endTrack)
 {
     for (track_idx_t track = startTrack; track < endTrack; ++track) {
@@ -2322,10 +2296,6 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
             TLayout::layoutOrnamentCueNote(ornament, ctx);
         }
     }
-
-    // Chord brackets depend on the final layouts of all voices in the same segment and visual staff.
-    // Re-layout them after the segment elements have been laid out.
-    relayoutChordBracketsAfterSegmentLayout(posInfo.chords, ctx);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -22,6 +22,7 @@
 #include <cfloat>
 
 #include "horizontalspacing.h"
+#include "chordbracketlayout.h"
 #include "parenthesislayout.h"
 
 #include "dom/barline.h"
@@ -1336,6 +1337,11 @@ double HorizontalSpacing::minHorizontalDistance(const Segment* f, const Segment*
             // so make sure segment is as wide as it needs to be
             d = std::max(d, f->staffShape(staffIdx).right());
         }
+
+        // Multi-staff ChordBrackets are stored on their owner chords
+        // and are therefore not fully represented in every visually spanned staff Shape.
+        // Add the missing bracket collisions before combining the per-staff minimum distances.
+        ChordBracketLayout::updateHorizontalSpacing(f, ns, staffIdx, squeezeFactor, d);
 
         if (f->isChordRestType() && ns->isChordRestType()) {
             checkCollisionsWithCrossStaffStems(f, ns, staffIdx, d);

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -1341,7 +1341,9 @@ double HorizontalSpacing::minHorizontalDistance(const Segment* f, const Segment*
         // Multi-staff ChordBrackets are stored on their owner chords
         // and are therefore not fully represented in every visually spanned staff Shape.
         // Add the missing bracket collisions before combining the per-staff minimum distances.
-        ChordBracketLayout::updateHorizontalSpacing(f, ns, staffIdx, squeezeFactor, d);
+        if (f->isChordRestType() || ns->isChordRestType()) {
+            ChordBracketLayout::updateHorizontalSpacing(f, ns, staffIdx, squeezeFactor, d);
+        }
 
         if (f->isChordRestType() && ns->isChordRestType()) {
             checkCollisionsWithCrossStaffStems(f, ns, staffIdx, d);
@@ -1615,7 +1617,7 @@ void HorizontalSpacing::computeLyricsPadding(const Lyrics* lyrics1, const Engrav
 void HorizontalSpacing::computeChordBracketPadding(const EngravingItem* item1, const ChordBracket* chordBracket, double& padding)
 {
     const Chord* chord = chordBracket->chord();
-    const Chord* itemChord = static_cast<const Chord*>(item1->findAncestor(ElementType::CHORD));
+    const Chord* itemChord = toChord(item1->findAncestor(ElementType::CHORD));
     if (chord && itemChord && chord->segment() == itemChord->segment() && chord->part() == itemChord->part()) {
         // Padding a right-handed chord bracket to chords in the same Segment and part: use the same padding values as the left-handed case
         padding = item1->score()->paddingTable().at(ElementType::CHORD_BRACKET).at(item1->type());

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -1615,8 +1615,9 @@ void HorizontalSpacing::computeLyricsPadding(const Lyrics* lyrics1, const Engrav
 void HorizontalSpacing::computeChordBracketPadding(const EngravingItem* item1, const ChordBracket* chordBracket, double& padding)
 {
     const Chord* chord = chordBracket->chord();
-    if (chord && chord == item1->findAncestor(ElementType::CHORD)) {
-        // Padding a right-handed chord bracket to its own chord: use the same padding values as the left-handed case
+    const Chord* itemChord = static_cast<const Chord*>(item1->findAncestor(ElementType::CHORD));
+    if (chord && itemChord && chord->segment() == itemChord->segment() && chord->part() == itemChord->part()) {
+        // Padding a right-handed chord bracket to chords in the same Segment and part: use the same padding values as the left-handed case
         padding = item1->score()->paddingTable().at(ElementType::CHORD_BRACKET).at(item1->type());
     }
 }

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -56,6 +56,7 @@
 
 #include "arpeggiolayout.h"
 #include "beamlayout.h"
+#include "chordbracketlayout.h"
 #include "chordlayout.h"
 #include "horizontalspacing.h"
 #include "layoutcontext.h"
@@ -302,6 +303,7 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
                 }
             }
         } else if (segment.isChordRestType()) {
+            ChordBracketLayout::layoutSegment(&segment, ctx);
             for (EngravingItem* e : segment.annotations()) {
                 if (e->isSymbol() || e->isHarmony() || e->isFretDiagram()) {
                     TLayout::layoutItem(e, ctx);
@@ -500,6 +502,7 @@ void MeasureLayout::computePreSpacingItems(Measure* m, LayoutContext& ctx)
             }
         }
 
+        ChordBracketLayout::layoutSegment(&seg, ctx);
         seg.createShapes();
         isFirstChordInMeasure = false;
     }

--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -51,6 +51,7 @@
 #include "arpeggiolayout.h"
 #include "beamlayout.h"
 #include "chordlayout.h"
+#include "chordbracketlayout.h"
 #include "headerfooterlayout.h"
 #include "masklayout.h"
 #include "measurelayout.h"
@@ -366,7 +367,12 @@ void PageLayout::collectPage(LayoutContext& ctx)
                             ArpeggioLayout::layoutArpeggio2(c->arpeggio(), ctx);
                             for (EngravingItem* e : c->el()) {
                                 if (e->isChordBracket()) {
-                                    ArpeggioLayout::layoutArpeggio2(toChordBracket(e), ctx);
+                                    ChordBracket* bracket = toChordBracket(e);
+                                    if (c->onTabStaff()) {
+                                        ArpeggioLayout::layoutArpeggio2(bracket, ctx);
+                                    } else {
+                                        ChordBracketLayout::updateVerticalGeometry(bracket, ctx);
+                                    }
                                 }
                             }
                             ChordLayout::layoutSpanners(c, ctx);

--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -369,7 +369,7 @@ void PageLayout::collectPage(LayoutContext& ctx)
                                 if (e->isChordBracket()) {
                                     ChordBracket* bracket = toChordBracket(e);
                                     if (c->onTabStaff()) {
-                                        ArpeggioLayout::layoutArpeggio2(bracket, ctx);
+                                        TLayout::layoutItem(bracket, ctx);
                                     } else {
                                         ChordBracketLayout::updateVerticalGeometry(bracket, ctx);
                                     }

--- a/src/engraving/rendering/score/rendering.cmake
+++ b/src/engraving/rendering/score/rendering.cmake
@@ -35,6 +35,8 @@ set(RENDERING_SCORE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/beamtremololayout.h
     ${CMAKE_CURRENT_LIST_DIR}/chordlayout.cpp
     ${CMAKE_CURRENT_LIST_DIR}/chordlayout.h
+    ${CMAKE_CURRENT_LIST_DIR}/chordbracketlayout.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/chordbracketlayout.h
     ${CMAKE_CURRENT_LIST_DIR}/accidentalslayout.cpp
     ${CMAKE_CURRENT_LIST_DIR}/accidentalslayout.h
     ${CMAKE_CURRENT_LIST_DIR}/tupletlayout.cpp

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -49,6 +49,7 @@
 #include "beamlayout.h"
 #include "tupletlayout.h"
 #include "chordlayout.h"
+#include "chordbracketlayout.h"
 #include "arpeggiolayout.h"
 #include "measurelayout.h"
 #include "horizontalspacing.h"
@@ -212,6 +213,16 @@ void ScoreHorizontalViewLayout::layoutLinear(LayoutContext& ctx)
                             }
                         }
                         ArpeggioLayout::layoutArpeggio2(c->arpeggio(), ctx);
+                        for (EngravingItem* element : c->el()) {
+                            if (element->isChordBracket()) {
+                                ChordBracket* bracket = toChordBracket(element);
+                                if (c->onTabStaff()) {
+                                    ArpeggioLayout::layoutArpeggio2(bracket, ctx);
+                                } else {
+                                    ChordBracketLayout::updateVerticalGeometry(bracket, ctx);
+                                }
+                            }
+                        }
                         ChordLayout::layoutSpanners(c, ctx);
                         if (c->tremoloSingleChord()) {
                             TremoloLayout::layout(c->tremoloSingleChord(), ctx);

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -217,7 +217,7 @@ void ScoreHorizontalViewLayout::layoutLinear(LayoutContext& ctx)
                             if (element->isChordBracket()) {
                                 ChordBracket* bracket = toChordBracket(element);
                                 if (c->onTabStaff()) {
-                                    ArpeggioLayout::layoutArpeggio2(bracket, ctx);
+                                    TLayout::layoutItem(bracket, ctx);
                                 } else {
                                     ChordBracketLayout::updateVerticalGeometry(bracket, ctx);
                                 }

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -931,7 +931,7 @@ void TLayout::layoutChordBracket(const ChordBracket* item, Arpeggio::LayoutData*
     ldata->setMag(item->staff() ? item->staff()->staffMag(item->tick()) : item->mag());
     ldata->magS = conf.magS(ldata->mag());
 
-    ldata->setShape(Shape(RectF(0.0, ldata->top, item->absoluteFromSpatium(item->hookLength()), ldata->bottom), item));
+    ldata->setShape(Shape(RectF(0.0, ldata->top, item->absoluteFromSpatium(item->hookLength()), ldata->bottom).normalized(), item));
 
     const Note* upnote = item->chord()->upNote();
     ldata->setPosY(upnote->y() + upnote->ldata()->bbox().top());


### PR DESCRIPTION
Follow-up to https://github.com/musescore/MuseScore/pull/33983#issuecomment-4994302341

This PR extends the previous chord bracket spacing fix to cases where the relevant chords are distributed across visual staves.

## Problems addressed

### Case 1
A chord bracket is visually contained within a single staff, but one of the chords spanned by the bracket is a cross-staff chord.
<img width="654" height="385" alt="スクリーンショット 2026-07-29 184615" src="https://github.com/user-attachments/assets/1e91270c-ea4c-49f7-977c-c511c1c097ac" />

### Case 2
A chord bracket spans chords that are visually placed on multiple staves within the same part.
<img width="956" height="1034" alt="スクリーンショット 2026-07-29 184230" src="https://github.com/user-attachments/assets/d9fdc432-988b-4682-899f-abf6969831b5" />

In the Case 2 matrix, `*` marks a rendering where the accidental and chord bracket collide.
The matrix covers 16 combinations of the relative pitch ordering of the bracket anchors and voices 1 and 2 on the upper and lower staves. Each combination is repeated with the accidental placed on each of the four chords, producing 64 renderings in total.

In these cases, accidentals on the relevant chords were not consistently taken into account when positioning the chord bracket.

## Root cause and design rationale

Chord bracket layout previously ran at Chord scope. In cross-staff cases, some of the geometry needed for placement belongs to another visual staff and may not yet be available, depending on staff and track iteration order.

The layout is therefore moved to Segment scope, where all chords at the same tick can be considered together. The process consists of initial horizontal placement after staff-local chord layout, horizontal spacing between Segments, and a final vertical update after staff distances are known.

The existing tablature layout path is left unchanged.

## Implementation

A new `ChordBracketLayout` component handles pitched chord brackets at Segment scope. Its methods correspond to the three layout stages:

- `layoutSegment()` performs the initial horizontal placement.
- `updateHorizontalSpacing()` accounts for brackets when spacing adjacent Segments.
- `updateVerticalGeometry()` performs the final update after staff spacing.

`MeasureLayout` runs the Segment-level pass before Segment Shapes are finalized, while page and horizontal view layout perform the final vertical update after staff spacing.

The chord-level layout and relayout passes for pitched chord brackets are removed.

`TLayout` also normalizes reversed top and bottom coordinates when the bracket endpoints are manually edited.

## Tests
Manually verified the layout results for both cases shown above.

Test score: [33883_chordBracket4c.zip](https://github.com/user-attachments/files/30612826/33883_chordBracket4c.zip)

<img width="426" height="274" alt="スクリーンショット 2026-07-29 191122" src="https://github.com/user-attachments/assets/b2b62bfd-9ba7-4b88-9c67-967d9ee9196f" />

<img width="947" height="1049" alt="スクリーンショット 2026-07-29 191116" src="https://github.com/user-attachments/assets/e18783a0-88c2-4bac-93f4-849ded6892f4" />


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->
- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): 9zu8co<!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).