### PR TITLE
Fix guitar bend hold line assert during writeProperties

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1672,7 +1672,10 @@ void TWrite::writeProperties(const Spanner* item, XmlWriter& xml, WriteContext& 
         xml.tag("track2", t2);
         xml.tagFraction("startTick", item->tick());
         xml.tagFraction("ticks", item->ticks());
-    } else {
+    } else if (!item->isGuitarBendHold()) {
+        /* GuitarBendHold lines are regenerated during layout by GuitarBend::updateHoldLine(),
+         * which recomputes their endpoints, so there is no point in serializing them */
+
         const bool isPartialTieOrLV = item->isPartialTie() || item->isLaissezVib();
         const bool hasStartEndElements = item->startElement() && item->endElement();
         IF_ASSERT_FAILED(item->score()->isPaletteScore() || isPartialTieOrLV || hasStartEndElements) {


### PR DESCRIPTION
Inserting a `GuitarBendHold` line and saving was triggering the `endElEID.isValid()` assert in `TWrite::writeProperties(const Spanner*...)`. 

The `GuitarBendHold` is written nested inside its parent `GuitarBend`, while its end element lies after the bend, on a note that may or may not have been written yet and so may have no EID assigned.

Since the start and end elements of hold lines are recomputed during `GuitarBend::updateHoldLine()`, I have simply stopped writing these two values to the mscx - the read values weren't actually used anyway. Other properties of the hold line are still written.