### PR TITLE
Copy master score's `metaTags` to part score on `MscSaver::exportPart`

### DIFF
--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -208,6 +208,14 @@ bool MscSaver::exportPart(Score* partScore, MscWriter& mscWriter)
         mscWriter.writeStyleFile(excerptStyleData);
     }
 
+    // Add the master score's metaTags to the part
+    const std::map<String, String> partTags = partScore->metaTags();
+    std::map<String, String> effectiveTags = partScore->masterScore()->metaTags();
+    for (const auto& [key, val] : partTags) {
+        effectiveTags.insert_or_assign(key, val);
+    }
+    partScore->setMetaTags(effectiveTags);
+
     // Write excerpt as main score
     {
         ByteArray excerptData;
@@ -217,6 +225,9 @@ bool MscSaver::exportPart(Score* partScore, MscWriter& mscWriter)
 
         mscWriter.writeScoreFile(excerptData);
     }
+
+    // restore in-memory part score's metaTags
+    partScore->setMetaTags(partTags);
 
     // Write thumbnail
     {


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/34440

Resolves: [#34390](https://github.com/musescore/MuseScore/issues/34390)

Note: depends on https://github.com/musescore/MuseScore/pull/34611