### PR TITLE
MusicXML: import multi-child dynamics as a single marking

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -4205,6 +4205,28 @@ void MusicXmlParserDirection::swing()
 }
 
 //---------------------------------------------------------
+//   musicXmlDynamicToMarkup
+//---------------------------------------------------------
+
+/**
+ Convert a single child of a dynamics node to the SMuFL markup MuseScore spells it with.
+ A child element names a dynamic; other-dynamics carries arbitrary text that may still name one.
+ Spelling the children out in glyphs is what lets them be concatenated into a single marking:
+ their names cannot be, as "sf" + "mp" gives "sfmp", which names no dynamic and would end up as
+ plain text. Text naming no dynamic is passed through unchanged.
+ */
+
+static String musicXmlDynamicToMarkup(const String& text)
+{
+    const std::string name = text.toStdString();
+    if (!TConv::dynamicValid(name)) {
+        return text;
+    }
+    const DynamicType type = TConv::fromXml(name, DynamicType::OTHER);
+    return type == DynamicType::OTHER ? text : Dynamic::dynamicText(type);
+}
+
+//---------------------------------------------------------
 //   dynamics
 //---------------------------------------------------------
 
@@ -4218,13 +4240,21 @@ void MusicXmlParserDirection::dynamics()
     m_enclosure = m_e.attribute("enclosure");
     m_dynamicsPlacement = m_e.attribute("placement");
 
+    // A dynamics node is a single marking, whose children spell out the glyphs it is drawn with,
+    // as in the "<sf/><mp/>" the MusicXML specification gives for dynamics elements combined to
+    // create marks not covered by a single element. Collect them into one dynamic.
+    String markup;
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "other-dynamics") {
-            m_dynamicsList.push_back(m_e.readText());
+            markup += musicXmlDynamicToMarkup(m_e.readText());
         } else {
-            m_dynamicsList.push_back(String::fromAscii(m_e.name().ascii()));
+            markup += musicXmlDynamicToMarkup(String::fromAscii(m_e.name().ascii()));
             m_e.skipCurrentElement();
         }
+    }
+
+    if (!markup.empty()) {
+        m_dynamicsList.push_back(markup);
     }
 }
 
@@ -8500,13 +8530,19 @@ void MusicXmlParserNotations::dynamics()
     m_dynamicsColor = Color::fromString(m_e.attribute("color"));
     m_dynamicsPlacement = m_e.attribute("placement");
 
+    // As in MusicXmlParserDirection::dynamics, the children spell out one marking
+    String markup;
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "other-dynamics") {
-            m_dynamicsList.push_back(m_e.readText());
+            markup += musicXmlDynamicToMarkup(m_e.readText());
         } else {
-            m_dynamicsList.push_back(String::fromAscii(m_e.name().ascii()));
+            markup += musicXmlDynamicToMarkup(String::fromAscii(m_e.name().ascii()));
             m_e.skipCurrentElement();  // skip but don't log
         }
+    }
+
+    if (!markup.empty()) {
+        m_dynamicsList.push_back(markup);
     }
 }
 
@@ -9538,7 +9574,8 @@ void MusicXmlParserNotations::addToScore(ChordRest* const cr, Note* const note, 
         }
     }
 
