### PR TITLE
[4.7.5] Fix #34438: erase stale chord pointer

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -304,7 +304,8 @@ void TrackList::append(EngravingItem* e)
                             ++idx;
                         }
                         delete element;
-                        element = 0;
+                        element = nullptr;
+                        m_clonedChord.erase(chord);
                     }
                 }
             }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34438