### PR TITLE
Fix crash in text popup

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationviewinputcontroller.cpp
@@ -178,7 +178,7 @@ void NotationViewInputController::onNotationChanged()
         m_view->hideContextMenu();
 
         const TextBase* item = notation->interaction()->editedText();
-        if (AbstractElementPopupModel::hasTextStylePopup(item)) {
+        if (AbstractElementPopupModel::hasTextStylePopup(item) && item->selected()) {
             static const std::set<ElementType> TYPES_NEEDING_STAFF {
                 ElementType::LYRICS,
                 ElementType::FINGERING,
@@ -212,7 +212,7 @@ void NotationViewInputController::onNotationChanged()
         }
 
         const TextBase* item = notation->interaction()->editedText();
-        if (AbstractElementPopupModel::hasTextStylePopup(item) && item->cursor()->hasSelection()) {
+        if (AbstractElementPopupModel::hasTextStylePopup(item) && item->cursor()->hasSelection() && item->selected()) {
             m_view->showElementPopup(item->type());
         }
     }, Asyncable::Mode::SetReplace /* FIXME */);
@@ -1030,7 +1030,7 @@ void NotationViewInputController::updateTextCursorPosition()
         // Show text style popup
         const TextBase* item = viewInteraction()->editedText();
         if (AbstractElementPopupModel::hasTextStylePopup(item)
-            && (!item->isLyrics() || !item->empty())) {
+            && (!item->isLyrics() || !item->empty()) && item->selected()) {
             m_view->showElementPopup(item->type());
         }
     }

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textstylepopup/textstylepopupmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/text/textstylepopup/textstylepopupmodel.cpp
@@ -44,6 +44,10 @@ void TextStylePopupModel::doInit()
 {
     AbstractElementPopupModel::init();
 
+    IF_ASSERT_FAILED(m_item) {
+        return;
+    }
+
     m_textSettingsModel = new TextSettingsModel(this, iocContext(), m_elementRepositoryService.get());
     m_textSettingsModel->init();
 


### PR DESCRIPTION
Resolves: #34460 

We need to make sure text items returned from `notation->interaction()->editedText()` are selected via `Selection`, as it is not guaranteed.