### PR TITLE
Wait for playback to load before rendering a headless audio export

### DIFF
--- a/src/importexport/audioexport/internal/abstractaudiowriter.cpp
+++ b/src/importexport/audioexport/internal/abstractaudiowriter.cpp
@@ -108,6 +108,13 @@ Ret AbstractAudioWriter::doWriteAndWait(INotationPtr notation,
         QThread::yieldCurrentThread();
     }
 
+    //! NOTE Playback (tracks and duration) loads asynchronously; rendering before it is
+    //! ready yields 0 tracks and 0 duration ("No audio to export"). Wait for it first.
+    while (!playbackController()->isPlaybackInited()) {
+        application()->processEvents();
+        QThread::yieldCurrentThread();
+    }
+
     m_isCompleted = false;
     m_writeRet = muse::Ret();
 


### PR DESCRIPTION
Resolves: #34580

## Summary

Headless audio export (`mscore -o out.mp3 score.mscz`, also WAV/FLAC/OGG) produced "No audio to export" and no valid file. The project's playback (mixer tracks and total duration) is loaded asynchronously after the project becomes current, but `AbstractAudioWriter::doWriteAndWait` only waited for the audio engine to start and then rendered immediately, so the render saw 0 tracks and duration 0. The GUI works because the project is loaded long before the user triggers export.

## Context

Adds a wait in `AbstractAudioWriter::doWriteAndWait`, after the existing "audio engine started" wait and before rendering, until `IPlaybackController::isPlaybackInited()` is true, using the same `application()->processEvents()` / `QThread::yieldCurrentThread()` wait as the adjacent code in this function (and in the video exporter). By then `setupPlayback` has run, so the track-add and set-duration RPCs are enqueued and, by FIFO ordering, applied before the export's render RPC.

Verified on macOS: `mscore -o out.mp3 vtest/scores/tapping-1.mscz` now writes a valid MPEG file (128 kbps, 44.1 kHz) and exits 0, instead of "No audio to export".

Depends on / related:
- #34577 (console startup crash) is fixed in `main`, so `mscore -o` now reaches this code path (this branch is rebased on top of that fix).
-  https://github.com/musescore/muse_framework/pull/220  is needed so the render does not race the real-time driver on the shared reverb.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
