### PR TITLE
Fret drop tuning chords as a unit on tablature staves

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -22,6 +22,8 @@
 
 #include "stringdata.h"
 
+#include <algorithm>
+#include <limits>
 #include <map>
 
 #include "defer.h"
@@ -195,7 +197,15 @@ void StringData::fretChords(Chord* chord) const
     int count = 0;
     // if chord parent is not a segment, the chord is special (usually a grace chord):
     // fret it by itself, ignoring the segment
+    // note any existing fretting before sortChordNotes() erases the invalid ones:
+    // the re-fretting at the end of this function only applies to chords which
+    // arrive with no fretting at all
+    int chordsInSegment = 0;
+    bool anyPreassigned = false;
+
     if (!chord->explicitParent()->isSegment()) {
+        chordsInSegment = 1;
+        anyPreassigned = hasPreassignedNote(chord);
         sortChordNotes(sortedNotes, chord, &count);
     } else {
         // scan each chord of seg from same staff as 'chord', inserting each of its notes in sortedNotes
@@ -206,6 +216,10 @@ void StringData::fretChords(Chord* chord) const
         for (trk = trkFrom; trk < trkTo; ++trk) {
             EngravingItem* ch = seg->elist().at(trk);
             if (ch && ch->isChord()) {
+                ++chordsInSegment;
+                if (hasPreassignedNote(toChord(ch))) {
+                    anyPreassigned = true;
+                }
                 sortChordNotes(sortedNotes, toChord(ch), &count);
             }
         }
@@ -240,6 +254,17 @@ void StringData::fretChords(Chord* chord) const
         if (note->fret() != INVALID_FRET_INDEX && note->fret() > maxFret) {
             maxFret = note->fret();
         }
+    }
+
+    // a chord in a drop tuning has to be fretted as a unit: fretting it note by note
+    // puts power chords onto open strings instead of the barre shape which is really
+    // played. everything else is fretted note by note below
+    if (chord->configuration()->fretDropTuningChordsAsUnit()
+        && chordsInSegment == 1 && !anyPreassigned
+        && isMonotonicTuning() && isDropLikeTuning()
+        && !chord->staff()->capo(chord->tick()).active
+        && fretChordAsUnit(chord, sortedNotes, bUsed)) {
+        return;
     }
 
     // scan chord notes from highest, matching with strings from the highest
@@ -302,8 +327,6 @@ void StringData::fretChords(Chord* chord) const
             && bUsed[nNewString] > 1) {
             tryResolveStringConflictWithOutOfRangeFret(note, strings, bUsed, nNewString, nNewFret);
         }
-
-        // TODO : try to optimize used fret range, avoiding excessively open positions
 
         // if fretting did change, store as a fret change
         if (nFret != nNewFret) {
@@ -757,7 +780,8 @@ void StringData::sortChordNotesUseSameString(const Chord* chord) const
 //          then by order of submission to disambiguate notes with the same pitch.
 //          Everything else being equal, this makes notes in higher-numbered voices
 //          to be sorted after notes in lower-numbered voices (voice 2 after voice 1 and so on)
-//    Notes without a string assigned yet, are sorted according to the lowest string which can accommodate them.
+//    Notes without a string assigned yet sort ahead of all assigned notes, via the
+//    INVALID_STRING_INDEX sentinel.
 //---------------------------------------------------------
 
 void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* chord, int* count) const
