### PR TITLE
App start. Show the window only when content is ready

### DIFF
--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -1,5 +1,8 @@
 #include "guiapp.h"
 
+#include <QQuickWindow>
+#include <QTimer>
+
 #include "modularity/ioc.h"
 #include "appshell/internal/istartupscenario.h"
 #include "dockwindow/idockwindowprovider.h"
@@ -130,17 +133,50 @@ void MuseScoreGuiApp::doStartupScenario(const muse::modularity::ContextPtr& ctxI
         auto dockWindowProvider = muse::modularity::ioc(ctxId)->resolve<muse::dock::IDockWindowProvider>("app");
         muse::dock::IDockWindow* dockWindow = dockWindowProvider ? dockWindowProvider->window() : nullptr;
         if (dockWindow) {
-            dockWindow->currentPageChanged().onNotify(this, [this, dockWindow]() {
+            dockWindow->currentPageChanged().onNotify(this, [this, ctxId, dockWindow]() {
                 dockWindow->currentPageChanged().disconnect(this);
 
-                QMetaObject::invokeMethod(qApp, [this]() {
-                    closeSplash();
+                QMetaObject::invokeMethod(qApp, [this, ctxId]() {
+                    showMainWindowAndCloseSplash(ctxId);
                 }, Qt::QueuedConnection);
             });
+        } else {
+            //! NOTE No dock window - no page loading to wait for
+            showMainWindowAndCloseSplash(ctxId);
         }
 
         startupScenario->runAfterSplashScreen();
     }, Qt::QueuedConnection);
+}
+
+void MuseScoreGuiApp::showMainWindowAndCloseSplash(const muse::modularity::ContextPtr& ctxId)
+{
+    auto it = m_windows.find(ctxId->id);
+    QQuickWindow* window = it != m_windows.end() ? it->second : nullptr;
+    if (!window) {
+        closeSplash();
+        return;
+    }
+
+    //! NOTE Close the splash only after the window has rendered its first frame,
+    //! so that the empty window is never visible
+    auto conn = std::make_shared<QMetaObject::Connection>();
+    *conn = QObject::connect(window, &QQuickWindow::frameSwapped, qApp, [this, conn]() {
+        QObject::disconnect(*conn);
+        closeSplash();
+    }, Qt::QueuedConnection);
+
+    //! NOTE Safety net for the case when the window never renders a frame;
+    //! long enough so that it cannot fire before the first frame of a healthy startup
+    static constexpr int SPLASH_CLOSE_TIMEOUT_MS = 10000;
+    QTimer::singleShot(SPLASH_CLOSE_TIMEOUT_MS, qApp, [this]() {
+        if (m_splashScreen) {
+            LOGW() << "the main window has not rendered any frame, closing the splash screen forcibly";
+            closeSplash();
+        }
+    });
+
+    window->setVisible(true);
 }
 
 void MuseScoreGuiApp::closeSplash()

--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -2,6 +2,8 @@
 
 #include "modularity/ioc.h"
 #include "appshell/internal/istartupscenario.h"
+#include "dockwindow/idockwindowprovider.h"
+#include "dockwindow/idockwindow.h"
 
 #include "commandlineparser.h"
 
@@ -125,16 +127,31 @@ void MuseScoreGuiApp::doStartupScenario(const muse::modularity::ContextPtr& ctxI
     startupScenario->runOnSplashScreen();
 
     QMetaObject::invokeMethod(qApp, [this, ctxId, startupScenario]() {
-#ifdef MUE_ENABLE_SPLASHSCREEN
-        if (m_splashScreen) {
-            m_splashScreen->close();
-            delete m_splashScreen;
-            m_splashScreen = nullptr;
+        auto dockWindowProvider = muse::modularity::ioc(ctxId)->resolve<muse::dock::IDockWindowProvider>("app");
+        muse::dock::IDockWindow* dockWindow = dockWindowProvider ? dockWindowProvider->window() : nullptr;
+        if (dockWindow) {
+            dockWindow->currentPageChanged().onNotify(this, [this, dockWindow]() {
+                dockWindow->currentPageChanged().disconnect(this);
+
+                QMetaObject::invokeMethod(qApp, [this]() {
+                    closeSplash();
+                }, Qt::QueuedConnection);
+            });
         }
-#endif
 
         startupScenario->runAfterSplashScreen();
     }, Qt::QueuedConnection);
+}
+
+void MuseScoreGuiApp::closeSplash()
+{
+#ifdef MUE_ENABLE_SPLASHSCREEN
+    if (m_splashScreen) {
+        m_splashScreen->close();
+        delete m_splashScreen;
+        m_splashScreen = nullptr;
+    }
+#endif
 }
 
 void MuseScoreGuiApp::applyCommandLineOptions(const std::shared_ptr<CmdOptions>& opt)

--- a/src/app/internal/guiapp.h
+++ b/src/app/internal/guiapp.h
@@ -6,6 +6,7 @@
 #include "ui/internal/guiapplication.h"
 #include "../cmdoptions.h"
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "multiwindows/imultiwindowsprovider.h"
 #include "appshell/iappshellconfiguration.h"
@@ -16,7 +17,7 @@
 class QQuickWindow;
 
 namespace mu::app {
-class MuseScoreGuiApp : public muse::ui::GuiApplication
+class MuseScoreGuiApp : public muse::ui::GuiApplication, public muse::async::Asyncable
 {
     muse::GlobalInject<muse::mi::IMultiWindowsProvider> multiwindowsProvider;
     muse::GlobalInject<appshell::IAppShellConfiguration> appshellConfiguration;
@@ -26,6 +27,7 @@ public:
     MuseScoreGuiApp(const std::shared_ptr<MuseScoreCmdOptions>& options);
 
     void showSplash() override;
+    void closeSplash() override;
 
 private:
 

--- a/src/app/internal/guiapp.h
+++ b/src/app/internal/guiapp.h
@@ -45,6 +45,7 @@ private:
     void showContextSplash(const muse::modularity::ContextPtr& ctxId) override;
     QString mainWindowQmlPath(const QString& platform) const override;
     void doStartupScenario(const muse::modularity::ContextPtr& ctxId) override;
+    void showMainWindowAndCloseSplash(const muse::modularity::ContextPtr& ctxId);
 
     appshell::SplashScreen* m_splashScreen = nullptr;
 };

--- a/src/appshell/qml/MuseScore/AppShell/AppWindow.qml
+++ b/src/appshell/qml/MuseScore/AppShell/AppWindow.qml
@@ -47,11 +47,6 @@ ApplicationWindow {
 
     visible: false
 
-    //! NOTE The window must be shown early,
-    //! but should not be visible until the first page has loaded,
-    //! so it starts fully transparent; WindowContent restores the opacity.
-    opacity: 0
-
     color: ui.theme.backgroundPrimaryColor
 
     Component.onCompleted: {

--- a/src/appshell/qml/MuseScore/AppShell/AppWindow.qml
+++ b/src/appshell/qml/MuseScore/AppShell/AppWindow.qml
@@ -47,6 +47,11 @@ ApplicationWindow {
 
     visible: false
 
+    //! NOTE The window must be shown early,
+    //! but should not be visible until the first page has loaded,
+    //! so it starts fully transparent; WindowContent restores the opacity.
+    opacity: 0
+
     color: ui.theme.backgroundPrimaryColor
 
     Component.onCompleted: {

--- a/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
+++ b/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
@@ -42,6 +42,10 @@ DockWindow {
 
     onPageLoaded: {
         console.log("WindowContent::onPageLoaded")
+
+        //! NOTE The window content is ready now, remove the startup transparency (see AppWindow)
+        root.window.opacity = 1.0
+
         interactiveProvider.onPageOpened()
     }
 

--- a/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
+++ b/src/appshell/qml/MuseScore/AppShell/WindowContent.qml
@@ -43,9 +43,6 @@ DockWindow {
     onPageLoaded: {
         console.log("WindowContent::onPageLoaded")
 
-        //! NOTE The window content is ready now, remove the startup transparency (see AppWindow)
-        root.window.opacity = 1.0
-
         interactiveProvider.onPageOpened()
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33596
Resolves: https://github.com/musescore/MuseScore/issues/32612

It is the third option from https://github.com/musescore/MuseScore/issues/32612

Depends on https://github.com/musescore/muse_framework/pull/247