### PR TITLE
Don't create unneeded spanner segments on layout

### DIFF
--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -611,10 +611,6 @@ LayoutContext::LayoutContext(Score* score)
 
 LayoutContext::~LayoutContext()
 {
-    for (Spanner* s : m_state.processedSpanners()) {
-        TLayout::layoutSystemsDone(s);
-    }
-
     for (MuseScoreView* v : m_score->getViewer()) {
         v->layoutChanged();
     }

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -287,8 +287,6 @@ public:
     void setPageOldMeasure(MeasureBase* m) { m_pageOldMeasure = m; }
     void setMeasureNumber(int n) { m_measureNumber = n; }
 
-    std::set<Spanner*>& processedSpanners() { return m_processedSpanners; }
-
     void setRangeDone(bool val) { m_rangeDone = val; }
 
     void setMustRecomputeHeadersFooters(bool val) { m_mustRecomputeHeadersFooters = val; }

--- a/src/engraving/rendering/score/tappinglayout.cpp
+++ b/src/engraving/rendering/score/tappinglayout.cpp
@@ -169,6 +169,10 @@ void TappingLayout::layoutHalfSlur(Tapping* item, TappingHalfSlur* slur, LayoutC
         return;
     }
 
+    for (SpannerSegment* seg : slur->spannerSegments()) {
+        seg->resetExplicitParent();
+    }
+
     Skyline& skyline = system->staff(item->staffIdx())->skyline();
     TappingHalfSlurSegment* slurSeg = toTappingHalfSlurSegment(SlurTieLayout::layoutSystem(slur, system, ctx));
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -6744,13 +6744,22 @@ SpannerSegment* TLayout::layoutSystem(Spanner* item, System* system, LayoutConte
 SpannerSegment* TLayout::getNextLayoutSystemSegment(Spanner* spanner, System* system,
                                                     std::function<SpannerSegment* (System* parent)> createSegment)
 {
+    // Prefer a segment which has already been added to the system
     SpannerSegment* seg = nullptr;
+    SpannerSegment* detached = nullptr;
     for (SpannerSegment* ss : spanner->spannerSegments()) {
-        if (!ss->system() || ss->system() == system || ss->isTappingHalfSlurSegment()) {
+        if (ss->system() == system || ss->isTappingHalfSlurSegment()) {
             seg = ss;
             break;
         }
+        if (!detached && !ss->system()) {
+            detached = ss;
+        }
     }
+    if (!seg) {
+        seg = detached;
+    }
+
     if (!seg) {
         if ((seg = spanner->popUnusedSegment())) {
             spanner->reuse(seg);

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -6746,7 +6746,7 @@ SpannerSegment* TLayout::getNextLayoutSystemSegment(Spanner* spanner, System* sy
 {
     SpannerSegment* seg = nullptr;
     for (SpannerSegment* ss : spanner->spannerSegments()) {
-        if (!ss->system() || ss->isTappingHalfSlurSegment()) {
+        if (!ss->system() || ss->system() == system || ss->isTappingHalfSlurSegment()) {
             seg = ss;
             break;
         }

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -6945,19 +6945,3 @@ SpannerSegment* TLayout::layoutSystem(Slur* line, System* system, LayoutContext&
     LAYOUT_CALL_ITEM(line);
     return SlurTieLayout::layoutSystem(line, system, ctx);
 }
-
-// Called after layout of all systems is done so precise
-// number of systems for this spanner becomes available.
-void TLayout::layoutSystemsDone(Spanner* item)
-{
-    LAYOUT_CALL_ITEM(item);
-    std::vector<SpannerSegment*> validSegments;
-    for (SpannerSegment* seg : item->spannerSegments()) {
-        if (seg->system()) {
-            validSegments.push_back(seg);
-        } else { // TODO: score()->selection().remove(ss); needed?
-            item->pushUnusedSegment(seg);
-        }
-    }
-    item->setSpannerSegments(validSegments);
-}

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -6748,7 +6748,7 @@ SpannerSegment* TLayout::getNextLayoutSystemSegment(Spanner* spanner, System* sy
     SpannerSegment* seg = nullptr;
     SpannerSegment* detached = nullptr;
     for (SpannerSegment* ss : spanner->spannerSegments()) {
-        if (ss->system() == system || ss->isTappingHalfSlurSegment()) {
+        if (ss->system() == system) {
             seg = ss;
             break;
         }

--- a/src/engraving/rendering/score/tlayout.h
+++ b/src/engraving/rendering/score/tlayout.h
@@ -381,7 +381,6 @@ public:
     static SpannerSegment* layoutSystem(LyricsLine* line, System* system, LayoutContext& ctx);
     static SpannerSegment* layoutSystem(Volta* line, System* system, LayoutContext& ctx);
     static SpannerSegment* layoutSystem(Slur* line, System* system, LayoutContext& ctx);
-    static void layoutSystemsDone(Spanner* item);
 
 private:
 


### PR DESCRIPTION
Resolves: #34393 (Duplicated lyrics line issue)
Resolves: https://github.com/musescore/MuseScore/issues/34451

If a spanner already contains a segment with this system as a parent, there's no need to create another. Previously, we were assuming all spanner segments were detached from the system first. Spanners should only contain one segment per system.

This was introduced in 84e504d532. This caused us to layout all spanner segments without clearing the system first. Clearing the system first would require us to perform an even more full layout, so should be avoided if we can help it.

Also removes a bit of a hack for tapping half slurs. Depends on [this PR](https://github.com/musescore/MuseScore/pull/34502) to fix half slur layout.