### PR TITLE
Fix crash on CLI exit

### DIFF
--- a/src/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/src/framework/audio/main/internal/startaudiocontroller.cpp
@@ -290,24 +290,42 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
 void StartAudioController::stopAudioProcessing()
 {
 #ifndef Q_OS_WASM
-    m_rpcChannel->send(rpc::make_request(Method::EngineDeinit), [this](const Msg&) {
+    /* Process pending incoming messages first, so that if the engine start
+     * has not been completed yet (EngineRunning has not been received), EngineInit
+     * is sent before the EngineDeinit request below, and the engine is not
+     * initialized again right after having been deinited. */
+    m_rpcChannel->process();
+
+    /* We must wait for the engine to be deinited, because deinit is what unsubscribes
+     * the engine objects from their channels (and it can only be done on the engine
+     * thread while it is still running). If we stop the engine thread before that, the
+     * subscriptions remain dangling and crash when the engine objects are destroyed. */
+    auto isEngineDeinited = std::make_shared<bool>(false);
+    m_rpcChannel->send(rpc::make_request(Method::EngineDeinit), [this, isEngineDeinited](const Msg&) {
+        *isEngineDeinited = true;
         if (m_isAudioStarted.val) {
             m_isAudioStarted.set(false);
         }
     });
 
+    constexpr size_t MAX_WAIT_DEINIT_ATTEMPTS = 100; // 100 * 10 ms = 1 sec
+    size_t attempts = 0;
     do {
         // Ensure that RPC process() is called at least once
         m_rpcChannel->process();
 
-        if (!m_isAudioStarted.val) {
+        if (*isEngineDeinited) {
             break;
         }
 
         std::this_thread::yield();
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(10ms);
-    } while (m_isAudioStarted.val);
+    } while (++attempts < MAX_WAIT_DEINIT_ATTEMPTS);
+
+    if (!*isEngineDeinited) {
+        LOGW() << "Failed to deinit the audio engine";
+    }
 
     audioDriverController()->close();
 


### PR DESCRIPTION
Resolves: #34445

The programme crashes at exit after any successful CLI conversion which doesn't require the audio engine (e.g. `-o out.pdf`, `--score-parts`, etc.).

**Cause:** `StartAudioController::stopAudioProcessing()` sends `EngineDeinit` to the engine thread and then waits — but it waited on `m_isAudioStarted`, which is not set in console mode: nothing pumps the RPC channel on the main thread while the CLI task runs (the RPC ticker is a `QTimer`, and the task holds the main thread until `qApp->exit()`), so the `EngineRunning` -> `EngineInit` handshake never completes. The wait therefore returned immediately and `m_worker->stop()` joined the engine thread before it could handle `EngineDeinit`, so `EngineController::deinit()` never ran and `EngineRpcController` stayed subscribed to `EnginePlayback`'s channels.

Those objects live in the global IoC, so they are destroyed after `main()` returns. By then `EngineRpcController` is already freed but still listed as a receiver, and `~ChannelImpl` -> `clearReceivers()` calls `async_disconnect()` on it.

**Fix:** Wait for the `EngineDeinit` response instead of for `m_isAudioStarted`, capped at 1 s so shutdown cannot hang. The engine then unsubscribes on its own thread (`EnginePlayback::deinit()` clears the channels while subscribers are still alive), and nothing dangles at teardown.

This doesn't happen in conversions which do require the audio engine, because `AbstractAudioWriter::doWriteAndWait` already waits for the audio system to properly start.

Note the crash is timing-dependent, so it may take several runs to reproduce on the old build.