### PR TITLE
[4.7.5] Fix #34566: Crash when closing score with selected chord symbol

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
@@ -540,6 +540,11 @@ void AbstractInspectorModel::requestElements()
     }
 }
 
+void AbstractInspectorModel::disconnectAll()
+{
+    async_disconnectAll();
+}
+
 void AbstractInspectorModel::onCurrentNotationChanged()
 {
 }

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
@@ -185,6 +185,8 @@ public:
 
     virtual void requestElements();
 
+    virtual void disconnectAll();
+
     virtual void onCurrentNotationChanged();
 
     virtual void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
@@ -91,6 +91,15 @@ void AbstractInspectorProxyModel::requestResetToDefaults()
     }
 }
 
+void AbstractInspectorProxyModel::disconnectAll()
+{
+    for (AbstractInspectorModel* model : modelList()) {
+        model->disconnectAll();
+    }
+
+    AbstractInspectorModel::disconnectAll();
+}
+
 bool AbstractInspectorProxyModel::isEmpty() const
 {
     for (const AbstractInspectorModel* model : modelList()) {
@@ -114,7 +123,10 @@ void AbstractInspectorProxyModel::setModels(const QList<AbstractInspectorModel*>
         auto oldModel = m_models.take(model->modelType());
 
         //! NOTE: may run synchronously from a model's own property-change callback;
-        //! deleting immediately would destroy "this" mid-call, so defer it
+        //! deleting immediately would destroy "this" mid-call, so defer it.
+        //! Disconnect now so it (and its submodels) doesn't react to further updates
+        //! while it awaits destruction
+        oldModel->disconnectAll();
         oldModel->deleteLater();
     }
 

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
@@ -61,6 +61,7 @@ public:
 
     void requestElements() override;
     void requestResetToDefaults() override;
+    void disconnectAll() override;
     bool isEmpty() const override;
 
     void updateModels(const ElementKeySet& newElementKeySet);

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
@@ -285,7 +285,10 @@ void InspectorListModel::removeUnusedModels(const ElementKeySet& newElementKeySe
         m_modelList.removeAt(index);
 
         //! NOTE: may run synchronously from a model's own property-change callback;
-        //! deleting immediately would destroy "this" mid-call, so defer it
+        //! deleting immediately would destroy "this" mid-call, so defer it.
+        //! Disconnect now so it (and its submodels) doesn't react to further updates
+        //! while it awaits destruction
+        model->disconnectAll();
         model->deleteLater();
 
         endRemoveRows();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34566

Caused by: https://github.com/musescore/MuseScore/pull/34084