### PR TITLE
MuseSounds: fetch the catalogue with a cached GET

### DIFF
--- a/src/musesounds/internal/musesoundsconfiguration.cpp
+++ b/src/musesounds/internal/musesoundsconfiguration.cpp
@@ -95,7 +95,7 @@ QUrl MuseSoundsConfiguration::checkForMuseSoundsUpdateUrl() const
 
 QUrl MuseSoundsConfiguration::checkForMuseSamplerUpdateUrl() const
 {
-    return QUrl("https://cosmos-customer-webservice.azurewebsites.net/graphql/v3");
+    return QUrl("https://customers-api.musehub.com/graphql/v3");
 }
 
 QString MuseSoundsConfiguration::getMuseSamplerVersionQuery() const

--- a/src/musesounds/internal/musesoundsconfiguration.cpp
+++ b/src/musesounds/internal/musesoundsconfiguration.cpp
@@ -76,8 +76,8 @@ RequestHeaders MuseSoundsConfiguration::headers() const
 UriQuery MuseSoundsConfiguration::soundsUri() const
 {
     return !getSoundsTestMode()
-           ? UriQuery("https://cosmos-customer-webservice.azurewebsites.net/graphql/v3")
-           : UriQuery("https://cosmos-customer-webservice-dev.azurewebsites.net/graphql/v3");
+           ? UriQuery("https://customers-api.musehub.com/graphql/v3")
+           : UriQuery("https://customers-api-dev.musehub.com/graphql/v3");
 }
 
 UriQuery MuseSoundsConfiguration::soundPageUri(const muse::String& soundCode) const

--- a/src/musesounds/internal/musesoundsrepository.cpp
+++ b/src/musesounds/internal/musesoundsrepository.cpp
@@ -25,6 +25,7 @@
 #include "serialization/json.h"
 
 #include <QBuffer>
+#include <QUrlQuery>
 
 using namespace mu::musesounds;
 using namespace muse;
@@ -54,68 +55,39 @@ static muse::UriQuery correctThumbnailSize(const UriQuery& uri)
     return UriQuery(uriStr.toStdString());
 }
 
-static QByteArray soundsRequestJson()
+static QUrl soundsRequestUrl(const QUrl& baseUrl)
 {
     QLocale locale = QLocale();
     String localeStr = locale.bcp47Name() + "-" + QLocale::territoryToCode(locale.territory());
 
-    String query = String(
-        R"(query MyQuery {
-          product_pages_configuration {
-            museScoreStudioPageSections {
-              ... on ProductPageSectionDynamic {
-                title(locale: {locale: "%1"})
-                productCards { ...CardFields }
-              }
-              ... on ProductPageSectionRegular {
-                title(locale: {locale: "%1"})
-                productCards { ...CardFields }
-              }
-            }
-          }
-        }
-        fragment CardFields on ProductCard {
-          ... on ProductCardRegular {
-            iconImageUrl
-            product(locale: {locale: "%1"}) {
-              ... on ProductBase {
-                code
-                title
-                subtitle
-              }
-              ... on ProductLibrary {
-                compatibleWith {
-                  museSoundManager
-                  museHub
-                }
-              }
-            }
-          }
-        })").arg(localeStr);
+    JsonObject variables;
+    variables["locale"] = localeStr;
 
-    JsonObject json;
-    json["query"] = query;
+    QUrlQuery query;
+    query.addQueryItem("pqId", "musescore-studio-sounds-page-v1");
+    query.addQueryItem("variables",
+                       QString::fromUtf8(JsonDocument(variables).toJson(JsonDocument::Format::Compact).toQByteArray()));
 
-    return JsonDocument(json).toJson(JsonDocument::Format::Compact).toQByteArray();
+    QUrl url = baseUrl;
+    url.setQuery(query);
+
+    return url;
 }
 
 void MuseSoundsRepository::init()
 {
     TRACEFUNC;
 
-    QUrl url = QUrl(QString::fromStdString(configuration()->soundsUri().toString()));
-    QByteArray jsonData = soundsRequestJson();
+    QUrl url = soundsRequestUrl(QUrl(QString::fromStdString(configuration()->soundsUri().toString())));
     RequestHeaders headers = configuration()->headers();
 
-    auto device = std::make_shared<QBuffer>();
-    device->setData(jsonData);
     auto receivedData = std::make_shared<QBuffer>();
 
     if (!m_networkManager) {
         m_networkManager = networkManagerCreator()->makeNetworkManager();
     }
 
-    RetVal<Progress> progress = m_networkManager->post(url, device, receivedData, headers);
+    RetVal<Progress> progress = m_networkManager->get(url, receivedData, headers);
     if (!progress.ret) {
         LOGE() << progress.ret.toString();
         return;


### PR DESCRIPTION
The MuseSounds catalogue is fetched on every launch by POSTing a GraphQL document. This switches it to a GET against a server-side persisted operation, so the response can be cached.

- locale moves from string interpolation in the query text into a GraphQL variable
- endpoints move to `customers-api.musehub.com` / `customers-api-dev.musehub.com` (Cloudflare-fronted)
- request becomes `GET ?pqId=musescore-studio-sounds-page-v1&variables={"locale":"..."}`

The response payload is unchanged, so `parseSounds()` is untouched. The old POST path continues to work, so existing releases are unaffected.
