### PR TITLE
Attach associated chord and fret diagrams on XML import

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
@@ -425,6 +425,14 @@ void MusicXmlParserPass1::setExporterSoftware(String& exporter)
     }
 }
 
+void MusicXmlParserPass1::setExporterStyles()
+{
+    // If exporters have different default styles to MuseScore, assume they are being used here
+    if (sibOrDolet()) {
+        m_score->style().set(Sid::fretFrets, 5);
+    }
+}
+
 //---------------------------------------------------------
 //   initPartState
 //---------------------------------------------------------
@@ -1527,6 +1535,7 @@ void MusicXmlParserPass1::identification()
                 } else if (m_e.name() == "software") {
                     String exporterString = m_e.readText().toLower();
                     setExporterSoftware(exporterString);
+                    setExporterStyles();
                 } else if (m_e.name() == "supports" && m_e.asciiAttribute("element") == "beam" && m_e.asciiAttribute("type") == "yes") {
                     m_hasBeamingInfo = true;
                     m_e.skipCurrentElement();

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass1.h
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass1.h
@@ -220,6 +220,7 @@ private:
     // functions
     void addError(const muse::String& error);        // Add an error to be shown in the GUI
     void setExporterSoftware(muse::String& exporter);
+    void setExporterStyles();
 
     // generic pass 1 data
     muse::XmlStreamReader m_e;

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -7768,7 +7768,9 @@ FretDiagram* MusicXmlParserPass2::frame()
             int val = m_e.readInt();
             if (val > 0) {
                 fd->setProperty(Pid::FRET_FRETS, val);
-                fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
+                if (val != fd->propertyDefault(Pid::FRET_FRETS).toInt()) {
+                    fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
+                }
             } else {
                 m_logger->logError(String(u"FretDiagram::readMusicXml: illegal frame-fret %1").arg(val), &m_e);
             }

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -2960,17 +2960,19 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
     for (auto& harmony : delayedHarmony) {
         HarmonyDesc harmonyDesc = harmony.second;
         Fraction tick = Fraction::fromTicks(harmony.first);
-        if (harmonyDesc.m_fretDiagram) {
-            harmonyDesc.m_fretDiagram->setTrack(harmonyDesc.m_track);
+        if (FretDiagram* fd = harmonyDesc.m_fretDiagram) {
+            fd->setTrack(harmonyDesc.m_track);
             Segment* s = measure->getSegment(SegmentType::ChordRest, tick);
-            harmonyDesc.m_harmony->setProperty(Pid::ALIGN, Align(AlignH::HCENTER, AlignV::TOP));
-            s->add(harmonyDesc.m_fretDiagram);
-        }
-
-        if (harmonyDesc.m_harmony) {
-            harmonyDesc.m_harmony->setTrack(harmonyDesc.m_track);
+            if (Harmony* harmony = harmonyDesc.m_harmony) {
+                harmony->setProperty(Pid::ALIGN, Align(AlignH::HCENTER, AlignV::TOP));
+                harmony->setTrack(harmonyDesc.m_track);
+                fd->add(harmony);
+            }
+            s->add(fd);
+        } else if (Harmony* harmony = harmonyDesc.m_harmony) {
+            harmony->setTrack(harmonyDesc.m_track);
             Segment* s = measure->getSegment(SegmentType::ChordRest, tick);
-            s->add(harmonyDesc.m_harmony);
+            s->add(harmony);
         }
     }
 

--- a/src/importexport/musicxml/tests/data/importTie3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie3_ref.mscx
@@ -27,6 +27,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/importTie4_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie4_ref.mscx
@@ -30,6 +30,7 @@
       <romanNumeralFontFace>Palatino,serif</romanNumeralFontFace>
       <nashvilleNumberFontFace>Palatino,serif</nashvilleNumberFontFace>
       <nashvilleNumberFontSize>22</nashvilleNumberFontSize>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>

--- a/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
@@ -21,6 +21,7 @@
       <staffLineWidth>0.09375</staffLineWidth>
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>

--- a/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
@@ -144,6 +144,14 @@
           <FretDiagram>
             <frets>5</frets>
             <eid>K_K</eid>
+            <Harmony>
+              <harmonyInfo>
+                <name>add9</name>
+                <root>13</root>
+                <bass>17</bass>
+                </harmonyInfo>
+              <eid>L_L</eid>
+              </Harmony>
             <fretDiagram>
               <string no="0">
                 <marker>cross</marker>
@@ -165,14 +173,6 @@
                 </string>
               </fretDiagram>
             </FretDiagram>
-          <Harmony>
-            <harmonyInfo>
-              <name>add9</name>
-              <root>13</root>
-              <bass>17</bass>
-              </harmonyInfo>
-            <eid>L_L</eid>
-            </Harmony>
           <Chord>
             <eid>M_M</eid>
             <durationType>whole</durationType>
@@ -190,6 +190,12 @@
           <FretDiagram>
             <frets>5</frets>
             <eid>P_P</eid>
+            <Harmony>
+              <harmonyInfo>
+                <root>12</root>
+                </harmonyInfo>
+              <eid>Q_Q</eid>
+              </Harmony>
             <fretDiagram>
               <string no="0">
                 <marker>cross</marker>
@@ -206,12 +212,6 @@
               <barre start="1" end="5">1</barre>
               </fretDiagram>
             </FretDiagram>
-          <Harmony>
-            <harmonyInfo>
-              <root>12</root>
-              </harmonyInfo>
-            <eid>Q_Q</eid>
-            </Harmony>
           <Chord>
             <eid>R_R</eid>
             <durationType>whole</durationType>

--- a/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
@@ -21,6 +21,7 @@
       <staffLineWidth>0.09375</staffLineWidth>
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>
@@ -142,7 +143,6 @@
             <sigD>4</sigD>
             </TimeSig>
           <FretDiagram>
-            <frets>5</frets>
             <eid>K_K</eid>
             <Harmony>
               <harmonyInfo>
@@ -188,7 +188,6 @@
         <eid>O_O</eid>
         <voice>
           <FretDiagram>
-            <frets>5</frets>
             <eid>P_P</eid>
             <Harmony>
               <harmonyInfo>

--- a/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
@@ -26,6 +26,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -21,6 +21,7 @@
       <staffLineWidth>0.125</staffLineWidth>
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>

--- a/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
@@ -26,6 +26,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
@@ -26,6 +26,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
@@ -27,6 +27,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
@@ -27,6 +27,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testInferredTempoText_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredTempoText_ref.mscx
@@ -26,6 +26,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>

--- a/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
@@ -26,6 +26,7 @@
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
       <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <slurEndWidth>0.0625</slurEndWidth>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -36,6 +36,7 @@
       <romanNumeralFontFace>Quicksand</romanNumeralFontFace>
       <nashvilleNumberFontFace>Quicksand</nashvilleNumberFontFace>
       <nashvilleNumberFontSize>11.9365</nashvilleNumberFontSize>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>

--- a/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
@@ -21,6 +21,7 @@
       <staffLineWidth>0.09375</staffLineWidth>
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>

--- a/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
@@ -21,6 +21,7 @@
       <staffLineWidth>0.125</staffLineWidth>
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <fretFrets>5</fretFrets>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
       <concertPitch>1</concertPitch>

--- a/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
@@ -28,6 +28,7 @@
       <romanNumeralFontFace>Plantin MT Std</romanNumeralFontFace>
       <nashvilleNumberFontFace>Plantin MT Std</nashvilleNumberFontFace>
       <nashvilleNumberFontSize>11.9365</nashvilleNumberFontSize>
+      <fretFrets>5</fretFrets>
       <slurEndWidth>0.07</slurEndWidth>
       <tieEndWidth>0.07</tieEndWidth>
       <tupletFontFace>Plantin MT Std</tupletFontFace>


### PR DESCRIPTION
Resolves: Fret diagrams and chord symbols not being linked when importing MusicXML