### PR TITLE
added missed MaskLayout for horisontal mode

### DIFF
--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -53,6 +53,7 @@
 #include "arpeggiolayout.h"
 #include "measurelayout.h"
 #include "horizontalspacing.h"
+#include "masklayout.h"
 #include "tremololayout.h"
 #include "slurtielayout.h"
 #include "systemheaderlayout.h"
@@ -262,6 +263,7 @@ void ScoreHorizontalViewLayout::layoutLinear(LayoutContext& ctx)
     system->setPos(lm, tm);
     ctx.mutState().page()->setWidth(lm + system->width() + rm);
     ctx.mutState().page()->setHeight(tm + system->height() + bm);
+    MaskLayout::computeMasks(ctx, ctx.mutState().page());
     ctx.mutState().page()->invalidateBspTree();
 }
 


### PR DESCRIPTION
As we have in PageLayout https://github.com/musescore/MuseScore/blob/0e99966a1c81036c41a6cb42f60211682d7050a2/src/engraving/rendering/score/pagelayout.cpp#L444