### PR TITLE
[MEI] Preserve microtonal accidentals and cent offsets

### DIFF
--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -176,9 +176,29 @@ engraving::AccidentalType Convert::accidFromMEI(const libmei::data_ACCIDENTAL_WR
     case (libmei::ACCIDENTAL_WRITTEN_nf): return engraving::AccidentalType::NATURAL_FLAT;
     case (libmei::ACCIDENTAL_WRITTEN_ns): return engraving::AccidentalType::NATURAL_SHARP;
     case (libmei::ACCIDENTAL_WRITTEN_ss): return engraving::AccidentalType::SHARP_SHARP;
+    case (libmei::ACCIDENTAL_WRITTEN_su): return engraving::AccidentalType::SHARP_ARROW_UP;
+    case (libmei::ACCIDENTAL_WRITTEN_sd): return engraving::AccidentalType::SHARP_ARROW_DOWN;
+    case (libmei::ACCIDENTAL_WRITTEN_fu): return engraving::AccidentalType::FLAT_ARROW_UP;
+    case (libmei::ACCIDENTAL_WRITTEN_fd): return engraving::AccidentalType::FLAT_ARROW_DOWN;
+    case (libmei::ACCIDENTAL_WRITTEN_nu): return engraving::AccidentalType::NATURAL_ARROW_UP;
+    case (libmei::ACCIDENTAL_WRITTEN_nd): return engraving::AccidentalType::NATURAL_ARROW_DOWN;
+    case (libmei::ACCIDENTAL_WRITTEN_xu): return engraving::AccidentalType::SHARP2_ARROW_UP;
+    case (libmei::ACCIDENTAL_WRITTEN_xd): return engraving::AccidentalType::SHARP2_ARROW_DOWN;
+    case (libmei::ACCIDENTAL_WRITTEN_ffu): return engraving::AccidentalType::FLAT2_ARROW_UP;
+    case (libmei::ACCIDENTAL_WRITTEN_ffd): return engraving::AccidentalType::FLAT2_ARROW_DOWN;
+    case (libmei::ACCIDENTAL_WRITTEN_1qf): return engraving::AccidentalType::MIRRORED_FLAT;
+    case (libmei::ACCIDENTAL_WRITTEN_3qf): return engraving::AccidentalType::MIRRORED_FLAT2;
+    case (libmei::ACCIDENTAL_WRITTEN_1qs): return engraving::AccidentalType::SHARP_SLASH;
+    case (libmei::ACCIDENTAL_WRITTEN_3qs): return engraving::AccidentalType::SHARP_SLASH4;
+    case (libmei::ACCIDENTAL_WRITTEN_bms): return engraving::AccidentalType::SHARP_SLASH2;
+    case (libmei::ACCIDENTAL_WRITTEN_kms): return engraving::AccidentalType::SHARP_SLASH3;
+    case (libmei::ACCIDENTAL_WRITTEN_bf): return engraving::AccidentalType::FLAT_SLASH;
+    case (libmei::ACCIDENTAL_WRITTEN_bmf): return engraving::AccidentalType::FLAT_SLASH2;
+    case (libmei::ACCIDENTAL_WRITTEN_koron): return engraving::AccidentalType::KORON;
+    case (libmei::ACCIDENTAL_WRITTEN_sori): return engraving::AccidentalType::SORI;
     default:
         warning = true;
-        return engraving::AccidentalType::NATURAL;
+        return engraving::AccidentalType::NONE;
     }
 }
 
@@ -196,42 +216,138 @@ libmei::data_ACCIDENTAL_WRITTEN Convert::accidToMEI(const engraving::AccidentalT
     case (engraving::AccidentalType::NATURAL_FLAT): return libmei::ACCIDENTAL_WRITTEN_nf;
     case (engraving::AccidentalType::NATURAL_SHARP): return libmei::ACCIDENTAL_WRITTEN_ns;
     case (engraving::AccidentalType::SHARP_SHARP): return libmei::ACCIDENTAL_WRITTEN_ss;
+    case (engraving::AccidentalType::SHARP_ARROW_UP): return libmei::ACCIDENTAL_WRITTEN_su;
+    case (engraving::AccidentalType::SHARP_ARROW_DOWN): return libmei::ACCIDENTAL_WRITTEN_sd;
+    case (engraving::AccidentalType::FLAT_ARROW_UP): return libmei::ACCIDENTAL_WRITTEN_fu;
+    case (engraving::AccidentalType::FLAT_ARROW_DOWN): return libmei::ACCIDENTAL_WRITTEN_fd;
+    case (engraving::AccidentalType::NATURAL_ARROW_UP): return libmei::ACCIDENTAL_WRITTEN_nu;
+    case (engraving::AccidentalType::NATURAL_ARROW_DOWN): return libmei::ACCIDENTAL_WRITTEN_nd;
+    case (engraving::AccidentalType::SHARP2_ARROW_UP): return libmei::ACCIDENTAL_WRITTEN_xu;
+    case (engraving::AccidentalType::SHARP2_ARROW_DOWN): return libmei::ACCIDENTAL_WRITTEN_xd;
+    case (engraving::AccidentalType::FLAT2_ARROW_UP): return libmei::ACCIDENTAL_WRITTEN_ffu;
+    case (engraving::AccidentalType::FLAT2_ARROW_DOWN): return libmei::ACCIDENTAL_WRITTEN_ffd;
+    case (engraving::AccidentalType::MIRRORED_FLAT): return libmei::ACCIDENTAL_WRITTEN_1qf;
+    case (engraving::AccidentalType::MIRRORED_FLAT2): return libmei::ACCIDENTAL_WRITTEN_3qf;
+    case (engraving::AccidentalType::SHARP_SLASH): return libmei::ACCIDENTAL_WRITTEN_1qs;
+    case (engraving::AccidentalType::SHARP_SLASH4): return libmei::ACCIDENTAL_WRITTEN_3qs;
+    case (engraving::AccidentalType::SHARP_SLASH2): return libmei::ACCIDENTAL_WRITTEN_bms;
+    case (engraving::AccidentalType::SHARP_SLASH3): return libmei::ACCIDENTAL_WRITTEN_kms;
+    case (engraving::AccidentalType::FLAT_SLASH): return libmei::ACCIDENTAL_WRITTEN_bf;
+    case (engraving::AccidentalType::FLAT_SLASH2): return libmei::ACCIDENTAL_WRITTEN_bmf;
+    case (engraving::AccidentalType::KORON): return libmei::ACCIDENTAL_WRITTEN_koron;
+    case (engraving::AccidentalType::SORI): return libmei::ACCIDENTAL_WRITTEN_sori;
     default:
-        return libmei::ACCIDENTAL_WRITTEN_n;
+        return libmei::ACCIDENTAL_WRITTEN_NONE;
     }
 }
 
