### PR TITLE
Recover parsed MIDI events after unexpected EOF

### DIFF
--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -29,6 +29,10 @@
 using namespace mu::engraving;
 
 namespace mu::iex::midi {
+namespace {
+const QString UNEXPECTED_EOF_ERROR("bad midifile: unexpected EOF");
+}
+
 MidiFile::MidiFile()
 {
     fp               = 0;
@@ -317,8 +321,16 @@ bool MidiFile::readTrack()
 
     for (;;) {
         MidiEvent event;
-        if (!readEvent(&event)) {
-            return true;
+        try {
+            if (!readEvent(&event)) {
+                return true;
+            }
+        } catch (const QString& error) {
+            if (fp->atEnd() && error == UNEXPECTED_EOF_ERROR) {
+                LOGW("MIDI track ends unexpectedly; treating EOF as end-of-track");
+                break;
+            }
+            throw;
         }
 
         // check for end of track:
@@ -347,7 +359,7 @@ void MidiFile::read(void* p, qint64 len)
     curPos += len;
     qint64 rv = fp->read((char*)p, len);
     if (rv != len) {
-        throw(QString("bad midifile: unexpected EOF"));
+        throw(UNEXPECTED_EOF_ERROR);
     }
 }
 


### PR DESCRIPTION
Hello, 

Thank you for this great software.

This PR makes MIDI file reading more robust to mid-event EOF so we will return the MIDI events we've successfully parsed so far instead of throwing everything away.

**Context:** I was investigating why MuseScore was failing to open a MIDI file, while other tools could open it. The underlying issue ended up being slightly different than I first thought. The incorrect chunkLength is already tolerated by MuseScore, but mid-event EOF was not.

Mid-event EOF MIDI files DO exist in the real world so it's worth this small change IMO. For example, my users can encounter these files when power is lost unexpectedly during MIDI writing. 

For reference, here are some other tools that can open my corrupt file without issue, meaning they too can handle mid-event EOF:

- [https://elysiatools.com/en/viewers/midi](https://elysiatools.com/en/viewers/midi)
- [https://tuneonmusic.com/music-tools/midi-player/#google_vignette](https://tuneonmusic.com/music-tools/midi-player/#google_vignette)
- [https://miditoolbox.com/player](https://miditoolbox.com/player)

Including my own: [https://jamcorder.com/miditool](https://jamcorder.com/midi-viewer)

Test file:
[Jmx-A00027-Aug-07-2026.mid.zip](https://github.com/user-attachments/files/30883618/Jmx-A00027-Aug-07-2026.mid.zip)

Kind regards,
Chip Weinberger
Jamcorder ([https://jamcorder.com](https://jamcorder.com))
