### PR TITLE
Fix missing segment anchored spanners at the start of a score

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1670,7 +1670,7 @@ void TWrite::writeProperties(const Spanner* item, XmlWriter& xml, WriteContext& 
     if (item->anchor() == Spanner::Anchor::SEGMENT) {
         int t2 = static_cast<int>(item->track2()) + ctx.trackDiff();
         xml.tag("track2", t2);
-        xml.tagFraction("startTick", item->tick());
+        xml.tagFraction("startTick", item->tick(), /* default = */ Fraction(-1, 0)); // Need to be able to write start of score, so a different default is needed
         xml.tagFraction("ticks", item->ticks());
     } else {
         const bool isPartialTieOrLV = item->isPartialTie() || item->isLaissezVib();

--- a/src/engraving/tests/compat114_data/ottava-ref.mscx
+++ b/src/engraving/tests/compat114_data/ottava-ref.mscx
@@ -198,6 +198,7 @@
         <beginText>&lt;font size=&quot;12&quot;/&gt;8va</beginText>
         <continueText>&lt;font size=&quot;12&quot;/&gt;(8va)</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>Y_Y</eid>
         <track>0</track>

--- a/src/engraving/tests/compat114_data/pedal-ref.mscx
+++ b/src/engraving/tests/compat114_data/pedal-ref.mscx
@@ -197,6 +197,7 @@
         <continueText>&lt;font size=&quot;11&quot;/&gt;</continueText>
         <endTextPlace>auto</endTextPlace>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>Y_Y</eid>
         <track>0</track>

--- a/src/engraving/tests/compat114_data/textline-ref.mscx
+++ b/src/engraving/tests/compat114_data/textline-ref.mscx
@@ -195,6 +195,7 @@
       <TextLine>
         <beginText>&lt;font size=&quot;12&quot;/&gt;VII</beginText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>Y_Y</eid>
         <track>0</track>

--- a/src/engraving/tests/compat206_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat206_data/hairpin-ref.mscx
@@ -617,6 +617,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>5/1</ticks>
         <eid>yB_yB</eid>
         <track>0</track>
@@ -1253,6 +1254,7 @@
           <beginHookHeight>-1.9</beginHookHeight>
           <endHookHeight>-1.9</endHookHeight>
           <track2>0</track2>
+          <startTick>0/1</startTick>
           <ticks>5/1</ticks>
           <eid>nD_nD</eid>
           <track>0</track>

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -565,24 +565,7 @@
         <continueTextPlace>auto</continueTextPlace>
         <endTextPlace>auto</endTextPlace>
         <track2>0</track2>
-        <startTick>-1/1</startTick>
-        <ticks>1/1</ticks>
-        <eid>iB_iB</eid>
-        <track>0</track>
-        </Pedal>
-      <Ottava>
-        <subtype>8va</subtype>
-        <track2>0</track2>
-        <startTick>-1/1</startTick>
-        <ticks>1/1</ticks>
-        <eid>jB_jB</eid>
-        <track>0</track>
-        </Ottava>
-      <Pedal>
-        <endHookType>1</endHookType>
-        <continueTextPlace>auto</continueTextPlace>
-        <endTextPlace>auto</endTextPlace>
-        <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>w_w</eid>
         <track>0</track>
@@ -590,6 +573,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>x_x</eid>
         <track>0</track>
@@ -657,6 +641,24 @@
           <track>0</track>
           </Ornament>
         </Trill>
+      <Pedal>
+        <endHookType>1</endHookType>
+        <continueTextPlace>auto</continueTextPlace>
+        <endTextPlace>auto</endTextPlace>
+        <track2>0</track2>
+        <startTick>11/4</startTick>
+        <ticks>1/1</ticks>
+        <eid>iB_iB</eid>
+        <track>0</track>
+        </Pedal>
+      <Ottava>
+        <subtype>8va</subtype>
+        <track2>0</track2>
+        <startTick>11/4</startTick>
+        <ticks>1/1</ticks>
+        <eid>jB_jB</eid>
+        <track>0</track>
+        </Ottava>
       <Slur>
         <startElement>9_9</startElement>
         <endElement>BB_BB</endElement>
@@ -1294,43 +1296,25 @@
           <continueTextPlace>auto</continueTextPlace>
           <endTextPlace>auto</endTextPlace>
           <track2>0</track2>
-          <startTick>-1/1</startTick>
+          <startTick>0/1</startTick>
           <ticks>1/1</ticks>
           <eid>eD_eD</eid>
-          <linkedTo>iB_iB</linkedTo>
-          <track>0</track>
-          </Pedal>
-        <Ottava>
-          <subtype>8va</subtype>
-          <track2>0</track2>
-          <startTick>-1/1</startTick>
-          <ticks>1/1</ticks>
-          <eid>fD_fD</eid>
-          <linkedTo>jB_jB</linkedTo>
-          <track>0</track>
-          </Ottava>
-        <Pedal>
-          <endHookType>1</endHookType>
-          <continueTextPlace>auto</continueTextPlace>
-          <endTextPlace>auto</endTextPlace>
-          <track2>0</track2>
-          <ticks>1/1</ticks>
-          <eid>gD_gD</eid>
           <linkedTo>w_w</linkedTo>
           <track>0</track>
           </Pedal>
         <Ottava>
           <subtype>8va</subtype>
           <track2>0</track2>
+          <startTick>0/1</startTick>
           <ticks>1/1</ticks>
-          <eid>hD_hD</eid>
+          <eid>fD_fD</eid>
           <linkedTo>x_x</linkedTo>
           <track>0</track>
           </Ottava>
         <Slur>
           <startElement>HC_HC</startElement>
           <endElement>LC_LC</endElement>
-          <eid>iD_iD</eid>
+          <eid>gD_gD</eid>
           <linkedTo>y_y</linkedTo>
           <track>0</track>
           </Slur>
@@ -1339,7 +1323,7 @@
           <beginText>1.</beginText>
           <startElement>VC_VC</startElement>
           <endElement>VC_VC</endElement>
-          <eid>jD_jD</eid>
+          <eid>hD_hD</eid>
           <linkedTo>5B_5B</linkedTo>
           <track>0</track>
           <endings>1</endings>
@@ -1351,7 +1335,7 @@
           <track2>0</track2>
           <startTick>1/1</startTick>
           <ticks>3/4</ticks>
-          <eid>kD_kD</eid>
+          <eid>iD_iD</eid>
           <linkedTo>z_z</linkedTo>
           <track>0</track>
           </HairPin>
@@ -1360,22 +1344,22 @@
           <track2>0</track2>
           <startTick>7/4</startTick>
           <ticks>1/4</ticks>
-          <eid>lD_lD</eid>
+          <eid>jD_jD</eid>
           <linkedTo>0_0</linkedTo>
           <track>0</track>
           <lineWidth>0.1488</lineWidth>
           <Ornament>
             <Chord>
-              <eid>mD_mD</eid>
+              <eid>kD_kD</eid>
               <track>0</track>
               <small>1</small>
               <Note>
-                <eid>nD_nD</eid>
+                <eid>lD_lD</eid>
                 <track>0</track>
                 <parentheses>both</parentheses>
                 <Accidental>
                   <subtype>accidentalSharp</subtype>
-                  <eid>oD_oD</eid>
+                  <eid>mD_mD</eid>
                   <track>0</track>
                   </Accidental>
                 <pitch>75</pitch>
@@ -1384,17 +1368,37 @@
                 </Note>
               <NoteParenGroup>
                 <Notes>
-                  <NoteEID>nD_nD</NoteEID>
+                  <NoteEID>lD_lD</NoteEID>
                   </Notes>
                 </NoteParenGroup>
               </Chord>
             <intervalAbove>third,major</intervalAbove>
             <subtype>ornamentTrill</subtype>
-            <eid>pD_pD</eid>
+            <eid>nD_nD</eid>
             <linkedTo>4_4</linkedTo>
             <track>0</track>
             </Ornament>
           </Trill>
+        <Pedal>
+          <endHookType>1</endHookType>
+          <continueTextPlace>auto</continueTextPlace>
+          <endTextPlace>auto</endTextPlace>
+          <track2>0</track2>
+          <startTick>11/4</startTick>
+          <ticks>1/1</ticks>
+          <eid>oD_oD</eid>
+          <linkedTo>iB_iB</linkedTo>
+          <track>0</track>
+          </Pedal>
+        <Ottava>
+          <subtype>8va</subtype>
+          <track2>0</track2>
+          <startTick>11/4</startTick>
+          <ticks>1/1</ticks>
+          <eid>pD_pD</eid>
+          <linkedTo>jB_jB</linkedTo>
+          <track>0</track>
+          </Ottava>
         <Slur>
           <startElement>4C_4C</startElement>
           <endElement>8C_8C</endElement>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
@@ -941,6 +941,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>YC_YC</eid>
         <track>0</track>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
@@ -672,6 +672,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>YC_YC</eid>
         <track>0</track>

--- a/src/engraving/tests/join_data/join03-ref.mscx
+++ b/src/engraving/tests/join_data/join03-ref.mscx
@@ -138,6 +138,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>3/4</ticks>
         <eid>T_T</eid>
         <track>0</track>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter15-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter15-base-ref.xml
@@ -59,6 +59,7 @@
     <TextLine>
       <beginText>VII</beginText>
       <track2>0</track2>
+      <startTick>0/1</startTick>
       <ticks>1/1</ticks>
       <eid>N_N</eid>
       <track>0</track>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter8-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter8-base-ref.xml
@@ -42,6 +42,7 @@
     <Ottava>
       <subtype>8va</subtype>
       <track2>0</track2>
+      <startTick>0/1</startTick>
       <ticks>3/4</ticks>
       <eid>J_J</eid>
       <track>0</track>

--- a/src/engraving/tests/selectionfilter_data/selectionfilter9-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter9-base-ref.xml
@@ -45,6 +45,7 @@
       <continueTextPlace>auto</continueTextPlace>
       <endTextPlace>auto</endTextPlace>
       <track2>0</track2>
+      <startTick>0/1</startTick>
       <ticks>3/4</ticks>
       <eid>J_J</eid>
       <track>0</track>

--- a/src/engraving/tests/spanners_data/linecolor01-ref.mscx
+++ b/src/engraving/tests/spanners_data/linecolor01-ref.mscx
@@ -139,6 +139,7 @@
         <continueTextPlace>auto</continueTextPlace>
         <endTextPlace>auto</endTextPlace>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>N_N</eid>
         <track>0</track>

--- a/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
+++ b/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
@@ -147,6 +147,7 @@
         <continueTextPlace>auto</continueTextPlace>
         <endTextPlace>auto</endTextPlace>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>P_P</eid>
         <track>0</track>

--- a/src/engraving/tests/split_data/split03-ref.mscx
+++ b/src/engraving/tests/split_data/split03-ref.mscx
@@ -149,6 +149,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>3/4</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/engraving/tests/timesig_data/timesig-05-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-05-ref.mscx
@@ -508,6 +508,7 @@
         <beginHookHeight>-1.9</beginHookHeight>
         <endHookHeight>-1.9</endHookHeight>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>9/4</ticks>
         <eid>jB_jB</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
@@ -255,6 +255,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>Fdbk</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>k_k</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
@@ -255,6 +255,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>Fdbk</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>k_k</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
@@ -161,6 +161,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp5-ref.mscx
@@ -154,6 +154,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>U_U</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp-ref.mscx
@@ -519,6 +519,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>MB_MB</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp5-ref.mscx
@@ -514,6 +514,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>LB_LB</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/let-ring-tied.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring-tied.gp5-ref.mscx
@@ -142,6 +142,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>4/8</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
@@ -123,6 +123,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp4-ref.mscx
@@ -122,6 +122,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp5-ref.mscx
@@ -117,6 +117,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>Q_Q</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
@@ -123,6 +123,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
@@ -1072,6 +1072,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>2/4</ticks>
         <eid>dC_dC</eid>
         <track>0</track>
@@ -1079,6 +1080,7 @@
       <Vibrato>
         <subtype>guitarVibrato</subtype>
         <track2>8</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>eC_eC</eid>
         <track>8</track>
@@ -1088,6 +1090,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>16</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>fC_fC</eid>
         <track>16</track>
@@ -1097,6 +1100,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>TH</continueText>
         <track2>16</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>gC_gC</eid>
         <track>16</track>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
@@ -872,6 +872,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>2/4</ticks>
         <eid>9B_9B</eid>
         <track>0</track>
@@ -879,6 +880,7 @@
       <Vibrato>
         <subtype>guitarVibrato</subtype>
         <track2>8</track2>
+        <startTick>0/1</startTick>
         <ticks>2/4</ticks>
         <eid>+B_+B</eid>
         <track>8</track>
@@ -888,6 +890,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>16</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>/B_/B</eid>
         <track>16</track>
@@ -897,6 +900,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>TH</continueText>
         <track2>16</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>AC_AC</eid>
         <track>16</track>

--- a/src/importexport/guitarpro/tests/data/ottava-simile.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava-simile.gp-ref.mscx
@@ -196,6 +196,7 @@
       <Ottava>
         <subtype>8vb</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>12/4</ticks>
         <eid>f_f</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
@@ -294,6 +294,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>0_0</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
@@ -294,6 +294,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>5/4</ticks>
         <eid>0_0</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
@@ -441,6 +441,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>IB_IB</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
@@ -441,6 +441,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>IB_IB</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
@@ -165,6 +165,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>T_T</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
@@ -165,6 +165,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>T_T</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
@@ -441,6 +441,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>IB_IB</eid>
         <track>0</track>
@@ -448,6 +449,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>4</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>JB_JB</eid>
         <track>4</track>

--- a/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
@@ -441,6 +441,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>IB_IB</eid>
         <track>0</track>
@@ -448,6 +449,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>4</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>JB_JB</eid>
         <track>4</track>

--- a/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
@@ -266,6 +266,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>n_n</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
@@ -266,6 +266,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>n_n</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
@@ -123,6 +123,7 @@
     <SpannerMap>
       <PalmMute>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp4-ref.mscx
@@ -122,6 +122,7 @@
     <SpannerMap>
       <PalmMute>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp5-ref.mscx
@@ -117,6 +117,7 @@
     <SpannerMap>
       <PalmMute>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>Q_Q</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
@@ -123,6 +123,7 @@
     <SpannerMap>
       <PalmMute>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>R_R</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
@@ -104,6 +104,7 @@
       <Rasgueado>
         <beginTextOffset x="0" y="0"/>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>O_O</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
@@ -104,6 +104,7 @@
       <Rasgueado>
         <beginTextOffset x="0" y="0"/>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>O_O</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp-ref.mscx
@@ -140,6 +140,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>6/4</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp5-ref.mscx
@@ -135,6 +135,7 @@
     <SpannerMap>
       <LetRing>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>6/4</ticks>
         <eid>U_U</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
@@ -197,6 +197,7 @@
       <Vibrato>
         <subtype>guitarVibrato</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>j_j</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
@@ -138,6 +138,7 @@
       <Vibrato>
         <subtype>guitarVibrato</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>U_U</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
@@ -197,6 +197,7 @@
       <Vibrato>
         <subtype>guitarVibrato</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/4</ticks>
         <eid>j_j</eid>
         <track>0</track>

--- a/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_artificial_harmonic-gp.mscx
+++ b/src/importexport/guitarpro/tests/guitarbendimporter_data/dive_artificial_harmonic-gp.mscx
@@ -283,6 +283,7 @@
         <beginTextOffset x="0" y="0"/>
         <continueText>AH</continueText>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>15/8</ticks>
         <eid>k_k</eid>
         <track>0</track>

--- a/src/importexport/mei/tests/data/pedal-01.mscx
+++ b/src/importexport/mei/tests/data/pedal-01.mscx
@@ -370,6 +370,7 @@
         <continueTextPlace>auto</continueTextPlace>
         <endTextPlace>auto</endTextPlace>
         <track2>4</track2>
+        <startTick>0/1</startTick>
         <ticks>6/4</ticks>
         <eid>/_/</eid>
         <track>4</track>

--- a/src/importexport/mei/tests/data/trill-01.mscx
+++ b/src/importexport/mei/tests/data/trill-01.mscx
@@ -368,6 +368,7 @@
       <Trill>
         <subtype>trill</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>4/2</ticks>
         <eid>FB_FB</eid>
         <track>0</track>

--- a/src/importexport/mnx/tests/data/project_examples/ottavas_ref.mscx
+++ b/src/importexport/mnx/tests/data/project_examples/ottavas_ref.mscx
@@ -176,6 +176,7 @@
       <Ottava>
         <subtype>15ma</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>6/4</ticks>
         <eid>X_X</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -211,6 +211,7 @@
     <SpannerMap>
       <TextLine>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>X_X</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
@@ -267,6 +267,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>X_X</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
@@ -2633,6 +2633,7 @@
         <direction>down</direction>
         <lineVisible>0</lineVisible>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <eid>NH_NH</eid>
         <track>0</track>
         </HairPin>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
@@ -701,6 +701,7 @@
         <direction>down</direction>
         <lineVisible>0</lineVisible>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>nB_nB</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -456,6 +456,7 @@
         <continueTextPlace>auto</continueTextPlace>
         <endTextPlace>auto</endTextPlace>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>HB_HB</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -641,6 +641,7 @@
         <subtype>0</subtype>
         <direction>up</direction>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>3/1</ticks>
         <eid>bB_bB</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -328,6 +328,7 @@
       <Ottava>
         <subtype>8va</subtype>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/2</ticks>
         <eid>Y_Y</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
@@ -203,6 +203,7 @@
         <beginText>Rit.</beginText>
         <beginTextOffset x="0" y="0"/>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>3/1</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testTempoLineFermata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoLineFermata_ref.mscx
@@ -208,6 +208,7 @@
         <beginText>rit.</beginText>
         <beginTextOffset x="0" y="0"/>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>8/4</ticks>
         <eid>V_V</eid>
         <track>0</track>

--- a/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
@@ -115,6 +115,7 @@
         <subtype>0</subtype>
         <direction>down</direction>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>7/16</ticks>
         <eid>K_K</eid>
         <track>0</track>

--- a/vtest/scores/default-position-3.mscx
+++ b/vtest/scores/default-position-3.mscx
@@ -203,6 +203,7 @@
       <Pedal>
         <endHookType>1</endHookType>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>M3niFYbb/sO_ApJs0jo/kkC</eid>
         <track>0</track>
@@ -211,6 +212,7 @@
         <endHookType>1</endHookType>
         <placement>above</placement>
         <track2>0</track2>
+        <startTick>0/1</startTick>
         <ticks>1/1</ticks>
         <eid>BUmutQ28oON_007vOL+IdFE</eid>
         <track>0</track>


### PR DESCRIPTION
Resolves: #34556 

`tagFraction` takes a `def` argument which is (0, 1) by default. If the fraction passed in is equal then we don't write it. We need to be able to write the start of the score in this case, so we provide a default which we should never see here (-1, 0)