### PR TITLE
MNX: get mnxdom's json dependencies from muse_deps 

### DIFF
--- a/buildscripts/cmake/DependencyManifest.cmake
+++ b/buildscripts/cmake/DependencyManifest.cmake
@@ -5,3 +5,10 @@ require_dep(opus)
 require_dep(libsndfile)
 
 require_source_dep(liblouis)
+
+# mnxdom's dependencies. mnxdom itself is fetched by src/importexport/mnx,
+# which points it at these prefixes instead of letting it fetch its own.
+if (MUE_BUILD_IMPEXP_MNX_MODULE AND NOT MSS_USE_SYSTEM_MNXDOM)
+    require_dep(nlohmann_json)
+    require_dep(json_schema_validator)
+endif()

--- a/src/importexport/mnx/CMakeLists.txt
+++ b/src/importexport/mnx/CMakeLists.txt
@@ -20,6 +20,23 @@ if(MSS_USE_SYSTEM_MNXDOM)
         "mnxdom source control revision to embed in provenance" FORCE)
     message(STATUS "Using system-installed mnxdom ${mnxdom_VERSION}")
 else()
+    # nlohmann_json and json_schema_validator come from muse_deps (see
+    # buildscripts/cmake/DependencyManifest.cmake); mnxdom finds them there
+    # instead of fetching and building its own copies. The w3c schema and
+    # examples are vendored in mnxdom itself, so nothing to point it at.
+    get_property(NLOHMANN_JSON_PREFIX GLOBAL PROPERTY nlohmann_json_PREFIX)
+    get_property(JSON_SCHEMA_VALIDATOR_PREFIX GLOBAL PROPERTY json_schema_validator_PREFIX)
+    if(NOT NLOHMANN_JSON_PREFIX OR NOT JSON_SCHEMA_VALIDATOR_PREFIX)
+        # Without this, mnxdom would quietly fetch and build its own copies
+        message(FATAL_ERROR "[mnxdom] nlohmann_json / json_schema_validator not resolved; "
+                            "DependencyManifest.cmake must run before this module")
+    endif()
+    list(PREPEND CMAKE_PREFIX_PATH "${NLOHMANN_JSON_PREFIX}" "${JSON_SCHEMA_VALIDATOR_PREFIX}")
+    set(USE_SYSTEM_NLOHMANN_JSON ON CACHE BOOL "" FORCE)
+    set(USE_SYSTEM_JSON_SCHEMA_VALIDATOR ON CACHE BOOL "" FORCE)
+    message(STATUS "Using muse_deps nlohmann_json from ${NLOHMANN_JSON_PREFIX}")
+    message(STATUS "Using muse_deps json_schema_validator from ${JSON_SCHEMA_VALIDATOR_PREFIX}")
+
     set(MNXDOM_GIT_TAG 45bf46221c00411e968c851ff9a1be4e202af5c2)
     string(SUBSTRING "${MNXDOM_GIT_TAG}" 0 7 MNXDOM_GIT_COMMIT)
     FetchContent_Declare(


### PR DESCRIPTION

First steps towards: #33965 <!-- does not fully resolve it; see "What this does not do" -->

<!-- Add a short description of and motivation for the changes here -->

`mnxdom` fetched and built its own copies of `nlohmann_json` and `json-schema-validator`, so a MuseScore build compiled both libraries twice — once for the app, once inside `_deps/mnxdom-build`. `muse_deps` already ships
recipes for both, so this points `mnxdom` at those prefixes instead.

- `buildscripts/cmake/DependencyManifest.cmake` requires `nlohmann_json` and `json_schema_validator` when the MNX module is enabled and a system mnxdom is  not in use.
- `src/importexport/mnx/CMakeLists.txt` prepends those prefixes to `CMAKE_PREFIX_PATH` and sets mnxdom's `USE_SYSTEM_NLOHMANN_JSON` / `USE_SYSTEM_JSON_SCHEMA_VALIDATOR` before `FetchContent_MakeAvailable`. mnxdom's `find_package` then resolves both from muse_deps. Versions match what
  mnxdom asks for: nlohmann_json 3.12.0 and json-schema-validator at the same revision mnxdom pinned.
- Configure now reports where they came from, and fails with a clear error if the manifest has not run. Otherwise `mnxdom` would silently fall back to fetching its own copies again.

`mnx_w3c` is deliberately not part of this. `mnxdom` now vendors the W3C schema and examples under `third_party/w3c-mnx` (rpatters1/mnxdom#56, #58), and reports that path at configure time.

## What this does not do

The `mnxdom` source itself is unchanged: still fetched by `FetchContent` at the pinned commit `45bf462`, and the `MSS_USE_SYSTEM_MNXDOM` path still works as before (there the system package supplies its own dependencies, so neither `muse_deps` recipe is required).

As I understand the current thinking, `mnxdom` will not move into `muse_deps` until MNX has an official spec. The schema is still revising, and each revision moves `mnxdom` with it. Behind `muse_deps` that becomes a recipe bump, a prebuilt/lock cycle, and a submodule pin bump per revision, for a dependency only the MNX module uses. `FetchContent` at a pinned commit keeps that churn to a one-line change here. Whether `mnxdom` continues with FetchContent or eventually becomes a submodule or a vendored tarball is still open. That, and possibly retiring `MSS_USE_SYSTEM_MNXDOM`, is the remaining part of #33965.

## Follow-up

`muse_deps` carries `mnxdom` and `mnx_w3c` recipes that no consumer references. Until `mnxdom` is stable enough to be part of `muse_deps` (likely many months), it seems prudent to remove the stale versions currently in `muse_deps`. A separate independent `muse_deps` PR removes them.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
- [ ] 