### PR TITLE
fixed fret diagram transpose: enharmonic fallback

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -101,6 +101,18 @@ static std::unordered_map<String /*pattern*/, std::vector<String /*harmonyName*/
 
 static const muse::io::path_t HARMONY_TO_DIAGRAM_FILE_PATH(":/data/harmony_to_diagram.xml");
 
+static int canonicalEnharmonicTpc(int tpc)
+{
+    static const std::unordered_map<int, int> map = {
+        { TPC_F_B, TPC_E },
+        { TPC_C_B, TPC_B },
+        { TPC_E_S, TPC_F },
+        { TPC_B_S, TPC_C },
+    };
+    auto it = map.find(tpc);
+    return it != map.end() ? it->second : tpc;
+}
+
 static HarmonyMapKey createHarmonyMapKey(const String& harmony, const NoteSpellingType& spellingType, const ChordList* cl)
 {
     String s = harmony;
@@ -826,10 +838,15 @@ std::vector<DiagramInfo> FretDiagram::patternsFromHarmony(const String& harmonyN
         readHarmonyToDiagramFile(HARMONY_TO_DIAGRAM_FILE_PATH);
     }
 
-    String _harmonyName = harmonyName;
-
     NoteSpellingType spellingType = style().styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
-    HarmonyMapKey key = createHarmonyMapKey(_harmonyName, spellingType, score()->chordList());
+    HarmonyMapKey key = createHarmonyMapKey(harmonyName, spellingType, score()->chordList());
+
+    if (tpcIsValid(key.rootTpc)) {
+        key.rootTpc = canonicalEnharmonicTpc(key.rootTpc);
+    }
+    if (tpcIsValid(key.bassTpc)) {
+        key.bassTpc = canonicalEnharmonicTpc(key.bassTpc);
+    }
 
     return muse::value(s_harmonyToDiagramMap, key);
 }
@@ -1392,6 +1409,13 @@ bool FretDiagram::isCustom(const String& harmonyNameForCompare) const
 
     NoteSpellingType spellingType = style().styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
     HarmonyMapKey key = createHarmonyMapKey(harmonyNameForCompare, spellingType, score()->chordList());
+
+    if (tpcIsValid(key.rootTpc)) {
+        key.rootTpc = canonicalEnharmonicTpc(key.rootTpc);
+    }
+    if (tpcIsValid(key.bassTpc)) {
+        key.bassTpc = canonicalEnharmonicTpc(key.bassTpc);
+    }
 
     std::vector<DiagramInfo> availableDiagrams = muse::value(s_harmonyToDiagramMap, key);
     if (availableDiagrams.empty()) {

--- a/src/engraving/tests/fretdiagram_tests.cpp
+++ b/src/engraving/tests/fretdiagram_tests.cpp
@@ -80,3 +80,22 @@ TEST_F(Engraving_FretDiagramTests, harmonyToFretDiagramSolfeggio)
 
     testChordSymToFretDiagram(score);
 }
+
+TEST_F(Engraving_FretDiagramTests, enharmonicFallbackRootAndBass)
+{
+    MasterScore* score = ScoreRW::readScore(FRETDIAGRAM_DATA_DIR + u"harmonytofrettest.mscx");
+    FretDiagram* fd = Factory::createFretDiagram(score->dummy()->segment());
+
+    // Root fallback: Fbdim7 -> Edim7 (Fb->E)
+    ASSERT_FALSE(fd->patternsFromHarmony(String(u"Edim7")).empty());
+    EXPECT_FALSE(fd->patternsFromHarmony(String(u"Fbdim7")).empty())
+        << "Fbdim7 should resolve via enharmonic root fallback (Fb->E)";
+
+    // Bass fallback: Am/Fb -> Am/E (Fb->E)
+    ASSERT_FALSE(fd->patternsFromHarmony(String(u"Am/E")).empty());
+    EXPECT_FALSE(fd->patternsFromHarmony(String(u"Am/Fb")).empty())
+        << "Am/Fb should resolve via enharmonic bass fallback (Fb->E)";
+
+    delete fd;
+    delete score;
+}


### PR DESCRIPTION
Fret diagram's data for enharmonic names (ex, E#) couldn't be found in the map

<img width="47" height="48" alt="Screenshot 2026-08-07 at 12 32 07 PM" src="https://github.com/user-attachments/assets/e34c2ee7-7195-4c76-b578-28dc44475952" />