### PR TITLE
Fix crash when removing guitar bend hold lines

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -3240,6 +3240,7 @@ void Score::deleteItem(EngravingItem* el)
     case ElementType::STEM_SLASH:                   // cannot delete this elements
     case ElementType::HOOK:
     case ElementType::GUITAR_BEND_TEXT:
+    case ElementType::GUITAR_BEND_HOLD_SEGMENT:
         LOGD("cannot remove %s", el->typeName());
         break;
 


### PR DESCRIPTION
Resolves: #34481

The crash:
1. `GuitarBendHold` is created, owned and destroyed by its `GuitarBend`, not by the score. Also, `GuitarBend::updateHoldLine()` calls `setGenerated(true)` on it, but **not** on its segments.
3. The hold line _segment_ falls into `Score::deleteItem`'s default case, which does not really remove the hold line, but a `RemoveElement` command _is_ being created for it.
4. Then, when the tie is removed, `updateHoldLine()` deletes the hold line and all its segments.
5. On close, `UndoStack::~UndoStack()` calls `cleanup(true)` on the `RemoveElement` command, which deletes the already freed `GuitarBendHoldSegment`.

The fix was to add a special switch case to `Score::deleteItem` to avoid the step 2 above (so the hold line simply cannot be removed in itself).