### PR TITLE
Fix Mixer volume/pan and Solo state resetting after Solo toggle + playback

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1325,18 +1325,28 @@ ControlParams PlaybackController::trackControlParams(const InstrumentTrackId& in
                                                      bool rebuildVolume, bool rebuildPan)
 {
     ControlParams control = outParams.control();
+
+    const INotationAutomationPtr automation = m_masterNotation ? m_masterNotation->automation() : nullptr;
+    const AutomationDataConstPtr automationData = automation ? automation->automationData() : nullptr;
+
+    //! NOTE Only trust the cached automated control params while an automation curve is actually
+    //! driving this track; otherwise a stale cache entry (e.g. seeded at load time) would keep
+    //! overriding manual volume/pan changes made in the Mixer whenever this is called with
+    //! rebuildVolume/rebuildPan == false (e.g. on solo/mute toggles).
     const auto it = m_automatedControlParamsCache.find(instrumentTrackId);
-    if (it != m_automatedControlParamsCache.end()) {
-        control.volume = it->second.volume;
-        control.balance = it->second.balance;
+    if (it != m_automatedControlParamsCache.end() && automationData && instrumentTrackId.isValid()) {
+        if (!automationData->curve(AutomationCurveKey::instrument(AutomationType::Volume, instrumentTrackId)).empty()) {
+            control.volume = it->second.volume;
+        }
+        if (!automationData->curve(AutomationCurveKey::instrument(AutomationType::Pan, instrumentTrackId)).empty()) {
+            control.balance = it->second.balance;
+        }
     }
 
     if (!rebuildVolume && !rebuildPan) {
         return control;
     }
 
-    const INotationAutomationPtr automation = m_masterNotation ? m_masterNotation->automation() : nullptr;
-    const AutomationDataConstPtr automationData = automation ? automation->automationData() : nullptr;
     if (!automationData || !instrumentTrackId.isValid()) {
         m_automatedControlParamsCache.erase(instrumentTrackId);
         return outParams.control();

--- a/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
@@ -272,6 +272,11 @@ void MixerChannelItem::loadInputParams(const AudioInputParams& newParams)
 
 void MixerChannelItem::loadOutputParams(const AudioOutputParams& newParams)
 {
+    //! NOTE Deliberately not touching solo/muted/forceMute here: those are owned by
+    //! INotationSoloMuteState (or, for aux tracks, IProjectAudioSettings::auxSoloMuteState)
+    //! and by PlaybackController's live force-mute computation, and are always default-false
+    //! on an AudioOutputParams fetched from IProjectAudioSettings. Applying them here would
+    //! clobber the solo/mute state already loaded via loadSoloMuteState().
     if (!muse::RealIsEqual(m_outParams.volume, newParams.volume)) {
         m_outParams.volume = newParams.volume;
         if (!m_hasVolumeAutomation) {
@@ -284,21 +289,6 @@ void MixerChannelItem::loadOutputParams(const AudioOutputParams& newParams)
         if (!m_hasBalanceAutomation) {
             setDisplayedBalance(m_outParams.balance.raw() * BALANCE_SCALING_FACTOR);
         }
-    }
-
-    if (m_outParams.solo != newParams.solo) {
-        m_outParams.solo = newParams.solo;
-        emit soloChanged();
-    }
-
-    if (m_outParams.muted != newParams.muted) {
-        m_outParams.muted = newParams.muted;
-        emit mutedChanged();
-    }
-
-    if (m_outParams.forceMute != newParams.forceMute) {
-        m_outParams.forceMute = newParams.forceMute;
-        emit forceMuteChanged();
     }
 
     loadOutputResourceItems(newParams.fxChain);

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -517,8 +517,15 @@ MixerChannelItem* MixerPanelModel::buildInstrumentChannelItem(const TrackId trac
         playback()->setSourceParams(trackId, params);
     });
 
-    connect(item, &MixerChannelItem::controlParamsChanged, this, [this, trackId](const AudioOutputParams& params) {
+    connect(item, &MixerChannelItem::controlParamsChanged, this, [this, trackId, instrumentTrackId](const AudioOutputParams& params) {
         playback()->setControlParams(trackId, params.control());
+
+        //! NOTE Only persist volume/balance here; solo/mute/forceMute are owned by
+        //! INotationSoloMuteState and must not be echoed back into the saved output params.
+        AudioOutputParams outParams = audioSettings()->trackOutputParams(instrumentTrackId);
+        outParams.volume = params.volume;
+        outParams.balance = params.balance;
+        audioSettings()->setTrackOutputParams(instrumentTrackId, outParams);
     });
 
     connect(item, &MixerChannelItem::fxChainParamsChanged, this, [this, trackId](const AudioOutputParams& params) {
@@ -575,8 +582,13 @@ MixerChannelItem* MixerPanelModel::buildAuxChannelItem(aux_channel_idx_t index, 
                << ", " << text;
     });
 
-    connect(item, &MixerChannelItem::controlParamsChanged, this, [this, trackId](const AudioOutputParams& params) {
+    connect(item, &MixerChannelItem::controlParamsChanged, this, [this, trackId, index](const AudioOutputParams& params) {
         playback()->setControlParams(trackId, params.control());
+
+        AudioOutputParams outParams = audioSettings()->auxOutputParams(index);
+        outParams.volume = params.volume;
+        outParams.balance = params.balance;
+        audioSettings()->setAuxOutputParams(index, outParams);
     });
     connect(item, &MixerChannelItem::fxChainParamsChanged, this, [this, trackId](const AudioOutputParams& params) {
         playback()->setFxChainParams(trackId, params.fxChain);
@@ -615,6 +627,11 @@ MixerChannelItem* MixerPanelModel::buildMasterChannelItem()
 
     connect(item, &MixerChannelItem::controlParamsChanged, this, [this](const AudioOutputParams& params) {
         playback()->setMasterControlParams(params.control());
+
+        AudioOutputParams outParams = audioSettings()->masterAudioOutputParams();
+        outParams.volume = params.volume;
+        outParams.balance = params.balance;
+        audioSettings()->setMasterAudioOutputParams(outParams);
     });
 
     connect(item, &MixerChannelItem::fxChainParamsChanged, this, [this](const AudioOutputParams& params) {


### PR DESCRIPTION
Resolves: #34673

## Problem

Two related regressions in the Mixer, both triggered by the same reproduction steps:

1. **Manual volume/pan resets to 0 dB.** If you manually lower an instrument's volume (or change its pan) in the Mixer, then enable Solo on any track and play back, the manually-set value silently reverts to 0 dB (unity gain) — even without ever touching an automation curve.
2. **The Solo button itself reverts to unchecked.** Enable Solo on a track, play back a few measures, stop, and reopen (or just re-check) the Mixer: the Solo checkbox is unchecked again, even though solo/mute playback behavior and the underlying notation state are unaffected.

### Steps to reproduce (both bugs)

1. Open the Mixer.
2. (For bug 1) Lower an instrument's volume, e.g. to -6 dB.
3. Enable Solo on a track.
4. Start playback for a measure or two, then stop.
5. Look at the Mixer again: the volume has reset to 0 dB, and/or the Solo button is unchecked.

Bug 2 reproduces on its own too — no volume change is needed, just Solo + playback.

## Root causes

These are two independent bugs in the same area, both stemming from the same architectural mistake: reading a field from an `AudioOutputParams` snapshot that isn't actually the authoritative source for that field.

**Bug 1 — stale automated-control-params cache overrides manual volume/pan**

`PlaybackController::trackControlParams()` caches the last computed `ControlParams` per track in `m_automatedControlParamsCache`, so that repeated calls (e.g. from `updateSoloMuteStates()`, with `rebuildVolume = rebuildPan = false`) don't need to rebuild the automation envelope each time. The problem: the cached `volume`/`balance` were reapplied **unconditionally**, whether or not that track actually has an active automation curve.

This cache gets seeded for *every* track the first time `resendAutomatedControlParams()` runs (e.g. on project load, since it's wired to `totalPlayTimeChanged`), even when no automation exists — in that case it just stores a flat snapshot of whatever `outParams.volume`/`balance` was at that moment (typically 0 dB / centered pan, the defaults).

Sequence: user changes volume or pan in the Mixer → sent straight to the audio engine via `setControlParams`, bypassing `trackControlParams()`/the cache entirely → toggling Solo calls `updateSoloMuteStates()`, which calls `trackControlParams(id, params, /*rebuildVolume*/ false, /*rebuildPan*/ false)` → the stale cache entry (from load time) unconditionally overwrites `control.volume`/`control.balance`, and that stale value gets sent to the engine, audibly resetting the value.

Fix: only reuse the cached value when the track actually has a non-empty Volume/Pan automation curve right now. Otherwise, `control` keeps the volume/balance from the live `outParams` passed in.

**Bug 2 — Solo/Mute checkbox reset from a source that never tracks them**

`MixerChannelItem::loadOutputParams()` was also copying `solo`/`muted`/`forceMute` from whatever `AudioOutputParams` it was given. Several code paths call it with an `AudioOutputParams` fetched from `IProjectAudioSettings` (`trackOutputParams()` / `auxOutputParams()` / `masterAudioOutputParams()`) — but solo/mute state is **never** written into that store. It's owned by `INotationSoloMuteState` (instrument tracks) or `IProjectAudioSettings::auxSoloMuteState()` (aux tracks), and `forceMute` is computed live in `PlaybackController::updateSoloMuteStates()` and sent directly to the engine — neither ever round-trips through `IProjectAudioSettings::AudioOutputParams`, so that struct's `solo`/`muted`/`forceMute` fields are always at their default of `false`.

Sequence: user clicks Solo → `MixerChannelItem::setSolo(true)` correctly sets the notation-level state and the item's own display state → but the async promise from `playback()->params(trackId)` used to (re)build the channel item (`MixerPanelModel::buildInstrumentChannelItem`) resolves afterwards and calls `loadOutputParams()` with an `AudioOutputParams` freshly fetched from `IProjectAudioSettings` — whose `solo` field is `false` — clobbering the checkbox back to unchecked. The same pattern affects the `fxChainParamsChanged` reload path and the aux-channel build path.

Confirmed via targeted `LOGD` tracing:
```
MixerChannelItem::loadSoloMuteState | trackId: 2, oldSolo: 0, newSolo: 1   <- correct, from notation state
MixerChannelItem::loadOutputParams  | trackId: 2, oldSolo: 1, newSolo: 0   <- clobbered right after
```

Fix: `loadOutputParams()` no longer touches `solo`/`muted`/`forceMute` at all — those fields have their own dedicated, correct update path (`loadSoloMuteState()`, and `updateSoloMuteStates()` for the live force-mute computation) and should never be sourced from `IProjectAudioSettings`.

## Additional fix needed to make bug 1's fix effective

Independently of the cache issue, `MixerPanelModel`'s `controlParamsChanged` handlers (instrument tracks, aux tracks, and master) never persisted manual volume/balance edits back to `IProjectAudioSettings` — only the live audio engine got the new value via `setControlParams`. So even after fixing the cache bug above, any later rebuild of a track's output params (e.g. from `IProjectAudioSettings::trackOutputParams()`) would still read the old, never-updated volume/balance. These handlers now persist `volume`/`balance` back to `IProjectAudioSettings` — deliberately *not* including `solo`/`muted`/`forceMute`, per the bug 2 root cause above.

## Testing

- Manually built and tested locally (macOS).
- Reproduced both bugs before the fix, confirmed both are resolved after, using several instruments and multiple simultaneous Solo toggles.
- Manually re-verified the volume fix; the pan/balance fix follows the exact same code path (both bugs handle `volume` and `balance` symmetrically) but wasn't separately re-verified by ear.
- Verified with debug logging (`-d` flag) that the Solo state is now correctly preserved through the Mixer's channel-item rebuild path.
- Ran `checkcodestyle.cmake` against `src/` — no style issues in the changed files.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).