-engraving::AccidentalVal Convert::accidGesFromMEI(const libmei::data_ACCIDENTAL_GESTURAL meiAccid, bool& warning)
+Convert::AccidentalSemantics Convert::accidGesFromMEI(const libmei::data_ACCIDENTAL_GESTURAL meiAccid, bool& warning)
 {
     warning = false;
     switch (meiAccid) {
-    case (libmei::ACCIDENTAL_GESTURAL_NONE): return engraving::AccidentalVal::NATURAL;
-    case (libmei::ACCIDENTAL_GESTURAL_n): return engraving::AccidentalVal::NATURAL;
-    case (libmei::ACCIDENTAL_GESTURAL_f): return engraving::AccidentalVal::FLAT;
-    case (libmei::ACCIDENTAL_GESTURAL_ff): return engraving::AccidentalVal::FLAT2;
-    case (libmei::ACCIDENTAL_GESTURAL_tf): return engraving::AccidentalVal::FLAT3;
-    case (libmei::ACCIDENTAL_GESTURAL_s): return engraving::AccidentalVal::SHARP;
-    case (libmei::ACCIDENTAL_GESTURAL_ss): return engraving::AccidentalVal::SHARP2;
-    case (libmei::ACCIDENTAL_GESTURAL_ts): return engraving::AccidentalVal::SHARP3;
+    case (libmei::ACCIDENTAL_GESTURAL_NONE): return { 0, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_n): return { 0, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_f): return { -1, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_ff): return { -2, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_tf): return { -3, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_s): return { 1, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_ss): return { 2, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_ts): return { 3, 0.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_su): return { 0, 150.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_sd): return { 0, 50.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_fu): return { 0, -50.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_fd): return { 0, -150.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_xu): return { 0, 250.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_ffd): return { 0, -250.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_bms): return { 0, 89.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_kms): return { 0, 56.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_bs): return { 0, 44.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_ks): return { 0, 11.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_kf): return { 0, -11.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_bf): return { 0, -44.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_kmf): return { 0, -56.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_bmf): return { 0, -89.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_koron): return { 0, -67.0 };
+    case (libmei::ACCIDENTAL_GESTURAL_sori): return { 0, 33.0 };
     default:
         warning = true;
-        return engraving::AccidentalVal::NATURAL;
+        return { 0, 0.0 };
     }
 }
 
