### PR TITLE
[4.7.5] Switch to VS 2026, if CMAKE is >= 4.2

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,14 +5,13 @@
             "name": "windows-base",
             "description": "Target Windows with the Visual Studio development environment.",
             "hidden": true,
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "binaryDir": "${sourceDir}/msvc.build/${presetName}",
             "installDir": "${sourceDir}/msvc.install/${presetName}",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl.exe",
                 "CMAKE_CXX_COMPILER": "cl.exe",
-                "CMAKE_WARN_DEPRECATED": "FALSE",
-                "CMAKE_PRESET_NAME": "${presetName}"
+                "CMAKE_WARN_DEPRECATED": "FALSE"
             },
             "condition": {
                 "type": "equals",
@@ -21,7 +20,7 @@
             }
         },
         {
-            "name": "x64-debug",
+            "name": "x64-Debug",
             "displayName": "x64 Debug",
             "description": "Target Windows (64-bit) with the Visual Studio development environment. (Debug)",
             "inherits": "windows-base",
@@ -38,7 +37,7 @@
             "name": "x64-MinSizeRel",
             "displayName": "x64 Release",
             "description": "Target Windows (64-bit) with the Visual Studio development environment. (MinSizeRel)",
-            "inherits": "x64-debug",
+            "inherits": "x64-Debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel"
             }
@@ -47,7 +46,7 @@
             "name": "x64-Release",
             "displayName": "x64 Release",
             "description": "Target Windows (64-bit) with the Visual Studio development environment. (Release)",
-            "inherits": "x64-debug",
+            "inherits": "x64-Debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
@@ -56,7 +55,7 @@
             "name": "x64-RelWithDebInfo",
             "displayName": "x64 RelWithDebInfo",
             "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
-            "inherits": "x64-debug",
+            "inherits": "x64-Debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }

--- a/build.cmake
+++ b/build.cmake
@@ -17,7 +17,12 @@ if(NOT DEFINED CMAKE_SCRIPT_MODE_FILE)
     )
 endif()
 
-cmake_minimum_required(VERSION 3.22) # should match version in CMakeLists.txt
+# should match version requirement in CMakeLists.txt
+if (APPLE)
+    cmake_minimum_required(VERSION 3.26...3.31) # Min. required for Swift-C++ interop
+else()
+    cmake_minimum_required(VERSION 3.22...3.31) # Min. required by Qt 6.10
+endif()
 
 # CMake arguments up to '-P' (ignore these)
 set(i "1")
@@ -143,7 +148,11 @@ endif()
 
 fn__get_option(GENERATOR -G ${CONFIGURE_ARGS})
 if(WIN32)
-    fn__set_default(GENERATOR "Visual Studio 17 2022")
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 4.2)
+        fn__set_default(GENERATOR "Visual Studio 18 2026")
+    else()
+        fn__set_default(GENERATOR "Visual Studio 17 2022")
+    endif()
 else()
     fn__set_default(GENERATOR "Unix Makefiles")
 endif()


### PR DESCRIPTION
and name the (debug) targets after their build name (i.e. with upper case D).

Synchronize build.cmake with CMakeLists.txt as far as CMAKE requirements are concerned for Mac and Linux.

Backport of #34651