### PR TITLE
Fix #34605: Delegate standard edit shortcuts to First Responder during native macOS dialogs

### DIFF
--- a/src/appshell/internal/iappmenumodelhook.h
+++ b/src/appshell/internal/iappmenumodelhook.h
@@ -23,6 +23,7 @@
 #define MU_APPSHELL_IAPPMENUMODELHOOK_H
 
 #include "modularity/imoduleinterface.h"
+#include "uicomponents/qml/Muse/UiComponents/menuitem.h"
 
 namespace mu::appshell {
 class IAppMenuModelHook : MODULE_CONTEXT_INTERFACE
@@ -32,13 +33,14 @@ class IAppMenuModelHook : MODULE_CONTEXT_INTERFACE
 public:
     virtual ~IAppMenuModelHook() = default;
 
-    virtual void onAppMenuInited() = 0;
+    //! Invoked once the application's top-level menu hierarchy has been loaded.
+    virtual void onAppMenuInited(const muse::uicomponents::MenuItemList& items) = 0;
 };
 
 class AppMenuModelHookStub : public IAppMenuModelHook
 {
 public:
-    void onAppMenuInited() override {}
+    void onAppMenuInited(const muse::uicomponents::MenuItemList& /*items*/) override {}
 };
 }
 

--- a/src/appshell/internal/platform/macos/macosappmenumodelhook.h
+++ b/src/appshell/internal/platform/macos/macosappmenumodelhook.h
@@ -27,6 +27,6 @@ namespace mu::appshell {
 class MacOSAppMenuModelHook : public IAppMenuModelHook
 {
 public:
-    void onAppMenuInited() override;
+    void onAppMenuInited(const muse::uicomponents::MenuItemList& items) override;
 };
 }

--- a/src/appshell/internal/platform/macos/macosappmenumodelhook.mm
+++ b/src/appshell/internal/platform/macos/macosappmenumodelhook.mm
@@ -24,10 +24,59 @@
 
 #include <Cocoa/Cocoa.h>
 
+#include "interactive/internal/platform/macos/macosinteractivehelper.h"
+#include "notationscene/notationcommands.h"
+
 using namespace mu::appshell;
 
-void MacOSAppMenuModelHook::onAppMenuInited()
+void MacOSAppMenuModelHook::onAppMenuInited(const muse::uicomponents::MenuItemList& items)
 {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledDictationMenuItem"];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledCharacterPaletteMenuItem"];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSMenuEnableActionImages"];
+
+    const muse::uicomponents::MenuItem* editMenu = nullptr;
+    int editTopLevelIndex = -1;
+    for (int i = 0; i < items.size(); ++i) {
+        if (items[i] && items[i]->id() == "menu-edit") {
+            editMenu = items[i];
+            editTopLevelIndex = i;
+            break;
+        }
+    }
+
+    if (!editMenu || editTopLevelIndex < 0) {
+        return;
+    }
+
+    // AppKit inserts the Application menu at index 0 on macOS, shifting top-level menus by +1
+    muse::MacOSInteractiveHelper::setEditMenuIndex(editTopLevelIndex + 1);
+
+    int index = 0;
+    std::map<muse::MacOSInteractiveHelper::EditAction, int> structure;
+
+    for (const muse::uicomponents::MenuItem* subitem : editMenu->subitems()) {
+        if (!subitem || subitem->id().isEmpty()) {
+            index++;
+            continue;
+        }
+
+        if (subitem->id() == mu::notation::UNDO_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::Undo] = index;
+        } else if (subitem->id() == mu::notation::REDO_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::Redo] = index;
+        } else if (subitem->id() == mu::notation::CUT_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::Cut] = index;
+        } else if (subitem->id() == mu::notation::COPY_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::Copy] = index;
+        } else if (subitem->id() == mu::notation::PASTE_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::Paste] = index;
+        } else if (subitem->id() == mu::notation::SELECT_ALL_COMMAND.toString()) {
+            structure[muse::MacOSInteractiveHelper::EditAction::SelectAll] = index;
+        }
+
+        index++;
+    }
+
+    muse::MacOSInteractiveHelper::setEditMenuStructure(structure);
 }

--- a/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/MuseScore/AppShell/appmenumodel.cpp
@@ -111,7 +111,7 @@ void AppMenuModel::load()
 
     //! NOTE: removes some undesired platform-specific items
     //! (such as "Start Dictation" and "Special Characters" on macOS)
-    appMenuModelHook()->onAppMenuInited();
+    appMenuModelHook()->onAppMenuInited(items);
 }
 
 bool AppMenuModel::isGlobalMenuAvailable()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34605
Depends on: https://github.com/musescore/muse_framework/pull/238

### Summary of Changes
Fixes keyboard shortcuts (⌘A, ⌘C, ⌘V, ⌘X, ⌘Z, ⇧⌘Z) failing with error beeps or executing background score actions when typing in native macOS Save/Export/Open dialogs (`NSSavePanel` / `NSOpenPanel`).

1. **100% Platform-Agnostic `AppMenuModel`**:
   - `AppMenuModel::makeEditMenu()` contains pure cross-platform item declarations with zero macOS-specific headers or `#ifdef` branches.
   - `AppMenuModel::load()` notifies platform hooks via `appMenuModelHook()->onAppMenuInited(items)`.

2. **Dynamic Menu Introspection in `MacOSAppMenuModelHook`**:
   - Locates `menu-edit` dynamically to determine the top-level Edit menu index in `[NSApp mainMenu]`.
   - Inspects `editMenu->subitems()` against command constants (`UNDO_COMMAND`, `REDO_COMMAND`, `CUT_COMMAND`, `COPY_COMMAND`, `PASTE_COMMAND`, `SELECT_ALL_COMMAND`) and passes the linear indices to `muse::MacOSInteractiveHelper`.
   - Sets `NSMenuEnableActionImages = NO` in `NSUserDefaults` on startup alongside existing dictation and character palette suppression to keep menus icon-free on macOS Tahoe / Sequoia.

3. **Submodule Update**:
   - Updates `muse` submodule to include `MacOSInteractiveHelper::NativeDialogScope` and 12 unit tests (from https://github.com/musescore/muse_framework/pull/238).

- [x] I signed the [CLA](https://musescore.org/en/cla) as yuan3y
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