-libmei::data_ACCIDENTAL_GESTURAL Convert::accidGesToMEI(const engraving::AccidentalVal accid)
+libmei::data_ACCIDENTAL_GESTURAL Convert::accidGesToMEI(const AccidentalSemantics& accid, bool& warning)
 {
-    switch (accid) {
-    case (engraving::AccidentalVal::NATURAL): return libmei::ACCIDENTAL_GESTURAL_n;
-    case (engraving::AccidentalVal::FLAT): return libmei::ACCIDENTAL_GESTURAL_f;
-    case (engraving::AccidentalVal::FLAT2): return libmei::ACCIDENTAL_GESTURAL_ff;
-    case (engraving::AccidentalVal::FLAT3): return libmei::ACCIDENTAL_GESTURAL_tf;
-    case (engraving::AccidentalVal::SHARP): return libmei::ACCIDENTAL_GESTURAL_s;
-    case (engraving::AccidentalVal::SHARP2): return libmei::ACCIDENTAL_GESTURAL_ss;
-    case (engraving::AccidentalVal::SHARP3): return libmei::ACCIDENTAL_GESTURAL_ts;
-    default:
-        return libmei::ACCIDENTAL_GESTURAL_n;
+    warning = false;
+    if (accid.semitoneOffset != 0 && !muse::RealIsNull(accid.centOffset)) {
+        warning = true;
+        return libmei::ACCIDENTAL_GESTURAL_NONE;
     }
+    if (muse::RealIsNull(accid.centOffset)) {
+        switch (accid.semitoneOffset) {
+        case -3: return libmei::ACCIDENTAL_GESTURAL_tf;
+        case -2: return libmei::ACCIDENTAL_GESTURAL_ff;
+        case -1: return libmei::ACCIDENTAL_GESTURAL_f;
+        case 0: return libmei::ACCIDENTAL_GESTURAL_n;
+        case 1: return libmei::ACCIDENTAL_GESTURAL_s;
+        case 2: return libmei::ACCIDENTAL_GESTURAL_ss;
+        case 3: return libmei::ACCIDENTAL_GESTURAL_ts;
+        default:
+            warning = true;
+            return libmei::ACCIDENTAL_GESTURAL_NONE;
+        }
+    }
+
+    if (muse::RealIsEqual(accid.centOffset, 250.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_xu;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 150.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_su;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 89.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_bms;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 56.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_kms;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 50.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_sd;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 44.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_bs;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 33.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_sori;
+    }
+    if (muse::RealIsEqual(accid.centOffset, 11.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_ks;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -11.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_kf;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -44.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_bf;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -50.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_fu;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -56.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_kmf;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -67.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_koron;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -89.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_bmf;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -150.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_fd;
+    }
+    if (muse::RealIsEqual(accid.centOffset, -250.0)) {
+        return libmei::ACCIDENTAL_GESTURAL_ffd;
+    }
+
+    warning = true;
+    return libmei::ACCIDENTAL_GESTURAL_NONE;
 }
 
 engraving::ArticulationAnchor Convert::anchorFromMEI(const libmei::data_STAFFREL meiPlace, bool& warning)
@@ -2783,15 +2899,14 @@ Convert::PitchStruct Convert::pitchFromMEI(const libmei::Note& meiNote, const li
 
     int oct = meiNote.HasOct() ? meiNote.GetOct() : 3;
 
-    engraving::AccidentalVal alter = engraving::AccidentalVal::NATURAL;
+    AccidentalSemantics soundingAccidental;
     if (meiAccid.HasAccid() || meiAccid.HasAccidGes()) {
         bool accidWarning = false;
         libmei::data_ACCIDENTAL_GESTURAL meiAccidGes
             = (meiAccid.HasAccidGes()) ? meiAccid.GetAccidGes() : libmei::Att::AccidentalWrittenToGestural(meiAccid.GetAccid());
-        alter = Convert::accidGesFromMEI(meiAccidGes, accidWarning);
+        soundingAccidental = Convert::accidGesFromMEI(meiAccidGes, accidWarning);
         warning = (warning || accidWarning);
     }
-    int alterInt = static_cast<int>(alter);
 
     if (meiAccid.HasEnclose()) {
         switch (meiAccid.GetEnclose()) {
@@ -2813,8 +2928,16 @@ Convert::PitchStruct Convert::pitchFromMEI(const libmei::Note& meiNote, const li
     }
     pitchSt.accidType = Convert::accidFromMEI(meiAccid.GetAccid(), accidWarning);
     warning = (warning || accidWarning);
-    pitchSt.pitch = pitchMap[step] + alterInt + (oct + 1) * 12;
-    pitchSt.tpc2 = engraving::step2tpc(step, alter);
+    pitchSt.pitch = pitchMap[step] + soundingAccidental.semitoneOffset + (oct + 1) * 12;
+    pitchSt.centOffset = soundingAccidental.centOffset;
+
+    // TPC describes the written spelling. When @accid is absent, use the
+    // integer component of the sounding alteration instead.
+    engraving::AccidentalVal tpcAlter = static_cast<engraving::AccidentalVal>(soundingAccidental.semitoneOffset);
+    if (meiAccid.HasAccid() && pitchSt.accidType != engraving::AccidentalType::NONE) {
+        tpcAlter = engraving::Accidental::subtype2value(pitchSt.accidType);
+    }
+    pitchSt.tpc2 = engraving::step2tpc(step, tpcAlter);
     // The pitch retrieved from the MEI is the written pitch and we need to transpose it
     pitchSt.pitch += interval.chromatic;
 
@@ -2834,6 +2957,7 @@ std::pair<libmei::Note, libmei::Accid> Convert::pitchToMEI(const engraving::Note
     Convert::PitchStruct pitch;
     pitch.pitch = note->pitch();
     pitch.tpc2 = note->tpc2();
+    pitch.centOffset = note->centOffset();
     if (accid) {
         pitch.accidType = accid->accidentalType();
         pitch.accidBracket = accid->bracket();
@@ -2842,25 +2966,45 @@ std::pair<libmei::Note, libmei::Accid> Convert::pitchToMEI(const engraving::Note
     }
 
     // @pname
-    meiNote.SetPname(static_cast<libmei::data_PITCHNAME>(engraving::tpc2step(pitch.tpc2) + 1));
+    const int step = engraving::tpc2step(pitch.tpc2);
+    meiNote.SetPname(static_cast<libmei::data_PITCHNAME>(step + 1));
 
     int writtenAlterInt = static_cast<int>(engraving::Accidental::subtype2value(pitch.accidType));
-    int alterInt = tpc2alterByKey(pitch.tpc2, engraving::Key::C);
+    // Recover the sounding integer alteration independently of the written
+    // spelling. Microtonal displacement remains in pitch.centOffset.
+    static int pitchMap[7] = { 0, 2, 4, 5, 7, 9, 11 };
+    const int untransposedPitch = pitch.pitch - interval.chromatic;
+    int soundingAlterInt = (untransposedPitch - pitchMap[step]) % 12;
+    if (soundingAlterInt > 6) {
+        soundingAlterInt -= 12;
+    } else if (soundingAlterInt < -6) {
+        soundingAlterInt += 12;
+    }
 
     // @oct
     // We need to adjust the pitch to its transposed value for the octave calculation
-    int oct = ((pitch.pitch - interval.chromatic - alterInt) / 12) - 1;
+    int oct = ((untransposedPitch - soundingAlterInt - pitchMap[step]) / 12) - 1;
     meiNote.SetOct(oct);
 
     // @oct.ges
-    int octGes = ((note->ppitch() - interval.chromatic - alterInt) / 12) - 1;
+    const int untransposedPlaybackPitch = note->ppitch() - interval.chromatic;
+    int playbackAlterInt = (untransposedPlaybackPitch - pitchMap[step]) % 12;
+    if (playbackAlterInt > 6) {
+        playbackAlterInt -= 12;
+    } else if (playbackAlterInt < -6) {
+        playbackAlterInt += 12;
+    }
+    int octGes = ((untransposedPlaybackPitch - playbackAlterInt - pitchMap[step]) / 12) - 1;
     if (octGes != oct) {
         meiNote.SetOctGes(octGes);
     }
 
     // @accid
     if (pitch.accidType != engraving::AccidentalType::NONE) {
-        meiAccid.SetAccid(Convert::accidToMEI(pitch.accidType));
+        const libmei::data_ACCIDENTAL_WRITTEN writtenAccidental = Convert::accidToMEI(pitch.accidType);
+        if (writtenAccidental != libmei::ACCIDENTAL_WRITTEN_NONE) {
+            meiAccid.SetAccid(writtenAccidental);
+        }
         if (pitch.accidBracket == engraving::AccidentalBracket::BRACKET) {
             meiAccid.SetEnclose(libmei::ENCLOSURE_brack);
         } else if (pitch.accidBracket == engraving::AccidentalBracket::PARENTHESIS) {
@@ -2869,8 +3013,16 @@ std::pair<libmei::Note, libmei::Accid> Convert::pitchToMEI(const engraving::Note
     }
 
     // @accid.ges
-    if (alterInt && (alterInt != writtenAlterInt)) {
-        meiAccid.SetAccidGes(Convert::accidGesToMEI(static_cast<engraving::AccidentalVal>(alterInt)));
+    const double writtenCentOffset = engraving::Accidental::subtype2centOffset(pitch.accidType);
+    const bool soundingDiffersFromWritten = soundingAlterInt != writtenAlterInt
+                                            || !muse::RealIsEqual(pitch.centOffset, writtenCentOffset);
+    if (soundingDiffersFromWritten) {
+        bool accidWarning = false;
+        const AccidentalSemantics soundingAccidental { soundingAlterInt, pitch.centOffset };
+        const libmei::data_ACCIDENTAL_GESTURAL meiAccidGes = Convert::accidGesToMEI(soundingAccidental, accidWarning);
+        if (!accidWarning) {
+            meiAccid.SetAccidGes(meiAccidGes);
+        }
     }
 
     return { meiNote, meiAccid };

--- a/src/importexport/mei/internal/meiconverter.h
+++ b/src/importexport/mei/internal/meiconverter.h
@@ -127,9 +127,17 @@ public:
     struct PitchStruct {
         int pitch = 0;
         int tpc2 = 0;
+        // Sounding displacement, in cents, relative to the integer MIDI pitch.
+        // This value is invariant under transposition.
+        double centOffset = 0.0;
         engraving::AccidentalType accidType = engraving::AccidentalType::NONE;
         engraving::AccidentalBracket accidBracket = engraving::AccidentalBracket::NONE;
         engraving::AccidentalRole accidRole = engraving::AccidentalRole::AUTO;
+    };
+
+    struct AccidentalSemantics {
+        int semitoneOffset = 0;
+        double centOffset = 0.0;
     };
 
     /**
@@ -150,8 +158,8 @@ public:
     static engraving::AccidentalType accidFromMEI(const libmei::data_ACCIDENTAL_WRITTEN meiAccid, bool& warning);
     static libmei::data_ACCIDENTAL_WRITTEN accidToMEI(const engraving::AccidentalType accid);
 
-    static engraving::AccidentalVal accidGesFromMEI(const libmei::data_ACCIDENTAL_GESTURAL meiAccid, bool& warning);
-    static libmei::data_ACCIDENTAL_GESTURAL accidGesToMEI(const engraving::AccidentalVal accid);
+    static AccidentalSemantics accidGesFromMEI(const libmei::data_ACCIDENTAL_GESTURAL meiAccid, bool& warning);
+    static libmei::data_ACCIDENTAL_GESTURAL accidGesToMEI(const AccidentalSemantics& accid, bool& warning);
 
     static engraving::ArticulationAnchor anchorFromMEI(const libmei::data_STAFFREL meiPlace, bool& warning);
     static libmei::data_STAFFREL anchorToMEI(engraving::ArticulationAnchor anchor);

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -2121,6 +2121,9 @@ bool MeiImporter::readNote(pugi::xml_node noteNode, Measure* measure, int track,
     accid->setBracket(pitchSt.accidBracket);
     accid->setRole(pitchSt.accidRole);
     note->add(accid);
+    // setAccidentalType() applies the written accidental's intrinsic offset.
+    // Restore the independently derived gestural/sounding displacement last.
+    note->setCentOffset(pitchSt.centOffset);
 
     note->setTrack(track);
     chord->add(note);

--- a/src/importexport/mei/tests/CMakeLists.txt
+++ b/src/importexport/mei/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(MODULE_TEST_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mei_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mei_microtonal_tests.cpp
 )
 
 set(MODULE_TEST_LINK
@@ -38,3 +39,8 @@ set(MODULE_TEST_LINK
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 include(SetupGTest)
+
+target_include_directories(${MODULE_TEST} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/importexport/mei
+    ${_pugixml_src}/pugixml/src
+)

--- a/src/importexport/mei/tests/data/microtonal-roundtrip.mei
+++ b/src/importexport/mei/tests/data/microtonal-roundtrip.mei
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-basic.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1+basic">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>MEI microtonal round-trip regression</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2026-08-13" />
+         </pubStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
+                        <label>Voice</label>
+                        <labelAbbr>Vo.</labelAbbr>
+                        <clef shape="G" line="2" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section xml:id="section1">
+                  <measure xml:id="measure1" n="1">
+                     <staff xml:id="staff1" n="1">
+                        <layer xml:id="layer1" n="1">
+                           <note xml:id="control-sharp" dur="4" pname="c" oct="4"><accid accid="s" /></note>
+                           <note xml:id="quarter-sharp" dur="4" pname="d" oct="4"><accid accid="1qs" /></note>
+                           <note xml:id="three-quarter-sharp" dur="4" pname="e" oct="4"><accid accid="3qs" /></note>
+                           <note xml:id="sharp-down" dur="4" pname="f" oct="4"><accid accid="sd" /></note>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure xml:id="measure2" n="2" right="end">
+                     <staff xml:id="staff2" n="1">
+                        <layer xml:id="layer2" n="1">
+                           <note xml:id="sharp-up" dur="4" pname="g" oct="4"><accid accid="su" /></note>
+                           <rest xml:id="rest1" dur="2" />
+                           <rest xml:id="rest2" dur="4" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>

--- a/src/importexport/mei/tests/mei_microtonal_tests.cpp
+++ b/src/importexport/mei/tests/mei_microtonal_tests.cpp
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engraving/tests/utils/scorerw.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/note.h"
+
+#include "importexport/mei/internal/meiconverter.h"
+#include "importexport/mei/internal/meireader.h"
+#include "importexport/mei/thirdparty/libmei/att.h"
+
+namespace mu::iex::mei {
+namespace {
+using engraving::AccidentalType;
+
+struct WrittenCase {
+    libmei::data_ACCIDENTAL_WRITTEN mei;
+    AccidentalType museScore;
+    double cents;
+};
+
+constexpr std::array<WrittenCase, 31> WRITTEN_CASES { {
+    { libmei::ACCIDENTAL_WRITTEN_NONE, AccidentalType::NONE, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_s, AccidentalType::SHARP, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_f, AccidentalType::FLAT, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ss, AccidentalType::SHARP_SHARP, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_x, AccidentalType::SHARP2, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ff, AccidentalType::FLAT2, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ts, AccidentalType::SHARP3, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_tf, AccidentalType::FLAT3, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_n, AccidentalType::NATURAL, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_nf, AccidentalType::NATURAL_FLAT, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ns, AccidentalType::NATURAL_SHARP, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_su, AccidentalType::SHARP_ARROW_UP, 150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_sd, AccidentalType::SHARP_ARROW_DOWN, 50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_fu, AccidentalType::FLAT_ARROW_UP, -50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_fd, AccidentalType::FLAT_ARROW_DOWN, -150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_nu, AccidentalType::NATURAL_ARROW_UP, 50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_nd, AccidentalType::NATURAL_ARROW_DOWN, -50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_xu, AccidentalType::SHARP2_ARROW_UP, 250.0 },
+    { libmei::ACCIDENTAL_WRITTEN_xd, AccidentalType::SHARP2_ARROW_DOWN, 150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ffu, AccidentalType::FLAT2_ARROW_UP, -150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_ffd, AccidentalType::FLAT2_ARROW_DOWN, -250.0 },
+    { libmei::ACCIDENTAL_WRITTEN_1qf, AccidentalType::MIRRORED_FLAT, -50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_3qf, AccidentalType::MIRRORED_FLAT2, -150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_1qs, AccidentalType::SHARP_SLASH, 50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_3qs, AccidentalType::SHARP_SLASH4, 150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_bms, AccidentalType::SHARP_SLASH2, 89.0 },
+    { libmei::ACCIDENTAL_WRITTEN_kms, AccidentalType::SHARP_SLASH3, 56.0 },
+    { libmei::ACCIDENTAL_WRITTEN_bf, AccidentalType::FLAT_SLASH, -44.0 },
+    { libmei::ACCIDENTAL_WRITTEN_bmf, AccidentalType::FLAT_SLASH2, -89.0 },
+    { libmei::ACCIDENTAL_WRITTEN_koron, AccidentalType::KORON, -67.0 },
+    { libmei::ACCIDENTAL_WRITTEN_sori, AccidentalType::SORI, 33.0 },
+} };
+
+TEST(MeiMicrotonalTests, writtenAccidentalsPreserveIdentityAndCents)
+{
+    for (const WrittenCase& test : WRITTEN_CASES) {
+        bool warning = true;
+        const AccidentalType actual = Convert::accidFromMEI(test.mei, warning);
+        EXPECT_FALSE(warning) << static_cast<int>(test.mei);
+        EXPECT_EQ(actual, test.museScore) << static_cast<int>(test.mei);
+        EXPECT_DOUBLE_EQ(engraving::Accidental::subtype2centOffset(actual), test.cents)
+            << static_cast<int>(test.mei);
+        EXPECT_EQ(Convert::accidToMEI(actual), test.mei) << static_cast<int>(test.mei);
+    }
+}
+
+struct GesturalDerivationCase {
+    libmei::data_ACCIDENTAL_WRITTEN written;
+    libmei::data_ACCIDENTAL_GESTURAL gestural;
+};
+
+constexpr std::array<GesturalDerivationCase, 20> GESTURAL_DERIVATION_CASES { {
+    { libmei::ACCIDENTAL_WRITTEN_su, libmei::ACCIDENTAL_GESTURAL_su },
+    { libmei::ACCIDENTAL_WRITTEN_sd, libmei::ACCIDENTAL_GESTURAL_sd },
+    { libmei::ACCIDENTAL_WRITTEN_fu, libmei::ACCIDENTAL_GESTURAL_fu },
+    { libmei::ACCIDENTAL_WRITTEN_fd, libmei::ACCIDENTAL_GESTURAL_fd },
+    { libmei::ACCIDENTAL_WRITTEN_nu, libmei::ACCIDENTAL_GESTURAL_sd },
+    { libmei::ACCIDENTAL_WRITTEN_nd, libmei::ACCIDENTAL_GESTURAL_fu },
+    { libmei::ACCIDENTAL_WRITTEN_xu, libmei::ACCIDENTAL_GESTURAL_xu },
+    { libmei::ACCIDENTAL_WRITTEN_xd, libmei::ACCIDENTAL_GESTURAL_su },
+    { libmei::ACCIDENTAL_WRITTEN_ffu, libmei::ACCIDENTAL_GESTURAL_fd },
+    { libmei::ACCIDENTAL_WRITTEN_ffd, libmei::ACCIDENTAL_GESTURAL_ffd },
+    { libmei::ACCIDENTAL_WRITTEN_1qf, libmei::ACCIDENTAL_GESTURAL_fu },
+    { libmei::ACCIDENTAL_WRITTEN_3qf, libmei::ACCIDENTAL_GESTURAL_fd },
+    { libmei::ACCIDENTAL_WRITTEN_1qs, libmei::ACCIDENTAL_GESTURAL_sd },
+    { libmei::ACCIDENTAL_WRITTEN_3qs, libmei::ACCIDENTAL_GESTURAL_su },
+    { libmei::ACCIDENTAL_WRITTEN_bms, libmei::ACCIDENTAL_GESTURAL_bms },
+    { libmei::ACCIDENTAL_WRITTEN_kms, libmei::ACCIDENTAL_GESTURAL_kms },
+    { libmei::ACCIDENTAL_WRITTEN_bf, libmei::ACCIDENTAL_GESTURAL_bf },
+    { libmei::ACCIDENTAL_WRITTEN_bmf, libmei::ACCIDENTAL_GESTURAL_bmf },
+    { libmei::ACCIDENTAL_WRITTEN_koron, libmei::ACCIDENTAL_GESTURAL_koron },
+    { libmei::ACCIDENTAL_WRITTEN_sori, libmei::ACCIDENTAL_GESTURAL_sori },
+} };
+
+TEST(MeiMicrotonalTests, writtenToGesturalKeepsSoundingDisplacement)
+{
+    for (const GesturalDerivationCase& test : GESTURAL_DERIVATION_CASES) {
+        EXPECT_EQ(libmei::Att::AccidentalWrittenToGestural(test.written), test.gestural)
+            << static_cast<int>(test.written);
+    }
+}
+
+TEST(MeiMicrotonalTests, unrepresentableAndUnknownWrittenTokensFailExplicitly)
+{
+    constexpr std::array<libmei::data_ACCIDENTAL_WRITTEN, 7> unsupported { {
+        libmei::ACCIDENTAL_WRITTEN_xs,
+        libmei::ACCIDENTAL_WRITTEN_sx,
+        libmei::ACCIDENTAL_WRITTEN_bs,
+        libmei::ACCIDENTAL_WRITTEN_ks,
+        libmei::ACCIDENTAL_WRITTEN_kf,
+        libmei::ACCIDENTAL_WRITTEN_kmf,
+        libmei::ACCIDENTAL_WRITTEN_MAX,
+    } };
+
+    for (libmei::data_ACCIDENTAL_WRITTEN value : unsupported) {
+        bool warning = false;
+        EXPECT_EQ(Convert::accidFromMEI(value, warning), AccidentalType::NONE)
+            << static_cast<int>(value);
+        EXPECT_TRUE(warning) << static_cast<int>(value);
+    }
+}
+
+struct PitchCase {
+    libmei::data_ACCIDENTAL_WRITTEN written;
+    AccidentalType museScore;
+    int basePitch;
+    double cents;
+};
+
+constexpr std::array<PitchCase, 5> PITCH_CASES { {
+    { libmei::ACCIDENTAL_WRITTEN_s, AccidentalType::SHARP, 61, 0.0 },
+    { libmei::ACCIDENTAL_WRITTEN_1qs, AccidentalType::SHARP_SLASH, 60, 50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_3qs, AccidentalType::SHARP_SLASH4, 60, 150.0 },
+    { libmei::ACCIDENTAL_WRITTEN_sd, AccidentalType::SHARP_ARROW_DOWN, 60, 50.0 },
+    { libmei::ACCIDENTAL_WRITTEN_su, AccidentalType::SHARP_ARROW_UP, 60, 150.0 },
+} };
+
+TEST(MeiMicrotonalTests, pitchTransportSeparatesIntegerPitchAndCentOffset)
+{
+    for (const PitchCase& test : PITCH_CASES) {
+        libmei::Note meiNote;
+        meiNote.SetPname(libmei::PITCHNAME_c);
+        meiNote.SetOct(4);
+        libmei::Accid meiAccid;
+        meiAccid.SetAccid(test.written);
+
+        bool warning = true;
+        const Convert::PitchStruct pitch = Convert::pitchFromMEI(meiNote, meiAccid, engraving::Interval(), warning);
+        EXPECT_FALSE(warning) << static_cast<int>(test.written);
+        EXPECT_EQ(pitch.accidType, test.museScore) << static_cast<int>(test.written);
+        EXPECT_EQ(pitch.pitch, test.basePitch) << static_cast<int>(test.written);
+        EXPECT_DOUBLE_EQ(pitch.centOffset, test.cents) << static_cast<int>(test.written);
+        EXPECT_DOUBLE_EQ(pitch.pitch * 100.0 + pitch.centOffset,
+                         test.basePitch * 100.0 + test.cents)
+            << static_cast<int>(test.written);
+    }
+}
+
+TEST(MeiMicrotonalTests, explicitGesturalValueOverridesSoundButNotWrittenIdentity)
+{
+    libmei::Note meiNote;
+    meiNote.SetPname(libmei::PITCHNAME_c);
+    meiNote.SetOct(4);
+    libmei::Accid meiAccid;
+    meiAccid.SetAccid(libmei::ACCIDENTAL_WRITTEN_s);
+    meiAccid.SetAccidGes(libmei::ACCIDENTAL_GESTURAL_sd);
+
+    bool warning = true;
+    const Convert::PitchStruct pitch = Convert::pitchFromMEI(meiNote, meiAccid, engraving::Interval(), warning);
+    EXPECT_FALSE(warning);
+    EXPECT_EQ(pitch.accidType, AccidentalType::SHARP);
+    EXPECT_EQ(pitch.pitch, 60);
+    EXPECT_DOUBLE_EQ(pitch.centOffset, 50.0);
+    EXPECT_EQ(pitch.tpc2, engraving::step2tpc(0, engraving::AccidentalVal::SHARP));
+}
+
+TEST(MeiMicrotonalTests, gesturalMappingRoundTripsAllRepresentableSoundingValues)
+{
+    constexpr std::array<libmei::data_ACCIDENTAL_GESTURAL, 24> values { {
+        libmei::ACCIDENTAL_GESTURAL_n,
+        libmei::ACCIDENTAL_GESTURAL_s,
+        libmei::ACCIDENTAL_GESTURAL_f,
+        libmei::ACCIDENTAL_GESTURAL_ss,
+        libmei::ACCIDENTAL_GESTURAL_ff,
+        libmei::ACCIDENTAL_GESTURAL_ts,
+        libmei::ACCIDENTAL_GESTURAL_tf,
+        libmei::ACCIDENTAL_GESTURAL_su,
+        libmei::ACCIDENTAL_GESTURAL_sd,
+        libmei::ACCIDENTAL_GESTURAL_fu,
+        libmei::ACCIDENTAL_GESTURAL_fd,
+        libmei::ACCIDENTAL_GESTURAL_xu,
+        libmei::ACCIDENTAL_GESTURAL_ffd,
+        libmei::ACCIDENTAL_GESTURAL_bms,
+        libmei::ACCIDENTAL_GESTURAL_kms,
+        libmei::ACCIDENTAL_GESTURAL_bs,
+        libmei::ACCIDENTAL_GESTURAL_ks,
+        libmei::ACCIDENTAL_GESTURAL_kf,
+        libmei::ACCIDENTAL_GESTURAL_bf,
+        libmei::ACCIDENTAL_GESTURAL_kmf,
+        libmei::ACCIDENTAL_GESTURAL_bmf,
+        libmei::ACCIDENTAL_GESTURAL_koron,
+        libmei::ACCIDENTAL_GESTURAL_sori,
+        libmei::ACCIDENTAL_GESTURAL_NONE,
+    } };
+
+    for (libmei::data_ACCIDENTAL_GESTURAL value : values) {
+        bool importWarning = true;
+        const Convert::AccidentalSemantics semantics = Convert::accidGesFromMEI(value, importWarning);
+        EXPECT_FALSE(importWarning) << static_cast<int>(value);
+
+        bool exportWarning = true;
+        const libmei::data_ACCIDENTAL_GESTURAL exported = Convert::accidGesToMEI(semantics, exportWarning);
+        EXPECT_FALSE(exportWarning) << static_cast<int>(value);
+        const libmei::data_ACCIDENTAL_GESTURAL expected
+            = value == libmei::ACCIDENTAL_GESTURAL_NONE ? libmei::ACCIDENTAL_GESTURAL_n : value;
+        EXPECT_EQ(exported, expected) << static_cast<int>(value);
+    }
+}
+
+TEST(MeiMicrotonalTests, fullImportAndPitchExportPreserveMicrotonalTokens)
+{
+    auto importFunc = [](engraving::MasterScore* score, const muse::io::path_t& path) -> engraving::Err {
+        MeiReader meiReader(nullptr);
+        return meiReader.import(score, path);
+    };
+    std::unique_ptr<engraving::MasterScore> score(
+        engraving::ScoreRW::readScore(u"data/microtonal-roundtrip.mei", false, importFunc));
+    ASSERT_TRUE(score);
+
+    std::vector<const engraving::Note*> notes;
+    score->scanElements([&notes](engraving::EngravingItem* item) {
+        if (item->isNote()) {
+            notes.push_back(engraving::toNote(item));
+        }
+    });
+    ASSERT_EQ(notes.size(), PITCH_CASES.size());
+    constexpr std::array<int, 5> expectedBasePitches { 61, 62, 64, 65, 67 };
+    for (size_t i = 0; i < PITCH_CASES.size(); ++i) {
+        ASSERT_TRUE(notes[i]->accidental());
+        EXPECT_EQ(notes[i]->accidental()->accidentalType(), PITCH_CASES[i].museScore);
+        EXPECT_EQ(notes[i]->pitch(), expectedBasePitches[i]);
+        EXPECT_DOUBLE_EQ(notes[i]->centOffset(), PITCH_CASES[i].cents);
+        const auto converted = Convert::pitchToMEI(
+            notes[i], notes[i]->accidental(), engraving::Interval());
+        EXPECT_EQ(converted.second.GetAccid(), PITCH_CASES[i].written);
+        EXPECT_FALSE(converted.second.HasAccidGes());
+    }
+}
+} // namespace
+} // namespace mu::iex::mei

--- a/src/importexport/mei/thirdparty/libmei/att.cpp
+++ b/src/importexport/mei/thirdparty/libmei/att.cpp
@@ -866,12 +866,10 @@ data_ACCIDENTAL_GESTURAL Att::AccidentalWrittenToGestural(data_ACCIDENTAL_WRITTE
         case ACCIDENTAL_WRITTEN_ss:
         case ACCIDENTAL_WRITTEN_x: accidGes = ACCIDENTAL_GESTURAL_ss; break;
         case ACCIDENTAL_WRITTEN_ff: accidGes = ACCIDENTAL_GESTURAL_ff; break;
-        /* To verified - triple sharp missing in gestural ? */
         case ACCIDENTAL_WRITTEN_xs:
         case ACCIDENTAL_WRITTEN_sx:
-        case ACCIDENTAL_WRITTEN_ts: accidGes = ACCIDENTAL_GESTURAL_ss; break;
-        /* To be verified - triple flat missing in gestural ? */
-        case ACCIDENTAL_WRITTEN_tf: accidGes = ACCIDENTAL_GESTURAL_ff; break;
+        case ACCIDENTAL_WRITTEN_ts: accidGes = ACCIDENTAL_GESTURAL_ts; break;
+        case ACCIDENTAL_WRITTEN_tf: accidGes = ACCIDENTAL_GESTURAL_tf; break;
         case ACCIDENTAL_WRITTEN_n: accidGes = ACCIDENTAL_GESTURAL_n; break;
         case ACCIDENTAL_WRITTEN_nf: accidGes = ACCIDENTAL_GESTURAL_f; break;
         case ACCIDENTAL_WRITTEN_ns: accidGes = ACCIDENTAL_GESTURAL_s; break;
@@ -879,18 +877,26 @@ data_ACCIDENTAL_GESTURAL Att::AccidentalWrittenToGestural(data_ACCIDENTAL_WRITTE
         case ACCIDENTAL_WRITTEN_sd: accidGes = ACCIDENTAL_GESTURAL_sd; break;
         case ACCIDENTAL_WRITTEN_fu: accidGes = ACCIDENTAL_GESTURAL_fu; break;
         case ACCIDENTAL_WRITTEN_fd: accidGes = ACCIDENTAL_GESTURAL_fd; break;
-        /* To verified */
-        case ACCIDENTAL_WRITTEN_nu: accidGes = ACCIDENTAL_GESTURAL_n; break;
-        /* To verified */
-        case ACCIDENTAL_WRITTEN_nd: accidGes = ACCIDENTAL_GESTURAL_n; break;
-        /* To verified */
+        case ACCIDENTAL_WRITTEN_nu: accidGes = ACCIDENTAL_GESTURAL_sd; break;
+        case ACCIDENTAL_WRITTEN_nd: accidGes = ACCIDENTAL_GESTURAL_fu; break;
+        case ACCIDENTAL_WRITTEN_xu: accidGes = ACCIDENTAL_GESTURAL_xu; break;
+        case ACCIDENTAL_WRITTEN_xd: accidGes = ACCIDENTAL_GESTURAL_su; break;
+        case ACCIDENTAL_WRITTEN_ffu: accidGes = ACCIDENTAL_GESTURAL_fd; break;
+        case ACCIDENTAL_WRITTEN_ffd: accidGes = ACCIDENTAL_GESTURAL_ffd; break;
         case ACCIDENTAL_WRITTEN_1qf: accidGes = ACCIDENTAL_GESTURAL_fu; break;
-        /* To verified */
         case ACCIDENTAL_WRITTEN_3qf: accidGes = ACCIDENTAL_GESTURAL_fd; break;
-        /* To verified */
-        case ACCIDENTAL_WRITTEN_1qs: accidGes = ACCIDENTAL_GESTURAL_su; break;
-        /* To verified */
-        case ACCIDENTAL_WRITTEN_3qs: accidGes = ACCIDENTAL_GESTURAL_sd; break;
+        case ACCIDENTAL_WRITTEN_1qs: accidGes = ACCIDENTAL_GESTURAL_sd; break;
+        case ACCIDENTAL_WRITTEN_3qs: accidGes = ACCIDENTAL_GESTURAL_su; break;
+        case ACCIDENTAL_WRITTEN_bms: accidGes = ACCIDENTAL_GESTURAL_bms; break;
+        case ACCIDENTAL_WRITTEN_kms: accidGes = ACCIDENTAL_GESTURAL_kms; break;
+        case ACCIDENTAL_WRITTEN_bs: accidGes = ACCIDENTAL_GESTURAL_bs; break;
+        case ACCIDENTAL_WRITTEN_ks: accidGes = ACCIDENTAL_GESTURAL_ks; break;
+        case ACCIDENTAL_WRITTEN_kf: accidGes = ACCIDENTAL_GESTURAL_kf; break;
+        case ACCIDENTAL_WRITTEN_bf: accidGes = ACCIDENTAL_GESTURAL_bf; break;
+        case ACCIDENTAL_WRITTEN_kmf: accidGes = ACCIDENTAL_GESTURAL_kmf; break;
+        case ACCIDENTAL_WRITTEN_bmf: accidGes = ACCIDENTAL_GESTURAL_bmf; break;
+        case ACCIDENTAL_WRITTEN_koron: accidGes = ACCIDENTAL_GESTURAL_koron; break;
+        case ACCIDENTAL_WRITTEN_sori: accidGes = ACCIDENTAL_GESTURAL_sori; break;
         default: accidGes = ACCIDENTAL_GESTURAL_NONE; break;
     }
     return accidGes;


### PR DESCRIPTION
Resolves: #34567

## Problem

MEI import recognizes ordinary accidentals but sends legal extended written values such as `1qs`, `3qs`, `sd`, and `su` through a warning fallback. The fallback produces `AccidentalType::NATURAL`, and the pitch transport has no fractional-cent field. Import therefore loses written accidental identity and sounding displacement; export cannot reconstruct the input token. The warning also opens a synchronous confirmation dialog, which can leave headless import waiting without output.

## Root cause

- `Convert::accidFromMEI()` and `Convert::accidToMEI()` do not cover representable extended MEI written accidentals.
- `Convert::PitchStruct` transports integer pitch/TPC data but no independent cent offset.
- The hand-maintained `libmei::Att::AccidentalWrittenToGestural()` implementation reverses the `1qs` and `3qs` quarter-tone derivations.

## Fix

- Add exact bidirectional mappings for each MEI written accidental that has a distinct MuseScore `AccidentalType`.
- Reject legal values without an exact MuseScore written identity explicitly instead of silently converting them to natural.
- Carry a separate cent offset through `PitchStruct` and apply it to `engraving::Note` during import.
- Preserve the exact written token on export and emit `accid.ges` only when sounding and written semantics differ and the sounding value is exactly representable.
- Correct and complete the hand-maintained written-to-gestural mapping.

## Microtonal semantics preserved

| MEI token | MuseScore accidental | Integer alteration | Cent offset | Export |
|---|---|---:|---:|---|
| `s` | `SHARP` | +1 | 0 | `s` |
| `1qs` | `SHARP_SLASH` | 0 | +50 | `1qs` |
| `3qs` | `SHARP_SLASH4` | 0 | +150 | `3qs` |
| `sd` | `SHARP_ARROW_DOWN` | 0 | +50 | `sd` |
| `su` | `SHARP_ARROW_UP` | 0 | +150 | `su` |

Transposition keeps the independent cent component while preserving the existing integer pitch/TPC behavior.

## Tests

The current `main` port was built with MSVC and Qt 6.10.2 and ran the MEI test executable successfully:

- 71/71 MEI tests pass.
- 64/64 pre-existing MEI tests pass.
- 7/7 new microtonal tests pass.
- The written-domain tests partition every enum value into exact mappings or explicit failures.
- All representable gestural values are round-tripped.
- The physical MEI import/export test covers ordinary sharp plus `1qs`, `3qs`, `sd`, and `su`.
- The public MEI 5.1 Basic reproducer validates with two independent Relax NG implementations and zero diagnostics.

## Before / after

| Case | Before | After |
|---|---|---|
| `1qs` | warning; natural/integer fallback; cents lost | exact written type; +50 cents; exports `1qs` |
| `3qs` | warning; natural/integer fallback; cents lost | exact written type; +150 cents; exports `3qs` |
| `sd` / `su` | warning; exact sounding semantics unavailable | exact arrow type and +50/+150 cents preserved |
| unsupported exact written identity | silent natural reinterpretation | explicit failure with no semantic substitution |
| ordinary accidentals | existing behavior | unchanged; regression tests pass |

## MEI specification references

- [MEI accidental written extended datatype](https://music-encoding.org/guidelines/v5/data-types/data.ACCIDENTAL.WRITTEN.extended.html)
- [MEI accidental gestural extended datatype](https://music-encoding.org/guidelines/v5/data-types/data.ACCIDENTAL.GESTURAL.extended.html)
- [MEI AEU accidental datatype](https://music-encoding.org/guidelines/v5/data-types/data.ACCIDENTAL.aeu.html)
- [MEI Persian accidental datatype](https://music-encoding.org/guidelines/v5/data-types/data.ACCIDENTAL.persian.html)

## Scope

The change is confined to the generic MEI converter/importer, the hand-maintained libmei alternate converter, and MEI tests. It contains no application-specific fixtures, paths, IDs, event counts, build artifacts, or forensic data.

## Pull request checklist

- [x] CLA signed using MuseScore.org username: rasalinga
- [x] The title describes the purpose of the changes.
- [x] The commit message describes the purpose and effects and references issue #34567.
- [x] The changed first-party C++ files were formatted with the repository formatter.
- [x] The code and tests are understood and limited to the stated fix.
- [x] The current-main MEI test target compiles and runs locally; the same semantic repair was manually verified in the full v4.7.4 application.
- [x] Existing and new MEI tests pass.
- [x] No equivalent open or closed issue, pull request, or commit was found in the pre-publication search.
- [x] No unrelated changes are included.

