### PR TITLE
[4.7.5] Fix crash on open score caused by tick mismatch between main and part scores

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1618,8 +1618,8 @@ bool segmentsAreAdjacent(const Segment* firstSeg, const Segment* secondSeg)
     }
     const MasterScore* master = firstSeg->masterScore();
 
-    Measure* firstMeasure = firstSeg->measure();
-    Measure* secondMeasure = secondSeg->measure();
+    const Measure* firstMeasure = firstSeg->measure();
+    const Measure* secondMeasure = secondSeg->measure();
 
     if (firstMeasure == secondMeasure) {
         return true;
@@ -1628,8 +1628,11 @@ bool segmentsAreAdjacent(const Segment* firstSeg, const Segment* secondSeg)
     const Measure* firstMasterMeasure = master->tick2measure(firstMeasure->tick());
     const Measure* secondMasterMeasure = master->tick2measure(secondMeasure->tick());
 
-    Score* score = firstSeg->score();
+    IF_ASSERT_FAILED(firstMasterMeasure && secondMasterMeasure) {
+        return false;
+    }
 
+    const Score* score = firstSeg->score();
     const RepeatList& repeatList = score->repeatList(true, false);
 
     std::vector<const Measure*> measures;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34677

The part's (Oboe) first measure has a different tick length (1920) than the master score's corresponding measure (1440), due to a missing <TimeSig> on the part