### PR TITLE
Fix crash on startup in console mode (mscore -o) when the interactive module is absent

### DIFF
--- a/src/notationscene/internal/notationcommandsstate.cpp
+++ b/src/notationscene/internal/notationcommandsstate.cpp
@@ -292,9 +292,11 @@ void NotationCommandsState::init()
         updateCommandStates();
     });
 
-    interactive()->opened().onReceive(this, [this](const muse::Uri&) {
-        updateCommandStates();
-    });
+    if (interactive()) {
+        interactive()->opened().onReceive(this, [this](const muse::Uri&) {
+            updateCommandStates();
+        });
+    }
 
     controller()->selectionChanged().onNotify(this, [this]() {
         updateCommandStates(HAS_SELECTION_REQUIRED_COMMANDS);
@@ -357,7 +359,9 @@ void NotationCommandsState::init()
 void NotationCommandsState::deinit()
 {
     globalContext()->currentProjectChanged().disconnect(this);
-    interactive()->opened().disconnect(this);
+    if (interactive()) {
+        interactive()->opened().disconnect(this);
+    }
     controller()->selectionChanged().disconnect(this);
     controller()->stackChanged().disconnect(this);
     controller()->textEditingChanged().disconnect(this);
@@ -512,7 +516,7 @@ bool NotationCommandsState::isProjectOpened() const
         return false;
     }
 
-    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+    if (!interactive() || !interactive()->isOpened(PROJECT_PAGE_URI).val) {
         return false;
     }
 

--- a/src/playback/internal/playbackcommandsstate.cpp
+++ b/src/playback/internal/playbackcommandsstate.cpp
@@ -61,9 +61,11 @@ void PlaybackCommandsState::init()
         }, Asyncable::Mode::SetReplace);
     });
 
-    interactive()->opened().onReceive(this, [this](const muse::Uri&) {
-        updateCommandStates();
-    });
+    if (interactive()) {
+        interactive()->opened().onReceive(this, [this](const muse::Uri&) {
+            updateCommandStates();
+        });
+    }
 
     playbackController()->isPlayAllowedChanged().onReceive(this, [this](bool) {
         updateCommandStates();
@@ -125,7 +127,9 @@ void PlaybackCommandsState::deinit()
 {
     globalContext()->currentProjectChanged().disconnect(this);
     globalContext()->currentNotationChanged().disconnect(this);
-    interactive()->opened().disconnect(this);
+    if (interactive()) {
+        interactive()->opened().disconnect(this);
+    }
     playbackController()->isPlayAllowedChanged().disconnect(this);
     playbackController()->isPlayingChanged().disconnect(this);
     playbackController()->loopEnabledChanged().disconnect(this);
@@ -212,7 +216,7 @@ bool PlaybackCommandsState::isProjectOpened() const
         return false;
     }
 
-    if (!interactive()->isOpened(PROJECT_PAGE_URI).val) {
+    if (!interactive() || !interactive()->isOpened(PROJECT_PAGE_URI).val) {
         return false;
     }
 


### PR DESCRIPTION
Resolves: #34577

## Summary

Headless conversion (`mscore -o out.<fmt> score.mscz`) crashes at startup with a SIGSEGV for every output format (PDF, PNG, SVG, MusicXML, MIDI, audio), before producing any output.

In console/converter mode the interactive module is not loaded (`InteractiveModule` is added only for `RunMode::GuiApp`, src/app/appfactory.cpp:329), so the `muse::ContextInject<muse::IInteractive>` member in `PlaybackCommandsState` and `NotationCommandsState` resolves to null. But `RCommandModule` is loaded in console (appfactory.cpp:466), so `ICommandsState` exists and these `CommandsState` objects are registered unconditionally in `resolveImports()`. Their `init()`, `deinit()` and `isProjectOpened()` then dereference the null `interactive()`.

This is a regression: the classes were added on the 5.x line (PlaybackCommandsState in 5fa1cfc7be, 2026-06-17; NotationCommandsState in 76977e326d, 2026-07-03) and do not exist in 4.7, where headless conversion works.

## Context

Guards the three `interactive()` usages in each class with a null check, matching the existing pattern in `src/context/internal/uicontextresolver.cpp:95` for the same injected member. In headless mode there is no project page, so `isProjectOpened()` correctly returns false, and the `opened()` subscribe/disconnect are simply skipped. Registration is intentionally not run-mode gated, so guarding at the point of use is the minimal correct fix.

Verified on macOS by running `mscore -o out.pdf`, `out.png`, `out.musicxml`, `out.mid` on `main`: before, each crashes at startup; after, each exits 0 and writes the file. (The cause is run-mode based, so all platforms are affected.)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist (#34445 is a separate 4.7 crash-at-exit bug, not this startup crash).
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