@@ -845,5 +869,306 @@ int StringData::adjustBanjo5thFret(int fret) const
 bool StringData::isFiveStringBanjo() const
 {
     return m_stringTable.size() == 5 && m_stringTable[0].pitch > m_stringTable[1].pitch;
+}
+
+//---------------------------------------------------------
+//   hasPreassignedNote
+//    Returns true if any note of the chord already carries a fretting
+//    which sortChordNotes() will keep
+//---------------------------------------------------------
+
+bool StringData::hasPreassignedNote(const Chord* chord) const
+{
+    const int numStrings = static_cast<int>(m_stringTable.size());
+    for (const Note* note : chord->notes()) {
+        const int string = note->string();
+        const int noteFret = note->fret();
+        if (string < 0 || string >= numStrings || noteFret <= INVALID_FRET_INDEX) {
+            continue;
+        }
+        const int pitch = getPitch(string, noteFret, pitchOffsetAt(note->staff(), chord->tick(), string));
+        if (pitchIsValid(pitch) && pitch != note->pitch()) {
+            continue;               // no longer matches the pitch: sortChordNotes() will erase it
+        }
+        return true;
+    }
+    return false;
+}
+
+//---------------------------------------------------------
+//   fretChordAsUnit
+//    Frets the whole chord in one hand position, for the drop tunings where
+//    fretting note by note would spread a power chord over open strings.
+//    Returns false if the chord does not need it or no such fretting exists,
+//    in which case the caller frets note by note as usual
+//---------------------------------------------------------
+
+bool StringData::fretChordAsUnit(Chord* chord, const std::map<int, Note*>& sortedNotes, std::vector<int>& bUsed) const
+{
+    const int pitchOffset = pitchOffsetAt(chord->staff(), chord->tick());
+
+    std::vector<Note*> notes;
+    for (const auto& p : sortedNotes) {
+        Note* note = p.second;
+        if (note->deadNote() || note->negativeFretUsed()
+            || note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
+            return false;
+        }
+        notes.push_back(note);
+    }
+
+    if (notes.size() < 2) {
+        return false;
+    }
+
+    std::sort(notes.begin(), notes.end(), [](const Note* a, const Note* b) {
+        return a->pitch() < b->pitch();
+    });
+
+    // what fretting note by note would give: whether the chord needs this at all is
+    // decided against that, so that only the chords which come out wrong are changed
+    std::vector<std::pair<int, int> > noteByNote;
+    std::vector<int> pitches;
+    for (const Note* note : notes) {
+        int string = INVALID_STRING_INDEX;
+        int noteFret = INVALID_FRET_INDEX;
+        if (!convertPitch(note->pitch(), pitchOffset, &string, &noteFret)) {
+            return false;
+        }
+        noteFret = fret(note->pitch(), string, pitchOffsetAt(chord->staff(), chord->tick(), string));
+        if (noteFret == INVALID_FRET_INDEX) {
+            return false;
+        }
+        for (const auto& placed : noteByNote) {
+            if (placed.first == string) {
+                return false;           // two notes on one string: leave it to the normal path
+            }
+        }
+        noteByNote.push_back({ string, noteFret });
+        pitches.push_back(note->pitch());
+    }
+
+    if (!needsCompactFingering(noteByNote)) {
+        return false;
+    }
+
+    std::vector<std::pair<int, int> > fingering;
+    if (!findCompactFingering(pitches, &fingering, pitchOffset)) {
+        return false;
+    }
+
+    for (size_t i = 0; i < notes.size(); ++i) {
+        notes[i]->setFretConflict(false);
+        bUsed[fingering[i].first]++;
+        if (notes[i]->fret() != fingering[i].second) {
+            notes[i]->undoChangeProperty(Pid::FRET, fingering[i].second);
+        }
+        if (notes[i]->string() != fingering[i].first) {
+            notes[i]->undoChangeProperty(Pid::STRING, fingering[i].first);
+        }
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   needsCompactFingering
+//    Returns true if a note sits further than a hand span below the highest fretted
+//    note and on a higher string, i.e. it could have been fretted up in position
+//---------------------------------------------------------
+
+bool StringData::needsCompactFingering(const std::vector<std::pair<int, int> >& placements) const
+{
+    // highest fret which is in range: the out of range frets from
+    // tryResolveStringConflictWithOutOfRangeFret() must not raise the threshold
+    int highFret = -1;
+    for (const auto& placement : placements) {
+        if (placement.second >= 0 && placement.second <= m_frets && placement.second > highFret) {
+            highFret = placement.second;
+        }
+    }
+
+    if (highFret < HAND_SPAN + 1) {
+        return false;
+    }
+
+    const int reachableFrom = highFret - HAND_SPAN - 1;
+
+    for (const auto& high : placements) {
+        if (high.second != highFret) {
+            continue;
+        }
+        for (const auto& low : placements) {
+            if (low.second < 0 || low.second > m_frets) {
+                continue;
+            }
+            // low note is out of reach of the high note's hand position, but sits on a
+            // higher string, so it could have been fretted up there instead
+            if (low.second <= reachableFrom && low.first < high.first) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+//---------------------------------------------------------
+//   findCompactFingering
+//    Looks for a fretting of pitches (ascending) which fits under one hand,
+//    anchoring the lowest note on each string in turn.
+//    Fills *out and returns true only if the result is compact enough to be worth
+//    replacing the existing fretting
+//---------------------------------------------------------
+
+bool StringData::findCompactFingering(const std::vector<int>& pitches,
+                                      std::vector<std::pair<int, int> >* out,
+                                      int pitchOffset) const
+{
+    const int numStrings = static_cast<int>(m_stringTable.size());
+    if (pitches.size() < 2 || numStrings < 2) {
+        // nothing to re-fret
+        return false;
+    }
+
+    std::vector<std::pair<int, int> > best;
+    size_t bestDistinct = std::numeric_limits<size_t>::max();
+    int bestSpan = std::numeric_limits<int>::max();
+
+    // try the lowest note on each string which can play it, lowest string first
+    for (int anchor = numStrings - 1; anchor >= 0; --anchor) {
+        const int anchorFret = fret(pitches[0], anchor, pitchOffset);
+        if (anchorFret == INVALID_FRET_INDEX) {
+            continue;
+        }
+
+        std::vector<std::pair<int, int> > trial;
+        trial.push_back({ anchor, anchorFret });
+        int lo = anchorFret;
+        int hi = anchorFret;
+        int prev = anchor;
+        bool complete = true;
+
+        // each higher note takes the first string towards the top whose fret keeps
+        // the running span within reach
+        for (size_t i = 1; i < pitches.size(); ++i) {
+            bool placed = false;
+            for (int candidate = prev - 1; candidate >= 0; --candidate) {
+                const int f = fret(pitches[i], candidate, pitchOffset);
+                if (f == INVALID_FRET_INDEX) {
+                    continue;
+                }
+                const int newLo = std::min(lo, f);
+                const int newHi = std::max(hi, f);
+                if (newHi - newLo > HAND_SPAN) {
+                    continue;
+                }
+                trial.push_back({ candidate, f });
+                lo = newLo;
+                hi = newHi;
+                prev = candidate;
+                placed = true;
+                break;
+            }
+            if (!placed) {
+                complete = false;
+                break;
+            }
+        }
+
+        if (!complete) {
+            continue;
+        }
+
+        // count distinct fretted positions; open strings need no finger
+        std::vector<int> distinctFrets;
+        for (const auto& placement : trial) {
+            if (placement.second > 0 && !muse::contains(distinctFrets, placement.second)) {
+                distinctFrets.push_back(placement.second);
+            }
+        }
+
+        const int span = hi - lo;
+        if (distinctFrets.size() > MAX_ADOPT_DISTINCT_FRETS || span > MAX_ADOPT_SPAN) {
+            // playable, but not compact enough to be worth replacing what is there
+            continue;
+        }
+
+        if (distinctFrets.size() < bestDistinct
+            || (distinctFrets.size() == bestDistinct && span < bestSpan)) {
+            best = trial;
+            bestDistinct = distinctFrets.size();
+            bestSpan = span;
+        }
+    }
+
+    if (best.empty()) {
+        return false;
+    }
+
+    *out = best;
+    return true;
+}
+
+//---------------------------------------------------------
+//   isDropLikeTuning
+//    Returns true for a regular stack of fourths whose lowest string has been dropped
+//    below it (drop D, drop C, 7 and 8 string drops).
+//    False for standard, alternate and open tunings, where ringing open strings are
+//    part of the intended sound
+//---------------------------------------------------------
+
+bool StringData::isDropLikeTuning() const
+{
+    const size_t numStrings = m_stringTable.size();
+    if (numStrings < MIN_DROP_TUNING_STRINGS) {
+        // mountain dulcimer and 3-course bouzouki match the intervals otherwise
+        return false;
+    }
+
+    if (!isMonotonicTuning()) {
+        return false;
+    }
+
+    // m_stringTable is ordered lowest pitch first, so [1] - [0] is the bottom gap
+    if (m_stringTable[1].pitch - m_stringTable[0].pitch < MIN_DROPPED_STRING_GAP) {
+        return false;
+    }
+
+    for (size_t i = 1; i + 1 < numStrings; ++i) {
+        const int gap = m_stringTable[i + 1].pitch - m_stringTable[i].pitch;
+        if (gap != 4 && gap != 5) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   isMonotonicTuning
+//    False for re-entrant tunings (5 string banjo, theorbo, charango), which break
+//    the assumption that a lower string index means a higher pitch
+//---------------------------------------------------------
+
+bool StringData::isMonotonicTuning() const
+{
+    if (m_stringTable.size() < 2) {
+        return false;
+    }
+
+    for (size_t i = 1; i < m_stringTable.size(); ++i) {
+        if (m_stringTable[i].pitch <= m_stringTable[i - 1].pitch) {
+            return false;
+        }
+    }
+
+    for (const instrString& strg : m_stringTable) {
+        if (strg.startFret != 0) {
+            return false;
+        }
+    }
+
+    return true;
 }
 }

--- a/src/engraving/dom/stringdata.h
+++ b/src/engraving/dom/stringdata.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <cstddef>
+#include <utility>
 #include <vector>
 #include <map>
 
@@ -84,11 +85,23 @@ public:
     void        configBanjo5thString();
     int         adjustBanjo5thFret(int fret) const;
     bool        isFiveStringBanjo() const;
+    bool        isDropLikeTuning() const;
+    bool        isMonotonicTuning() const;
+    bool        findCompactFingering(const std::vector<int>& pitches, std::vector<std::pair<int, int> >* out, int pitchOffset = 0) const;
+    bool        needsCompactFingering(const std::vector<std::pair<int, int> >& placements) const;
     bool        useFlats() const { return m_useFlats; }
 
 private:
 
+    static constexpr size_t MIN_DROP_TUNING_STRINGS = 4;    // below this, drone instruments match the pattern too
+    static constexpr int MIN_DROPPED_STRING_GAP = 6;        // semitones the lowest string sits below the rest
+    static constexpr int HAND_SPAN = 4;                     // frets a fretting may stretch while being searched
+    static constexpr int MAX_ADOPT_SPAN = 2;                // only replace an existing fretting with a barre...
+    static constexpr size_t MAX_ADOPT_DISTINCT_FRETS = 2;   // ...plus at most one more finger
+
     int         fret(int pitch, int string, int pitchOffset) const;
+    bool        hasPreassignedNote(const Chord* chord) const;
+    bool        fretChordAsUnit(Chord* chord, const std::map<int, Note*>& sortedNotes, std::vector<int>& bUsed) const;
     void        sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* chord, int* count) const;
     void        sortChordNotesUseSameString(const Chord* chord) const;
     bool        hasPendingPitchChange(const Chord* chord) const;

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -142,6 +142,8 @@ public:
 
     virtual bool allowReadingImagesFromOutsideMscz() const = 0;
 
+    virtual bool fretDropTuningChordsAsUnit() const = 0;
+
     /// these configurations will be removed after solving https://github.com/musescore/MuseScore/issues/14294
     virtual bool guitarProImportExperimental() const = 0;
     virtual bool negativeFretsAllowed() const = 0;

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -54,6 +54,7 @@ static const Settings::Key UNLINKED_COLOR("engraving", "engraving/colors/unlinke
 
 static const Settings::Key DYNAMICS_APPLY_TO_ALL_VOICES("engraving", "score/dynamicsApplyToAllVoices");
 static const Settings::Key FRETBOARD_DIAGRAMS_AUTO_UPDATE("engraving", "score/fretboardDiagramsAutoUpdate");
+static const Settings::Key FRET_DROP_TUNING_CHORDS_AS_UNIT("engraving", "score/fretDropTuningChordsAsUnit");
 
 struct VoiceColor {
     Settings::Key key;
@@ -143,6 +144,8 @@ void EngravingConfiguration::init()
     settings()->valueChanged(DYNAMICS_APPLY_TO_ALL_VOICES).onReceive(this, [this](const Val& val) {
         m_dynamicsApplyToAllVoicesChanged.send(val.toBool());
     });
+
+    settings()->setDefaultValue(FRET_DROP_TUNING_CHORDS_AS_UNIT, Val(true));
 
     settings()->setDefaultValue(FRETBOARD_DIAGRAMS_AUTO_UPDATE, Val(true));
     settings()->valueChanged(FRETBOARD_DIAGRAMS_AUTO_UPDATE).onReceive(this, [this](const Val& val) {
@@ -383,6 +386,11 @@ muse::async::Channel<voice_idx_t, Color> EngravingConfiguration::selectionColorC
 Color EngravingConfiguration::highlightSelectionColor(voice_idx_t voice) const
 {
     return Color::fromQColor(selectionColor(voice).toQColor().lighter(135));
+}
+
+bool EngravingConfiguration::fretDropTuningChordsAsUnit() const
+{
+    return settings()->value(FRET_DROP_TUNING_CHORDS_AS_UNIT).toBool();
 }
 
 bool EngravingConfiguration::dynamicsApplyToAllVoices() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -111,6 +111,8 @@ public:
 
     bool allowReadingImagesFromOutsideMscz() const override;
 
+    bool fretDropTuningChordsAsUnit() const override;
+
     bool guitarProImportExperimental() const override;
     bool negativeFretsAllowed() const override;
     void setGuitarProMultivoiceEnabled(bool multiVoice) override;

--- a/src/engraving/tests/CMakeLists.txt
+++ b/src/engraving/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/tools_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transpose_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tab_transpose_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tab_fretting_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tuplet_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/unrollrepeats_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/changevisibility_tests.cpp

--- a/src/engraving/tests/environment.cpp
+++ b/src/engraving/tests/environment.cpp
@@ -59,6 +59,7 @@ static muse::testing::SuiteEnvironment engraving_se(
     ON_CALL(*configurator, displayedDefaultColor(::testing::_)).WillByDefault(::testing::Return(muse::draw::Color::BLACK));
     ON_CALL(*configurator, debuggingOptions()).WillByDefault(::testing::ReturnRef(debugOpt));
     ON_CALL(*configurator, allowReadingImagesFromOutsideMscz()).WillByDefault(::testing::Return(true));
+    ON_CALL(*configurator, fretDropTuningChordsAsUnit()).WillByDefault(::testing::Return(true));
 
     muse::modularity::globalIoc()->unregister<mu::engraving::IEngravingConfiguration>("utests");
     muse::modularity::globalIoc()->registerExport<mu::engraving::IEngravingConfiguration>("utests", configurator);

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -97,6 +97,8 @@ public:
 
     MOCK_METHOD(bool, allowReadingImagesFromOutsideMscz, (), (const, override));
 
+    MOCK_METHOD(bool, fretDropTuningChordsAsUnit, (), (const, override));
+
     MOCK_METHOD(bool, guitarProImportExperimental, (), (const, override));
     MOCK_METHOD(bool, negativeFretsAllowed, (), (const, override));
     MOCK_METHOD(void, setGuitarProMultivoiceEnabled, (bool), (override));

--- a/src/engraving/tests/tab_fretting_data/dadgad_drone.mscx
+++ b/src/engraving/tests/tab_fretting_data/dadgad_drone.mscx
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>38</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>38</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>38</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>57</string>
+          <string>62</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>43</pitch>
+              <tpc>15</tpc>
+            </Note>
+            <Note>
+              <pitch>50</pitch>
+              <tpc>16</tpc>
+            </Note>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+            </Note>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+            </Note>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_fretting_data/dropd_power_chord.mscx
+++ b/src/engraving/tests/tab_fretting_data/dropd_power_chord.mscx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.7</Spatium>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="tablature">
+          <name>Tab. 6-str common</name>
+          <lines>6</lines>
+          <lineDistance>1.5</lineDistance>
+          <timesig>0</timesig>
+          <durations>0</durations>
+          <durationFontName>MuseScore Tab Modern</durationFontName>
+          <durationFontSize>15</durationFontSize>
+          <fretFontName>MuseScore Tab Serif</fretFontName>
+          <fretFontSize>9</fretFontSize>
+          <linesThrough>0</linesThrough>
+          <onLines>1</onLines>
+          <showRests>0</showRests>
+          <stemsDown>1</stemsDown>
+          <stemsThrough>0</stemsThrough>
+          <upsideDown>0</upsideDown>
+          <useNumbers>1</useNumbers>
+        </StaffType>
+      </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument>
+        <trackName>Guitar</trackName>
+        <minPitchP>38</minPitchP>
+        <maxPitchP>88</maxPitchP>
+        <minPitchA>38</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <StringData>
+          <frets>24</frets>
+          <string>38</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+        </StringData>
+        <Channel>
+          <program value="25"/>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>43</pitch>
+              <tpc>15</tpc>
+            </Note>
+            <Note>
+              <pitch>50</pitch>
+              <tpc>16</tpc>
+            </Note>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+            </Note>
+          </Chord>
+          <Rest>
+            <durationType>half</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/tab_fretting_tests.cpp
+++ b/src/engraving/tests/tab_fretting_tests.cpp
@@ -1,0 +1,492 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Fretting of chords on tablature staves: the per-note assignment done by
+// convertPitch(), the drop tuning re-fretting done by fretChords(), and the
+// tuning classification which decides whether that re-fretting applies.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "engraving/dom/chord.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/measure.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/segment.h"
+#include "engraving/dom/stringdata.h"
+
+#include "utils/scorerw.h"
+
+using namespace mu::engraving;
+
+namespace {
+// Tunings, internal order: index 0 = lowest pitch.
+std::vector<int> TUNING_STANDARD = { 40, 45, 50, 55, 59, 64 };   // E2 A2 D3 G3 B3 E4
+std::vector<int> TUNING_DROP_D   = { 38, 45, 50, 55, 59, 64 };   // D2 A2 D3 G3 B3 E4
+std::vector<int> TUNING_DADGAD   = { 38, 45, 50, 55, 57, 62 };   // D2 A2 D3 G3 A3 D4
+std::vector<int> TUNING_OPEN_G   = { 38, 43, 50, 55, 59, 62 };   // D2 G2 D3 G3 B3 D4
+
+using Placement = std::pair<int, int>;                    // (visual string, fret)
+
+StringData makeTuning(std::vector<int>& pitches, int frets = 24)
+{
+    return StringData(frets, static_cast<int>(pitches.size()), pitches.data());
+}
+
+// Greedy assignment for each pitch, in the order given.
+std::vector<Placement> greedy(const StringData& sd, const std::vector<int>& pitches)
+{
+    std::vector<Placement> out;
+    for (int p : pitches) {
+        int string = -1;
+        int fret = -1;
+        sd.convertPitch(p, 0, &string, &fret);
+        out.push_back({ string, fret });
+    }
+    return out;
+}
+
+// Adjacent-string gaps in VISUAL order (v0 -> v(n-1)), i.e. highest-pitched first.
+std::vector<int> visualGaps(std::vector<int>& pitches)
+{
+    std::vector<int> gaps;
+    for (size_t i = pitches.size() - 1; i > 0; --i) {
+        gaps.push_back(pitches[i] - pitches[i - 1]);
+    }
+    return gaps;
+}
+}
+
+class Engraving_TabFrettingTests : public ::testing::Test
+{
+};
+
+// ---------------------------------------------------------------------------
+// Drop D. From the 5th fret up, a power chord is spread over open strings
+// instead of the barre shape which would actually be played.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, dropD_powerChord_fret5)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G5 = G2, D3, G3
+    std::vector<Placement> expected = { { 5, 5 }, { 3, 0 }, { 2, 0 } };
+    EXPECT_EQ(greedy(sd, { 43, 50, 55 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_powerChord_fret6_noOpenStrings)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G#5 = G#2, D#3, G#3. Same defect, but nothing lands on an open string.
+    std::vector<Placement> expected = { { 5, 6 }, { 3, 1 }, { 2, 1 } };
+    EXPECT_EQ(greedy(sd, { 44, 51, 56 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_powerChord_fourNote)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G2, D3, G3, D4: the 5-5-5-7 grip. D4 lands on the B string, not the high E.
+    std::vector<Placement> expected = { { 5, 5 }, { 3, 0 }, { 2, 0 }, { 1, 3 } };
+    EXPECT_EQ(greedy(sd, { 43, 50, 55, 62 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_rootAndOctave)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G2, G3. G3 is the open G string, not the D string.
+    std::vector<Placement> expected = { { 5, 5 }, { 2, 0 } };
+    EXPECT_EQ(greedy(sd, { 43, 55 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_belowFret5_isForced)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // F5 at fret 3: every note forced onto its only reachable string.
+    std::vector<Placement> expected = { { 5, 3 }, { 4, 3 }, { 3, 3 } };
+    EXPECT_EQ(greedy(sd, { 41, 48, 53 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_fifthOnAString_notDefective)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // C5 rooted on the A string: C3, G3. Nothing reaches fret 5.
+    std::vector<Placement> expected = { { 4, 3 }, { 2, 0 } };
+    EXPECT_EQ(greedy(sd, { 48, 55 }), expected);
+}
+
+// ---------------------------------------------------------------------------
+// Standard tuning must be unaffected.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, standard_openG)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    // G2 B2 D3 G3 B3 G4 -> 3-2-0-0-0-3
+    std::vector<Placement> expected = { { 5, 3 }, { 4, 2 }, { 3, 0 }, { 2, 0 }, { 1, 0 }, { 0, 3 } };
+    EXPECT_EQ(greedy(sd, { 43, 47, 50, 55, 59, 67 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, standard_openC)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    // C3 E3 G3 C4 E4 -> x-3-2-0-1-0
+    std::vector<Placement> expected = { { 4, 3 }, { 3, 2 }, { 2, 0 }, { 1, 1 }, { 0, 0 } };
+    EXPECT_EQ(greedy(sd, { 48, 52, 55, 60, 64 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, standard_openD_withHighMelody)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    // D3 A3 D4 A4 -> x-x-0-2-3-5. The high fret sits on the HIGHEST string,
+    // which is why a directional predicate must not fire here.
+    std::vector<Placement> expected = { { 3, 0 }, { 2, 2 }, { 1, 3 }, { 0, 5 } };
+    EXPECT_EQ(greedy(sd, { 50, 57, 62, 69 }), expected);
+}
+
+// ---------------------------------------------------------------------------
+// Alternate tunings, where the ringing open strings are the point of the tuning.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, dadgad_droneChord)
+{
+    StringData sd = makeTuning(TUNING_DADGAD);
+    // G2 D3 G3 A3 D4 -> one fretted note, four open drones.
+    std::vector<Placement> expected = { { 5, 5 }, { 3, 0 }, { 2, 0 }, { 1, 0 }, { 0, 0 } };
+    EXPECT_EQ(greedy(sd, { 43, 50, 55, 57, 62 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, openG_droneChord)
+{
+    StringData sd = makeTuning(TUNING_OPEN_G);
+    // C3 G3 B3 D4 -> x-5-x-0-0-0
+    std::vector<Placement> expected = { { 4, 5 }, { 2, 0 }, { 1, 0 }, { 0, 0 } };
+    EXPECT_EQ(greedy(sd, { 48, 55, 59, 62 }), expected);
+}
+
+// ---------------------------------------------------------------------------
+// Interval structure of the tunings used above, for reference.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, gapStructure_distinguishesDropFromDrone)
+{
+    EXPECT_EQ(visualGaps(TUNING_STANDARD), (std::vector<int> { 5, 4, 5, 5, 5 }));
+    EXPECT_EQ(visualGaps(TUNING_DROP_D), (std::vector<int> { 5, 4, 5, 5, 7 }));
+    EXPECT_EQ(visualGaps(TUNING_DADGAD), (std::vector<int> { 5, 2, 5, 5, 7 }));
+    EXPECT_EQ(visualGaps(TUNING_OPEN_G), (std::vector<int> { 3, 4, 5, 7, 5 }));
+}
+
+// ---------------------------------------------------------------------------
+// isDropLikeTuning(): at least 4 strings, every gap except the lowest a fourth
+// or a major third, and the lowest string dropped below that.
+// ---------------------------------------------------------------------------
+
+namespace {
+std::vector<int> TUNING_7STR_DROP_A = { 33, 40, 45, 50, 55, 59, 64 };  // A1 E2 A2 D3 G3 B3 E4
+std::vector<int> TUNING_7STR_DROP_D = { 33, 38, 45, 50, 55, 59, 64 };  // A1 D2 A2 D3 G3 B3 E4
+std::vector<int> TUNING_8STR_DROP_E = { 28, 35, 40, 45, 50, 55, 59, 64 };
+std::vector<int> TUNING_BASS        = { 28, 33, 38, 43 };              // E1 A1 D2 G2
+std::vector<int> TUNING_BASS_DROP_D = { 26, 33, 38, 43 };              // D1 A1 D2 G2
+std::vector<int> TUNING_DULCIMER    = { 50, 57, 62 };                  // D3 A3 D4
+std::vector<int> TUNING_BANJO5      = { 67, 50, 55, 59, 62 };          // re-entrant
+}
+
+TEST_F(Engraving_TabFrettingTests, dropLike_acceptsDropTunings)
+{
+    EXPECT_TRUE(makeTuning(TUNING_DROP_D).isDropLikeTuning());
+    EXPECT_TRUE(makeTuning(TUNING_7STR_DROP_A).isDropLikeTuning());
+    EXPECT_TRUE(makeTuning(TUNING_8STR_DROP_E).isDropLikeTuning());
+    EXPECT_TRUE(makeTuning(TUNING_BASS_DROP_D).isDropLikeTuning());
+}
+
+TEST_F(Engraving_TabFrettingTests, dropLike_rejectsStandardTunings)
+{
+    EXPECT_FALSE(makeTuning(TUNING_STANDARD).isDropLikeTuning());
+    EXPECT_FALSE(makeTuning(TUNING_BASS).isDropLikeTuning());
+}
+
+TEST_F(Engraving_TabFrettingTests, dropLike_rejectsDroneTunings)
+{
+    EXPECT_FALSE(makeTuning(TUNING_DADGAD).isDropLikeTuning());
+    EXPECT_FALSE(makeTuning(TUNING_OPEN_G).isDropLikeTuning());
+}
+
+TEST_F(Engraving_TabFrettingTests, dropLike_rejectsThreeStringDroneInstruments)
+{
+    // Mountain dulcimer D3 A3 D4: gaps [7,5] would otherwise qualify.
+    EXPECT_FALSE(makeTuning(TUNING_DULCIMER).isDropLikeTuning());
+}
+
+TEST_F(Engraving_TabFrettingTests, dropLike_rejectsDropAboveLowestString)
+{
+    // The shipped 7 string "Drop D" adds a low A below the dropped D, so the wide
+    // gap is second from the bottom rather than at the bottom. Known exclusion:
+    // the same pattern is used by open tunings such as Open G6.
+    EXPECT_FALSE(makeTuning(TUNING_7STR_DROP_D).isDropLikeTuning());
+}
+
+// ---------------------------------------------------------------------------
+// isMonotonicTuning(): guards the re-entrant tunings of #31909.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, monotonic_acceptsOrdinaryTunings)
+{
+    EXPECT_TRUE(makeTuning(TUNING_STANDARD).isMonotonicTuning());
+    EXPECT_TRUE(makeTuning(TUNING_DROP_D).isMonotonicTuning());
+}
+
+TEST_F(Engraving_TabFrettingTests, monotonic_rejectsReentrantTuning)
+{
+    // 5-string banjo: the 5th string is higher-pitched than the 4th.
+    EXPECT_FALSE(makeTuning(TUNING_BANJO5).isMonotonicTuning());
+}
+
+// ---------------------------------------------------------------------------
+// findCompactFingering(). This does not check the tuning itself; that is done by
+// the caller in fretChords(). These tests all use drop D.
+// ---------------------------------------------------------------------------
+
+namespace {
+// Convenience: run the search and return the placements, or an empty vector if
+// the function declined to offer a re-fingering.
+std::vector<Placement> compact(const StringData& sd, const std::vector<int>& pitches)
+{
+    std::vector<Placement> out;
+    if (!sd.findCompactFingering(pitches, &out)) {
+        return {};
+    }
+    return out;
+}
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_dropD_powerChord_becomesBarre)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    std::vector<Placement> expected = { { 5, 5 }, { 4, 5 }, { 3, 5 } };
+    EXPECT_EQ(compact(sd, { 43, 50, 55 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_dropD_fret6_becomesBarre)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    std::vector<Placement> expected = { { 5, 6 }, { 4, 6 }, { 3, 6 } };
+    EXPECT_EQ(compact(sd, { 44, 51, 56 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_dropD_fourNoteGrip)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // 5-5-5-7: a barre plus one finger.
+    std::vector<Placement> expected = { { 5, 5 }, { 4, 5 }, { 3, 5 }, { 2, 7 } };
+    EXPECT_EQ(compact(sd, { 43, 50, 55, 62 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_dropD_rootAndOctave_skipsAString)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G3 on the A string would be the 10th fret, out of reach, so it lands on D.
+    std::vector<Placement> expected = { { 5, 5 }, { 3, 5 } };
+    EXPECT_EQ(compact(sd, { 43, 55 }), expected);
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_declinesWhenResultIsNotCompact)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G2 + E4 can only be fretted 5 and 9, too far apart to be worth imposing.
+    EXPECT_EQ(compact(sd, { 43, 64 }), std::vector<Placement> {});
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_declinesSingleNote)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // Nothing to re-fret.
+    EXPECT_EQ(compact(sd, { 43 }), std::vector<Placement> {});
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_declinesPitchBelowLowestString)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // C2 is below the dropped D, so no string can reach it.
+    EXPECT_EQ(compact(sd, { 36, 50 }), std::vector<Placement> {});
+}
+
+// ---------------------------------------------------------------------------
+// needsCompactFingering(). True when a note sits further than a hand span below
+// the highest fretted note and on a higher string, so it could have been fretted
+// up in position instead.
+// ---------------------------------------------------------------------------
+
+TEST_F(Engraving_TabFrettingTests, trigger_firesOnDropDPowerChord)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    EXPECT_TRUE(sd.needsCompactFingering({ { 5, 5 }, { 3, 0 }, { 2, 0 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_firesAtFret6WithNoOpenStrings)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // Same defect at the 6th fret, where no open string is involved at all.
+    EXPECT_TRUE(sd.needsCompactFingering({ { 5, 6 }, { 3, 1 }, { 2, 1 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_firesOnFourNoteGrip)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    EXPECT_TRUE(sd.needsCompactFingering({ { 5, 5 }, { 3, 0 }, { 2, 0 }, { 1, 3 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_silentBelowFret5)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // F5 at fret 3, and the C5 shape rooted on the A string.
+    EXPECT_FALSE(sd.needsCompactFingering({ { 5, 3 }, { 4, 3 }, { 3, 3 } }));
+    EXPECT_FALSE(sd.needsCompactFingering({ { 4, 3 }, { 2, 0 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_silentWhenHighFretIsOnHighestString)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    // Open D chord with an A4 melody. The fretted note is on the highest string,
+    // so no open note could have been fretted up in its position.
+    EXPECT_FALSE(sd.needsCompactFingering({ { 3, 0 }, { 2, 2 }, { 1, 3 }, { 0, 5 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_silentOnStandardOpenChords)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    EXPECT_FALSE(sd.needsCompactFingering({ { 5, 3 }, { 4, 2 }, { 3, 0 }, { 2, 0 }, { 1, 0 }, { 0, 3 } }));
+    EXPECT_FALSE(sd.needsCompactFingering({ { 4, 3 }, { 3, 2 }, { 2, 0 }, { 1, 1 }, { 0, 0 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, trigger_silentOnStandardDMinor)
+{
+    StringData sd = makeTuning(TUNING_STANDARD);
+    // x-5-3-2-3-x. The 5th fret here comes from conflict resolution, but the lowest
+    // fret is 2, which is still within reach of it.
+    EXPECT_FALSE(sd.needsCompactFingering({ { 4, 5 }, { 3, 3 }, { 2, 2 }, { 1, 3 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_honoursPitchOffset)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // Guitar is a transposing instrument, so the caller passes the staff pitch offset
+    // through. +2 moves the barre up two frets, as fret() already does.
+    std::vector<Placement> out;
+    ASSERT_TRUE(sd.findCompactFingering({ 43, 50, 55 }, &out, 2));
+    std::vector<Placement> expected = { { 5, 7 }, { 4, 7 }, { 3, 7 } };
+    EXPECT_EQ(out, expected);
+}
+
+// ---------------------------------------------------------------------------
+// The re-fretting as it runs inside fretChords(), on a real score.
+// ---------------------------------------------------------------------------
+
+namespace {
+const String FRETTING_DATA_DIR(u"tab_fretting_data/");
+
+// Every note's (visual string, fret), sorted by string so comparisons are stable.
+std::vector<Placement> tabOf(MasterScore* score)
+{
+    std::vector<Placement> result;
+    Measure* m = score->firstMeasure();
+    if (!m) {
+        return result;
+    }
+    for (Segment& seg : m->segments()) {
+        if (!seg.isChordRestType()) {
+            continue;
+        }
+        for (track_idx_t trk = 0; trk < VOICES; ++trk) {
+            EngravingItem* el = seg.element(trk);
+            if (!el || !el->isChord()) {
+                continue;
+            }
+            for (Note* note : toChord(el)->notes()) {
+                result.push_back({ note->string(), note->fret() });
+            }
+        }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+}
+}
+
+TEST_F(Engraving_TabFrettingTests, integration_dropDPowerChordBecomesBarre)
+{
+    MasterScore* score = ScoreRW::readScore(FRETTING_DATA_DIR + u"dropd_power_chord.mscx");
+    ASSERT_TRUE(score);
+    score->doLayout();
+
+    // G2 D3 G3 in drop D, entered with no fretting. Without the re-fretting this
+    // comes out as the 5th fret of the low string plus two open strings.
+    std::vector<Placement> expected = { { 3, 5 }, { 4, 5 }, { 5, 5 } };
+    EXPECT_EQ(tabOf(score), expected);
+
+    delete score;
+}
+
+TEST_F(Engraving_TabFrettingTests, integration_dadgadDroneIsUntouched)
+{
+    MasterScore* score = ScoreRW::readScore(FRETTING_DATA_DIR + u"dadgad_drone.mscx");
+    ASSERT_TRUE(score);
+    score->doLayout();
+
+    // DADGAD is not a drop tuning, so the open strings are left alone.
+    std::vector<Placement> expected = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 }, { 5, 5 } };
+    EXPECT_EQ(tabOf(score), expected);
+
+    delete score;
+}
+
+TEST_F(Engraving_TabFrettingTests, dropD_fullChordAgainstOpenTopStrings)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // G2 D3 G3 B3 E4 in drop D: a fretted bass against the four standard-tuned
+    // strings ringing open. Re-fretted as an A shape barre at the 5th fret.
+    std::vector<Placement> today = greedy(sd, { 43, 50, 55, 59, 64 });
+    EXPECT_EQ(today, (std::vector<Placement> { { 5, 5 }, { 3, 0 }, { 2, 0 }, { 1, 0 }, { 0, 0 } }));
+
+    std::vector<Placement> sorted = today;
+    std::sort(sorted.begin(), sorted.end());
+    EXPECT_TRUE(sd.needsCompactFingering(today));
+
+    std::vector<Placement> out;
+    const bool adopted = sd.findCompactFingering({ 43, 50, 55, 59, 64 }, &out);
+    EXPECT_TRUE(adopted);
+    EXPECT_EQ(out, (std::vector<Placement> { { 5, 5 }, { 4, 5 }, { 3, 5 }, { 2, 4 }, { 1, 5 } }));
+}
+
+TEST_F(Engraving_TabFrettingTests, compact_aloneIsNotEnoughToDecide)
+{
+    StringData sd = makeTuning(TUNING_DROP_D);
+    // C5 rooted on the A string frets perfectly well as a barre at the 10th, so the
+    // compact search on its own would move it right up the neck. Note by note it is
+    // A string 3rd fret plus the open G, which is what should be kept. This is why
+    // fretChordAsUnit() compares against the note by note fretting before replacing
+    // anything, rather than just taking a compact shape whenever one exists.
+    std::vector<Placement> out;
+    ASSERT_TRUE(sd.findCompactFingering({ 48, 55 }, &out));
+    EXPECT_EQ(out, (std::vector<Placement> { { 5, 10 }, { 4, 10 } }));
+
+    // and the trigger is what stops it: note by note is already within reach
+    EXPECT_FALSE(sd.needsCompactFingering(greedy(sd, { 48, 55 })));
+}


### PR DESCRIPTION
Resolves: #34690

In a drop tuning, a power chord written from the 5th fret up gets fretted across open strings instead of the barre shape that's actually played. The pitches are right, so nothing flags it, but the result can't be palm muted and there's no shape to move if the passage is transposed.

```
      expected                    actual
e|------|                    e|------|
B|------|                    B|------|
G|------|                    G|--0---|   G3  (open G)
D|--5---|  G3                D|--0---|   D3  (open D)
A|--5---|  D3                A|------|
D|--5---|  G2                D|--5---|   G2
```

It isn't only about open strings. At the 6th fret the same chord comes out `6`, `1`, `1`, just as spread but with nothing open. A chromatic riff G, G#, A comes out wrong, wrong, right.

### Cause

Fretting is decided one note at a time. `StringData::convertPitch()` takes a single pitch and returns the thinnest string that can reach it, which is always the lowest fret. Below the 5th fret that happens to be correct because no other string can reach those notes. From the 5th fret up the open D and G become available and get taken instead. `fretChords()` doesn't correct it because there's no string conflict to resolve.

The TODO in `fretChords()` describes the same gap, and `minFret`/`maxFret` are calculated just above it and never read.

### Approach

`fretChords()` now picks between two strategies rather than always fretting note by note:

```cpp
if (... && fretChordAsUnit(chord, sortedNotes, bUsed)) {
    return;
}

// scan chord notes from highest, matching with strings from the highest
```

Drop tuning chords are fretted as a unit, everything else stays on the existing path, which I haven't touched. Conflict resolution never sees a chord fretted as a unit since that always uses distinct strings.

I originally wrote this as a pass that ran afterwards and corrected the result. Someone pointed out that's how you end up with two places to look for voicing behaviour and no way to tell which one to change, which I think was right. This version has one decision point and notes get written once instead of written and then rewritten.

### What is and isn't affected

`fretChordAsUnit()` works out what note by note fretting would give and only replaces it when that comes out spread. That comparison can't be dropped: if you just use a compact shape whenever one exists, drop D `C3 G3` gets moved to a 10th fret barre when the right answer is the A string 3rd fret plus the open G. There's a test for that case specifically (`compact_aloneIsNotEnoughToDecide`).

It only applies to tunings where the lowest string is dropped below an otherwise regular stack of fourths. Alternate tunings like DADGAD and open G are excluded, since there the ringing open strings are the whole point. A DADGAD drone chord does have a perfectly good barre available and taking it would be wrong. I went through all 76 `<StringData>` blocks in `instruments.xml` and the 67 presets in `string_tunings_presets.json` to check the classification. The 4 string minimum is there because three string drone instruments match on intervals alone, including the mountain dulcimers, which do have tablature staff types.

Re-entrant tunings and chords under a capo are skipped. Chords that already carry a fretting are never touched, so the linked staff behaviour described in #32304 is unaffected.

Known limitation: the shipped 7 string "Drop D" preset (`A1 D2 A2 D3 G3 B3 E4`) has the same problem and isn't fixed, because its wide gap is second from the bottom rather than at the bottom. Relaxing the rule to "one wide gap anywhere" picks it up, but also picks up Open G6 (`D2 G2 D3 G3 B3 E4`), which has an identical gap pattern and shouldn't be touched. I couldn't find a rule that separates them, so I've left 7 string drops out for now. Suggestions welcome.

Behind `fretDropTuningChordsAsUnit`, settings backed, on by default.

### Testing

`src/engraving/tests/tab_fretting_tests.cpp`, 24 tests. The note by note fretting of every case is asserted first against unmodified `main`, so the baseline is pinned before anything changes: drop D at frets 3, 5 and 6, the four note grip, standard tuning open G, open C and open D with a high melody, and the DADGAD and open G drones. Two more fret a real score end to end.

Full `engraving` suite passes, 826 tests.

`Engraving_CopyPasteTests.copypasteparts` fails intermittently for me, about one run in three. It does the same with these tests excluded from the run, and its fixture is a single flute part on a pitched staff so `fretChords()` is never reached. Looks pre-existing and unrelated, but flagging it in case it shows up in CI.

### Prior attempts

#22254 came at string assignment from the other direction, letting fingering text drive it, and was closed unmerged after running into capo semantics. This takes no user input and skips capo'd chords, so it doesn't hit the same problem. #22228 is still open as the request for user directed assignment and isn't addressed here.

---

- [x] I signed the [CLA](https://musescore.org/en/cla) as [sambeson](https://musescore.org/en/user):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
