### PR TITLE
Fix broken EID links for parenthesis

### DIFF
--- a/src/engraving/rw/read500/tread.cpp
+++ b/src/engraving/rw/read500/tread.cpp
@@ -3964,20 +3964,6 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
         rightParen->setTrack(ctx.track());
     }
 
-    if (ch->links() && ch->links()->mainElement() != ch) {
-        Chord* mainChord = toChord(ch->links()->mainElement());
-        Note* firstNote = notes.front();
-        Note* mainNote = firstNote ? toNote(firstNote->findLinkedInStaff(mainChord->staff())) : nullptr;
-        const NoteParenthesisInfo* mainNoteParenInfo = mainChord && mainNote ? mainChord->findNoteParenthesisInfo(mainNote) : nullptr;
-        Parenthesis* mainLeftParen = mainNoteParenInfo ? mainNoteParenInfo->leftParen() : nullptr;
-        Parenthesis* mainRightParen = mainNoteParenInfo ? mainNoteParenInfo->rightParen() : nullptr;
-
-        if (mainLeftParen && mainRightParen) {
-            leftParen->linkTo(mainLeftParen);
-            rightParen->linkTo(mainRightParen);
-        }
-    }
-
     NoteParenthesisInfo* noteParenInfo = new NoteParenthesisInfo(leftParen, rightParen, notes);
     ch->addNoteParenthesisInfo(noteParenInfo);
 }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1147,12 +1147,9 @@ void TWrite::write(const Chord* item, XmlWriter& xml, WriteContext& ctx)
     // Write parens
     for (const NoteParenthesisInfo* parenPair : item->noteParentheses()) {
         xml.startElement("NoteParenGroup");
-        if (parenPair->leftParen()->isUserModified()) {
-            write(parenPair->leftParen(), xml, ctx);
-        }
-        if (parenPair->rightParen()->isUserModified()) {
-            write(parenPair->rightParen(), xml, ctx);
-        }
+
+        write(parenPair->leftParen(), xml, ctx);
+        write(parenPair->rightParen(), xml, ctx);
 
         xml.startElement("Notes");
         for (const Note* note : parenPair->notes()) {

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="5.00">
   <Score>
-    <eid>rB_rB</eid>
+    <eid>vB_vB</eid>
     <Division>480</Division>
     <Style>
       <spatium>1.75</spatium>
@@ -73,9 +73,9 @@
         </section>
       </Order>
     <Part id="1">
-      <eid>sB_sB</eid>
+      <eid>wB_wB</eid>
       <Staff>
-        <eid>tB_tB</eid>
+        <eid>xB_xB</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -99,17 +99,17 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <eid>uB_uB</eid>
+        <eid>yB_yB</eid>
         </VBox>
       <Measure>
-        <eid>vB_vB</eid>
+        <eid>zB_zB</eid>
         <voice>
           <KeySig>
-            <eid>wB_wB</eid>
+            <eid>0B_0B</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>xB_xB</eid>
+            <eid>1B_1B</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -200,7 +200,7 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>yB_yB</eid>
+        <eid>2B_2B</eid>
         <voice>
           <KeySig>
             <eid>U_U</eid>
@@ -275,7 +275,7 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>zB_zB</eid>
+        <eid>3B_3B</eid>
         <voice>
           <KeySig>
             <eid>j_j</eid>
@@ -345,141 +345,141 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>0B_0B</eid>
+        <eid>4B_4B</eid>
         <voice>
           <Chord>
-            <eid>5_5</eid>
+            <eid>7_7</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>6_6</eid>
+              <eid>8_8</eid>
               </Articulation>
             <Note>
-              <eid>7_7</eid>
+              <eid>9_9</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <ChordLine>
                 <subtype>1</subtype>
-                <eid>8_8</eid>
+                <eid>+_+</eid>
                 </ChordLine>
               </Note>
             </Chord>
           <Chord>
-            <eid>9_9</eid>
+            <eid>/_/</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
-              <eid>+_+</eid>
+              <eid>AB_AB</eid>
               </Articulation>
             <Note>
-              <eid>/_/</eid>
+              <eid>BB_BB</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>AB_AB</eid>
+                <eid>CB_CB</eid>
                 </Accidental>
               <pitch>73</pitch>
               <tpc>21</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>BB_BB</eid>
+            <eid>DB_DB</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <eid>CB_CB</eid>
+              <eid>EB_EB</eid>
               </Articulation>
             <Note>
-              <eid>DB_DB</eid>
+              <eid>FB_FB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <eid>EB_EB</eid>
+            <eid>GB_GB</eid>
             </Fermata>
           <Chord>
-            <eid>FB_FB</eid>
+            <eid>HB_HB</eid>
             <durationType>32nd</durationType>
             <grace32/>
             <Note>
-              <eid>GB_GB</eid>
+              <eid>IB_IB</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>HB_HB</eid>
+            <eid>JB_JB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>IB_IB</eid>
+              <eid>KB_KB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             <TremoloSingleChord>
               <subtype>r16</subtype>
-              <eid>JB_JB</eid>
+              <eid>LB_LB</eid>
               </TremoloSingleChord>
             </Chord>
           </voice>
         </Measure>
       <Measure>
-        <eid>1B_1B</eid>
+        <eid>5B_5B</eid>
         <voice>
           <Dynamic>
             <subtype>p</subtype>
             <velocity>49</velocity>
-            <eid>KB_KB</eid>
+            <eid>MB_MB</eid>
             </Dynamic>
           <Chord>
-            <eid>LB_LB</eid>
+            <eid>NB_NB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>MB_MB</eid>
+              <eid>OB_OB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             <Note>
-              <eid>NB_NB</eid>
+              <eid>PB_PB</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>2B_2B</eid>
+                <eid>6B_6B</eid>
                 </Accidental>
               <pitch>78</pitch>
               <tpc>20</tpc>
               </Note>
             <Arpeggio>
               <subtype>0</subtype>
-              <eid>OB_OB</eid>
+              <eid>QB_QB</eid>
               </Arpeggio>
             </Chord>
           <Breath>
             <symbol>caesuraCurved</symbol>
             <pause>2</pause>
-            <eid>PB_PB</eid>
+            <eid>RB_RB</eid>
             </Breath>
           <Chord>
-            <eid>QB_QB</eid>
+            <eid>SB_SB</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articMarcatoAbove</subtype>
-              <eid>RB_RB</eid>
+              <eid>TB_TB</eid>
               </Articulation>
             <Note>
-              <eid>SB_SB</eid>
+              <eid>UB_UB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>TB_TB</eid>
+            <eid>VB_VB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>UB_UB</eid>
+              <eid>WB_WB</eid>
               <Tie>
-                <startElement>SB_SB</startElement>
-                <endElement>UB_UB</endElement>
-                <eid>VB_VB</eid>
+                <startElement>UB_UB</startElement>
+                <endElement>WB_WB</endElement>
+                <eid>XB_XB</eid>
                 <track>0</track>
                 </Tie>
               <pitch>71</pitch>
@@ -489,13 +489,13 @@
           <Clef>
             <concertClefType>F</concertClefType>
             <transposingClefType>F</transposingClefType>
-            <eid>WB_WB</eid>
+            <eid>YB_YB</eid>
             </Clef>
           <Chord>
-            <eid>XB_XB</eid>
+            <eid>ZB_ZB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>YB_YB</eid>
+              <eid>aB_aB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
@@ -503,45 +503,45 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>3B_3B</eid>
+        <eid>7B_7B</eid>
         <voice>
           <Chord>
-            <eid>ZB_ZB</eid>
+            <eid>bB_bB</eid>
             <durationType>half</durationType>
             <duration>1/4</duration>
             <Note>
-              <eid>aB_aB</eid>
+              <eid>cB_cB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             <TremoloTwoChord>
               <subtype>c32</subtype>
-              <eid>bB_bB</eid>
+              <eid>dB_dB</eid>
               <l1>22</l1>
               <l2>22</l2>
               </TremoloTwoChord>
             </Chord>
           <Chord>
-            <eid>cB_cB</eid>
+            <eid>eB_eB</eid>
             <durationType>half</durationType>
             <duration>1/4</duration>
             <Note>
-              <eid>dB_dB</eid>
+              <eid>fB_fB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>eB_eB</eid>
+            <eid>gB_gB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>fB_fB</eid>
+              <eid>hB_hB</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <Glissando>
-                <startElement>dB_dB</startElement>
-                <endElement>fB_fB</endElement>
-                <eid>gB_gB</eid>
+                <startElement>fB_fB</startElement>
+                <endElement>hB_hB</endElement>
+                <eid>iB_iB</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
@@ -550,10 +550,10 @@
           <Clef>
             <concertClefType>G</concertClefType>
             <transposingClefType>G</transposingClefType>
-            <eid>hB_hB</eid>
+            <eid>jB_jB</eid>
             </Clef>
           <Rest>
-            <eid>4B_4B</eid>
+            <eid>8B_8B</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -587,9 +587,9 @@
       <Volta>
         <endHookType>1</endHookType>
         <beginText>1.</beginText>
-        <startElement>yB_yB</startElement>
-        <endElement>yB_yB</endElement>
-        <eid>5B_5B</eid>
+        <startElement>2B_2B</startElement>
+        <endElement>2B_2B</endElement>
+        <eid>9B_9B</eid>
         <track>0</track>
         <endings>1</endings>
         </Volta>
@@ -630,6 +630,13 @@
               <headType>quarter</headType>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>4_4</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>5_5</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>2_2</NoteEID>
                 </Notes>
@@ -637,7 +644,7 @@
             </Chord>
           <intervalAbove>third,major</intervalAbove>
           <subtype>ornamentTrill</subtype>
-          <eid>4_4</eid>
+          <eid>6_6</eid>
           <track>0</track>
           </Ornament>
         </Trill>
@@ -648,7 +655,7 @@
         <track2>0</track2>
         <startTick>11/4</startTick>
         <ticks>1/1</ticks>
-        <eid>iB_iB</eid>
+        <eid>kB_kB</eid>
         <track>0</track>
         </Pedal>
       <Ottava>
@@ -656,13 +663,13 @@
         <track2>0</track2>
         <startTick>11/4</startTick>
         <ticks>1/1</ticks>
-        <eid>jB_jB</eid>
+        <eid>lB_lB</eid>
         <track>0</track>
         </Ottava>
       <Slur>
-        <startElement>9_9</startElement>
-        <endElement>BB_BB</endElement>
-        <eid>kB_kB</eid>
+        <startElement>/_/</startElement>
+        <endElement>DB_DB</endElement>
+        <eid>mB_mB</eid>
         <track>0</track>
         </Slur>
       <HairPin>
@@ -672,7 +679,7 @@
         <track2>0</track2>
         <startTick>15/4</startTick>
         <ticks>3/4</ticks>
-        <eid>lB_lB</eid>
+        <eid>nB_nB</eid>
         <track>0</track>
         </HairPin>
       <Trill>
@@ -680,21 +687,21 @@
         <track2>0</track2>
         <startTick>18/4</startTick>
         <ticks>1/4</ticks>
-        <eid>mB_mB</eid>
+        <eid>oB_oB</eid>
         <track>0</track>
         <lineWidth>0.1488</lineWidth>
         <Ornament>
           <Chord>
-            <eid>nB_nB</eid>
+            <eid>pB_pB</eid>
             <track>0</track>
             <small>1</small>
             <Note>
-              <eid>oB_oB</eid>
+              <eid>qB_qB</eid>
               <track>0</track>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>pB_pB</eid>
+                <eid>rB_rB</eid>
                 <track>0</track>
                 </Accidental>
               <pitch>75</pitch>
@@ -702,20 +709,29 @@
               <headType>quarter</headType>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>sB_sB</eid>
+                <track>0</track>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>tB_tB</eid>
+                <track>0</track>
+                </Parenthesis>
               <Notes>
-                <NoteEID>oB_oB</NoteEID>
+                <NoteEID>qB_qB</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <intervalAbove>third,major</intervalAbove>
           <subtype>ornamentTrill</subtype>
-          <eid>qB_qB</eid>
+          <eid>uB_uB</eid>
           <track>0</track>
           </Ornament>
         </Trill>
       </SpannerMap>
     <Score>
-      <eid>6B_6B</eid>
+      <eid>+B_+B</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -727,10 +743,10 @@
       <showMargins>0</showMargins>
       <metaTag name="partName">Flute</metaTag>
       <Part id="1">
-        <eid>7B_7B</eid>
+        <eid>/B_/B</eid>
         <Staff>
-          <eid>8B_8B</eid>
-          <linkedTo>tB_tB</linkedTo>
+          <eid>AC_AC</eid>
+          <linkedTo>xB_xB</linkedTo>
           <StaffType group="pitched">
             <name>stdNormal</name>
             </StaffType>
@@ -754,87 +770,87 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <eid>9B_9B</eid>
-          <linkedTo>uB_uB</linkedTo>
+          <eid>BC_BC</eid>
+          <linkedTo>yB_yB</linkedTo>
           <Text>
-            <eid>+B_+B</eid>
+            <eid>CC_CC</eid>
             <style>instrument_excerpt</style>
             <text>Flute</text>
             </Text>
           </VBox>
         <Measure>
-          <eid>/B_/B</eid>
+          <eid>DC_DC</eid>
           <voice>
             <KeySig>
-              <eid>AC_AC</eid>
-              <linkedTo>wB_wB</linkedTo>
+              <eid>EC_EC</eid>
+              <linkedTo>0B_0B</linkedTo>
               <concertKey>0</concertKey>
               </KeySig>
             <TimeSig>
-              <eid>BC_BC</eid>
-              <linkedTo>xB_xB</linkedTo>
+              <eid>FC_FC</eid>
+              <linkedTo>1B_1B</linkedTo>
               <sigN>4</sigN>
               <sigD>4</sigD>
               </TimeSig>
             <Tempo>
               <tempo>1.333333</tempo>
               <followText>1</followText>
-              <eid>CC_CC</eid>
+              <eid>GC_GC</eid>
               <linkedTo>B_B</linkedTo>
               <text><sym>metNoteQuarterUp</sym><font face="Edwin"/> = 80</text>
               </Tempo>
             <Chord>
-              <eid>DC_DC</eid>
+              <eid>HC_HC</eid>
               <linkedTo>C_C</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articAccentAbove</subtype>
-                <eid>EC_EC</eid>
+                <eid>IC_IC</eid>
                 <linkedTo>D_D</linkedTo>
                 </Articulation>
               <Note>
-                <eid>FC_FC</eid>
+                <eid>JC_JC</eid>
                 <linkedTo>E_E</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 <ChordLine>
                   <subtype>1</subtype>
-                  <eid>GC_GC</eid>
+                  <eid>KC_KC</eid>
                   <linkedTo>F_F</linkedTo>
                   </ChordLine>
                 </Note>
               </Chord>
             <Chord>
-              <eid>HC_HC</eid>
+              <eid>LC_LC</eid>
               <linkedTo>G_G</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articStaccatoAbove</subtype>
-                <eid>IC_IC</eid>
+                <eid>MC_MC</eid>
                 <linkedTo>H_H</linkedTo>
                 </Articulation>
               <Note>
-                <eid>JC_JC</eid>
+                <eid>NC_NC</eid>
                 <linkedTo>I_I</linkedTo>
                 <Accidental>
                   <subtype>accidentalSharp</subtype>
-                  <eid>KC_KC</eid>
+                  <eid>OC_OC</eid>
                   </Accidental>
                 <pitch>73</pitch>
                 <tpc>21</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>LC_LC</eid>
+              <eid>PC_PC</eid>
               <linkedTo>K_K</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articTenutoAbove</subtype>
-                <eid>MC_MC</eid>
+                <eid>QC_QC</eid>
                 <linkedTo>L_L</linkedTo>
                 </Articulation>
               <Note>
-                <eid>NC_NC</eid>
+                <eid>RC_RC</eid>
                 <linkedTo>M_M</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
@@ -842,54 +858,54 @@
               </Chord>
             <Fermata>
               <subtype>fermataAbove</subtype>
-              <eid>OC_OC</eid>
+              <eid>SC_SC</eid>
               <linkedTo>N_N</linkedTo>
               </Fermata>
             <Chord>
-              <eid>PC_PC</eid>
+              <eid>TC_TC</eid>
               <linkedTo>O_O</linkedTo>
               <durationType>32nd</durationType>
               <grace32/>
               <Note>
-                <eid>QC_QC</eid>
+                <eid>UC_UC</eid>
                 <linkedTo>P_P</linkedTo>
                 <pitch>59</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>RC_RC</eid>
+              <eid>VC_VC</eid>
               <linkedTo>Q_Q</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>SC_SC</eid>
+                <eid>WC_WC</eid>
                 <linkedTo>R_R</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <TremoloSingleChord>
                 <subtype>r16</subtype>
-                <eid>TC_TC</eid>
+                <eid>XC_XC</eid>
                 <linkedTo>S_S</linkedTo>
                 </TremoloSingleChord>
               </Chord>
             <BarLine>
               <subtype>double</subtype>
-              <eid>UC_UC</eid>
+              <eid>YC_YC</eid>
               <linkedTo>T_T</linkedTo>
               </BarLine>
             </voice>
           </Measure>
         <Measure>
-          <eid>VC_VC</eid>
+          <eid>ZC_ZC</eid>
           <voice>
             <KeySig>
-              <eid>WC_WC</eid>
+              <eid>aC_aC</eid>
               <linkedTo>U_U</linkedTo>
               <concertKey>4</concertKey>
               </KeySig>
             <TimeSig>
-              <eid>XC_XC</eid>
+              <eid>bC_bC</eid>
               <linkedTo>V_V</linkedTo>
               <sigN>3</sigN>
               <sigD>4</sigD>
@@ -897,64 +913,64 @@
             <Dynamic>
               <subtype>p</subtype>
               <velocity>49</velocity>
-              <eid>YC_YC</eid>
+              <eid>cC_cC</eid>
               <linkedTo>W_W</linkedTo>
               </Dynamic>
             <Chord>
-              <eid>ZC_ZC</eid>
+              <eid>dC_dC</eid>
               <linkedTo>X_X</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>aC_aC</eid>
+                <eid>eC_eC</eid>
                 <linkedTo>Y_Y</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <Note>
-                <eid>bC_bC</eid>
+                <eid>fC_fC</eid>
                 <linkedTo>Z_Z</linkedTo>
                 <pitch>78</pitch>
                 <tpc>20</tpc>
                 </Note>
               <Arpeggio>
                 <subtype>0</subtype>
-                <eid>cC_cC</eid>
+                <eid>gC_gC</eid>
                 <linkedTo>a_a</linkedTo>
                 </Arpeggio>
               </Chord>
             <Breath>
               <symbol>caesuraCurved</symbol>
               <pause>2</pause>
-              <eid>dC_dC</eid>
+              <eid>hC_hC</eid>
               <linkedTo>b_b</linkedTo>
               </Breath>
             <Chord>
-              <eid>eC_eC</eid>
+              <eid>iC_iC</eid>
               <linkedTo>c_c</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articMarcatoAbove</subtype>
-                <eid>fC_fC</eid>
+                <eid>jC_jC</eid>
                 <linkedTo>d_d</linkedTo>
                 </Articulation>
               <Note>
-                <eid>gC_gC</eid>
+                <eid>kC_kC</eid>
                 <linkedTo>e_e</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>hC_hC</eid>
+              <eid>lC_lC</eid>
               <linkedTo>f_f</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>iC_iC</eid>
+                <eid>mC_mC</eid>
                 <linkedTo>g_g</linkedTo>
                 <Tie>
-                  <startElement>gC_gC</startElement>
-                  <endElement>iC_iC</endElement>
-                  <eid>jC_jC</eid>
+                  <startElement>kC_kC</startElement>
+                  <endElement>mC_mC</endElement>
+                  <eid>nC_nC</eid>
                   <linkedTo>h_h</linkedTo>
                   <track>0</track>
                   </Tie>
@@ -965,80 +981,80 @@
             <Clef>
               <concertClefType>F</concertClefType>
               <transposingClefType>F</transposingClefType>
-              <eid>kC_kC</eid>
+              <eid>oC_oC</eid>
               <linkedTo>i_i</linkedTo>
               </Clef>
             </voice>
           </Measure>
         <Measure>
-          <eid>lC_lC</eid>
+          <eid>pC_pC</eid>
           <voice>
             <KeySig>
-              <eid>mC_mC</eid>
+              <eid>qC_qC</eid>
               <linkedTo>j_j</linkedTo>
               <concertKey>0</concertKey>
               </KeySig>
             <TimeSig>
-              <eid>nC_nC</eid>
+              <eid>rC_rC</eid>
               <linkedTo>k_k</linkedTo>
               <sigN>4</sigN>
               <sigD>4</sigD>
               </TimeSig>
             <Chord>
-              <eid>oC_oC</eid>
+              <eid>sC_sC</eid>
               <linkedTo>l_l</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>pC_pC</eid>
+                <eid>tC_tC</eid>
                 <linkedTo>m_m</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>qC_qC</eid>
+              <eid>uC_uC</eid>
               <linkedTo>n_n</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>rC_rC</eid>
+                <eid>vC_vC</eid>
                 <linkedTo>o_o</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <TremoloTwoChord>
                 <subtype>c32</subtype>
-                <eid>sC_sC</eid>
+                <eid>wC_wC</eid>
                 <linkedTo>p_p</linkedTo>
                 <l1>22</l1>
                 <l2>22</l2>
                 </TremoloTwoChord>
               </Chord>
             <Chord>
-              <eid>tC_tC</eid>
+              <eid>xC_xC</eid>
               <linkedTo>q_q</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>uC_uC</eid>
+                <eid>yC_yC</eid>
                 <linkedTo>r_r</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>vC_vC</eid>
+              <eid>zC_zC</eid>
               <linkedTo>s_s</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>wC_wC</eid>
+                <eid>0C_0C</eid>
                 <linkedTo>t_t</linkedTo>
                 <pitch>65</pitch>
                 <tpc>13</tpc>
                 <Glissando>
-                  <startElement>uC_uC</startElement>
-                  <endElement>wC_wC</endElement>
-                  <eid>xC_xC</eid>
+                  <startElement>yC_yC</startElement>
+                  <endElement>0C_0C</endElement>
+                  <eid>1C_1C</eid>
                   <linkedTo>u_u</linkedTo>
                   <track>0</track>
                   <diagonal>1</diagonal>
@@ -1048,166 +1064,166 @@
             <Clef>
               <concertClefType>G</concertClefType>
               <transposingClefType>G</transposingClefType>
-              <eid>yC_yC</eid>
+              <eid>2C_2C</eid>
               <linkedTo>v_v</linkedTo>
               </Clef>
             </voice>
           </Measure>
         <Measure>
-          <eid>zC_zC</eid>
+          <eid>3C_3C</eid>
           <voice>
             <Chord>
-              <eid>0C_0C</eid>
-              <linkedTo>5_5</linkedTo>
+              <eid>4C_4C</eid>
+              <linkedTo>7_7</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articAccentAbove</subtype>
-                <eid>1C_1C</eid>
-                <linkedTo>6_6</linkedTo>
+                <eid>5C_5C</eid>
+                <linkedTo>8_8</linkedTo>
                 </Articulation>
               <Note>
-                <eid>2C_2C</eid>
-                <linkedTo>7_7</linkedTo>
+                <eid>6C_6C</eid>
+                <linkedTo>9_9</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 <ChordLine>
                   <subtype>1</subtype>
-                  <eid>3C_3C</eid>
-                  <linkedTo>8_8</linkedTo>
+                  <eid>7C_7C</eid>
+                  <linkedTo>+_+</linkedTo>
                   </ChordLine>
                 </Note>
               </Chord>
             <Chord>
-              <eid>4C_4C</eid>
-              <linkedTo>9_9</linkedTo>
+              <eid>8C_8C</eid>
+              <linkedTo>/_/</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articStaccatoAbove</subtype>
-                <eid>5C_5C</eid>
-                <linkedTo>+_+</linkedTo>
+                <eid>9C_9C</eid>
+                <linkedTo>AB_AB</linkedTo>
                 </Articulation>
               <Note>
-                <eid>6C_6C</eid>
-                <linkedTo>/_/</linkedTo>
+                <eid>+C_+C</eid>
+                <linkedTo>BB_BB</linkedTo>
                 <Accidental>
                   <subtype>accidentalSharp</subtype>
-                  <eid>7C_7C</eid>
+                  <eid>/C_/C</eid>
                   </Accidental>
                 <pitch>73</pitch>
                 <tpc>21</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>8C_8C</eid>
-              <linkedTo>BB_BB</linkedTo>
+              <eid>AD_AD</eid>
+              <linkedTo>DB_DB</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articTenutoAbove</subtype>
-                <eid>9C_9C</eid>
-                <linkedTo>CB_CB</linkedTo>
+                <eid>BD_BD</eid>
+                <linkedTo>EB_EB</linkedTo>
                 </Articulation>
               <Note>
-                <eid>+C_+C</eid>
-                <linkedTo>DB_DB</linkedTo>
+                <eid>CD_CD</eid>
+                <linkedTo>FB_FB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Fermata>
               <subtype>fermataAbove</subtype>
-              <eid>/C_/C</eid>
-              <linkedTo>EB_EB</linkedTo>
+              <eid>DD_DD</eid>
+              <linkedTo>GB_GB</linkedTo>
               </Fermata>
             <Chord>
-              <eid>AD_AD</eid>
-              <linkedTo>FB_FB</linkedTo>
+              <eid>ED_ED</eid>
+              <linkedTo>HB_HB</linkedTo>
               <durationType>32nd</durationType>
               <grace32/>
               <Note>
-                <eid>BD_BD</eid>
-                <linkedTo>GB_GB</linkedTo>
+                <eid>FD_FD</eid>
+                <linkedTo>IB_IB</linkedTo>
                 <pitch>59</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>CD_CD</eid>
-              <linkedTo>HB_HB</linkedTo>
+              <eid>GD_GD</eid>
+              <linkedTo>JB_JB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>DD_DD</eid>
-                <linkedTo>IB_IB</linkedTo>
+                <eid>HD_HD</eid>
+                <linkedTo>KB_KB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <TremoloSingleChord>
                 <subtype>r16</subtype>
-                <eid>ED_ED</eid>
-                <linkedTo>JB_JB</linkedTo>
+                <eid>ID_ID</eid>
+                <linkedTo>LB_LB</linkedTo>
                 </TremoloSingleChord>
               </Chord>
             </voice>
           </Measure>
         <Measure>
-          <eid>FD_FD</eid>
+          <eid>JD_JD</eid>
           <voice>
             <Dynamic>
               <subtype>p</subtype>
               <velocity>49</velocity>
-              <eid>GD_GD</eid>
-              <linkedTo>KB_KB</linkedTo>
+              <eid>KD_KD</eid>
+              <linkedTo>MB_MB</linkedTo>
               </Dynamic>
             <Chord>
-              <eid>HD_HD</eid>
-              <linkedTo>LB_LB</linkedTo>
+              <eid>LD_LD</eid>
+              <linkedTo>NB_NB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>ID_ID</eid>
-                <linkedTo>MB_MB</linkedTo>
+                <eid>MD_MD</eid>
+                <linkedTo>OB_OB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <Note>
-                <eid>JD_JD</eid>
-                <linkedTo>NB_NB</linkedTo>
+                <eid>ND_ND</eid>
+                <linkedTo>PB_PB</linkedTo>
                 <pitch>78</pitch>
                 <tpc>20</tpc>
                 </Note>
               <Arpeggio>
                 <subtype>0</subtype>
-                <eid>KD_KD</eid>
-                <linkedTo>OB_OB</linkedTo>
+                <eid>OD_OD</eid>
+                <linkedTo>QB_QB</linkedTo>
                 </Arpeggio>
               </Chord>
             <Breath>
               <symbol>caesuraCurved</symbol>
               <pause>2</pause>
-              <eid>LD_LD</eid>
-              <linkedTo>PB_PB</linkedTo>
+              <eid>PD_PD</eid>
+              <linkedTo>RB_RB</linkedTo>
               </Breath>
             <Chord>
-              <eid>MD_MD</eid>
-              <linkedTo>QB_QB</linkedTo>
+              <eid>QD_QD</eid>
+              <linkedTo>SB_SB</linkedTo>
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>articMarcatoAbove</subtype>
-                <eid>ND_ND</eid>
-                <linkedTo>RB_RB</linkedTo>
+                <eid>RD_RD</eid>
+                <linkedTo>TB_TB</linkedTo>
                 </Articulation>
               <Note>
-                <eid>OD_OD</eid>
-                <linkedTo>SB_SB</linkedTo>
+                <eid>SD_SD</eid>
+                <linkedTo>UB_UB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>PD_PD</eid>
-              <linkedTo>TB_TB</linkedTo>
+              <eid>TD_TD</eid>
+              <linkedTo>VB_VB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>QD_QD</eid>
-                <linkedTo>UB_UB</linkedTo>
+                <eid>UD_UD</eid>
+                <linkedTo>WB_WB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
@@ -1215,16 +1231,16 @@
             <Clef>
               <concertClefType>F</concertClefType>
               <transposingClefType>F</transposingClefType>
-              <eid>RD_RD</eid>
-              <linkedTo>WB_WB</linkedTo>
+              <eid>VD_VD</eid>
+              <linkedTo>YB_YB</linkedTo>
               </Clef>
             <Chord>
-              <eid>SD_SD</eid>
-              <linkedTo>XB_XB</linkedTo>
+              <eid>WD_WD</eid>
+              <linkedTo>ZB_ZB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>TD_TD</eid>
-                <linkedTo>YB_YB</linkedTo>
+                <eid>XD_XD</eid>
+                <linkedTo>aB_aB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
@@ -1232,46 +1248,46 @@
             </voice>
           </Measure>
         <Measure>
-          <eid>UD_UD</eid>
+          <eid>YD_YD</eid>
           <voice>
             <Chord>
-              <eid>VD_VD</eid>
-              <linkedTo>ZB_ZB</linkedTo>
+              <eid>ZD_ZD</eid>
+              <linkedTo>bB_bB</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>WD_WD</eid>
-                <linkedTo>aB_aB</linkedTo>
+                <eid>aD_aD</eid>
+                <linkedTo>cB_cB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               <TremoloTwoChord>
                 <subtype>c32</subtype>
-                <eid>XD_XD</eid>
-                <linkedTo>bB_bB</linkedTo>
+                <eid>bD_bD</eid>
+                <linkedTo>dB_dB</linkedTo>
                 <l1>0</l1>
                 <l2>0</l2>
                 </TremoloTwoChord>
               </Chord>
             <Chord>
-              <eid>YD_YD</eid>
-              <linkedTo>cB_cB</linkedTo>
+              <eid>cD_cD</eid>
+              <linkedTo>eB_eB</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>ZD_ZD</eid>
-                <linkedTo>dB_dB</linkedTo>
+                <eid>dD_dD</eid>
+                <linkedTo>fB_fB</linkedTo>
                 <pitch>71</pitch>
                 <tpc>19</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>aD_aD</eid>
-              <linkedTo>eB_eB</linkedTo>
+              <eid>eD_eD</eid>
+              <linkedTo>gB_gB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>bD_bD</eid>
-                <linkedTo>fB_fB</linkedTo>
+                <eid>fD_fD</eid>
+                <linkedTo>hB_hB</linkedTo>
                 <pitch>65</pitch>
                 <tpc>13</tpc>
                 </Note>
@@ -1279,12 +1295,12 @@
             <Clef>
               <concertClefType>G</concertClefType>
               <transposingClefType>G</transposingClefType>
-              <eid>cD_cD</eid>
-              <linkedTo>hB_hB</linkedTo>
+              <eid>gD_gD</eid>
+              <linkedTo>jB_jB</linkedTo>
               </Clef>
             <Rest>
-              <eid>dD_dD</eid>
-              <linkedTo>4B_4B</linkedTo>
+              <eid>hD_hD</eid>
+              <linkedTo>8B_8B</linkedTo>
               <durationType>quarter</durationType>
               </Rest>
             </voice>
@@ -1298,7 +1314,7 @@
           <track2>0</track2>
           <startTick>0/1</startTick>
           <ticks>1/1</ticks>
-          <eid>eD_eD</eid>
+          <eid>iD_iD</eid>
           <linkedTo>w_w</linkedTo>
           <track>0</track>
           </Pedal>
@@ -1307,24 +1323,24 @@
           <track2>0</track2>
           <startTick>0/1</startTick>
           <ticks>1/1</ticks>
-          <eid>fD_fD</eid>
+          <eid>jD_jD</eid>
           <linkedTo>x_x</linkedTo>
           <track>0</track>
           </Ottava>
         <Slur>
-          <startElement>HC_HC</startElement>
-          <endElement>LC_LC</endElement>
-          <eid>gD_gD</eid>
+          <startElement>LC_LC</startElement>
+          <endElement>PC_PC</endElement>
+          <eid>kD_kD</eid>
           <linkedTo>y_y</linkedTo>
           <track>0</track>
           </Slur>
         <Volta>
           <endHookType>1</endHookType>
           <beginText>1.</beginText>
-          <startElement>VC_VC</startElement>
-          <endElement>VC_VC</endElement>
-          <eid>hD_hD</eid>
-          <linkedTo>5B_5B</linkedTo>
+          <startElement>ZC_ZC</startElement>
+          <endElement>ZC_ZC</endElement>
+          <eid>lD_lD</eid>
+          <linkedTo>9B_9B</linkedTo>
           <track>0</track>
           <endings>1</endings>
           </Volta>
@@ -1335,7 +1351,7 @@
           <track2>0</track2>
           <startTick>1/1</startTick>
           <ticks>3/4</ticks>
-          <eid>iD_iD</eid>
+          <eid>mD_mD</eid>
           <linkedTo>z_z</linkedTo>
           <track>0</track>
           </HairPin>
@@ -1344,22 +1360,22 @@
           <track2>0</track2>
           <startTick>7/4</startTick>
           <ticks>1/4</ticks>
-          <eid>jD_jD</eid>
+          <eid>nD_nD</eid>
           <linkedTo>0_0</linkedTo>
           <track>0</track>
           <lineWidth>0.1488</lineWidth>
           <Ornament>
             <Chord>
-              <eid>kD_kD</eid>
+              <eid>oD_oD</eid>
               <track>0</track>
               <small>1</small>
               <Note>
-                <eid>lD_lD</eid>
+                <eid>pD_pD</eid>
                 <track>0</track>
                 <parentheses>both</parentheses>
                 <Accidental>
                   <subtype>accidentalSharp</subtype>
-                  <eid>mD_mD</eid>
+                  <eid>qD_qD</eid>
                   <track>0</track>
                   </Accidental>
                 <pitch>75</pitch>
@@ -1367,15 +1383,22 @@
                 <headType>quarter</headType>
                 </Note>
               <NoteParenGroup>
+                <Parenthesis>
+                  <eid>rD_rD</eid>
+                  </Parenthesis>
+                <Parenthesis>
+                  <horizontalDirection>right</horizontalDirection>
+                  <eid>sD_sD</eid>
+                  </Parenthesis>
                 <Notes>
-                  <NoteEID>lD_lD</NoteEID>
+                  <NoteEID>pD_pD</NoteEID>
                   </Notes>
                 </NoteParenGroup>
               </Chord>
             <intervalAbove>third,major</intervalAbove>
             <subtype>ornamentTrill</subtype>
-            <eid>nD_nD</eid>
-            <linkedTo>4_4</linkedTo>
+            <eid>tD_tD</eid>
+            <linkedTo>6_6</linkedTo>
             <track>0</track>
             </Ornament>
           </Trill>
@@ -1386,8 +1409,8 @@
           <track2>0</track2>
           <startTick>11/4</startTick>
           <ticks>1/1</ticks>
-          <eid>oD_oD</eid>
-          <linkedTo>iB_iB</linkedTo>
+          <eid>uD_uD</eid>
+          <linkedTo>kB_kB</linkedTo>
           <track>0</track>
           </Pedal>
         <Ottava>
@@ -1395,15 +1418,15 @@
           <track2>0</track2>
           <startTick>11/4</startTick>
           <ticks>1/1</ticks>
-          <eid>pD_pD</eid>
-          <linkedTo>jB_jB</linkedTo>
+          <eid>vD_vD</eid>
+          <linkedTo>lB_lB</linkedTo>
           <track>0</track>
           </Ottava>
         <Slur>
-          <startElement>4C_4C</startElement>
-          <endElement>8C_8C</endElement>
-          <eid>qD_qD</eid>
-          <linkedTo>kB_kB</linkedTo>
+          <startElement>8C_8C</startElement>
+          <endElement>AD_AD</endElement>
+          <eid>wD_wD</eid>
+          <linkedTo>mB_mB</linkedTo>
           <track>0</track>
           </Slur>
         <HairPin>
@@ -1413,8 +1436,8 @@
           <track2>0</track2>
           <startTick>15/4</startTick>
           <ticks>3/4</ticks>
-          <eid>rD_rD</eid>
-          <linkedTo>lB_lB</linkedTo>
+          <eid>xD_xD</eid>
+          <linkedTo>nB_nB</linkedTo>
           <track>0</track>
           </HairPin>
         <Trill>
@@ -1422,22 +1445,22 @@
           <track2>0</track2>
           <startTick>18/4</startTick>
           <ticks>1/4</ticks>
-          <eid>sD_sD</eid>
-          <linkedTo>mB_mB</linkedTo>
+          <eid>yD_yD</eid>
+          <linkedTo>oB_oB</linkedTo>
           <track>0</track>
           <lineWidth>0.1488</lineWidth>
           <Ornament>
             <Chord>
-              <eid>tD_tD</eid>
+              <eid>zD_zD</eid>
               <track>0</track>
               <small>1</small>
               <Note>
-                <eid>uD_uD</eid>
+                <eid>0D_0D</eid>
                 <track>0</track>
                 <parentheses>both</parentheses>
                 <Accidental>
                   <subtype>accidentalSharp</subtype>
-                  <eid>vD_vD</eid>
+                  <eid>1D_1D</eid>
                   <track>0</track>
                   </Accidental>
                 <pitch>75</pitch>
@@ -1445,15 +1468,24 @@
                 <headType>quarter</headType>
                 </Note>
               <NoteParenGroup>
+                <Parenthesis>
+                  <eid>2D_2D</eid>
+                  <track>0</track>
+                  </Parenthesis>
+                <Parenthesis>
+                  <horizontalDirection>right</horizontalDirection>
+                  <eid>3D_3D</eid>
+                  <track>0</track>
+                  </Parenthesis>
                 <Notes>
-                  <NoteEID>uD_uD</NoteEID>
+                  <NoteEID>0D_0D</NoteEID>
                   </Notes>
                 </NoteParenGroup>
               </Chord>
             <intervalAbove>third,major</intervalAbove>
             <subtype>ornamentTrill</subtype>
-            <eid>wD_wD</eid>
-            <linkedTo>qB_qB</linkedTo>
+            <eid>4D_4D</eid>
+            <linkedTo>uB_uB</linkedTo>
             <track>0</track>
             </Ornament>
           </Trill>

--- a/src/engraving/tests/copypaste_data/copypaste_repeatListSelection-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_repeatListSelection-ref.mscx
@@ -171,16 +171,23 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>iIlSB4LQ97P_iIlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>jIlSB4LQ97P_jIlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>FnxFxecIhwM_/8Z5xhXCfuO</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>iIlSB4LQ97P_iIlSB4LQ97P</eid>
+            <eid>kIlSB4LQ97P_kIlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>jIlSB4LQ97P_jIlSB4LQ97P</eid>
+              <eid>lIlSB4LQ97P_lIlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -188,8 +195,15 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>mIlSB4LQ97P_mIlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>nIlSB4LQ97P_nIlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>jIlSB4LQ97P_jIlSB4LQ97P</NoteEID>
+                <NoteEID>lIlSB4LQ97P_lIlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
@@ -221,21 +235,21 @@
               </TremoloSingleChord>
             </Chord>
           <Chord>
-            <eid>kIlSB4LQ97P_kIlSB4LQ97P</eid>
+            <eid>oIlSB4LQ97P_oIlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>lIlSB4LQ97P_lIlSB4LQ97P</eid>
+              <eid>pIlSB4LQ97P_pIlSB4LQ97P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
-              <eid>mIlSB4LQ97P_mIlSB4LQ97P</eid>
+              <eid>qIlSB4LQ97P_qIlSB4LQ97P</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               </Note>
             <TremoloSingleChord>
               <subtype>r32</subtype>
-              <eid>nIlSB4LQ97P_nIlSB4LQ97P</eid>
+              <eid>rIlSB4LQ97P_rIlSB4LQ97P</eid>
               </TremoloSingleChord>
             </Chord>
           <Rest>
@@ -275,23 +289,23 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>oIlSB4LQ97P_oIlSB4LQ97P</eid>
+            <eid>sIlSB4LQ97P_sIlSB4LQ97P</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
-              <eid>pIlSB4LQ97P_pIlSB4LQ97P</eid>
+              <eid>tIlSB4LQ97P_tIlSB4LQ97P</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
-              <eid>qIlSB4LQ97P_qIlSB4LQ97P</eid>
+              <eid>uIlSB4LQ97P_uIlSB4LQ97P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <head>withx</head>
               </Note>
             </Chord>
           <Rest>
-            <eid>rIlSB4LQ97P_rIlSB4LQ97P</eid>
+            <eid>vIlSB4LQ97P_vIlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -343,12 +357,26 @@
               <tpc>17</tpc>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>wIlSB4LQ97P_wIlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>xIlSB4LQ97P_xIlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>0b3xdwlID2F_lE9ZJSjrm3O</NoteEID>
                 <NoteEID>ZNCtP8KEtVL_8Q08arUSHjK</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>yIlSB4LQ97P_yIlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>zIlSB4LQ97P_zIlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>VNqmebd+ofP_0xyw3HP9W4H</NoteEID>
                 <NoteEID>trrHu3W2RhJ_tCmSx2UkxVE</NoteEID>
@@ -357,43 +385,57 @@
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>sIlSB4LQ97P_sIlSB4LQ97P</eid>
+            <eid>0IlSB4LQ97P_0IlSB4LQ97P</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>tIlSB4LQ97P_tIlSB4LQ97P</eid>
+              <eid>1IlSB4LQ97P_1IlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <Note>
-              <eid>uIlSB4LQ97P_uIlSB4LQ97P</eid>
+              <eid>2IlSB4LQ97P_2IlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <Note>
-              <eid>vIlSB4LQ97P_vIlSB4LQ97P</eid>
+              <eid>3IlSB4LQ97P_3IlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <Note>
-              <eid>wIlSB4LQ97P_wIlSB4LQ97P</eid>
+              <eid>4IlSB4LQ97P_4IlSB4LQ97P</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>5IlSB4LQ97P_5IlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>6IlSB4LQ97P_6IlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>tIlSB4LQ97P_tIlSB4LQ97P</NoteEID>
-                <NoteEID>uIlSB4LQ97P_uIlSB4LQ97P</NoteEID>
+                <NoteEID>1IlSB4LQ97P_1IlSB4LQ97P</NoteEID>
+                <NoteEID>2IlSB4LQ97P_2IlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>7IlSB4LQ97P_7IlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>8IlSB4LQ97P_8IlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>vIlSB4LQ97P_vIlSB4LQ97P</NoteEID>
+                <NoteEID>3IlSB4LQ97P_3IlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
@@ -426,16 +468,16 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>xIlSB4LQ97P_xIlSB4LQ97P</eid>
+            <eid>9IlSB4LQ97P_9IlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>yIlSB4LQ97P_yIlSB4LQ97P</eid>
+              <eid>+IlSB4LQ97P_+IlSB4LQ97P</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <head>triangle-up</head>
               </Note>
             <Note>
-              <eid>zIlSB4LQ97P_zIlSB4LQ97P</eid>
+              <eid>/IlSB4LQ97P_/IlSB4LQ97P</eid>
               <pitch>86</pitch>
               <tpc>16</tpc>
               </Note>
@@ -462,15 +504,15 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>0IlSB4LQ97P_0IlSB4LQ97P</eid>
+            <eid>AJlSB4LQ97P_AJlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>1IlSB4LQ97P_1IlSB4LQ97P</eid>
+              <eid>BJlSB4LQ97P_BJlSB4LQ97P</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               </Note>
             <Note>
-              <eid>2IlSB4LQ97P_2IlSB4LQ97P</eid>
+              <eid>CJlSB4LQ97P_CJlSB4LQ97P</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <head>triangle-up</head>
@@ -501,24 +543,38 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>DJlSB4LQ97P_DJlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>EJlSB4LQ97P_EJlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>xSeIF5GSGDH_50j5/Y//e5N</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>3IlSB4LQ97P_3IlSB4LQ97P</eid>
+            <eid>FJlSB4LQ97P_FJlSB4LQ97P</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4IlSB4LQ97P_4IlSB4LQ97P</eid>
+              <eid>GJlSB4LQ97P_GJlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>HJlSB4LQ97P_HJlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>IJlSB4LQ97P_IJlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>4IlSB4LQ97P_4IlSB4LQ97P</NoteEID>
+                <NoteEID>GJlSB4LQ97P_GJlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
@@ -528,15 +584,15 @@
         <eid>mt/BFUiNG+O_8EVBTn9xdl</eid>
         <voice>
           <Chord>
-            <eid>5IlSB4LQ97P_5IlSB4LQ97P</eid>
+            <eid>JJlSB4LQ97P_JJlSB4LQ97P</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>6IlSB4LQ97P_6IlSB4LQ97P</eid>
+              <eid>KJlSB4LQ97P_KJlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <Tie>
-                <startElement>4IlSB4LQ97P_4IlSB4LQ97P</startElement>
-                <endElement>6IlSB4LQ97P_6IlSB4LQ97P</endElement>
-                <eid>7IlSB4LQ97P_7IlSB4LQ97P</eid>
+                <startElement>GJlSB4LQ97P_GJlSB4LQ97P</startElement>
+                <endElement>KJlSB4LQ97P_KJlSB4LQ97P</endElement>
+                <eid>LJlSB4LQ97P_LJlSB4LQ97P</eid>
                 <track>0</track>
                 </Tie>
               <pitch>76</pitch>
@@ -544,21 +600,28 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>MJlSB4LQ97P_MJlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>NJlSB4LQ97P_NJlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>6IlSB4LQ97P_6IlSB4LQ97P</NoteEID>
+                <NoteEID>KJlSB4LQ97P_KJlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>8IlSB4LQ97P_8IlSB4LQ97P</eid>
+            <eid>OJlSB4LQ97P_OJlSB4LQ97P</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>9IlSB4LQ97P_9IlSB4LQ97P</eid>
+              <eid>PJlSB4LQ97P_PJlSB4LQ97P</eid>
               <parentheses>both</parentheses>
               <Tie>
-                <startElement>6IlSB4LQ97P_6IlSB4LQ97P</startElement>
-                <endElement>9IlSB4LQ97P_9IlSB4LQ97P</endElement>
-                <eid>+IlSB4LQ97P_+IlSB4LQ97P</eid>
+                <startElement>KJlSB4LQ97P_KJlSB4LQ97P</startElement>
+                <endElement>PJlSB4LQ97P_PJlSB4LQ97P</endElement>
+                <eid>QJlSB4LQ97P_QJlSB4LQ97P</eid>
                 <track>0</track>
                 </Tie>
               <pitch>76</pitch>
@@ -566,17 +629,24 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>RJlSB4LQ97P_RJlSB4LQ97P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>SJlSB4LQ97P_SJlSB4LQ97P</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>9IlSB4LQ97P_9IlSB4LQ97P</NoteEID>
+                <NoteEID>PJlSB4LQ97P_PJlSB4LQ97P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>/IlSB4LQ97P_/IlSB4LQ97P</eid>
+            <eid>TJlSB4LQ97P_TJlSB4LQ97P</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <eid>AJlSB4LQ97P_AJlSB4LQ97P</eid>
+            <eid>UJlSB4LQ97P_UJlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -618,15 +688,15 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>BJlSB4LQ97P_BJlSB4LQ97P</eid>
+            <eid>VJlSB4LQ97P_VJlSB4LQ97P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>CJlSB4LQ97P_CJlSB4LQ97P</eid>
+              <eid>WJlSB4LQ97P_WJlSB4LQ97P</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
-              <eid>DJlSB4LQ97P_DJlSB4LQ97P</eid>
+              <eid>XJlSB4LQ97P_XJlSB4LQ97P</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>

--- a/src/engraving/tests/parts_data/part-spanners-parts.mscx
+++ b/src/engraving/tests/parts_data/part-spanners-parts.mscx
@@ -136,7 +136,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <eid>UB_UB</eid>
+        <eid>YB_YB</eid>
         </VBox>
       <Measure>
         <eid>E_E</eid>
@@ -271,6 +271,13 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>UB_UB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>VB_VB</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>g_g</NoteEID>
                 </Notes>
@@ -457,6 +464,13 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>WB_WB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>XB_XB</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>EB_EB</NoteEID>
                 </Notes>
@@ -557,7 +571,7 @@
         </GradualTempoChange>
       </SpannerMap>
     <Score>
-      <eid>VB_VB</eid>
+      <eid>ZB_ZB</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -569,9 +583,9 @@
       <showMargins>0</showMargins>
       <metaTag name="partName">Flute</metaTag>
       <Part id="1">
-        <eid>WB_WB</eid>
+        <eid>aB_aB</eid>
         <Staff>
-          <eid>XB_XB</eid>
+          <eid>bB_bB</eid>
           <linkedTo>QB_QB</linkedTo>
           <StaffType group="pitched">
             <name>stdNormal</name>
@@ -596,74 +610,74 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <eid>YB_YB</eid>
-          <linkedTo>UB_UB</linkedTo>
+          <eid>cB_cB</eid>
+          <linkedTo>YB_YB</linkedTo>
           <Text>
-            <eid>ZB_ZB</eid>
+            <eid>dB_dB</eid>
             <style>instrument_excerpt</style>
             <text>Flute</text>
             </Text>
           </VBox>
         <Measure>
-          <eid>aB_aB</eid>
+          <eid>eB_eB</eid>
           <voice>
             <KeySig>
-              <eid>bB_bB</eid>
+              <eid>fB_fB</eid>
               <linkedTo>F_F</linkedTo>
               <concertKey>0</concertKey>
               </KeySig>
             <TimeSig>
-              <eid>cB_cB</eid>
+              <eid>gB_gB</eid>
               <linkedTo>G_G</linkedTo>
               <sigN>4</sigN>
               <sigD>4</sigD>
               </TimeSig>
             <Chord>
-              <eid>dB_dB</eid>
+              <eid>hB_hB</eid>
               <linkedTo>I_I</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>eB_eB</eid>
+                <eid>iB_iB</eid>
                 <linkedTo>K_K</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>fB_fB</eid>
+              <eid>jB_jB</eid>
               <linkedTo>L_L</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>gB_gB</eid>
+                <eid>kB_kB</eid>
                 <linkedTo>M_M</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>hB_hB</eid>
+              <eid>lB_lB</eid>
               <linkedTo>N_N</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>iB_iB</eid>
+                <eid>mB_mB</eid>
                 <linkedTo>O_O</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>jB_jB</eid>
+              <eid>nB_nB</eid>
               <linkedTo>Q_Q</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>kB_kB</eid>
+                <eid>oB_oB</eid>
                 <linkedTo>R_R</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 <Glissando>
-                  <startElement>iB_iB</startElement>
-                  <endElement>kB_kB</endElement>
-                  <eid>lB_lB</eid>
+                  <startElement>mB_mB</startElement>
+                  <endElement>oB_oB</endElement>
+                  <eid>pB_pB</eid>
                   <linkedTo>P_P</linkedTo>
                   <track>0</track>
                   <diagonal>1</diagonal>
@@ -673,56 +687,56 @@
             </voice>
           </Measure>
         <Measure>
-          <eid>mB_mB</eid>
+          <eid>qB_qB</eid>
           <voice>
             <Chord>
-              <eid>nB_nB</eid>
+              <eid>rB_rB</eid>
               <linkedTo>U_U</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>oB_oB</eid>
+                <eid>sB_sB</eid>
                 <linkedTo>V_V</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               <TremoloTwoChord>
                 <subtype>c16</subtype>
-                <eid>pB_pB</eid>
+                <eid>tB_tB</eid>
                 <linkedTo>W_W</linkedTo>
                 <l1>0</l1>
                 <l2>2</l2>
                 </TremoloTwoChord>
               </Chord>
             <Chord>
-              <eid>qB_qB</eid>
+              <eid>uB_uB</eid>
               <linkedTo>X_X</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>rB_rB</eid>
+                <eid>vB_vB</eid>
                 <linkedTo>Y_Y</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>sB_sB</eid>
+              <eid>wB_wB</eid>
               <linkedTo>Z_Z</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>tB_tB</eid>
+                <eid>xB_xB</eid>
                 <linkedTo>a_a</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>uB_uB</eid>
+              <eid>yB_yB</eid>
               <linkedTo>c_c</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>vB_vB</eid>
+                <eid>zB_zB</eid>
                 <linkedTo>d_d</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
@@ -730,9 +744,9 @@
                   <guitarBendType>bend</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>1</bendEndTimeFactor>
-                  <startElement>tB_tB</startElement>
-                  <endElement>vB_vB</endElement>
-                  <eid>wB_wB</eid>
+                  <startElement>xB_xB</startElement>
+                  <endElement>zB_zB</endElement>
+                  <eid>0B_0B</eid>
                   <linkedTo>b_b</linkedTo>
                   <track>0</track>
                   </GuitarBend>
@@ -741,17 +755,17 @@
             </voice>
           </Measure>
         <Measure>
-          <eid>xB_xB</eid>
+          <eid>1B_1B</eid>
           <voice>
             <Chord>
-              <eid>yB_yB</eid>
+              <eid>2B_2B</eid>
               <linkedTo>f_f</linkedTo>
               <BeamMode>no</BeamMode>
               <durationType>eighth</durationType>
               <appoggiatura/>
               <noStem>1</noStem>
               <Note>
-                <eid>zB_zB</eid>
+                <eid>3B_3B</eid>
                 <linkedTo>g_g</linkedTo>
                 <parentheses>both</parentheses>
                 <pitch>65</pitch>
@@ -760,17 +774,26 @@
                 <ghost>1</ghost>
                 </Note>
               <NoteParenGroup>
+                <Parenthesis>
+                  <eid>4B_4B</eid>
+                  <linkedTo>UB_UB</linkedTo>
+                  </Parenthesis>
+                <Parenthesis>
+                  <horizontalDirection>right</horizontalDirection>
+                  <eid>5B_5B</eid>
+                  <linkedTo>VB_VB</linkedTo>
+                  </Parenthesis>
                 <Notes>
-                  <NoteEID>zB_zB</NoteEID>
+                  <NoteEID>3B_3B</NoteEID>
                   </Notes>
                 </NoteParenGroup>
               </Chord>
             <Chord>
-              <eid>0B_0B</eid>
+              <eid>6B_6B</eid>
               <linkedTo>k_k</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>1B_1B</eid>
+                <eid>7B_7B</eid>
                 <linkedTo>l_l</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
@@ -779,36 +802,36 @@
                   <guitarBendType>bend</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>1</bendEndTimeFactor>
-                  <startElement>zB_zB</startElement>
-                  <endElement>1B_1B</endElement>
-                  <eid>2B_2B</eid>
+                  <startElement>3B_3B</startElement>
+                  <endElement>7B_7B</endElement>
+                  <eid>8B_8B</eid>
                   <linkedTo>j_j</linkedTo>
                   <track>0</track>
                   </GuitarBend>
                 </Note>
               </Chord>
             <Chord>
-              <eid>3B_3B</eid>
+              <eid>9B_9B</eid>
               <linkedTo>m_m</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>4B_4B</eid>
+                <eid>+B_+B</eid>
                 <linkedTo>n_n</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>5B_5B</eid>
+              <eid>/B_/B</eid>
               <linkedTo>p_p</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>6B_6B</eid>
+                <eid>AC_AC</eid>
                 <linkedTo>q_q</linkedTo>
                 <Tie>
-                  <startElement>4B_4B</startElement>
-                  <endElement>6B_6B</endElement>
-                  <eid>7B_7B</eid>
+                  <startElement>+B_+B</startElement>
+                  <endElement>AC_AC</endElement>
+                  <eid>BC_BC</eid>
                   <linkedTo>o_o</linkedTo>
                   <track>0</track>
                   </Tie>
@@ -817,7 +840,7 @@
                 </Note>
               </Chord>
             <Rest>
-              <eid>8B_8B</eid>
+              <eid>CC_CC</eid>
               <linkedTo>r_r</linkedTo>
               <durationType>quarter</durationType>
               </Rest>
@@ -830,14 +853,14 @@
           <track2>0</track2>
           <startTick>-1/1</startTick>
           <ticks>1/1</ticks>
-          <eid>9B_9B</eid>
+          <eid>DC_DC</eid>
           <linkedTo>H_H</linkedTo>
           <track>0</track>
           </HairPin>
         <Slur>
-          <startElement>dB_dB</startElement>
-          <endElement>fB_fB</endElement>
-          <eid>+B_+B</eid>
+          <startElement>hB_hB</startElement>
+          <endElement>jB_jB</endElement>
+          <eid>EC_EC</eid>
           <linkedTo>J_J</linkedTo>
           <track>0</track>
           </Slur>
@@ -852,14 +875,14 @@
           <track2>0</track2>
           <startTick>1/1</startTick>
           <ticks>1/1</ticks>
-          <eid>/B_/B</eid>
+          <eid>FC_FC</eid>
           <linkedTo>T_T</linkedTo>
           <track>0</track>
           </GradualTempoChange>
         </SpannerMap>
       </Score>
     <Score>
-      <eid>AC_AC</eid>
+      <eid>GC_GC</eid>
       <name>Oboe</name>
       <Division>480</Division>
       <Style>
@@ -871,9 +894,9 @@
       <showMargins>0</showMargins>
       <metaTag name="partName">Oboe</metaTag>
       <Part id="2">
-        <eid>BC_BC</eid>
+        <eid>HC_HC</eid>
         <Staff>
-          <eid>CC_CC</eid>
+          <eid>IC_IC</eid>
           <linkedTo>RB_RB</linkedTo>
           <StaffType group="pitched">
             <name>stdNormal</name>
@@ -898,74 +921,74 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <eid>DC_DC</eid>
-          <linkedTo>UB_UB</linkedTo>
+          <eid>JC_JC</eid>
+          <linkedTo>YB_YB</linkedTo>
           <Text>
-            <eid>EC_EC</eid>
+            <eid>KC_KC</eid>
             <style>instrument_excerpt</style>
             <text>Oboe</text>
             </Text>
           </VBox>
         <Measure>
-          <eid>FC_FC</eid>
+          <eid>LC_LC</eid>
           <voice>
             <KeySig>
-              <eid>GC_GC</eid>
+              <eid>MC_MC</eid>
               <linkedTo>s_s</linkedTo>
               <concertKey>0</concertKey>
               </KeySig>
             <TimeSig>
-              <eid>HC_HC</eid>
+              <eid>NC_NC</eid>
               <linkedTo>t_t</linkedTo>
               <sigN>4</sigN>
               <sigD>4</sigD>
               </TimeSig>
             <Chord>
-              <eid>IC_IC</eid>
+              <eid>OC_OC</eid>
               <linkedTo>v_v</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>JC_JC</eid>
+                <eid>PC_PC</eid>
                 <linkedTo>x_x</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>KC_KC</eid>
+              <eid>QC_QC</eid>
               <linkedTo>y_y</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>LC_LC</eid>
+                <eid>RC_RC</eid>
                 <linkedTo>z_z</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>MC_MC</eid>
+              <eid>SC_SC</eid>
               <linkedTo>0_0</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>NC_NC</eid>
+                <eid>TC_TC</eid>
                 <linkedTo>1_1</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>OC_OC</eid>
+              <eid>UC_UC</eid>
               <linkedTo>3_3</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>PC_PC</eid>
+                <eid>VC_VC</eid>
                 <linkedTo>4_4</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 <Glissando>
-                  <startElement>NC_NC</startElement>
-                  <endElement>PC_PC</endElement>
-                  <eid>QC_QC</eid>
+                  <startElement>TC_TC</startElement>
+                  <endElement>VC_VC</endElement>
+                  <eid>WC_WC</eid>
                   <linkedTo>2_2</linkedTo>
                   <track>0</track>
                   <diagonal>1</diagonal>
@@ -975,56 +998,56 @@
             </voice>
           </Measure>
         <Measure>
-          <eid>RC_RC</eid>
+          <eid>XC_XC</eid>
           <voice>
             <Chord>
-              <eid>SC_SC</eid>
+              <eid>YC_YC</eid>
               <linkedTo>5_5</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>TC_TC</eid>
+                <eid>ZC_ZC</eid>
                 <linkedTo>6_6</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               <TremoloTwoChord>
                 <subtype>c16</subtype>
-                <eid>UC_UC</eid>
+                <eid>aC_aC</eid>
                 <linkedTo>7_7</linkedTo>
                 <l1>0</l1>
                 <l2>2</l2>
                 </TremoloTwoChord>
               </Chord>
             <Chord>
-              <eid>VC_VC</eid>
+              <eid>bC_bC</eid>
               <linkedTo>8_8</linkedTo>
               <durationType>half</durationType>
               <duration>1/4</duration>
               <Note>
-                <eid>WC_WC</eid>
+                <eid>cC_cC</eid>
                 <linkedTo>9_9</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>XC_XC</eid>
+              <eid>dC_dC</eid>
               <linkedTo>+_+</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>YC_YC</eid>
+                <eid>eC_eC</eid>
                 <linkedTo>/_/</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>ZC_ZC</eid>
+              <eid>fC_fC</eid>
               <linkedTo>BB_BB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>aC_aC</eid>
+                <eid>gC_gC</eid>
                 <linkedTo>CB_CB</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
@@ -1032,9 +1055,9 @@
                   <guitarBendType>bend</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>1</bendEndTimeFactor>
-                  <startElement>YC_YC</startElement>
-                  <endElement>aC_aC</endElement>
-                  <eid>bC_bC</eid>
+                  <startElement>eC_eC</startElement>
+                  <endElement>gC_gC</endElement>
+                  <eid>hC_hC</eid>
                   <linkedTo>AB_AB</linkedTo>
                   <track>0</track>
                   </GuitarBend>
@@ -1043,17 +1066,17 @@
             </voice>
           </Measure>
         <Measure>
-          <eid>cC_cC</eid>
+          <eid>iC_iC</eid>
           <voice>
             <Chord>
-              <eid>dC_dC</eid>
+              <eid>jC_jC</eid>
               <linkedTo>DB_DB</linkedTo>
               <BeamMode>no</BeamMode>
               <durationType>eighth</durationType>
               <appoggiatura/>
               <noStem>1</noStem>
               <Note>
-                <eid>eC_eC</eid>
+                <eid>kC_kC</eid>
                 <linkedTo>EB_EB</linkedTo>
                 <parentheses>both</parentheses>
                 <pitch>65</pitch>
@@ -1062,17 +1085,28 @@
                 <ghost>1</ghost>
                 </Note>
               <NoteParenGroup>
+                <Parenthesis>
+                  <eid>lC_lC</eid>
+                  <linkedTo>WB_WB</linkedTo>
+                  <track>4</track>
+                  </Parenthesis>
+                <Parenthesis>
+                  <horizontalDirection>right</horizontalDirection>
+                  <eid>mC_mC</eid>
+                  <linkedTo>XB_XB</linkedTo>
+                  <track>4</track>
+                  </Parenthesis>
                 <Notes>
-                  <NoteEID>eC_eC</NoteEID>
+                  <NoteEID>kC_kC</NoteEID>
                   </Notes>
                 </NoteParenGroup>
               </Chord>
             <Chord>
-              <eid>fC_fC</eid>
+              <eid>nC_nC</eid>
               <linkedTo>IB_IB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>gC_gC</eid>
+                <eid>oC_oC</eid>
                 <linkedTo>JB_JB</linkedTo>
                 <pitch>67</pitch>
                 <tpc>15</tpc>
@@ -1081,36 +1115,36 @@
                   <guitarBendType>bend</guitarBendType>
                   <bendStartTimeFactor>0</bendStartTimeFactor>
                   <bendEndTimeFactor>1</bendEndTimeFactor>
-                  <startElement>eC_eC</startElement>
-                  <endElement>gC_gC</endElement>
-                  <eid>hC_hC</eid>
+                  <startElement>kC_kC</startElement>
+                  <endElement>oC_oC</endElement>
+                  <eid>pC_pC</eid>
                   <linkedTo>HB_HB</linkedTo>
                   <track>0</track>
                   </GuitarBend>
                 </Note>
               </Chord>
             <Chord>
-              <eid>iC_iC</eid>
+              <eid>qC_qC</eid>
               <linkedTo>KB_KB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>jC_jC</eid>
+                <eid>rC_rC</eid>
                 <linkedTo>LB_LB</linkedTo>
                 <pitch>62</pitch>
                 <tpc>16</tpc>
                 </Note>
               </Chord>
             <Chord>
-              <eid>kC_kC</eid>
+              <eid>sC_sC</eid>
               <linkedTo>NB_NB</linkedTo>
               <durationType>quarter</durationType>
               <Note>
-                <eid>lC_lC</eid>
+                <eid>tC_tC</eid>
                 <linkedTo>OB_OB</linkedTo>
                 <Tie>
-                  <startElement>jC_jC</startElement>
-                  <endElement>lC_lC</endElement>
-                  <eid>mC_mC</eid>
+                  <startElement>rC_rC</startElement>
+                  <endElement>tC_tC</endElement>
+                  <eid>uC_uC</eid>
                   <linkedTo>MB_MB</linkedTo>
                   <track>0</track>
                   </Tie>
@@ -1119,7 +1153,7 @@
                 </Note>
               </Chord>
             <Rest>
-              <eid>nC_nC</eid>
+              <eid>vC_vC</eid>
               <linkedTo>PB_PB</linkedTo>
               <durationType>quarter</durationType>
               </Rest>
@@ -1132,14 +1166,14 @@
           <track2>0</track2>
           <startTick>-1/1</startTick>
           <ticks>1/1</ticks>
-          <eid>oC_oC</eid>
+          <eid>wC_wC</eid>
           <linkedTo>u_u</linkedTo>
           <track>0</track>
           </HairPin>
         <Slur>
-          <startElement>IC_IC</startElement>
-          <endElement>KC_KC</endElement>
-          <eid>pC_pC</eid>
+          <startElement>OC_OC</startElement>
+          <endElement>QC_QC</endElement>
+          <eid>xC_xC</eid>
           <linkedTo>w_w</linkedTo>
           <track>0</track>
           </Slur>
@@ -1154,7 +1188,7 @@
           <track2>0</track2>
           <startTick>1/1</startTick>
           <ticks>1/1</ticks>
-          <eid>qC_qC</eid>
+          <eid>yC_yC</eid>
           <linkedTo>T_T</linkedTo>
           <track>0</track>
           </GradualTempoChange>

--- a/src/engraving/tests/parts_data/part-spanners.mscx
+++ b/src/engraving/tests/parts_data/part-spanners.mscx
@@ -267,6 +267,13 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>UB_UB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>VB_VB</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>g_g</NoteEID>
                 </Notes>
@@ -453,6 +460,13 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>WB_WB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>XB_XB</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>EB_EB</NoteEID>
                 </Notes>

--- a/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
@@ -123,19 +123,26 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>8</fret>
@@ -144,18 +151,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>T_T</startElement>
-                <endElement>S_S</endElement>
-                <eid>U_U</eid>
+                <startElement>V_V</startElement>
+                <endElement>U_U</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <parentheses>both</parentheses>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -166,33 +173,40 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>T_T</endElement>
-                <eid>W_W</eid>
+                <endElement>V_V</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Z_Z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>a_a</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>T_T</NoteEID>
+                <NoteEID>V_V</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <BarLine>
-            <eid>X_X</eid>
+            <eid>b_b</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>Y_Y</eid>
+        <eid>c_c</eid>
         <voice>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>d_d</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>a_a</eid>
+              <eid>e_e</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>4</fret>
@@ -201,45 +215,11 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>b_b</startElement>
-                <endElement>a_a</endElement>
-                <eid>c_c</eid>
+                <startElement>f_f</startElement>
+                <endElement>e_e</endElement>
+                <eid>g_g</eid>
                 <track>0</track>
                 </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>d_d</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>b_b</eid>
-              <pitch>59</pitch>
-              <tpc>19</tpc>
-              <fret>4</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>e_e</startElement>
-                <endElement>b_b</endElement>
-                <eid>f_f</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>g_g</eid>
-            <durationType>half</durationType>
-            <Note>
-              <eid>e_e</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -249,7 +229,41 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
+              <eid>f_f</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>4</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.5</bendEndTimeFactor>
+                <startElement>i_i</startElement>
+                <endElement>f_f</endElement>
+                <eid>j_j</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>k_k</eid>
+            <durationType>half</durationType>
+            <Note>
               <eid>i_i</eid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>l_l</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>m_m</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -258,18 +272,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>j_j</startElement>
-                <endElement>i_i</endElement>
-                <eid>k_k</eid>
+                <startElement>n_n</startElement>
+                <endElement>m_m</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>l_l</eid>
+            <eid>p_p</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>j_j</eid>
+              <eid>n_n</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -277,21 +291,21 @@
               </Note>
             </Chord>
           <BarLine>
-            <eid>m_m</eid>
+            <eid>q_q</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>n_n</eid>
+        <eid>r_r</eid>
         <voice>
           <Chord>
-            <eid>o_o</eid>
+            <eid>s_s</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>p_p</eid>
+              <eid>t_t</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -300,16 +314,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>u_u</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>v_v</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>p_p</NoteEID>
+                <NoteEID>t_t</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>q_q</eid>
+            <eid>w_w</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>r_r</eid>
+              <eid>x_x</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -318,21 +339,21 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>p_p</startElement>
-                <endElement>r_r</endElement>
-                <eid>s_s</eid>
+                <startElement>t_t</startElement>
+                <endElement>x_x</endElement>
+                <eid>y_y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>t_t</eid>
+            <eid>z_z</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>u_u</eid>
+              <eid>0_0</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>5</fret>
@@ -341,21 +362,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.65</bendEndTimeFactor>
-                <startElement>v_v</startElement>
-                <endElement>u_u</endElement>
-                <eid>w_w</eid>
+                <startElement>1_1</startElement>
+                <endElement>0_0</endElement>
+                <eid>2_2</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>x_x</eid>
+            <eid>3_3</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>y_y</eid>
+              <eid>4_4</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -364,16 +385,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>5_5</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>6_6</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>y_y</NoteEID>
+                <NoteEID>4_4</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>z_z</eid>
+            <eid>7_7</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>v_v</eid>
+              <eid>1_1</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -382,9 +410,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>y_y</startElement>
-                <endElement>v_v</endElement>
-                <eid>0_0</eid>
+                <startElement>4_4</startElement>
+                <endElement>1_1</endElement>
+                <eid>8_8</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/data/bend.gp3-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp3-ref.mscx
@@ -123,19 +123,26 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>8</fret>
@@ -144,18 +151,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>T_T</startElement>
-                <endElement>S_S</endElement>
-                <eid>U_U</eid>
+                <startElement>V_V</startElement>
+                <endElement>U_U</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <parentheses>both</parentheses>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -166,30 +173,37 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>T_T</endElement>
-                <eid>W_W</eid>
+                <endElement>V_V</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Z_Z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>a_a</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>T_T</NoteEID>
+                <NoteEID>V_V</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           </voice>
         </Measure>
       <Measure>
-        <eid>X_X</eid>
+        <eid>b_b</eid>
         <voice>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>d_d</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>4</fret>
@@ -198,45 +212,11 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>a_a</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>b_b</eid>
+                <startElement>e_e</startElement>
+                <endElement>d_d</endElement>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>c_c</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>a_a</eid>
-              <pitch>59</pitch>
-              <tpc>19</tpc>
-              <fret>4</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>a_a</endElement>
-                <eid>e_e</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>f_f</eid>
-            <durationType>half</durationType>
-            <Note>
-              <eid>d_d</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -246,7 +226,41 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
+              <eid>e_e</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>4</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.5</bendEndTimeFactor>
+                <startElement>h_h</startElement>
+                <endElement>e_e</endElement>
+                <eid>i_i</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>j_j</eid>
+            <durationType>half</durationType>
+            <Note>
               <eid>h_h</eid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>k_k</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>l_l</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -255,18 +269,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>i_i</startElement>
-                <endElement>h_h</endElement>
-                <eid>j_j</eid>
+                <startElement>m_m</startElement>
+                <endElement>l_l</endElement>
+                <eid>n_n</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>k_k</eid>
+            <eid>o_o</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>m_m</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -276,16 +290,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>l_l</eid>
+        <eid>p_p</eid>
         <voice>
           <Chord>
-            <eid>m_m</eid>
+            <eid>q_q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>n_n</eid>
+              <eid>r_r</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -294,16 +308,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>n_n</NoteEID>
+                <NoteEID>r_r</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>o_o</eid>
+            <eid>u_u</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>p_p</eid>
+              <eid>v_v</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -312,21 +333,21 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>p_p</endElement>
-                <eid>q_q</eid>
+                <startElement>r_r</startElement>
+                <endElement>v_v</endElement>
+                <eid>w_w</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>r_r</eid>
+            <eid>x_x</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>s_s</eid>
+              <eid>y_y</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>5</fret>
@@ -335,21 +356,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0.333333</bendStartTimeFactor>
                 <bendEndTimeFactor>0.666667</bendEndTimeFactor>
-                <startElement>t_t</startElement>
-                <endElement>s_s</endElement>
-                <eid>u_u</eid>
+                <startElement>z_z</startElement>
+                <endElement>y_y</endElement>
+                <eid>0_0</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>v_v</eid>
+            <eid>1_1</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>w_w</eid>
+              <eid>2_2</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -358,16 +379,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>3_3</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>4_4</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>w_w</NoteEID>
+                <NoteEID>2_2</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>x_x</eid>
+            <eid>5_5</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>t_t</eid>
+              <eid>z_z</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -376,9 +404,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>w_w</startElement>
-                <endElement>t_t</endElement>
-                <eid>y_y</eid>
+                <startElement>2_2</startElement>
+                <endElement>z_z</endElement>
+                <eid>6_6</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/data/bend.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp4-ref.mscx
@@ -120,19 +120,26 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>8</fret>
@@ -141,18 +148,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>T_T</startElement>
-                <endElement>S_S</endElement>
-                <eid>U_U</eid>
+                <startElement>V_V</startElement>
+                <endElement>U_U</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <parentheses>both</parentheses>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -163,30 +170,37 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>T_T</endElement>
-                <eid>W_W</eid>
+                <endElement>V_V</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Z_Z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>a_a</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>T_T</NoteEID>
+                <NoteEID>V_V</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           </voice>
         </Measure>
       <Measure>
-        <eid>X_X</eid>
+        <eid>b_b</eid>
         <voice>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>d_d</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>4</fret>
@@ -195,45 +209,11 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>a_a</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>b_b</eid>
+                <startElement>e_e</startElement>
+                <endElement>d_d</endElement>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>c_c</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>a_a</eid>
-              <pitch>59</pitch>
-              <tpc>19</tpc>
-              <fret>4</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>a_a</endElement>
-                <eid>e_e</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>f_f</eid>
-            <durationType>half</durationType>
-            <Note>
-              <eid>d_d</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -243,7 +223,41 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
+              <eid>e_e</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>4</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.5</bendEndTimeFactor>
+                <startElement>h_h</startElement>
+                <endElement>e_e</endElement>
+                <eid>i_i</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>j_j</eid>
+            <durationType>half</durationType>
+            <Note>
               <eid>h_h</eid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>k_k</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>l_l</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -252,18 +266,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>i_i</startElement>
-                <endElement>h_h</endElement>
-                <eid>j_j</eid>
+                <startElement>m_m</startElement>
+                <endElement>l_l</endElement>
+                <eid>n_n</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>k_k</eid>
+            <eid>o_o</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>m_m</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -273,16 +287,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>l_l</eid>
+        <eid>p_p</eid>
         <voice>
           <Chord>
-            <eid>m_m</eid>
+            <eid>q_q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>n_n</eid>
+              <eid>r_r</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -291,16 +305,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>n_n</NoteEID>
+                <NoteEID>r_r</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>o_o</eid>
+            <eid>u_u</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>p_p</eid>
+              <eid>v_v</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -309,21 +330,21 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>p_p</endElement>
-                <eid>q_q</eid>
+                <startElement>r_r</startElement>
+                <endElement>v_v</endElement>
+                <eid>w_w</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>r_r</eid>
+            <eid>x_x</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>s_s</eid>
+              <eid>y_y</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>5</fret>
@@ -332,21 +353,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0.333333</bendStartTimeFactor>
                 <bendEndTimeFactor>0.666667</bendEndTimeFactor>
-                <startElement>t_t</startElement>
-                <endElement>s_s</endElement>
-                <eid>u_u</eid>
+                <startElement>z_z</startElement>
+                <endElement>y_y</endElement>
+                <eid>0_0</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>v_v</eid>
+            <eid>1_1</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>w_w</eid>
+              <eid>2_2</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -355,16 +376,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>3_3</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>4_4</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>w_w</NoteEID>
+                <NoteEID>2_2</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>x_x</eid>
+            <eid>5_5</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>t_t</eid>
+              <eid>z_z</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -373,9 +401,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>w_w</startElement>
-                <endElement>t_t</endElement>
-                <eid>y_y</eid>
+                <startElement>2_2</startElement>
+                <endElement>z_z</endElement>
+                <eid>6_6</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
@@ -120,19 +120,26 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>8</fret>
@@ -141,18 +148,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>T_T</startElement>
-                <endElement>S_S</endElement>
-                <eid>U_U</eid>
+                <startElement>V_V</startElement>
+                <endElement>U_U</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <parentheses>both</parentheses>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -163,30 +170,37 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>T_T</endElement>
-                <eid>W_W</eid>
+                <endElement>V_V</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Z_Z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>a_a</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>T_T</NoteEID>
+                <NoteEID>V_V</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           </voice>
         </Measure>
       <Measure>
-        <eid>X_X</eid>
+        <eid>b_b</eid>
         <voice>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>d_d</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>4</fret>
@@ -195,45 +209,11 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>a_a</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>b_b</eid>
+                <startElement>e_e</startElement>
+                <endElement>d_d</endElement>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>c_c</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>a_a</eid>
-              <pitch>59</pitch>
-              <tpc>19</tpc>
-              <fret>4</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>a_a</endElement>
-                <eid>e_e</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>f_f</eid>
-            <durationType>half</durationType>
-            <Note>
-              <eid>d_d</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -243,7 +223,41 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
+              <eid>e_e</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>4</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.5</bendEndTimeFactor>
+                <startElement>h_h</startElement>
+                <endElement>e_e</endElement>
+                <eid>i_i</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>j_j</eid>
+            <durationType>half</durationType>
+            <Note>
               <eid>h_h</eid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>k_k</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>l_l</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -252,18 +266,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>i_i</startElement>
-                <endElement>h_h</endElement>
-                <eid>j_j</eid>
+                <startElement>m_m</startElement>
+                <endElement>l_l</endElement>
+                <eid>n_n</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>k_k</eid>
+            <eid>o_o</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>m_m</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -273,16 +287,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>l_l</eid>
+        <eid>p_p</eid>
         <voice>
           <Chord>
-            <eid>m_m</eid>
+            <eid>q_q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>n_n</eid>
+              <eid>r_r</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -291,16 +305,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>n_n</NoteEID>
+                <NoteEID>r_r</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>o_o</eid>
+            <eid>u_u</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>p_p</eid>
+              <eid>v_v</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -309,21 +330,21 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>p_p</endElement>
-                <eid>q_q</eid>
+                <startElement>r_r</startElement>
+                <endElement>v_v</endElement>
+                <eid>w_w</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>r_r</eid>
+            <eid>x_x</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>s_s</eid>
+              <eid>y_y</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>5</fret>
@@ -332,21 +353,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0.333333</bendStartTimeFactor>
                 <bendEndTimeFactor>0.666667</bendEndTimeFactor>
-                <startElement>t_t</startElement>
-                <endElement>s_s</endElement>
-                <eid>u_u</eid>
+                <startElement>z_z</startElement>
+                <endElement>y_y</endElement>
+                <eid>0_0</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>v_v</eid>
+            <eid>1_1</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>w_w</eid>
+              <eid>2_2</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -355,16 +376,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>3_3</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>4_4</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>w_w</NoteEID>
+                <NoteEID>2_2</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>x_x</eid>
+            <eid>5_5</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>t_t</eid>
+              <eid>z_z</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -373,9 +401,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>w_w</startElement>
-                <endElement>t_t</endElement>
-                <eid>y_y</eid>
+                <startElement>2_2</startElement>
+                <endElement>z_z</endElement>
+                <eid>6_6</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
@@ -123,16 +123,23 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <parentheses>both</parentheses>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -143,33 +150,40 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>S_S</endElement>
-                <eid>T_T</eid>
+                <endElement>U_U</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>W_W</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>X_X</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>S_S</NoteEID>
+                <NoteEID>U_U</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <BarLine>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>V_V</eid>
+        <eid>Z_Z</eid>
         <voice>
           <Chord>
-            <eid>W_W</eid>
+            <eid>a_a</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>X_X</eid>
+              <eid>b_b</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>4</fret>
@@ -178,45 +192,11 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Y_Y</startElement>
-                <endElement>X_X</endElement>
-                <eid>Z_Z</eid>
+                <startElement>c_c</startElement>
+                <endElement>b_b</endElement>
+                <eid>d_d</eid>
                 <track>0</track>
                 </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>a_a</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>Y_Y</eid>
-              <pitch>59</pitch>
-              <tpc>19</tpc>
-              <fret>4</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>b_b</startElement>
-                <endElement>Y_Y</endElement>
-                <eid>c_c</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>d_d</eid>
-            <durationType>half</durationType>
-            <Note>
-              <eid>b_b</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -226,7 +206,41 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
+              <eid>c_c</eid>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>4</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>1</bendEndTimeFactor>
+                <startElement>f_f</startElement>
+                <endElement>c_c</endElement>
+                <eid>g_g</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>h_h</eid>
+            <durationType>half</durationType>
+            <Note>
               <eid>f_f</eid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>i_i</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>j_j</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -235,18 +249,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>g_g</startElement>
-                <endElement>f_f</endElement>
-                <eid>h_h</eid>
+                <startElement>k_k</startElement>
+                <endElement>j_j</endElement>
+                <eid>l_l</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>i_i</eid>
+            <eid>m_m</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>g_g</eid>
+              <eid>k_k</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -254,21 +268,21 @@
               </Note>
             </Chord>
           <BarLine>
-            <eid>j_j</eid>
+            <eid>n_n</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>k_k</eid>
+        <eid>o_o</eid>
         <voice>
           <Chord>
-            <eid>l_l</eid>
+            <eid>p_p</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>m_m</eid>
+              <eid>q_q</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -277,16 +291,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>r_r</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>s_s</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>m_m</NoteEID>
+                <NoteEID>q_q</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>n_n</eid>
+            <eid>t_t</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>o_o</eid>
+              <eid>u_u</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -295,21 +316,21 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>m_m</startElement>
-                <endElement>o_o</endElement>
-                <eid>p_p</eid>
+                <startElement>q_q</startElement>
+                <endElement>u_u</endElement>
+                <eid>v_v</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>q_q</eid>
+            <eid>w_w</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>r_r</eid>
+              <eid>x_x</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>5</fret>
@@ -318,21 +339,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>s_s</startElement>
-                <endElement>r_r</endElement>
-                <eid>t_t</eid>
+                <startElement>y_y</startElement>
+                <endElement>x_x</endElement>
+                <eid>z_z</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>u_u</eid>
+            <eid>0_0</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>v_v</eid>
+              <eid>1_1</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -341,16 +362,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>2_2</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>3_3</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>v_v</NoteEID>
+                <NoteEID>1_1</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>w_w</eid>
+            <eid>4_4</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>s_s</eid>
+              <eid>y_y</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -359,9 +387,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>v_v</startElement>
-                <endElement>s_s</endElement>
-                <eid>x_x</eid>
+                <startElement>1_1</startElement>
+                <endElement>y_y</endElement>
+                <eid>5_5</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/data/bend_and_glissando.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_glissando.gp-ref.mscx
@@ -138,16 +138,23 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>T_T</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>U_U</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
@@ -155,15 +162,15 @@
               <Glissando>
                 <text></text>
                 <startElement>N_N</startElement>
-                <endElement>U_U</endElement>
-                <eid>V_V</eid>
+                <endElement>W_W</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
               </Note>
             </Chord>
           <Rest>
-            <eid>W_W</eid>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -172,8 +179,8 @@
     <SpannerMap>
       <Slur>
         <startElement>M_M</startElement>
-        <endElement>T_T</endElement>
-        <eid>X_X</eid>
+        <endElement>V_V</endElement>
+        <eid>Z_Z</eid>
         <track>0</track>
         </Slur>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/data/bend_and_glissando.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_glissando.gp5-ref.mscx
@@ -131,31 +131,38 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>S_S</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>T_T</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>7</fret>
               <string>4</string>
               <Glissando>
                 <startElement>M_M</startElement>
-                <endElement>T_T</endElement>
-                <eid>U_U</eid>
+                <endElement>V_V</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
               </Note>
             </Chord>
           <Rest>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -164,8 +171,8 @@
     <SpannerMap>
       <Slur>
         <startElement>L_L</startElement>
-        <endElement>S_S</endElement>
-        <eid>W_W</eid>
+        <endElement>U_U</endElement>
+        <eid>Y_Y</eid>
         <track>0</track>
         </Slur>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
@@ -114,16 +114,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Q_Q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>R_R</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>R_R</eid>
+              <eid>T_T</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>4</fret>
@@ -133,13 +140,13 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>R_R</endElement>
-                <eid>S_S</eid>
+                <endElement>T_T</endElement>
+                <eid>U_U</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <pitch>83</pitch>
               <tpc>19</tpc>
               <head>diamond</head>
@@ -149,7 +156,7 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>W_W</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -163,7 +170,7 @@
         <track2>0</track2>
         <startTick>0/1</startTick>
         <ticks>1/2</ticks>
-        <eid>V_V</eid>
+        <eid>X_X</eid>
         <track>0</track>
         </HarmonicMark>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp5-ref.mscx
@@ -107,16 +107,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>4</fret>
@@ -126,13 +133,13 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>R_R</eid>
+                <endElement>S_S</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <head>diamond</head>
@@ -142,7 +149,7 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -156,7 +163,7 @@
         <track2>0</track2>
         <startTick>0/1</startTick>
         <ticks>1/2</ticks>
-        <eid>U_U</eid>
+        <eid>W_W</eid>
         <track>0</track>
         </HarmonicMark>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
@@ -88,21 +88,28 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>L_L</eid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <eid>M_M</eid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
             <eid>N_N</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>O_O</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
@@ -88,21 +88,28 @@
               <hideGeneratedParentheses>1</hideGeneratedParentheses>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>L_L</eid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <eid>M_M</eid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
             <eid>N_N</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>O_O</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
@@ -430,13 +430,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>7_7</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>8_8</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>6_6</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>7_7</eid>
+            <eid>9_9</eid>
             <durationType>eighth</durationType>
             <Note>
               <eid>3_3</eid>
@@ -450,22 +457,22 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>6_6</startElement>
                 <endElement>3_3</endElement>
-                <eid>8_8</eid>
+                <eid>+_+</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>9_9</eid>
+            <eid>/_/</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>+_+</eid>
+              <eid>AB_AB</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>/_/</eid>
+                <eid>BB_BB</eid>
                 </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -474,25 +481,25 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0.35</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>AB_AB</startElement>
-                <endElement>+_+</endElement>
-                <eid>BB_BB</eid>
+                <startElement>CB_CB</startElement>
+                <endElement>AB_AB</endElement>
+                <eid>DB_DB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>CB_CB</eid>
+            <eid>EB_EB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>AB_AB</eid>
+              <eid>CB_CB</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalSharp</subtype>
-                <eid>DB_DB</eid>
+                <eid>FB_FB</eid>
                 </Accidental>
               <pitch>54</pitch>
               <tpc>20</tpc>
@@ -501,21 +508,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.35</bendEndTimeFactor>
-                <startElement>EB_EB</startElement>
-                <endElement>AB_AB</endElement>
-                <eid>FB_FB</eid>
+                <startElement>GB_GB</startElement>
+                <endElement>CB_CB</endElement>
+                <eid>HB_HB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>GB_GB</eid>
+            <eid>IB_IB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>HB_HB</eid>
+              <eid>JB_JB</eid>
               <parentheses>both</parentheses>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -524,16 +531,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>KB_KB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>LB_LB</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>HB_HB</NoteEID>
+                <NoteEID>JB_JB</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>IB_IB</eid>
+            <eid>MB_MB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>EB_EB</eid>
+              <eid>GB_GB</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
               <fret>0</fret>
@@ -542,33 +556,33 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>HB_HB</startElement>
-                <endElement>EB_EB</endElement>
-                <eid>JB_JB</eid>
+                <startElement>JB_JB</startElement>
+                <endElement>GB_GB</endElement>
+                <eid>NB_NB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>KB_KB</eid>
+            <eid>OB_OB</eid>
             <durationType>half</durationType>
             </Rest>
           <BarLine>
-            <eid>LB_LB</eid>
+            <eid>PB_PB</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Rest>
-            <eid>MB_MB</eid>
+            <eid>QB_QB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
-            <eid>NB_NB</eid>
+            <eid>RB_RB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>OB_OB</eid>
+              <eid>SB_SB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>0</fret>
@@ -576,7 +590,7 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>PB_PB</eid>
+            <eid>TB_TB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -586,19 +600,19 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>QB_QB</eid>
+            <eid>UB_UB</eid>
             <concertKey>0</concertKey>
             <mode>major</mode>
             </KeySig>
           <TimeSig>
-            <eid>RB_RB</eid>
+            <eid>VB_VB</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <eid>SB_SB</eid>
+            <eid>WB_WB</eid>
             </Dynamic>
           <StringTunings>
             <visibleStrings></visibleStrings>
@@ -610,38 +624,16 @@
               <string useFlat="1">38</string>
               <string useFlat="1">43</string>
               </StringData>
-            <eid>TB_TB</eid>
+            <eid>XB_XB</eid>
             <style>string_tunings</style>
             <text/>
             </StringTunings>
-          <Chord>
-            <eid>UB_UB</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>VB_VB</eid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>WB_WB</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>XB_XB</eid>
-              <pitch>72</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
           <Chord>
             <eid>YB_YB</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>ZB_ZB</eid>
-              <pitch>72</pitch>
+              <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
               <string>1</string>
@@ -658,23 +650,45 @@
               <string>1</string>
               </Note>
             </Chord>
-          <BarLine>
+          <Chord>
             <eid>cB_cB</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>dB_dB</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>eB_eB</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>fB_fB</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <BarLine>
+            <eid>gB_gB</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Beam>
-            <eid>dB_dB</eid>
+            <eid>hB_hB</eid>
             <l1>16</l1>
             <l2>16</l2>
             </Beam>
           <Chord>
-            <eid>eB_eB</eid>
+            <eid>iB_iB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>fB_fB</eid>
+              <eid>jB_jB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <head>cross</head>
@@ -684,10 +698,10 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>gB_gB</eid>
+            <eid>kB_kB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>hB_hB</eid>
+              <eid>lB_lB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <head>cross</head>
@@ -697,14 +711,14 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>iB_iB</eid>
+            <eid>mB_mB</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
-            <eid>jB_jB</eid>
+            <eid>nB_nB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>kB_kB</eid>
+              <eid>oB_oB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <head>cross</head>
@@ -714,18 +728,18 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>lB_lB</eid>
+            <eid>pB_pB</eid>
             <durationType>half</durationType>
             </Rest>
           <BarLine>
-            <eid>mB_mB</eid>
+            <eid>qB_qB</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Rest>
-            <eid>nB_nB</eid>
+            <eid>rB_rB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -736,12 +750,12 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>oB_oB</eid>
+            <eid>sB_sB</eid>
             <concertKey>0</concertKey>
             <mode>major</mode>
             </KeySig>
           <TimeSig>
-            <eid>pB_pB</eid>
+            <eid>tB_tB</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -755,25 +769,25 @@
               <string useFlat="1">38</string>
               <string useFlat="1">43</string>
               </StringData>
-            <eid>qB_qB</eid>
+            <eid>uB_uB</eid>
             <style>string_tunings</style>
             <text/>
             </StringTunings>
           <Rest>
-            <eid>rB_rB</eid>
+            <eid>vB_vB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <eid>sB_sB</eid>
+            <eid>wB_wB</eid>
             </Dynamic>
           <Chord>
-            <eid>tB_tB</eid>
+            <eid>xB_xB</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>uB_uB</eid>
+              <eid>yB_yB</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -782,21 +796,21 @@
             </Chord>
           <BarLine>
             <span>1</span>
-            <eid>vB_vB</eid>
+            <eid>zB_zB</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Chord>
-            <eid>wB_wB</eid>
+            <eid>0B_0B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>xB_xB</eid>
+              <eid>1B_1B</eid>
               <Tie>
-                <startElement>uB_uB</startElement>
-                <endElement>xB_xB</endElement>
-                <eid>yB_yB</eid>
+                <startElement>yB_yB</startElement>
+                <endElement>1B_1B</endElement>
+                <eid>2B_2B</eid>
                 <track>12</track>
                 </Tie>
               <pitch>48</pitch>
@@ -806,26 +820,26 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>zB_zB</eid>
+            <eid>3B_3B</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Beam>
-            <eid>0B_0B</eid>
+            <eid>4B_4B</eid>
             <l1>42</l1>
             <l2>42</l2>
             </Beam>
           <Chord>
-            <eid>1B_1B</eid>
+            <eid>5B_5B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>2B_2B</eid>
+              <eid>6B_6B</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
             <Note>
-              <eid>3B_3B</eid>
+              <eid>7B_7B</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <head>diamond</head>
@@ -835,17 +849,17 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4B_4B</eid>
+            <eid>8B_8B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>5B_5B</eid>
+              <eid>9B_9B</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
             <Note>
-              <eid>6B_6B</eid>
+              <eid>+B_+B</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <head>diamond</head>
@@ -855,19 +869,19 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>7B_7B</eid>
+            <eid>/B_/B</eid>
             <durationType>half</durationType>
             </Rest>
           <BarLine>
             <span>1</span>
-            <eid>8B_8B</eid>
+            <eid>AC_AC</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Rest>
-            <eid>9B_9B</eid>
+            <eid>BC_BC</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -878,28 +892,28 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>+B_+B</eid>
+            <eid>CC_CC</eid>
             <concertKey>0</concertKey>
             <mode>major</mode>
             </KeySig>
           <TimeSig>
-            <eid>/B_/B</eid>
+            <eid>DC_DC</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <eid>AC_AC</eid>
+            <eid>EC_EC</eid>
             </Dynamic>
           <Chord>
-            <eid>BC_BC</eid>
+            <eid>FC_FC</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>CC_CC</eid>
+              <eid>GC_GC</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>DC_DC</eid>
+                <eid>HC_HC</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>24</tpc>
@@ -907,17 +921,17 @@
               <string>2</string>
               </Note>
             <Note>
-              <eid>EC_EC</eid>
+              <eid>IC_IC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
               <string>1</string>
               </Note>
             <Note>
-              <eid>FC_FC</eid>
+              <eid>JC_JC</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>GC_GC</eid>
+                <eid>KC_KC</eid>
                 </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
@@ -927,7 +941,7 @@
               <string>2</string>
               </Note>
             <Note>
-              <eid>HC_HC</eid>
+              <eid>LC_LC</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <head>diamond</head>
@@ -937,20 +951,20 @@
               </Note>
             </Chord>
           <BarLine>
-            <eid>IC_IC</eid>
+            <eid>MC_MC</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Chord>
-            <eid>JC_JC</eid>
+            <eid>NC_NC</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>KC_KC</eid>
+              <eid>OC_OC</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>LC_LC</eid>
+                <eid>PC_PC</eid>
                 </Accidental>
               <pitch>49</pitch>
               <tpc>21</tpc>
@@ -958,10 +972,10 @@
               <string>4</string>
               </Note>
             <Note>
-              <eid>MC_MC</eid>
+              <eid>QC_QC</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>NC_NC</eid>
+                <eid>RC_RC</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -969,10 +983,10 @@
               <string>1</string>
               </Note>
             <Note>
-              <eid>OC_OC</eid>
+              <eid>SC_SC</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>PC_PC</eid>
+                <eid>TC_TC</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>21</tpc>
@@ -982,7 +996,7 @@
               <string>4</string>
               </Note>
             <Note>
-              <eid>QC_QC</eid>
+              <eid>UC_UC</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <head>diamond</head>
@@ -992,17 +1006,17 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>RC_RC</eid>
+            <eid>VC_VC</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
-            <eid>SC_SC</eid>
+            <eid>WC_WC</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>TC_TC</eid>
+              <eid>XC_XC</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>UC_UC</eid>
+                <eid>YC_YC</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -1010,7 +1024,7 @@
               <string>1</string>
               </Note>
             <Note>
-              <eid>VC_VC</eid>
+              <eid>ZC_ZC</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <head>diamond</head>
@@ -1019,36 +1033,9 @@
               <string>1</string>
               </Note>
             </Chord>
-          <Chord>
-            <eid>WC_WC</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>XC_XC</eid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            <Note>
-              <eid>YC_YC</eid>
-              <pitch>72</pitch>
-              <tpc>14</tpc>
-              <head>diamond</head>
-              <play>0</play>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
-          <BarLine>
-            <eid>ZC_ZC</eid>
-            </BarLine>
-          </voice>
-        </Measure>
-      <Measure>
-        <voice>
           <Chord>
             <eid>aC_aC</eid>
-            <durationType>whole</durationType>
+            <durationType>quarter</durationType>
             <Note>
               <eid>bC_bC</eid>
               <pitch>60</pitch>
@@ -1066,6 +1053,33 @@
               <string>1</string>
               </Note>
             </Chord>
+          <BarLine>
+            <eid>dC_dC</eid>
+            </BarLine>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <eid>eC_eC</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>fC_fC</eid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            <Note>
+              <eid>gC_gC</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              <head>diamond</head>
+              <play>0</play>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
           </voice>
         </Measure>
       </Staff>
@@ -1074,7 +1088,7 @@
         <track2>0</track2>
         <startTick>0/1</startTick>
         <ticks>2/4</ticks>
-        <eid>dC_dC</eid>
+        <eid>hC_hC</eid>
         <track>0</track>
         </LetRing>
       <Vibrato>
@@ -1082,7 +1096,7 @@
         <track2>8</track2>
         <startTick>0/1</startTick>
         <ticks>1/4</ticks>
-        <eid>eC_eC</eid>
+        <eid>iC_iC</eid>
         <track>8</track>
         </Vibrato>
       <HarmonicMark>
@@ -1092,7 +1106,7 @@
         <track2>16</track2>
         <startTick>0/1</startTick>
         <ticks>5/4</ticks>
-        <eid>fC_fC</eid>
+        <eid>jC_jC</eid>
         <track>16</track>
         </HarmonicMark>
       <HarmonicMark>
@@ -1102,7 +1116,7 @@
         <track2>16</track2>
         <startTick>0/1</startTick>
         <ticks>1/1</ticks>
-        <eid>gC_gC</eid>
+        <eid>kC_kC</eid>
         <track>16</track>
         </HarmonicMark>
       <HairPin>
@@ -1110,7 +1124,7 @@
         <track2>0</track2>
         <startTick>1/4</startTick>
         <ticks>4/4</ticks>
-        <eid>hC_hC</eid>
+        <eid>lC_lC</eid>
         <track>0</track>
         </HairPin>
       <Rasgueado>
@@ -1118,7 +1132,7 @@
         <track2>0</track2>
         <startTick>1/4</startTick>
         <ticks>6/4</ticks>
-        <eid>iC_iC</eid>
+        <eid>mC_mC</eid>
         <track>0</track>
         </Rasgueado>
       <Ottava>
@@ -1126,7 +1140,7 @@
         <track2>8</track2>
         <startTick>1/4</startTick>
         <ticks>3/4</ticks>
-        <eid>jC_jC</eid>
+        <eid>nC_nC</eid>
         <track>8</track>
         </Ottava>
       <Vibrato>
@@ -1134,7 +1148,7 @@
         <track2>8</track2>
         <startTick>1/4</startTick>
         <ticks>1/4</ticks>
-        <eid>kC_kC</eid>
+        <eid>oC_oC</eid>
         <track>8</track>
         </Vibrato>
       <Vibrato>
@@ -1142,7 +1156,7 @@
         <track2>12</track2>
         <startTick>1/4</startTick>
         <ticks>7/8</ticks>
-        <eid>lC_lC</eid>
+        <eid>pC_pC</eid>
         <track>12</track>
         </Vibrato>
       <Vibrato>
@@ -1150,14 +1164,14 @@
         <track2>8</track2>
         <startTick>2/4</startTick>
         <ticks>1/4</ticks>
-        <eid>mC_mC</eid>
+        <eid>qC_qC</eid>
         <track>8</track>
         </Vibrato>
       <PalmMute>
         <track2>0</track2>
         <startTick>3/4</startTick>
         <ticks>2/4</ticks>
-        <eid>nC_nC</eid>
+        <eid>rC_rC</eid>
         <track>0</track>
         </PalmMute>
       <Vibrato>
@@ -1165,7 +1179,7 @@
         <track2>8</track2>
         <startTick>3/4</startTick>
         <ticks>1/4</ticks>
-        <eid>oC_oC</eid>
+        <eid>sC_sC</eid>
         <track>8</track>
         </Vibrato>
       <PickScrape>
@@ -1173,7 +1187,7 @@
         <track2>8</track2>
         <startTick>4/4</startTick>
         <ticks>2/8</ticks>
-        <eid>pC_pC</eid>
+        <eid>tC_tC</eid>
         <track>8</track>
         </PickScrape>
       <Vibrato>
@@ -1181,7 +1195,7 @@
         <track2>12</track2>
         <startTick>4/4</startTick>
         <ticks>1/8</ticks>
-        <eid>qC_qC</eid>
+        <eid>uC_uC</eid>
         <track>12</track>
         </Vibrato>
       <HarmonicMark>
@@ -1191,14 +1205,14 @@
         <track2>16</track2>
         <startTick>4/4</startTick>
         <ticks>1/4</ticks>
-        <eid>rC_rC</eid>
+        <eid>vC_vC</eid>
         <track>16</track>
         </HarmonicMark>
       <LetRing>
         <track2>4</track2>
         <startTick>5/4</startTick>
         <ticks>6/4</ticks>
-        <eid>sC_sC</eid>
+        <eid>wC_wC</eid>
         <track>4</track>
         </LetRing>
       <HarmonicMark>
@@ -1208,7 +1222,7 @@
         <track2>12</track2>
         <startTick>5/4</startTick>
         <ticks>1/8</ticks>
-        <eid>tC_tC</eid>
+        <eid>xC_xC</eid>
         <track>12</track>
         </HarmonicMark>
       <Vibrato>
@@ -1216,7 +1230,7 @@
         <track2>12</track2>
         <startTick>5/4</startTick>
         <ticks>1/8</ticks>
-        <eid>uC_uC</eid>
+        <eid>yC_yC</eid>
         <track>12</track>
         </Vibrato>
       <Vibrato>
@@ -1224,7 +1238,7 @@
         <track2>12</track2>
         <startTick>5/4</startTick>
         <ticks>1/8</ticks>
-        <eid>vC_vC</eid>
+        <eid>zC_zC</eid>
         <track>12</track>
         </Vibrato>
       <PickScrape>
@@ -1232,7 +1246,7 @@
         <track2>8</track2>
         <startTick>11/8</startTick>
         <ticks>1/8</ticks>
-        <eid>wC_wC</eid>
+        <eid>0C_0C</eid>
         <track>8</track>
         </PickScrape>
       <HarmonicMark>
@@ -1242,7 +1256,7 @@
         <track2>12</track2>
         <startTick>11/8</startTick>
         <ticks>1/8</ticks>
-        <eid>xC_xC</eid>
+        <eid>1C_1C</eid>
         <track>12</track>
         </HarmonicMark>
       <HairPin>
@@ -1250,7 +1264,7 @@
         <track2>0</track2>
         <startTick>6/4</startTick>
         <ticks>4/4</ticks>
-        <eid>yC_yC</eid>
+        <eid>2C_2C</eid>
         <track>0</track>
         </HairPin>
       <Ottava>
@@ -1258,7 +1272,7 @@
         <track2>0</track2>
         <startTick>6/4</startTick>
         <ticks>4/4</ticks>
-        <eid>zC_zC</eid>
+        <eid>3C_3C</eid>
         <track>0</track>
         </Ottava>
       <HarmonicMark>
@@ -1268,7 +1282,7 @@
         <track2>16</track2>
         <startTick>6/4</startTick>
         <ticks>6/4</ticks>
-        <eid>0C_0C</eid>
+        <eid>4C_4C</eid>
         <track>16</track>
         </HarmonicMark>
       <Ottava>
@@ -1276,7 +1290,7 @@
         <track2>0</track2>
         <startTick>10/4</startTick>
         <ticks>1/4</ticks>
-        <eid>1C_1C</eid>
+        <eid>5C_5C</eid>
         <track>0</track>
         </Ottava>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
@@ -226,19 +226,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>j_j</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>k_k</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>i_i</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>j_j</eid>
+            <eid>l_l</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>k_k</eid>
+              <eid>m_m</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>l_l</eid>
+                <eid>n_n</eid>
                 </Accidental>
               <pitch>49</pitch>
               <tpc>21</tpc>
@@ -249,20 +256,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>i_i</startElement>
-                <endElement>k_k</endElement>
-                <eid>m_m</eid>
+                <endElement>m_m</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>n_n</eid>
+            <eid>p_p</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>o_o</eid>
+              <eid>q_q</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>7</fret>
@@ -271,21 +278,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>p_p</startElement>
-                <endElement>o_o</endElement>
-                <eid>q_q</eid>
+                <startElement>r_r</startElement>
+                <endElement>q_q</endElement>
+                <eid>s_s</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>r_r</eid>
+            <eid>t_t</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>s_s</eid>
+              <eid>u_u</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -294,16 +301,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>v_v</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>w_w</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>s_s</NoteEID>
+                <NoteEID>u_u</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>t_t</eid>
+            <eid>x_x</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>p_p</eid>
+              <eid>r_r</eid>
               <pitch>49</pitch>
               <tpc>21</tpc>
               <fret>15</fret>
@@ -312,41 +326,41 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>s_s</startElement>
-                <endElement>p_p</endElement>
-                <eid>u_u</eid>
+                <startElement>u_u</startElement>
+                <endElement>r_r</endElement>
+                <eid>y_y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>v_v</eid>
+            <eid>z_z</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>w_w</eid>
+            <eid>0_0</eid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
-            <eid>x_x</eid>
+            <eid>1_1</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>y_y</eid>
+        <eid>2_2</eid>
         <voice>
           <Chord>
-            <eid>z_z</eid>
+            <eid>3_3</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>0_0</eid>
+              <eid>4_4</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalSharp</subtype>
-                <eid>1_1</eid>
+                <eid>5_5</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
@@ -356,49 +370,8 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.483333</bendEndTimeFactor>
-                <startElement>2_2</startElement>
-                <endElement>0_0</endElement>
-                <eid>3_3</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>4_4</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <appoggiatura/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>5_5</eid>
-              <parentheses>both</parentheses>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <ghost>1</ghost>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>5_5</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>6_6</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>2_2</eid>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>pre-dive</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>5_5</startElement>
-                <endElement>2_2</endElement>
+                <startElement>6_6</startElement>
+                <endElement>4_4</endElement>
                 <eid>7_7</eid>
                 <track>0</track>
                 </GuitarBend>
@@ -420,16 +393,71 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>+_+</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>/_/</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>9_9</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>+_+</eid>
+            <eid>AB_AB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>/_/</eid>
+              <eid>6_6</eid>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>pre-dive</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>1</bendEndTimeFactor>
+                <startElement>9_9</startElement>
+                <endElement>6_6</endElement>
+                <eid>BB_BB</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>CB_CB</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>DB_DB</eid>
+              <parentheses>both</parentheses>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <ghost>1</ghost>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>EB_EB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>FB_FB</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>DB_DB</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Chord>
+            <eid>GB_GB</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>HB_HB</eid>
               <pitch>66</pitch>
               <tpc>20</tpc>
               <fret>1</fret>
@@ -438,19 +466,19 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>9_9</startElement>
-                <endElement>/_/</endElement>
-                <eid>AB_AB</eid>
+                <startElement>DB_DB</startElement>
+                <endElement>HB_HB</endElement>
+                <eid>IB_IB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>BB_BB</eid>
+            <eid>JB_JB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>CB_CB</eid>
+            <eid>KB_KB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
@@ -226,19 +226,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>j_j</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>k_k</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>i_i</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>j_j</eid>
+            <eid>l_l</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>k_k</eid>
+              <eid>m_m</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>l_l</eid>
+                <eid>n_n</eid>
                 </Accidental>
               <pitch>49</pitch>
               <tpc>21</tpc>
@@ -249,20 +256,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>i_i</startElement>
-                <endElement>k_k</endElement>
-                <eid>m_m</eid>
+                <endElement>m_m</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>n_n</eid>
+            <eid>p_p</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>o_o</eid>
+              <eid>q_q</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>7</fret>
@@ -271,21 +278,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>p_p</startElement>
-                <endElement>o_o</endElement>
-                <eid>q_q</eid>
+                <startElement>r_r</startElement>
+                <endElement>q_q</endElement>
+                <eid>s_s</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>r_r</eid>
+            <eid>t_t</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>s_s</eid>
+              <eid>u_u</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -294,16 +301,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>v_v</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>w_w</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>s_s</NoteEID>
+                <NoteEID>u_u</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>t_t</eid>
+            <eid>x_x</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>p_p</eid>
+              <eid>r_r</eid>
               <pitch>49</pitch>
               <tpc>21</tpc>
               <fret>15</fret>
@@ -312,41 +326,41 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>s_s</startElement>
-                <endElement>p_p</endElement>
-                <eid>u_u</eid>
+                <startElement>u_u</startElement>
+                <endElement>r_r</endElement>
+                <eid>y_y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>v_v</eid>
+            <eid>z_z</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>w_w</eid>
+            <eid>0_0</eid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
-            <eid>x_x</eid>
+            <eid>1_1</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>y_y</eid>
+        <eid>2_2</eid>
         <voice>
           <Chord>
-            <eid>z_z</eid>
+            <eid>3_3</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>0_0</eid>
+              <eid>4_4</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalSharp</subtype>
-                <eid>1_1</eid>
+                <eid>5_5</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
@@ -356,49 +370,8 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.483333</bendEndTimeFactor>
-                <startElement>2_2</startElement>
-                <endElement>0_0</endElement>
-                <eid>3_3</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>4_4</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <appoggiatura/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>5_5</eid>
-              <parentheses>both</parentheses>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <ghost>1</ghost>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>5_5</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>6_6</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>2_2</eid>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>pre-dive</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>5_5</startElement>
-                <endElement>2_2</endElement>
+                <startElement>6_6</startElement>
+                <endElement>4_4</endElement>
                 <eid>7_7</eid>
                 <track>0</track>
                 </GuitarBend>
@@ -420,16 +393,71 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>+_+</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>/_/</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>9_9</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>+_+</eid>
+            <eid>AB_AB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>/_/</eid>
+              <eid>6_6</eid>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>pre-dive</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>1</bendEndTimeFactor>
+                <startElement>9_9</startElement>
+                <endElement>6_6</endElement>
+                <eid>BB_BB</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>CB_CB</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>DB_DB</eid>
+              <parentheses>both</parentheses>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <ghost>1</ghost>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>EB_EB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>FB_FB</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>DB_DB</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Chord>
+            <eid>GB_GB</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>HB_HB</eid>
               <pitch>66</pitch>
               <tpc>20</tpc>
               <fret>1</fret>
@@ -438,19 +466,19 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>9_9</startElement>
-                <endElement>/_/</endElement>
-                <eid>AB_AB</eid>
+                <startElement>DB_DB</startElement>
+                <endElement>HB_HB</endElement>
+                <eid>IB_IB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>BB_BB</eid>
+            <eid>JB_JB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>CB_CB</eid>
+            <eid>KB_KB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_chord_tied-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_chord_tied-gp.mscx
@@ -239,26 +239,40 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>j_j</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>k_k</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>f_f</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>l_l</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>m_m</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>c_c</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <BarLine>
-            <eid>j_j</eid>
+            <eid>n_n</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>k_k</eid>
+        <eid>o_o</eid>
         <voice>
           <Rest>
-            <eid>l_l</eid>
+            <eid>p_p</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_hold-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_hold-gp.mscx
@@ -106,100 +106,35 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>O_O</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>P_P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <durationType>half</durationType>
             </Rest>
           <BarLine>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>Q_Q</eid>
+        <eid>S_S</eid>
         <voice>
-          <Chord>
-            <eid>R_R</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>S_S</eid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
           <Chord>
             <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>U_U</eid>
-              <parentheses>both</parentheses>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>S_S</startElement>
-                <endElement>U_U</endElement>
-                <eid>V_V</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>U_U</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>W_W</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>X_X</eid>
-              <parentheses>both</parentheses>
-              <Tie>
-                <startElement>U_U</startElement>
-                <endElement>X_X</endElement>
-                <eid>Y_Y</eid>
-                <track>0</track>
-                </Tie>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>X_X</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Rest>
-            <eid>Z_Z</eid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <BarLine>
-            <eid>a_a</eid>
-            </BarLine>
-          </voice>
-        </Measure>
-      <Measure>
-        <eid>b_b</eid>
-        <voice>
-          <Chord>
-            <eid>c_c</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>d_d</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -207,10 +142,10 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>e_e</eid>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>f_f</eid>
+              <eid>W_W</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -220,28 +155,35 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>f_f</endElement>
-                <eid>g_g</eid>
+                <startElement>U_U</startElement>
+                <endElement>W_W</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Y_Y</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Z_Z</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>f_f</NoteEID>
+                <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>h_h</eid>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>b_b</eid>
               <parentheses>both</parentheses>
               <Tie>
-                <startElement>f_f</startElement>
-                <endElement>i_i</endElement>
-                <eid>j_j</eid>
+                <startElement>W_W</startElement>
+                <endElement>b_b</endElement>
+                <eid>c_c</eid>
                 <track>0</track>
                 </Tie>
               <pitch>62</pitch>
@@ -250,33 +192,73 @@
               <string>1</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>d_d</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>e_e</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>i_i</NoteEID>
+                <NoteEID>b_b</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
+            <eid>f_f</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <BarLine>
+            <eid>g_g</eid>
+            </BarLine>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>h_h</eid>
+        <voice>
+          <Chord>
+            <eid>i_i</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>j_j</eid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
             <eid>k_k</eid>
             <durationType>quarter</durationType>
-            </Rest>
-          <BarLine>
-            <eid>l_l</eid>
-            </BarLine>
-          </voice>
-        </Measure>
-      <Measure>
-        <eid>m_m</eid>
-        <voice>
-          <Chord>
-            <eid>n_n</eid>
-            <durationType>quarter</durationType>
             <Note>
-              <eid>o_o</eid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
+              <eid>l_l</eid>
+              <parentheses>both</parentheses>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
               <fret>1</fret>
               <string>1</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>j_j</startElement>
+                <endElement>l_l</endElement>
+                <eid>m_m</eid>
+                <track>0</track>
+                </GuitarBend>
               </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>n_n</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>o_o</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>l_l</NoteEID>
+                </Notes>
+              </NoteParenGroup>
             </Chord>
           <Chord>
             <eid>p_p</eid>
@@ -284,36 +266,10 @@
             <Note>
               <eid>q_q</eid>
               <parentheses>both</parentheses>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>o_o</startElement>
+              <Tie>
+                <startElement>l_l</startElement>
                 <endElement>q_q</endElement>
                 <eid>r_r</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>q_q</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>s_s</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>t_t</eid>
-              <parentheses>both</parentheses>
-              <Tie>
-                <startElement>q_q</startElement>
-                <endElement>t_t</endElement>
-                <eid>u_u</eid>
                 <track>0</track>
                 </Tie>
               <pitch>62</pitch>
@@ -322,13 +278,106 @@
               <string>1</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>t_t</NoteEID>
+                <NoteEID>q_q</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
+            <eid>u_u</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <BarLine>
             <eid>v_v</eid>
+            </BarLine>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>w_w</eid>
+        <voice>
+          <Chord>
+            <eid>x_x</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>y_y</eid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>z_z</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>0_0</eid>
+              <parentheses>both</parentheses>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>y_y</startElement>
+                <endElement>0_0</endElement>
+                <eid>1_1</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>2_2</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>3_3</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>0_0</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Chord>
+            <eid>4_4</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>5_5</eid>
+              <parentheses>both</parentheses>
+              <Tie>
+                <startElement>0_0</startElement>
+                <endElement>5_5</endElement>
+                <eid>6_6</eid>
+                <track>0</track>
+                </Tie>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>7_7</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>8_8</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>5_5</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Rest>
+            <eid>9_9</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_on_tuplet-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_on_tuplet-gp.mscx
@@ -150,17 +150,24 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>T_T</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>U_U</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>R_R</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>U_U</eid>
+            <eid>W_W</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_on_unequal_chords-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bend_on_unequal_chords-gp.mscx
@@ -101,16 +101,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>N_N</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>O_O</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>N_N</eid>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>O_O</eid>
+              <eid>Q_Q</eid>
               <parentheses>both</parentheses>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -121,13 +128,13 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>O_O</endElement>
-                <eid>P_P</eid>
+                <endElement>Q_Q</endElement>
+                <eid>R_R</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>2</fret>
@@ -137,39 +144,23 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>M_M</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>R_R</eid>
+                <endElement>S_S</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>U_U</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>V_V</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>O_O</NoteEID>
+                <NoteEID>Q_Q</NoteEID>
                 </Notes>
               </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>S_S</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>T_T</eid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>grace-note-bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>T_T</endElement>
-                <eid>V_V</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
             </Chord>
           <Chord>
             <eid>W_W</eid>
@@ -179,12 +170,12 @@
             <noStem>1</noStem>
             <Note>
               <eid>X_X</eid>
-              <pitch>46</pitch>
-              <tpc>12</tpc>
-              <fret>3</fret>
-              <string>4</string>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>2</string>
               <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
+                <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
                 <startElement>Y_Y</startElement>
@@ -193,8 +184,31 @@
                 <track>0</track>
                 </GuitarBend>
               </Note>
+            </Chord>
+          <Chord>
+            <eid>a_a</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
             <Note>
-              <eid>U_U</eid>
+              <eid>b_b</eid>
+              <pitch>46</pitch>
+              <tpc>12</tpc>
+              <fret>3</fret>
+              <string>4</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>c_c</startElement>
+                <endElement>b_b</endElement>
+                <eid>d_d</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            <Note>
+              <eid>Y_Y</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>9</fret>
@@ -203,25 +217,25 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>a_a</startElement>
-                <endElement>U_U</endElement>
-                <eid>b_b</eid>
+                <startElement>e_e</startElement>
+                <endElement>Y_Y</endElement>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>c_c</eid>
+            <eid>g_g</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>d_d</eid>
+              <eid>h_h</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>e_e</eid>
+                <eid>i_i</eid>
                 </Accidental>
               <pitch>46</pitch>
               <tpc>12</tpc>
@@ -230,16 +244,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>j_j</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>k_k</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>d_d</NoteEID>
+                <NoteEID>h_h</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>f_f</eid>
+            <eid>l_l</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>Y_Y</eid>
+              <eid>c_c</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -248,14 +269,14 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>Y_Y</endElement>
-                <eid>g_g</eid>
+                <startElement>h_h</startElement>
+                <endElement>c_c</endElement>
+                <eid>m_m</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>h_h</eid>
+              <eid>n_n</eid>
               <parentheses>both</parentheses>
               <pitch>53</pitch>
               <tpc>13</tpc>
@@ -265,14 +286,14 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>O_O</startElement>
-                <endElement>h_h</endElement>
-                <eid>i_i</eid>
+                <startElement>Q_Q</startElement>
+                <endElement>n_n</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>a_a</eid>
+              <eid>e_e</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -282,25 +303,39 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>Q_Q</startElement>
-                <endElement>a_a</endElement>
-                <eid>j_j</eid>
+                <startElement>S_S</startElement>
+                <endElement>e_e</endElement>
+                <eid>p_p</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>q_q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>r_r</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>h_h</NoteEID>
+                <NoteEID>n_n</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>a_a</NoteEID>
+                <NoteEID>e_e</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>k_k</eid>
+            <eid>u_u</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bends_tied_1-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bends_tied_1-gp.mscx
@@ -106,28 +106,35 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>O_O</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>P_P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <durationType>half</durationType>
             </Rest>
           <BarLine>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>Q_Q</eid>
+        <eid>S_S</eid>
         <voice>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -135,10 +142,10 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -148,23 +155,30 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>S_S</startElement>
-                <endElement>U_U</endElement>
-                <eid>V_V</eid>
+                <startElement>U_U</startElement>
+                <endElement>W_W</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Y_Y</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Z_Z</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>U_U</NoteEID>
+                <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>W_W</eid>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>X_X</eid>
+              <eid>b_b</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -174,89 +188,47 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>X_X</endElement>
-                <eid>Y_Y</eid>
+                <startElement>W_W</startElement>
+                <endElement>b_b</endElement>
+                <eid>c_c</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>d_d</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>e_e</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>X_X</NoteEID>
+                <NoteEID>b_b</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>Z_Z</eid>
+            <eid>f_f</eid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
-            <eid>a_a</eid>
+            <eid>g_g</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>b_b</eid>
+        <eid>h_h</eid>
         <voice>
           <Chord>
-            <eid>c_c</eid>
+            <eid>i_i</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>d_d</eid>
+              <eid>j_j</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
               <string>1</string>
               </Note>
-            </Chord>
-          <Chord>
-            <eid>e_e</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>f_f</eid>
-              <parentheses>both</parentheses>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>f_f</endElement>
-                <eid>g_g</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>f_f</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            </Chord>
-          <Chord>
-            <eid>h_h</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>i_i</eid>
-              <parentheses>both</parentheses>
-              <Tie>
-                <startElement>f_f</startElement>
-                <endElement>i_i</endElement>
-                <eid>j_j</eid>
-                <track>0</track>
-                </Tie>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>i_i</NoteEID>
-                </Notes>
-              </NoteParenGroup>
             </Chord>
           <Chord>
             <eid>k_k</eid>
@@ -264,10 +236,43 @@
             <Note>
               <eid>l_l</eid>
               <parentheses>both</parentheses>
-              <Tie>
-                <startElement>i_i</startElement>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>j_j</startElement>
                 <endElement>l_l</endElement>
                 <eid>m_m</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>n_n</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>o_o</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>l_l</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Chord>
+            <eid>p_p</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>q_q</eid>
+              <parentheses>both</parentheses>
+              <Tie>
+                <startElement>l_l</startElement>
+                <endElement>q_q</endElement>
+                <eid>r_r</eid>
                 <track>0</track>
                 </Tie>
               <pitch>62</pitch>
@@ -276,8 +281,45 @@
               <string>1</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>s_s</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>t_t</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>l_l</NoteEID>
+                <NoteEID>q_q</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            </Chord>
+          <Chord>
+            <eid>u_u</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>v_v</eid>
+              <parentheses>both</parentheses>
+              <Tie>
+                <startElement>q_q</startElement>
+                <endElement>v_v</endElement>
+                <eid>w_w</eid>
+                <track>0</track>
+                </Tie>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>x_x</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>y_y</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>v_v</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/bends_tied_2-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/bends_tied_2-gp.mscx
@@ -129,13 +129,20 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>N_N</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_across_measure-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_across_measure-gp.mscx
@@ -116,6 +116,13 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Q_Q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>R_R</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_artificial_harmonic-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_artificial_harmonic-gp.mscx
@@ -138,16 +138,23 @@
               <string>3</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>T_T</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>U_U</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -158,17 +165,17 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>U_U</endElement>
-                <eid>V_V</eid>
+                <endElement>W_W</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>W_W</eid>
+              <eid>Y_Y</eid>
               <Tie>
                 <startElement>R_R</startElement>
-                <endElement>W_W</endElement>
-                <eid>X_X</eid>
+                <endElement>Y_Y</endElement>
+                <eid>Z_Z</eid>
                 <track>0</track>
                 </Tie>
               <pitch>72</pitch>
@@ -179,20 +186,27 @@
               <string>3</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>a_a</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>b_b</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>U_U</NoteEID>
+                <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>d_d</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>a_a</eid>
+                <eid>e_e</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -202,18 +216,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>b_b</eid>
+                <startElement>W_W</startElement>
+                <endElement>d_d</endElement>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>c_c</eid>
+              <eid>g_g</eid>
               <Tie>
-                <startElement>W_W</startElement>
-                <endElement>c_c</endElement>
-                <eid>d_d</eid>
+                <startElement>Y_Y</startElement>
+                <endElement>g_g</endElement>
+                <eid>h_h</eid>
                 <track>0</track>
                 </Tie>
               <pitch>72</pitch>
@@ -224,16 +238,23 @@
               <string>3</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>i_i</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>j_j</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Z_Z</NoteEID>
+                <NoteEID>d_d</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>e_e</eid>
+            <eid>k_k</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>f_f</eid>
+              <eid>l_l</eid>
               <parentheses>both</parentheses>
               <pitch>50</pitch>
               <tpc>16</tpc>
@@ -243,18 +264,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>Z_Z</startElement>
-                <endElement>f_f</endElement>
-                <eid>g_g</eid>
+                <startElement>d_d</startElement>
+                <endElement>l_l</endElement>
+                <eid>m_m</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>h_h</eid>
+              <eid>n_n</eid>
               <Tie>
-                <startElement>c_c</startElement>
-                <endElement>h_h</endElement>
-                <eid>i_i</eid>
+                <startElement>g_g</startElement>
+                <endElement>n_n</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </Tie>
               <pitch>72</pitch>
@@ -265,13 +286,20 @@
               <string>3</string>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>p_p</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>q_q</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>f_f</NoteEID>
+                <NoteEID>l_l</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>j_j</eid>
+            <eid>r_r</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>
@@ -285,7 +313,7 @@
         <track2>0</track2>
         <startTick>0/1</startTick>
         <ticks>15/8</ticks>
-        <eid>k_k</eid>
+        <eid>s_s</eid>
         <track>0</track>
         </HarmonicMark>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_bend-gp.mscx
@@ -106,20 +106,27 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>O_O</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>P_P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>Q_Q</eid>
+                <eid>S_S</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -130,25 +137,32 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
                 <startElement>M_M</startElement>
-                <endElement>P_P</endElement>
-                <eid>R_R</eid>
+                <endElement>R_R</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>U_U</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>V_V</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>P_P</NoteEID>
+                <NoteEID>R_R</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>W_W</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>T_T</eid>
+              <eid>X_X</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>4</fret>
@@ -157,18 +171,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>T_T</endElement>
-                <eid>V_V</eid>
+                <startElement>Y_Y</startElement>
+                <endElement>X_X</endElement>
+                <eid>Z_Z</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>W_W</eid>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>Y_Y</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -178,15 +192,22 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>P_P</startElement>
-                <endElement>U_U</endElement>
-                <eid>X_X</eid>
+                <startElement>R_R</startElement>
+                <endElement>Y_Y</endElement>
+                <eid>b_b</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>c_c</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>d_d</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>U_U</NoteEID>
+                <NoteEID>Y_Y</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_chord_return-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_chord_return-gp.mscx
@@ -188,6 +188,13 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>b_b</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>c_c</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>X_X</NoteEID>
                 <NoteEID>Y_Y</NoteEID>
@@ -197,7 +204,7 @@
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>b_b</eid>
+            <eid>d_d</eid>
             <durationType>whole</durationType>
             <Note>
               <eid>L_L</eid>
@@ -211,7 +218,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>X_X</startElement>
                 <endElement>L_L</endElement>
-                <eid>c_c</eid>
+                <eid>e_e</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
@@ -227,7 +234,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>Y_Y</startElement>
                 <endElement>O_O</endElement>
-                <eid>d_d</eid>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
@@ -243,7 +250,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>Z_Z</startElement>
                 <endElement>R_R</endElement>
-                <eid>e_e</eid>
+                <eid>g_g</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
@@ -259,7 +266,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>a_a</startElement>
                 <endElement>U_U</endElement>
-                <eid>f_f</eid>
+                <eid>h_h</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_continued_whammy-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_continued_whammy-gp.mscx
@@ -90,19 +90,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>N_N</eid>
+                <eid>P_P</eid>
                 </Accidental>
               <pitch>49</pitch>
               <tpc>21</tpc>
@@ -113,20 +120,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>O_O</eid>
+                <endElement>O_O</endElement>
+                <eid>Q_Q</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>7</fret>
@@ -135,21 +142,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>R_R</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>S_S</eid>
+                <startElement>T_T</startElement>
+                <endElement>S_S</endElement>
+                <eid>U_U</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -158,16 +165,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>X_X</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Y_Y</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>U_U</NoteEID>
+                <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>R_R</eid>
+              <eid>T_T</eid>
               <pitch>49</pitch>
               <tpc>21</tpc>
               <fret>15</fret>
@@ -176,19 +190,19 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>R_R</endElement>
-                <eid>W_W</eid>
+                <startElement>W_W</startElement>
+                <endElement>T_T</endElement>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>X_X</eid>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_cross_zero_up-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_cross_zero_up-gp.mscx
@@ -90,16 +90,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -109,20 +116,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>N_N</eid>
+                <endElement>O_O</endElement>
+                <eid>P_P</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <string>2</string>
@@ -130,18 +137,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Q_Q</startElement>
-                <endElement>P_P</endElement>
-                <eid>R_R</eid>
+                <startElement>S_S</startElement>
+                <endElement>R_R</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <parentheses>both</parentheses>
               <pitch>64</pitch>
               <tpc>18</tpc>
@@ -151,20 +158,27 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>M_M</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>T_T</eid>
+                <startElement>O_O</startElement>
+                <endElement>S_S</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>W_W</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>X_X</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Q_Q</NoteEID>
+                <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_dip_multiple-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_dip_multiple-gp.mscx
@@ -142,13 +142,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>T_T</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>U_U</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>whole</durationType>
             <Note>
               <eid>P_P</eid>
@@ -162,7 +169,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>S_S</startElement>
                 <endElement>P_P</endElement>
-                <eid>U_U</eid>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_glissando-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_glissando-gp.mscx
@@ -115,18 +115,25 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Beam>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <l1>24</l1>
             <l2>22</l2>
             </Beam>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
@@ -141,16 +148,16 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
                 <endElement>L_L</endElement>
-                <eid>R_R</eid>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <fret>15</fret>
@@ -158,20 +165,20 @@
               <Glissando>
                 <text></text>
                 <startElement>L_L</startElement>
-                <endElement>T_T</endElement>
-                <eid>U_U</eid>
+                <endElement>V_V</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
               </Note>
             </Chord>
           <Rest>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <eid>W_W</eid>
+            <eid>Y_Y</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -179,9 +186,9 @@
       </Staff>
     <SpannerMap>
       <Slur>
-        <startElement>Q_Q</startElement>
-        <endElement>S_S</endElement>
-        <eid>X_X</eid>
+        <startElement>S_S</startElement>
+        <endElement>U_U</endElement>
+        <eid>Z_Z</eid>
         <track>0</track>
         </Slur>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_hold-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_hold-gp.mscx
@@ -129,16 +129,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>Q_Q</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <fret>3</fret>
@@ -148,14 +155,14 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>Q_Q</startElement>
-                <endElement>S_S</endElement>
-                <eid>T_T</eid>
+                <endElement>U_U</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>W_W</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_different_fret-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_different_fret-gp.mscx
@@ -119,19 +119,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Q_Q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>R_R</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             <Note>
               <eid>M_M</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>R_R</eid>
+                <eid>T_T</eid>
                 </Accidental>
               <pitch>49</pitch>
               <tpc>9</tpc>
@@ -143,19 +150,19 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
                 <endElement>M_M</endElement>
-                <eid>S_S</eid>
+                <eid>U_U</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>12</fret>
@@ -164,21 +171,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.116667</bendEndTimeFactor>
-                <startElement>V_V</startElement>
-                <endElement>U_U</endElement>
-                <eid>W_W</eid>
+                <startElement>X_X</startElement>
+                <endElement>W_W</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>Z_Z</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>Y_Y</eid>
+              <eid>a_a</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -187,16 +194,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>b_b</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>c_c</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Y_Y</NoteEID>
+                <NoteEID>a_a</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>d_d</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>V_V</eid>
+              <eid>X_X</eid>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <fret>12</fret>
@@ -205,9 +219,9 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Y_Y</startElement>
-                <endElement>V_V</endElement>
-                <eid>a_a</eid>
+                <startElement>a_a</startElement>
+                <endElement>X_X</endElement>
+                <eid>e_e</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_neutral_pitch-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_neutral_pitch-gp.mscx
@@ -138,23 +138,30 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>S_S</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>T_T</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalFlat</subtype>
-                <eid>U_U</eid>
+                <eid>W_W</eid>
                 </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
@@ -164,24 +171,24 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0.25</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>V_V</startElement>
-                <endElement>T_T</endElement>
-                <eid>W_W</eid>
+                <startElement>X_X</startElement>
+                <endElement>V_V</endElement>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>Z_Z</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>V_V</eid>
+              <eid>X_X</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>Y_Y</eid>
+                <eid>a_a</eid>
                 </Accidental>
               <pitch>68</pitch>
               <tpc>10</tpc>
@@ -191,18 +198,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>Z_Z</startElement>
-                <endElement>V_V</endElement>
-                <eid>a_a</eid>
+                <startElement>b_b</startElement>
+                <endElement>X_X</endElement>
+                <eid>c_c</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>b_b</eid>
+            <eid>d_d</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>b_b</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <fret>15</fret>
@@ -210,21 +217,21 @@
               <Glissando>
                 <text></text>
                 <startElement>O_O</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>c_c</eid>
+                <endElement>b_b</endElement>
+                <eid>e_e</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
               </Note>
             </Chord>
           <Chord>
-            <eid>d_d</eid>
+            <eid>f_f</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>e_e</eid>
+              <eid>g_g</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <fret>13</fret>
@@ -233,21 +240,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>f_f</startElement>
-                <endElement>e_e</endElement>
-                <eid>g_g</eid>
+                <startElement>h_h</startElement>
+                <endElement>g_g</endElement>
+                <eid>i_i</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>h_h</eid>
+            <eid>j_j</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>i_i</eid>
+              <eid>k_k</eid>
               <parentheses>both</parentheses>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -256,16 +263,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>l_l</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>m_m</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>i_i</NoteEID>
+                <NoteEID>k_k</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>j_j</eid>
+            <eid>n_n</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>f_f</eid>
+              <eid>h_h</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <fret>13</fret>
@@ -274,31 +288,8 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>i_i</startElement>
-                <endElement>f_f</endElement>
-                <eid>k_k</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>l_l</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
-            <Note>
-              <eid>m_m</eid>
-              <pitch>74</pitch>
-              <tpc>16</tpc>
-              <fret>15</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>dive</guitarBendType>
-                <bendStartTimeFactor>0.25</bendStartTimeFactor>
-                <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>m_m</endElement>
+                <startElement>k_k</startElement>
+                <endElement>h_h</endElement>
                 <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
@@ -311,7 +302,30 @@
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>n_n</eid>
+              <eid>q_q</eid>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              <fret>15</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>dive</guitarBendType>
+                <bendStartTimeFactor>0.25</bendStartTimeFactor>
+                <bendEndTimeFactor>0.5</bendEndTimeFactor>
+                <startElement>r_r</startElement>
+                <endElement>q_q</endElement>
+                <eid>s_s</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>t_t</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>r_r</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <fret>13</fret>
@@ -320,18 +334,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>q_q</startElement>
-                <endElement>n_n</endElement>
-                <eid>r_r</eid>
+                <startElement>u_u</startElement>
+                <endElement>r_r</endElement>
+                <eid>v_v</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>s_s</eid>
+            <eid>w_w</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>q_q</eid>
+              <eid>u_u</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <fret>15</fret>
@@ -344,8 +358,8 @@
     <SpannerMap>
       <Slur>
         <startElement>Q_Q</startElement>
-        <endElement>b_b</endElement>
-        <eid>t_t</eid>
+        <endElement>d_d</endElement>
+        <eid>x_x</eid>
         <track>0</track>
         </Slur>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied-gp.mscx
@@ -90,16 +90,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>7</fret>
@@ -109,20 +116,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>N_N</eid>
+                <endElement>O_O</endElement>
+                <eid>P_P</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <string>2</string>
@@ -130,18 +137,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Q_Q</startElement>
-                <endElement>P_P</endElement>
-                <eid>R_R</eid>
+                <startElement>S_S</startElement>
+                <endElement>R_R</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -151,24 +158,31 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>M_M</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>T_T</eid>
+                <startElement>O_O</startElement>
+                <endElement>S_S</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>W_W</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>X_X</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Q_Q</NoteEID>
+                <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <eid>V_V</eid>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied_dip-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied_dip-gp.mscx
@@ -98,16 +98,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>N_N</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>O_O</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>N_N</eid>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>O_O</eid>
+              <eid>Q_Q</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <fret>17</fret>
@@ -117,28 +124,28 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>M_M</startElement>
-                <endElement>O_O</endElement>
-                <eid>P_P</eid>
+                <endElement>Q_Q</endElement>
+                <eid>R_R</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <BarLine>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>R_R</eid>
+        <eid>T_T</eid>
         <voice>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>17</fret>
@@ -147,21 +154,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0.816667</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>T_T</endElement>
-                <eid>V_V</eid>
+                <startElement>W_W</startElement>
+                <endElement>V_V</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>W_W</eid>
+            <eid>Y_Y</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <fret>7</fret>
@@ -170,18 +177,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.8</bendEndTimeFactor>
-                <startElement>X_X</startElement>
-                <endElement>U_U</endElement>
-                <eid>Y_Y</eid>
+                <startElement>Z_Z</startElement>
+                <endElement>W_W</endElement>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>b_b</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>X_X</eid>
+              <eid>Z_Z</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -191,20 +198,27 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.516667</bendEndTimeFactor>
-                <startElement>O_O</startElement>
-                <endElement>X_X</endElement>
-                <eid>a_a</eid>
+                <startElement>Q_Q</startElement>
+                <endElement>Z_Z</endElement>
+                <eid>c_c</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>d_d</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>e_e</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>X_X</NoteEID>
+                <NoteEID>Z_Z</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>b_b</eid>
+            <eid>f_f</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied_dip_chain-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_tied_dip_chain-gp.mscx
@@ -106,21 +106,28 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Beam>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <l1>18</l1>
             <l2>18</l2>
             </Beam>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>R_R</eid>
+              <eid>T_T</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <fret>17</fret>
@@ -130,21 +137,21 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
-                <endElement>R_R</endElement>
-                <eid>S_S</eid>
+                <endElement>T_T</endElement>
+                <eid>U_U</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <Tie>
-                <startElement>R_R</startElement>
-                <endElement>U_U</endElement>
-                <eid>V_V</eid>
+                <startElement>T_T</startElement>
+                <endElement>W_W</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </Tie>
               <pitch>47</pitch>
@@ -154,21 +161,21 @@
               </Note>
             </Chord>
           <BarLine>
-            <eid>W_W</eid>
+            <eid>Y_Y</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>X_X</eid>
+        <eid>Z_Z</eid>
         <voice>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>a_a</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>b_b</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>17</fret>
@@ -177,21 +184,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0.816667</bendStartTimeFactor>
                 <bendEndTimeFactor>0.983333</bendEndTimeFactor>
-                <startElement>a_a</startElement>
-                <endElement>Z_Z</endElement>
-                <eid>b_b</eid>
+                <startElement>c_c</startElement>
+                <endElement>b_b</endElement>
+                <eid>d_d</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>c_c</eid>
+            <eid>e_e</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>a_a</eid>
+              <eid>c_c</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <fret>7</fret>
@@ -200,18 +207,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.8</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>a_a</endElement>
-                <eid>e_e</eid>
+                <startElement>f_f</startElement>
+                <endElement>c_c</endElement>
+                <eid>g_g</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>f_f</eid>
+            <eid>h_h</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>d_d</eid>
+              <eid>f_f</eid>
               <parentheses>both</parentheses>
               <pitch>57</pitch>
               <tpc>17</tpc>
@@ -221,24 +228,31 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.516667</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>d_d</endElement>
-                <eid>g_g</eid>
+                <startElement>W_W</startElement>
+                <endElement>f_f</endElement>
+                <eid>i_i</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>j_j</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>k_k</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>d_d</NoteEID>
+                <NoteEID>f_f</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>h_h</eid>
+            <eid>l_l</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
-            <eid>i_i</eid>
+            <eid>m_m</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_up_glissando-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_return_up_glissando-gp.mscx
@@ -122,19 +122,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>Q_Q</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             <duration>1/32</duration>
             <acciaccatura/>
             <showStemSlash>0</showStemSlash>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -142,13 +149,13 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
               <eid>N_N</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>U_U</eid>
+                <eid>W_W</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
@@ -160,14 +167,14 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>Q_Q</startElement>
                 <endElement>N_N</endElement>
-                <eid>V_V</eid>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               <Glissando>
                 <text></text>
-                <startElement>S_S</startElement>
+                <startElement>U_U</startElement>
                 <endElement>N_N</endElement>
-                <eid>W_W</eid>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 <diagonal>1</diagonal>
                 </Glissando>
@@ -178,9 +185,9 @@
       </Staff>
     <SpannerMap>
       <Slur>
-        <startElement>R_R</startElement>
-        <endElement>T_T</endElement>
-        <eid>X_X</eid>
+        <startElement>T_T</startElement>
+        <endElement>V_V</endElement>
+        <eid>Z_Z</eid>
         <track>0</track>
         </Slur>
       </SpannerMap>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_tied_predive_return-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_tied_predive_return-gp.mscx
@@ -182,13 +182,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>b_b</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>c_c</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>a_a</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>b_b</eid>
+            <eid>d_d</eid>
             <durationType>half</durationType>
             <Note>
               <eid>X_X</eid>
@@ -202,7 +209,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>a_a</startElement>
                 <endElement>X_X</endElement>
-                <eid>c_c</eid>
+                <eid>e_e</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_tied_return-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_tied_return-gp.mscx
@@ -138,17 +138,24 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>S_S</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>T_T</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_two_beats-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_two_beats-gp.mscx
@@ -152,13 +152,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>V_V</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>W_W</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>U_U</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>R_R</eid>
@@ -172,13 +179,13 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>U_U</startElement>
                 <endElement>R_R</endElement>
-                <eid>W_W</eid>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>X_X</eid>
+            <eid>Z_Z</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_two_beats_2-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_two_beats_2-gp.mscx
@@ -161,13 +161,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>X_X</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Y_Y</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             <Note>
               <eid>T_T</eid>
@@ -181,17 +188,17 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>W_W</startElement>
                 <endElement>T_T</endElement>
-                <eid>Y_Y</eid>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>Z_Z</eid>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <eid>a_a</eid>
+            <eid>c_c</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_prebend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_prebend-gp.mscx
@@ -202,13 +202,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>c_c</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>d_d</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>b_b</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>c_c</eid>
+            <eid>e_e</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>U_U</eid>
@@ -222,7 +229,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>b_b</startElement>
                 <endElement>U_U</endElement>
-                <eid>d_d</eid>
+                <eid>f_f</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
@@ -242,11 +249,11 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>e_e</eid>
+            <eid>g_g</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>f_f</eid>
+            <eid>h_h</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_rest-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_rest-gp.mscx
@@ -151,13 +151,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>V_V</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>W_W</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>U_U</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
               <eid>R_R</eid>
@@ -171,7 +178,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>U_U</startElement>
                 <endElement>R_R</endElement>
-                <eid>W_W</eid>
+                <eid>Y_Y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_rest_2-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_with_rest_2-gp.mscx
@@ -188,13 +188,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>X_X</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Y_Y</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>W_W</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>Z_Z</eid>
             <durationType>half</durationType>
             <Note>
               <eid>T_T</eid>
@@ -208,27 +215,27 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>W_W</startElement>
                 <endElement>T_T</endElement>
-                <eid>Y_Y</eid>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <BarLine>
-            <eid>Z_Z</eid>
+            <eid>b_b</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>a_a</eid>
+        <eid>c_c</eid>
         <voice>
           <Chord>
-            <eid>b_b</eid>
+            <eid>d_d</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>c_c</eid>
+              <eid>e_e</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -237,29 +244,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>d_d</startElement>
-                <endElement>c_c</endElement>
-                <eid>e_e</eid>
+                <startElement>f_f</startElement>
+                <endElement>e_e</endElement>
+                <eid>g_g</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>f_f</eid>
+            <eid>h_h</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>d_d</eid>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
-              <fret>5</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>g_g</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>h_h</eid>
+              <eid>f_f</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -268,12 +264,23 @@
             </Chord>
           <Chord>
             <eid>i_i</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>j_j</eid>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              <fret>5</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>k_k</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>j_j</eid>
+              <eid>l_l</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -282,21 +289,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.15</bendEndTimeFactor>
-                <startElement>k_k</startElement>
-                <endElement>j_j</endElement>
-                <eid>l_l</eid>
+                <startElement>m_m</startElement>
+                <endElement>l_l</endElement>
+                <eid>n_n</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>m_m</eid>
+            <eid>o_o</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>n_n</eid>
+              <eid>p_p</eid>
               <parentheses>both</parentheses>
               <pitch>64</pitch>
               <tpc>18</tpc>
@@ -305,16 +312,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>q_q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>r_r</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>n_n</NoteEID>
+                <NoteEID>p_p</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>o_o</eid>
+            <eid>s_s</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>k_k</eid>
+              <eid>m_m</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
@@ -323,9 +337,9 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>k_k</endElement>
-                <eid>p_p</eid>
+                <startElement>p_p</startElement>
+                <endElement>m_m</endElement>
+                <eid>t_t</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
@@ -337,28 +351,28 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>q_q</eid>
+            <eid>u_u</eid>
             <concertKey>0</concertKey>
             <mode>major</mode>
             </KeySig>
           <TimeSig>
-            <eid>r_r</eid>
+            <eid>v_v</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <eid>s_s</eid>
+            <eid>w_w</eid>
             </Dynamic>
           <Chord>
-            <eid>t_t</eid>
+            <eid>x_x</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>u_u</eid>
+              <eid>y_y</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -367,55 +381,55 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>v_v</startElement>
-                <endElement>u_u</endElement>
-                <eid>w_w</eid>
+                <startElement>z_z</startElement>
+                <endElement>y_y</endElement>
+                <eid>0_0</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>x_x</eid>
+            <eid>1_1</eid>
             <durationType>half</durationType>
-            <Note>
-              <eid>v_v</eid>
-              <pitch>69</pitch>
-              <tpc>17</tpc>
-              <fret>5</fret>
-              <string>0</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>y_y</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
             <Note>
               <eid>z_z</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>0</string>
-              <GuitarBend>
-                <guitarBendType>dive</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.15</bendEndTimeFactor>
-                <startElement>0_0</startElement>
-                <endElement>z_z</endElement>
-                <eid>1_1</eid>
-                <track>4</track>
-                </GuitarBend>
               </Note>
             </Chord>
           <Chord>
             <eid>2_2</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
-            <appoggiatura/>
+            <grace8after/>
             <noStem>1</noStem>
             <Note>
               <eid>3_3</eid>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              <fret>5</fret>
+              <string>0</string>
+              <GuitarBend>
+                <guitarBendType>dive</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.15</bendEndTimeFactor>
+                <startElement>4_4</startElement>
+                <endElement>3_3</endElement>
+                <eid>5_5</eid>
+                <track>4</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>6_6</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <appoggiatura/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>7_7</eid>
               <parentheses>both</parentheses>
               <pitch>69</pitch>
               <tpc>17</tpc>
@@ -424,16 +438,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>8_8</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>9_9</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>3_3</NoteEID>
+                <NoteEID>7_7</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>4_4</eid>
+            <eid>+_+</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>0_0</eid>
+              <eid>4_4</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -442,28 +463,28 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>3_3</startElement>
-                <endElement>0_0</endElement>
-                <eid>5_5</eid>
+                <startElement>7_7</startElement>
+                <endElement>4_4</endElement>
+                <eid>/_/</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <BarLine>
-            <eid>6_6</eid>
+            <eid>AB_AB</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Chord>
-            <eid>7_7</eid>
+            <eid>BB_BB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>8_8</eid>
+              <eid>CB_CB</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>3</fret>
@@ -472,18 +493,18 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.75</bendEndTimeFactor>
-                <startElement>9_9</startElement>
-                <endElement>8_8</endElement>
-                <eid>+_+</eid>
+                <startElement>DB_DB</startElement>
+                <endElement>CB_CB</endElement>
+                <eid>EB_EB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>/_/</eid>
+            <eid>FB_FB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9_9</eid>
+              <eid>DB_DB</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
@@ -491,13 +512,13 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>AB_AB</eid>
+            <eid>GB_GB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>BB_BB</eid>
+              <eid>HB_HB</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
@@ -506,21 +527,21 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.15</bendEndTimeFactor>
-                <startElement>CB_CB</startElement>
-                <endElement>BB_BB</endElement>
-                <eid>DB_DB</eid>
+                <startElement>IB_IB</startElement>
+                <endElement>HB_HB</endElement>
+                <eid>JB_JB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>EB_EB</eid>
+            <eid>KB_KB</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>FB_FB</eid>
+              <eid>LB_LB</eid>
               <parentheses>both</parentheses>
               <pitch>69</pitch>
               <tpc>17</tpc>
@@ -529,16 +550,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>MB_MB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>NB_NB</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>FB_FB</NoteEID>
+                <NoteEID>LB_LB</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>GB_GB</eid>
+            <eid>OB_OB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>CB_CB</eid>
+              <eid>IB_IB</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -547,9 +575,9 @@
                 <guitarBendType>pre-dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>FB_FB</startElement>
-                <endElement>CB_CB</endElement>
-                <eid>HB_HB</eid>
+                <startElement>LB_LB</startElement>
+                <endElement>IB_IB</endElement>
+                <eid>PB_PB</eid>
                 <track>4</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dives_multi-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dives_multi-gp.mscx
@@ -142,19 +142,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>T_T</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>U_U</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>whole</durationType>
             <Note>
               <eid>P_P</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>U_U</eid>
+                <eid>W_W</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>21</tpc>
@@ -166,7 +173,7 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>S_S</startElement>
                 <endElement>P_P</endElement>
-                <eid>V_V</eid>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp.mscx
@@ -90,16 +90,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>1</fret>
@@ -109,20 +116,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>N_N</eid>
+                <endElement>O_O</endElement>
+                <eid>P_P</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -131,20 +138,27 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>S_S</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>T_T</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>P_P</NoteEID>
+                <NoteEID>R_R</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>R_R</eid>
+              <eid>V_V</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalQuarterToneSharpArrowDown</subtype>
-                <eid>S_S</eid>
+                <eid>W_W</eid>
                 </Accidental>
               <pitch>64</pitch>
               <centOffset>50</centOffset>
@@ -155,15 +169,15 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>P_P</startElement>
-                <endElement>R_R</endElement>
-                <eid>T_T</eid>
+                <startElement>R_R</startElement>
+                <endElement>V_V</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp5.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend-gp5.mscx
@@ -102,16 +102,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>O_O</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>P_P</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>N_N</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>1</fret>
@@ -121,20 +128,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>N_N</startElement>
-                <endElement>P_P</endElement>
-                <eid>Q_Q</eid>
+                <endElement>R_R</endElement>
+                <eid>S_S</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -143,20 +150,27 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>V_V</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>W_W</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>S_S</NoteEID>
+                <NoteEID>U_U</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>T_T</eid>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>Y_Y</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalQuarterToneSharpArrowDown</subtype>
-                <eid>V_V</eid>
+                <eid>Z_Z</eid>
                 </Accidental>
               <pitch>64</pitch>
               <centOffset>50</centOffset>
@@ -167,15 +181,15 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>S_S</startElement>
-                <endElement>U_U</endElement>
-                <eid>W_W</eid>
+                <startElement>U_U</startElement>
+                <endElement>Y_Y</endElement>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>X_X</eid>
+            <eid>b_b</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_bend-gp.mscx
@@ -113,13 +113,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>L_L</eid>
@@ -133,22 +140,22 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
                 <endElement>L_L</endElement>
-                <eid>Q_Q</eid>
+                <eid>S_S</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>T_T</eid>
+                <eid>V_V</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
@@ -158,21 +165,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>U_U</startElement>
-                <endElement>S_S</endElement>
-                <eid>V_V</eid>
+                <startElement>W_W</startElement>
+                <endElement>U_U</endElement>
+                <eid>X_X</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>W_W</eid>
+            <eid>Y_Y</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>X_X</eid>
+              <eid>Z_Z</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -181,20 +188,27 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>a_a</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>b_b</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>X_X</NoteEID>
+                <NoteEID>Z_Z</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>U_U</eid>
+              <eid>W_W</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalQuarterToneSharpArrowDown</subtype>
-                <eid>Z_Z</eid>
+                <eid>d_d</eid>
                 </Accidental>
               <pitch>65</pitch>
               <centOffset>50</centOffset>
@@ -205,24 +219,24 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>X_X</startElement>
-                <endElement>U_U</endElement>
-                <eid>a_a</eid>
+                <startElement>Z_Z</startElement>
+                <endElement>W_W</endElement>
+                <eid>e_e</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>b_b</eid>
+            <eid>f_f</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>c_c</eid>
+              <eid>g_g</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>d_d</eid>
+                <eid>h_h</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -232,21 +246,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.466667</bendEndTimeFactor>
-                <startElement>e_e</startElement>
-                <endElement>c_c</endElement>
-                <eid>f_f</eid>
+                <startElement>i_i</startElement>
+                <endElement>g_g</endElement>
+                <eid>j_j</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>g_g</eid>
+            <eid>k_k</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>h_h</eid>
+              <eid>l_l</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -255,19 +269,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>m_m</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>n_n</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>h_h</NoteEID>
+                <NoteEID>l_l</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>i_i</eid>
+            <eid>o_o</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>e_e</eid>
+              <eid>i_i</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>j_j</eid>
+                <eid>p_p</eid>
                 </Accidental>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -277,25 +298,25 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>h_h</startElement>
-                <endElement>e_e</endElement>
-                <eid>k_k</eid>
+                <startElement>l_l</startElement>
+                <endElement>i_i</endElement>
+                <eid>q_q</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>l_l</eid>
+            <eid>r_r</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>m_m</eid>
+              <eid>s_s</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalQuarterToneSharpArrowDown</subtype>
-                <eid>n_n</eid>
+                <eid>t_t</eid>
                 </Accidental>
               <pitch>64</pitch>
               <centOffset>50</centOffset>
@@ -306,21 +327,21 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>o_o</startElement>
-                <endElement>m_m</endElement>
-                <eid>p_p</eid>
+                <startElement>u_u</startElement>
+                <endElement>s_s</endElement>
+                <eid>v_v</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>q_q</eid>
+            <eid>w_w</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <appoggiatura/>
             <noStem>1</noStem>
             <Note>
-              <eid>r_r</eid>
+              <eid>x_x</eid>
               <parentheses>both</parentheses>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -329,20 +350,27 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>y_y</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>z_z</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>r_r</NoteEID>
+                <NoteEID>x_x</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>s_s</eid>
+            <eid>0_0</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>o_o</eid>
+              <eid>u_u</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalSharp</subtype>
-                <eid>t_t</eid>
+                <eid>1_1</eid>
                 </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
@@ -352,9 +380,9 @@
                 <guitarBendType>pre-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>r_r</startElement>
-                <endElement>o_o</endElement>
-                <eid>u_u</eid>
+                <startElement>x_x</startElement>
+                <endElement>u_u</endElement>
+                <eid>2_2</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_release_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/prebend_release_bend-gp.mscx
@@ -90,16 +90,23 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>1</fret>
@@ -109,20 +116,20 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>N_N</eid>
+                <endElement>O_O</endElement>
+                <eid>P_P</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>O_O</eid>
+            <eid>Q_Q</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>P_P</eid>
+              <eid>R_R</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
@@ -131,18 +138,18 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Q_Q</startElement>
-                <endElement>P_P</endElement>
-                <eid>R_R</eid>
+                <startElement>S_S</startElement>
+                <endElement>R_R</endElement>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <parentheses>both</parentheses>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -152,20 +159,27 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>M_M</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>T_T</eid>
+                <startElement>O_O</startElement>
+                <endElement>S_S</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>W_W</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>X_X</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Q_Q</NoteEID>
+                <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive-gp.mscx
@@ -90,19 +90,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>N_N</eid>
+                <eid>P_P</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -113,18 +120,18 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>O_O</eid>
+                <endElement>O_O</endElement>
+                <eid>Q_Q</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_dive-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_dive-gp.mscx
@@ -113,19 +113,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>L_L</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>Q_Q</eid>
+                <eid>S_S</eid>
                 </Accidental>
               <pitch>54</pitch>
               <tpc>20</tpc>
@@ -137,17 +144,17 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
                 <endElement>L_L</endElement>
-                <eid>R_R</eid>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_dive_same_sign-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_dive_same_sign-gp.mscx
@@ -117,13 +117,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Q_Q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>R_R</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             <Note>
               <eid>M_M</eid>
@@ -137,17 +144,17 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
                 <endElement>M_M</endElement>
-                <eid>R_R</eid>
+                <eid>T_T</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <eid>T_T</eid>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_non_neutral-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_non_neutral-gp.mscx
@@ -90,19 +90,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>L_L</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>M_M</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>K_K</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>L_L</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>M_M</eid>
+              <eid>O_O</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>N_N</eid>
+                <eid>P_P</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -113,21 +120,21 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>K_K</startElement>
-                <endElement>M_M</endElement>
-                <eid>O_O</eid>
+                <endElement>O_O</endElement>
+                <eid>Q_Q</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>Q_Q</eid>
+              <eid>S_S</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>R_R</eid>
+                <eid>T_T</eid>
                 </Accidental>
               <pitch>59</pitch>
               <tpc>19</tpc>
@@ -137,20 +144,27 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.9</bendEndTimeFactor>
-                <startElement>M_M</startElement>
-                <endElement>Q_Q</endElement>
-                <eid>S_S</eid>
+                <startElement>O_O</startElement>
+                <endElement>S_S</endElement>
+                <eid>U_U</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>V_V</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>W_W</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>Q_Q</NoteEID>
+                <NoteEID>S_S</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>T_T</eid>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_release-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_release-gp.mscx
@@ -115,13 +115,20 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             <Note>
               <eid>L_L</eid>
@@ -135,13 +142,13 @@
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>O_O</startElement>
                 <endElement>L_L</endElement>
-                <eid>Q_Q</eid>
+                <eid>S_S</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Rest>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_with_grace-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/predive_with_grace-gp.mscx
@@ -122,19 +122,26 @@
               <ghost>1</ghost>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Q_Q</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>R_R</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Q_Q</eid>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <duration>1/32</duration>
             <acciaccatura/>
             <showStemSlash>0</showStemSlash>
             <Note>
-              <eid>R_R</eid>
+              <eid>T_T</eid>
               <pitch>56</pitch>
               <tpc>10</tpc>
               <fret>12</fret>
@@ -142,11 +149,11 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>U_U</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>T_T</eid>
+              <eid>V_V</eid>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <fret>0</fret>
@@ -156,22 +163,22 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
                 <startElement>P_P</startElement>
-                <endElement>T_T</endElement>
-                <eid>U_U</eid>
+                <endElement>V_V</endElement>
+                <eid>W_W</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>W_W</eid>
+              <eid>Y_Y</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalFlat</subtype>
-                <eid>X_X</eid>
+                <eid>Z_Z</eid>
                 </Accidental>
               <pitch>44</pitch>
               <tpc>10</tpc>
@@ -181,15 +188,22 @@
                 <guitarBendType>dive</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.766667</bendEndTimeFactor>
-                <startElement>T_T</startElement>
-                <endElement>W_W</endElement>
-                <eid>Y_Y</eid>
+                <startElement>V_V</startElement>
+                <endElement>Y_Y</endElement>
+                <eid>a_a</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>b_b</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>c_c</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>W_W</NoteEID>
+                <NoteEID>Y_Y</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/simple_dive_tied-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/simple_dive_tied-gp.mscx
@@ -110,13 +110,20 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_hold-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_hold-gp.mscx
@@ -112,13 +112,20 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>P_P</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>Q_Q</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>M_M</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>P_P</eid>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_tied-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/slight_bend_tied-gp.mscx
@@ -160,16 +160,23 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>V_V</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>W_W</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>V_V</eid>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>W_W</eid>
+              <eid>Y_Y</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               <fret>14</fret>
@@ -178,18 +185,18 @@
                 <guitarBendType>slight-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>W_W</startElement>
-                <endElement>W_W</endElement>
-                <eid>X_X</eid>
+                <startElement>Y_Y</startElement>
+                <endElement>Y_Y</endElement>
+                <eid>Z_Z</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>Y_Y</eid>
+            <eid>a_a</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>Z_Z</eid>
+              <eid>b_b</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               <fret>14</fret>
@@ -197,23 +204,23 @@
               </Note>
             </Chord>
           <BarLine>
-            <eid>a_a</eid>
+            <eid>c_c</eid>
             </BarLine>
           </voice>
         </Measure>
       <Measure>
-        <eid>b_b</eid>
+        <eid>d_d</eid>
         <voice>
           <Chord>
-            <eid>c_c</eid>
+            <eid>e_e</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>d_d</eid>
+              <eid>f_f</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalQuarterToneFlatArrowUp</subtype>
-                <eid>e_e</eid>
+                <eid>g_g</eid>
                 </Accidental>
               <pitch>69</pitch>
               <centOffset>-50</centOffset>
@@ -224,20 +231,27 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>1</bendEndTimeFactor>
-                <startElement>Z_Z</startElement>
-                <endElement>d_d</endElement>
-                <eid>f_f</eid>
+                <startElement>b_b</startElement>
+                <endElement>f_f</endElement>
+                <eid>h_h</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>i_i</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>j_j</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>d_d</NoteEID>
+                <NoteEID>f_f</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>g_g</eid>
+            <eid>k_k</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bend_tieback-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bend_tieback-gp.mscx
@@ -120,16 +120,23 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>R_R</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>S_S</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>O_O</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>R_R</eid>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>S_S</eid>
+              <eid>U_U</eid>
               <parentheses>both</parentheses>
               <pitch>64</pitch>
               <tpc>18</tpc>
@@ -140,19 +147,26 @@
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
                 <startElement>O_O</startElement>
-                <endElement>S_S</endElement>
-                <eid>T_T</eid>
+                <endElement>U_U</endElement>
+                <eid>V_V</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>W_W</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>X_X</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>S_S</NoteEID>
+                <NoteEID>U_U</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Rest>
-            <eid>U_U</eid>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bends_release_or_hold-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_bends_release_or_hold-gp.mscx
@@ -184,31 +184,45 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>Z_Z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>a_a</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>P_P</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>b_b</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>c_c</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>T_T</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>a_a</eid>
+              <eid>e_e</eid>
               <pitch>61</pitch>
               <tpc>9</tpc>
               <fret>6</fret>
               <string>2</string>
               </Note>
             <Note>
-              <eid>b_b</eid>
+              <eid>f_f</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>c_c</eid>
+                <eid>g_g</eid>
                 </Accidental>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -217,17 +231,17 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>d_d</eid>
+            <eid>h_h</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>e_e</eid>
+              <eid>i_i</eid>
               <Accidental>
                 <role>1</role>
                 <subtype>accidentalFlat</subtype>
-                <eid>f_f</eid>
+                <eid>j_j</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -237,14 +251,14 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>g_g</startElement>
-                <endElement>e_e</endElement>
-                <eid>h_h</eid>
+                <startElement>k_k</startElement>
+                <endElement>i_i</endElement>
+                <eid>l_l</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>i_i</eid>
+              <eid>m_m</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>10</fret>
@@ -253,24 +267,24 @@
                 <guitarBendType>grace-note-bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>j_j</startElement>
-                <endElement>i_i</endElement>
-                <eid>k_k</eid>
+                <startElement>n_n</startElement>
+                <endElement>m_m</endElement>
+                <eid>o_o</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             </Chord>
           <Chord>
-            <eid>l_l</eid>
+            <eid>p_p</eid>
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <grace8after/>
             <noStem>1</noStem>
             <Note>
-              <eid>g_g</eid>
+              <eid>k_k</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>m_m</eid>
+                <eid>q_q</eid>
                 </Accidental>
               <pitch>64</pitch>
               <tpc>18</tpc>
@@ -280,14 +294,14 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>n_n</startElement>
-                <endElement>g_g</endElement>
-                <eid>o_o</eid>
+                <startElement>r_r</startElement>
+                <endElement>k_k</endElement>
+                <eid>s_s</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>j_j</eid>
+              <eid>n_n</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <fret>10</fret>
@@ -296,104 +310,22 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.5</bendEndTimeFactor>
-                <startElement>p_p</startElement>
-                <endElement>j_j</endElement>
-                <eid>q_q</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>r_r</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>n_n</eid>
-              <parentheses>both</parentheses>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>s_s</eid>
-                </Accidental>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <fret>6</fret>
-              <string>2</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.633333</bendEndTimeFactor>
-                <startElement>a_a</startElement>
+                <startElement>t_t</startElement>
                 <endElement>n_n</endElement>
-                <eid>t_t</eid>
-                <track>0</track>
-                </GuitarBend>
-              </Note>
-            <Note>
-              <eid>p_p</eid>
-              <parentheses>both</parentheses>
-              <pitch>67</pitch>
-              <tpc>15</tpc>
-              <fret>6</fret>
-              <string>1</string>
-              <GuitarBend>
-                <guitarBendType>bend</guitarBendType>
-                <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>b_b</startElement>
-                <endElement>p_p</endElement>
                 <eid>u_u</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>n_n</NoteEID>
-                </Notes>
-              </NoteParenGroup>
-            <NoteParenGroup>
-              <Notes>
-                <NoteEID>p_p</NoteEID>
-                </Notes>
-              </NoteParenGroup>
             </Chord>
-          <BarLine>
+          <Chord>
             <eid>v_v</eid>
-            </BarLine>
-          </voice>
-        </Measure>
-      <Measure>
-        <eid>w_w</eid>
-        <voice>
-          <Chord>
-            <eid>x_x</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>y_y</eid>
-              <Accidental>
-                <subtype>accidentalFlat</subtype>
-                <eid>z_z</eid>
-                </Accidental>
-              <pitch>61</pitch>
-              <tpc>9</tpc>
-              <fret>6</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <eid>0_0</eid>
-              <pitch>65</pitch>
-              <tpc>13</tpc>
-              <fret>6</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>1_1</eid>
-            <durationType>quarter</durationType>
-            <Note>
-              <eid>2_2</eid>
+              <eid>r_r</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>3_3</eid>
+                <eid>w_w</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -403,14 +335,14 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.633333</bendEndTimeFactor>
-                <startElement>y_y</startElement>
-                <endElement>2_2</endElement>
-                <eid>4_4</eid>
+                <startElement>e_e</startElement>
+                <endElement>r_r</endElement>
+                <eid>x_x</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>5_5</eid>
+              <eid>t_t</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -420,31 +352,53 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>0_0</startElement>
-                <endElement>5_5</endElement>
-                <eid>6_6</eid>
+                <startElement>f_f</startElement>
+                <endElement>t_t</endElement>
+                <eid>y_y</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>z_z</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>0_0</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>2_2</NoteEID>
+                <NoteEID>r_r</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>1_1</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>2_2</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>5_5</NoteEID>
+                <NoteEID>t_t</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>
+          <BarLine>
+            <eid>3_3</eid>
+            </BarLine>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>4_4</eid>
+        <voice>
           <Chord>
-            <eid>7_7</eid>
+            <eid>5_5</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>8_8</eid>
+              <eid>6_6</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>9_9</eid>
+                <eid>7_7</eid>
                 </Accidental>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -452,7 +406,7 @@
               <string>2</string>
               </Note>
             <Note>
-              <eid>+_+</eid>
+              <eid>8_8</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -460,57 +414,145 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>/_/</eid>
-            <BeamMode>no</BeamMode>
-            <durationType>eighth</durationType>
-            <grace8after/>
-            <noStem>1</noStem>
+            <eid>9_9</eid>
+            <durationType>quarter</durationType>
             <Note>
-              <eid>AB_AB</eid>
+              <eid>+_+</eid>
+              <parentheses>both</parentheses>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
-                <eid>BB_BB</eid>
+                <subtype>accidentalNatural</subtype>
+                <eid>/_/</eid>
                 </Accidental>
-              <pitch>61</pitch>
-              <tpc>9</tpc>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
               <fret>6</fret>
               <string>2</string>
               <GuitarBend>
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
-                <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>CB_CB</startElement>
-                <endElement>AB_AB</endElement>
-                <eid>DB_DB</eid>
+                <bendEndTimeFactor>0.633333</bendEndTimeFactor>
+                <startElement>6_6</startElement>
+                <endElement>+_+</endElement>
+                <eid>AB_AB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>EB_EB</eid>
-              <pitch>65</pitch>
-              <tpc>13</tpc>
+              <eid>BB_BB</eid>
+              <parentheses>both</parentheses>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
               <fret>6</fret>
               <string>1</string>
               <GuitarBend>
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>FB_FB</startElement>
-                <endElement>EB_EB</endElement>
-                <eid>GB_GB</eid>
+                <startElement>8_8</startElement>
+                <endElement>BB_BB</endElement>
+                <eid>CB_CB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>DB_DB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>EB_EB</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>+_+</NoteEID>
+                </Notes>
+              </NoteParenGroup>
+            <NoteParenGroup>
+              <Parenthesis>
+                <eid>FB_FB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>GB_GB</eid>
+                </Parenthesis>
+              <Notes>
+                <NoteEID>BB_BB</NoteEID>
+                </Notes>
+              </NoteParenGroup>
             </Chord>
           <Chord>
             <eid>HB_HB</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>CB_CB</eid>
+              <eid>IB_IB</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>JB_JB</eid>
+                </Accidental>
+              <pitch>61</pitch>
+              <tpc>9</tpc>
+              <fret>6</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <eid>KB_KB</eid>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              <fret>6</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>LB_LB</eid>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <grace8after/>
+            <noStem>1</noStem>
+            <Note>
+              <eid>MB_MB</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>NB_NB</eid>
+                </Accidental>
+              <pitch>61</pitch>
+              <tpc>9</tpc>
+              <fret>6</fret>
+              <string>2</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>OB_OB</startElement>
+                <endElement>MB_MB</endElement>
+                <eid>PB_PB</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            <Note>
+              <eid>QB_QB</eid>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              <fret>6</fret>
+              <string>1</string>
+              <GuitarBend>
+                <guitarBendType>bend</guitarBendType>
+                <bendStartTimeFactor>0</bendStartTimeFactor>
+                <bendEndTimeFactor>0.25</bendEndTimeFactor>
+                <startElement>RB_RB</startElement>
+                <endElement>QB_QB</endElement>
+                <eid>SB_SB</eid>
+                <track>0</track>
+                </GuitarBend>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>TB_TB</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>OB_OB</eid>
               <parentheses>both</parentheses>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>IB_IB</eid>
+                <eid>UB_UB</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -520,14 +562,14 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.633333</bendEndTimeFactor>
-                <startElement>8_8</startElement>
-                <endElement>CB_CB</endElement>
-                <eid>JB_JB</eid>
+                <startElement>IB_IB</startElement>
+                <endElement>OB_OB</endElement>
+                <eid>VB_VB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <Note>
-              <eid>FB_FB</eid>
+              <eid>RB_RB</eid>
               <parentheses>both</parentheses>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -537,20 +579,34 @@
                 <guitarBendType>bend</guitarBendType>
                 <bendStartTimeFactor>0</bendStartTimeFactor>
                 <bendEndTimeFactor>0.25</bendEndTimeFactor>
-                <startElement>+_+</startElement>
-                <endElement>FB_FB</endElement>
-                <eid>KB_KB</eid>
+                <startElement>KB_KB</startElement>
+                <endElement>RB_RB</endElement>
+                <eid>WB_WB</eid>
                 <track>0</track>
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>XB_XB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>YB_YB</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>CB_CB</NoteEID>
+                <NoteEID>OB_OB</NoteEID>
                 </Notes>
               </NoteParenGroup>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>ZB_ZB</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>aB_aB</eid>
+                </Parenthesis>
               <Notes>
-                <NoteEID>FB_FB</NoteEID>
+                <NoteEID>RB_RB</NoteEID>
                 </Notes>
               </NoteParenGroup>
             </Chord>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_chord_slight_bend-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/tied_chord_slight_bend-gp.mscx
@@ -141,6 +141,13 @@
                 </GuitarBend>
               </Note>
             <NoteParenGroup>
+              <Parenthesis>
+                <eid>U_U</eid>
+                </Parenthesis>
+              <Parenthesis>
+                <horizontalDirection>right</horizontalDirection>
+                <eid>V_V</eid>
+                </Parenthesis>
               <Notes>
                 <NoteEID>R_R</NoteEID>
                 </Notes>


### PR DESCRIPTION
Because we only write parenthesis if user modified, it can happen that the "main" element (e.g. the parenthesis in the notation stave) was not modified so it does not get written, but a linked element (e.g. the linked parenthesis in the TAB) was modified so it does get written. When writing the TAB parenthesis we try to link it to the EID of the main element, but because the main element was not written, its EID is invalid. In debug build this triggers an assertion failure when saving. In release build we save with an invalid EID which in debug builds will then trigger assertion failures on read.

I think it is safer to always write out the parenthesis, even if not strictly necessary, as it doesn't take that much space and it also allows to simplify the re-linking when reading.