### PR TITLE
Limit leading space and line thicknesses

### DIFF
--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -32,6 +32,7 @@
 #include "dom/glissando.h"
 #include "dom/lyrics.h"
 #include "dom/note.h"
+#include "dom/page.h"
 #include "dom/rest.h"
 #include "dom/score.h"
 #include "dom/stemslash.h"
@@ -290,6 +291,11 @@ std::vector<HorizontalSpacing::SegmentPosition> HorizontalSpacing::spaceSegments
 
         double leadingSpace = curSeg->extraLeadingSpace().toAbsolute(ctx.spatium);
         placedSegments.back().xPosInSystemCoords += leadingSpace;
+        Page* page = toPage(ctx.system->parent());
+        if (page) {
+            double pageLeftEdge = -page->lm();
+            placedSegments.back().xPosInSystemCoords = std::max(placedSegments.back().xPosInSystemCoords, pageLeftEdge);
+        }
 
         if (curSeg->isChordRestType()) {
             bool isFirstCROfSystem = curSeg->rtick().isZero() && curSeg->measure()->isFirstInSystem();

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -293,8 +293,7 @@ std::vector<HorizontalSpacing::SegmentPosition> HorizontalSpacing::spaceSegments
         placedSegments.back().xPosInSystemCoords += leadingSpace;
         Page* page = toPage(ctx.system->parent());
         if (page) {
-            double pageLeftEdge = -page->lm();
-            placedSegments.back().xPosInSystemCoords = std::max(placedSegments.back().xPosInSystemCoords, pageLeftEdge);
+            placedSegments.back().xPosInSystemCoords = std::max(placedSegments.back().xPosInSystemCoords, -page->lm());
         }
 
         if (curSeg->isChordRestType()) {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
@@ -101,7 +101,7 @@ StyledFlickable {
                 currentValue: beamsPageModel.beamWidth.value
 
                 minValue: 0
-                maxValue: 99
+                maxValue: 1
                 step: 0.01
                 decimals: 2
                 measureUnitsSymbol: qsTrc("global", "sp")

--- a/src/notationscene/widgets/editstyle.ui
+++ b/src/notationscene/widgets/editstyle.ui
@@ -459,6 +459,9 @@
                    <property name="suffix">
                     <string extracomment="spatium unit">sp</string>
                    </property>
+                   <property name="maximum">
+                    <double>1.000000000000000</double>
+                   </property>
                    <property name="singleStep">
                     <double>0.100000000000000</double>
                    </property>
@@ -4967,6 +4970,9 @@
                  <property name="singleStep">
                   <double>0.010000000000000</double>
                  </property>
+                 <property name="maximum">
+                  <double>2.000000000000000</double>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="0" colspan="2">
@@ -5035,6 +5041,9 @@
                  </property>
                  <property name="singleStep">
                   <double>0.010000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>2.000000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -5180,6 +5189,9 @@
                  </property>
                  <property name="singleStep">
                   <double>0.010000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>2.000000000000000</double>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Makes some progress on #25799

This PR adds a check to `HorizontalSpacing::spaceSegments` so that segments cannot be moved to the left off the page using a negative leading space. It also lowers the maximums on beam and staff line thicknesses (down to the thickness where the lines would overlap), as well as barline thickness.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [sundialrise](musescore.org/en/user/6660214)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits. (#25799 lists multiple problems, so this PR does not resolve it in the sense of closing it.)
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable). (Is this change large enough to need a unit test?)