-    // more than one dynamic ???
+    // One dynamic per dynamics node, as its children spell out a single marking,
+    // and a notations node may hold more than one of them
     // LVIFIX: check import/export of <other-dynamics>unknown_text</...>
     // TODO: remove duplicate code (see MusicXml::direction)
     for (const String& d : std::as_const(m_dynamicsList)) {

--- a/src/importexport/musicxml/tests/data/testMultipleDynamics.xml
+++ b/src/importexport/musicxml/tests/data/testMultipleDynamics.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Multiple dynamics</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore testfile</software>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <sf/>
+            <mp/>
+            </dynamics>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <other-dynamics>s</other-dynamics>
+            <f/>
+            <other-dynamics>m</other-dynamics>
+            <p/>
+            </dynamics>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2">
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <ff/>
+            <other-dynamics>z</other-dynamics>
+            </dynamics>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <other-dynamics>s</other-dynamics>
+            <f/>
+            </dynamics>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testMultipleDynamics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMultipleDynamics_ref.mscx
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="5.00">
+  <Score>
+    <eid>B_B</eid>
+    <Division>480</Division>
+    <Style>
+      <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>
+      <spatium>1.75</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Multiple dynamics</metaTag>
+    <Part id="1">
+      <eid>C_C</eid>
+      <Staff>
+        <eid>D_D</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <Instrument id="piano">
+        <InstrumentLabel>
+          <longName>Piano</longName>
+          </InstrumentLabel>
+        <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>E_E</eid>
+        <Text>
+          <eid>F_F</eid>
+          <style>title</style>
+          <text>Multiple dynamics</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <eid>G_G</eid>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            <eid>H_H</eid>
+            </Clef>
+          <TimeSig>
+            <eid>I_I</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>other-dynamics</subtype>
+            <direction>down</direction>
+            <eid>J_J</eid>
+            <text><sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicMezzo</sym><sym>dynamicPiano</sym></text>
+            </Dynamic>
+          <Chord>
+            <eid>K_K</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>L_L</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>M_M</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>N_N</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Dynamic>
+            <subtype>other-dynamics</subtype>
+            <direction>down</direction>
+            <eid>O_O</eid>
+            <text><sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicMezzo</sym><sym>dynamicPiano</sym></text>
+            </Dynamic>
+          <Chord>
+            <eid>P_P</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>Q_Q</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>R_R</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>S_S</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>T_T</eid>
+        <voice>
+          <Dynamic>
+            <subtype>other-dynamics</subtype>
+            <direction>down</direction>
+            <eid>U_U</eid>
+            <text><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicZ</sym></text>
+            </Dynamic>
+          <Chord>
+            <eid>V_V</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>W_W</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>X_X</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>Y_Y</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Dynamic>
+            <subtype>sf</subtype>
+            <velocity>112</velocity>
+            <direction>down</direction>
+            <eid>Z_Z</eid>
+            </Dynamic>
+          <Chord>
+            <eid>a_a</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>b_b</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>c_c</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>d_d</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <eid>e_e</eid>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -1024,6 +1024,9 @@ TEST_F(MusicXml_Tests, multiMeasureRest3) {
 TEST_F(MusicXml_Tests, multiMeasureRest4) {
     musicXmlIoTestRef("testMultiMeasureRest4");
 }
+TEST_F(MusicXml_Tests, multipleDynamics) {
+    musicXmlImportTestRef("testMultipleDynamics");
+}
 TEST_F(MusicXml_Tests, multipleNotations) {
     musicXmlIoTestRef("testMultipleNotations");
 }


### PR DESCRIPTION
Resolves: #34439 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
MusicXML allows a single `<dynamics>` element to hold several children, and the [specification](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/dynamics/) calls this out explicitly: *"Dynamics elements may also be combined to create marks not covered by a single element, such as `<sf/><mp/>`."* The element is one marking; its children spell out the glyph sequence it is drawn with.

The importer created one `Dynamic` per child instead, so such a marking rendered as several dynamics stacked on top of each other at the same tick. The file attached to the issue has three of them, and none of them read correctly.

### The fix

`MusicXmlParserDirection::dynamics()` and `MusicXmlParserNotations::dynamics()` now collect the children of each `<dynamics>` element into a single `Dynamic` instead of pushing one entry to `m_dynamicsList` per child.

Each child is converted to the SMuFL markup MuseScore spells it with before being concatenated. Their names cannot be concatenated directly: `"sf"` + `"mp"` gives `"sfmp"`, which names no dynamic, so `Dynamic::setDynamicType()` would leave it as plain text with no glyphs. Concatenating markup instead lets `Dynamic::parseDynamicText()` do its normal job. A combination that names a type still resolves to it, and one that does not stays `DynamicType::OTHER` while keeping the correct glyphs.

This also makes `m_dynamicsList` uniformly markup. It was already mixed, since `textToDynamic()` pushes `Dynamic::dynamicText()` into the same list.

| Source | Before | After |
|---|---|---|
| `<sf/><mp/>` | 2 dynamics, overlapping | 1 dynamic, `OTHER`, glyphs `s f m p` |
| `<other-dynamics>s</other-dynamics><f/><other-dynamics>m</other-dynamics><p/>` | 4 dynamics, overlapping | same as above |
| `<ff/><other-dynamics>z</other-dynamics>` | 2 dynamics, overlapping | 1 dynamic, `OTHER`, glyphs `f f z` |
| `<other-dynamics>s</other-dynamics><f/>` | 2 dynamics, overlapping | 1 dynamic, `DynamicType::SF` |

Dynamics that name a MuseScore type are unaffected, which is the overwhelming majority of real-world files: a single-child `<dynamics>` produces exactly what it did before.

One deliberate consequence: a combination MuseScore has no type for is `DynamicType::OTHER`, whose velocity is -1, so it has no playback effect unless the direction also carries `<sound dynamics="_"/>`. That matches how MuseScore treats any dynamic whose text it cannot classify, including ones typed by hand.

### Tests

`testMultipleDynamics` covers all four cases in the table, including one combination that resolves to a real type so the classification path is exercised too.

`inferredDynamicRange` is the existing test most exposed to this change, since `isLikelyDynamicRange()` tests `m_dynamicsList.size() == 2`. That still holds: a dynamic range is three sibling `<direction-type>` elements, each holding a single-child `<dynamics>`, not one element with two children.

Full suite passes on macOS apart from `inferredCredits1` and `inferredCredits2`, which fail on `main` as well. Both differ only in a vbox `<height>` (13.9828 vs 13.9746), the platform font-metric divergence the suite's `DISABLED_EXCEPT_ON_LINUX` macro exists for.

---

### Proposal: multi-glyph dynamics on the export side

I kept this PR to the reported bug, but the same idea has more to give, and I would rather show you the whole picture than open a surprise follow-up. **This section is a proposal, not part of the diff.** I am happy to fold it into this PR, do it as a follow-up, or drop it entirely — whichever you prefer.

The observation behind #34439 is that a MusicXML `<dynamics>` element is a *sequence*, so it can describe markings that no single element names. The importer now reads that. The exporter still does not write it.

**1. Decompose glyph runs on export.** `ExportMusicXml::dynamic()` writes any dynamic it cannot match to a single MusicXML element as one `<other-dynamics>` blob, so an `sfmp` marking exports as `<other-dynamics>sfmp</other-dynamics>` — text that other applications will render as literal letters. Emitting the longest valid MusicXML elements found in the glyph run, with `<other-dynamics>` only for fragments that have no element, would give:

- `sfmp` → `<sf/><mp/>`
- `ffz` → `<ff/><other-dynamics>z</other-dynamics>`
- `sff`, `sfff`, `sfffz` → `<sf/><f/>`, `<sf/><f/><f/>`, `<sf/><f/><f/><other-dynamics>z</other-dynamics>` (MuseScore types with no MusicXML element)
- `m`, `r`, `s`, `z` → unchanged; single glyphs with no MusicXML element and nothing to decompose

Combined with this PR, `sfmp` and `ffz` would then round-trip exactly. Note this changes `testDynamics1.xml`, which contains `<other-dynamics>sff</other-dynamics>` and is a `musicXmlIoTest`; converting it to `musicXmlIoTestRef` with a `_ref.xml` keeps the input file untouched and makes the intended output change visible in review.

**2. Read the glyphs rather than a codepoint table.** The export path maps `plainText()` characters against a hardcoded table of the seven single-letter SMuFL dynamics (`U+E520`–`U+E526`). Ligature glyphs such as `dynamicFF`, `dynamicMF`, `dynamicSforzato` and `dynamicPPPP` are not in it, so a dynamic containing one currently exports as a raw private-use character inside `<other-dynamics>`. Walking `Dynamic::fragmentList()` and resolving SymIds through `IEngravingFontsProvider` would handle those, and would also separate leading and trailing plain text from the glyph run properly.

**3. The matching import gap.** A single element MuseScore cannot classify still becomes plain text with no glyphs — `<sfzp/>`, which is valid MusicXML but has no MuseScore `DynamicType`, and hand-authored text such as `<other-dynamics>sfmp</other-dynamics>`. Decomposing the letters into glyphs would fix both. This becomes *required* rather than merely nice if (1) is done, because `sfzp` is a valid MusicXML dynamic: a glyph run spelling `sfzp` would export as `<sfzp/>` and would not survive the round trip back.

The MNX module already does all of this and could be drawn on: `toMnxDynamicFromSymIds()` and `dynamicGlyphLetters()` in `internal/shared/mnxtypesconv.cpp` derive glyph-to-letter spellings from MuseScore's own `DynamicType` table rather than a maintained second table, and `splitDynamicText()` in `internal/export/mnxexportparts.cpp` does the fragment walk in (2). Whether that is worth extracting somewhere both modules can use, or is better duplicated in the MusicXML module, is a question I would want your steer on.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).