### PR TITLE
Engraving: simplify dummy parent and eliminate `m_isParentExplicitlySet`

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -745,7 +745,7 @@ bool NotationBraille::addSlur()
 
             score()->startCmd(TranslatableString("undoableAction", "Add slur"));
 
-            Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
+            Slur* slur = Factory::createSlur(firstChordRest->score()->dummy());
             slur->setScore(firstChordRest->score());
             slur->setTick(firstChordRest->tick());
             slur->setTick2(secondChordRest->tick());
@@ -790,7 +790,7 @@ bool NotationBraille::addLongSlur()
 
             score()->startCmd(TranslatableString("undoableAction", "Add long slur"));
 
-            Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
+            Slur* slur = Factory::createSlur(firstChordRest->score()->dummy());
             slur->setScore(firstChordRest->score());
             slur->setTick(firstChordRest->tick());
             slur->setTick2(secondChordRest->tick());

--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -718,14 +718,16 @@ bool NotationBraille::addTie()
     }
 
     score()->startCmd(TranslatableString("undoableAction", "Add tie"));
-    Note* note = toNote(currentEngravingItem());
 
-    Tie* tie = Factory::createTie(score()->dummy());
-    tie->setStartNote(brailleInput()->tieStartNote());
-    tie->setEndNote(note);
-    tie->setTrack(brailleInput()->tieStartNote()->track());
-    tie->setTick(brailleInput()->tieStartNote()->chord()->segment()->tick());
-    tie->setTicks(note->chord()->segment()->tick() - brailleInput()->tieStartNote()->chord()->segment()->tick());
+    Note* startNote = brailleInput()->tieStartNote();
+    Note* endNote = toNote(currentEngravingItem());
+
+    Tie* tie = Factory::createTie(startNote);
+    tie->setStartNote(startNote);
+    tie->setEndNote(endNote);
+    tie->setTrack(startNote->track());
+    tie->setTick(startNote->chord()->segment()->tick());
+    tie->setTicks(endNote->chord()->segment()->tick() - startNote->chord()->segment()->tick());
     score()->undoAddElement(tie);
     score()->endCmd();
     return true;

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -328,8 +328,6 @@ target_sources(engraving PRIVATE
     compat/pageformat.h
     compat/writescorehook.cpp
     compat/writescorehook.h
-    compat/dummyelement.cpp
-    compat/dummyelement.h
     compat/engravingcompat.cpp
     compat/engravingcompat.h
 

--- a/src/engraving/api/tests/score_tests.cpp
+++ b/src/engraving/api/tests/score_tests.cpp
@@ -1537,7 +1537,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyAtDomLevel)
 {
     // [GIVEN] A score and a FretDiagram with no harmony
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* fd = Factory::createFretDiagram(score->dummy()->segment());
+    FretDiagram* fd = Factory::createFretDiagram(score->dummy());
 
     EXPECT_EQ(fd->harmony(), nullptr);
     EXPECT_EQ(fd->harmonyPlainText(), String());
@@ -1564,7 +1564,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramHarmonyApi)
 {
     // [GIVEN] A score with a FretDiagram carrying a chord symbol
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
     domFd->setHarmony(u"Fdim7");
 
     // Construct the wrapper through the public dispatcher so that
@@ -1615,7 +1615,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetDotApi)
     // FretDiagram::dot(s) returns a placeholder Dot(fret=0) when no dot is set,
     // so we check fret values rather than vector emptiness.
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
 
     apiv1::FretDiagram* apiFd
         = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
@@ -1658,7 +1658,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetMarkerApi)
 {
     // [GIVEN] A score and an empty FretDiagram, wrapped via the API
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
 
     apiv1::FretDiagram* apiFd
         = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
@@ -1696,7 +1696,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramSetBarreApi)
 {
     // [GIVEN] A score and an empty FretDiagram, wrapped via the API
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
 
     apiv1::FretDiagram* apiFd
         = qobject_cast<apiv1::FretDiagram*>(apiv1::wrap(domFd, apiv1::Ownership::SCORE));
@@ -1737,7 +1737,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramClearApi)
 {
     // [GIVEN] A score and a FretDiagram populated with a dot and a marker
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
     domFd->setDot(0, 3);
     domFd->setMarker(1, FretMarkerType::CROSS);
 
@@ -1780,7 +1780,7 @@ TEST_F(Engraving_ApiScoreTests, fretDiagramGettersApi)
 {
     // [GIVEN] A FretDiagram populated with known content
     MasterScore* domScore = compat::ScoreAccess::createMasterScore(nullptr);
-    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy()->segment());
+    FretDiagram* domFd = Factory::createFretDiagram(domScore->dummy());
 
     // Set a dot on string 0 fret 3, a marker on string 1, and a barre at fret 2
     domFd->setDot(0, 3);

--- a/src/engraving/api/v1/cursor.cpp
+++ b/src/engraving/api/v1/cursor.cpp
@@ -563,7 +563,6 @@ void Cursor::addTuplet(Fraction* ratio, Fraction* duration)
     m_score->changeCRlen(cr, fDuration);
 
     mu::engraving::Tuplet* tuplet = new mu::engraving::Tuplet(tupletMeasure);
-    tuplet->setOwnershipParent(tupletMeasure);
     tuplet->setTrack(track());
     tuplet->setTick(tupletTick);
     tuplet->setRatio(fRatio);

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -80,7 +80,6 @@ void Score::addText(const QString& type, const QString& txt)
     }
 
     mu::engraving::Text* text = mu::engraving::Factory::createText(mb, tid);
-    text->setOwnershipParent(mb);
     text->setXmlText(txt);
     score()->undoAddElement(text);
 }

--- a/src/engraving/compat/dummyelement.cpp
+++ b/src/engraving/compat/dummyelement.cpp
@@ -24,6 +24,7 @@
 #include "dom/barline.h"
 #include "dom/factory.h"
 #include "dom/score.h"
+#include "dom/rootitem.h"
 #include "dom/page.h"
 #include "dom/system.h"
 #include "dom/measure.h"

--- a/src/engraving/dom/accidental.cpp
+++ b/src/engraving/dom/accidental.cpp
@@ -243,7 +243,7 @@ AccidentalVal sym2accidentalVal(SymId id)
 //   Accidental
 //---------------------------------------------------------
 
-Accidental::Accidental(EngravingItem* parent)
+Accidental::Accidental(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::ACCIDENTAL, parent, ElementFlag::MOVABLE)
 {
 }

--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -315,7 +315,7 @@ private:
 
     friend class Factory;
 
-    Accidental(EngravingItem* parent);
+    Accidental(DummyParentOr<EngravingItem> parent);
 
     AccidentalType m_accidentalType = AccidentalType::NONE;
     AccidentalBracket m_bracket = AccidentalBracket::NONE;

--- a/src/engraving/dom/actionicon.cpp
+++ b/src/engraving/dom/actionicon.cpp
@@ -31,7 +31,7 @@ using namespace mu;
 using namespace muse::draw;
 using namespace mu::engraving;
 
-ActionIcon::ActionIcon(EngravingItem* parent)
+ActionIcon::ActionIcon(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::ACTION_ICON, parent)
 {
     m_iconFont = Font(configuration()->iconsFontFamily(), Font::Type::Icon);

--- a/src/engraving/dom/actionicon.h
+++ b/src/engraving/dom/actionicon.h
@@ -82,7 +82,7 @@ class ActionIcon final : public EngravingItem
     DECLARE_CLASSOF(ElementType::ACTION_ICON)
 
 public:
-    ActionIcon(EngravingItem* score);
+    ActionIcon(DummyParentOr<EngravingItem> score);
     ~ActionIcon() override = default;
 
     ActionIcon* clone() const override;

--- a/src/engraving/dom/ambitus.cpp
+++ b/src/engraving/dom/ambitus.cpp
@@ -44,7 +44,7 @@ using namespace mu::engraving;
 //   Ambitus
 //---------------------------------------------------------
 
-Ambitus::Ambitus(Segment* parent)
+Ambitus::Ambitus(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::AMBITUS, parent, ElementFlag::ON_STAFF)
 {
     m_noteHeadGroup    = NOTEHEADGROUP_DEFAULT;

--- a/src/engraving/dom/ambitus.cpp
+++ b/src/engraving/dom/ambitus.cpp
@@ -59,8 +59,6 @@ Ambitus::Ambitus(DummyParentOr<Segment> parent)
 
     m_topAccidental = Factory::createAccidental(this, false);
     m_bottomAccidental = Factory::createAccidental(this, false);
-    m_topAccidental->setOwnershipParent(this);
-    m_bottomAccidental->setOwnershipParent(this);
 }
 
 Ambitus::Ambitus(const Ambitus& a)

--- a/src/engraving/dom/ambitus.h
+++ b/src/engraving/dom/ambitus.h
@@ -116,7 +116,7 @@ public:
 private:
 
     friend class Factory;
-    Ambitus(Segment* parent);
+    Ambitus(DummyParentOr<Segment> parent);
     Ambitus(const Ambitus& a);
 
     void normalize();

--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -571,7 +571,7 @@ void MoveElementAnchors::rebaseOffsetOnMoveSegment(EngravingItem* element, const
  * TimeTickAnchor
  * *****************************************/
 
-TimeTickAnchor::TimeTickAnchor(Segment* parent)
+TimeTickAnchor::TimeTickAnchor(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::TIME_TICK_ANCHOR, parent,
                     ElementFlag::ON_STAFF
                     | ElementFlag::NOT_SELECTABLE

--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -137,7 +137,6 @@ TimeTickAnchor* EditTimeTickAnchors::createTimeTickAnchor(Measure* measure, Frac
         TimeTickAnchor* anchor = element ? toTimeTickAnchor(element) : nullptr;
         if (!anchor) {
             anchor = Factory::createTimeTickAnchor(segment);
-            anchor->setOwnershipParent(segment);
             anchor->setTrack(track);
             segment->add(anchor);
         }

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -65,7 +65,7 @@ private:
 
 class TimeTickAnchor : public EngravingItem
 {
-    TimeTickAnchor(Segment* parent);
+    TimeTickAnchor(DummyParentOr<Segment> parent);
     friend class Factory;
 
 public:

--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -41,7 +41,7 @@
 using namespace mu;
 using namespace mu::engraving;
 
-Arpeggio::Arpeggio(Chord* parent, ElementType type)
+Arpeggio::Arpeggio(DummyParentOr<Chord> parent, ElementType type)
     : EngravingItem(type, parent, ElementFlag::MOVABLE)
 {
     m_arpeggioType = ArpeggioType::NORMAL;
@@ -51,8 +51,9 @@ Arpeggio::Arpeggio(Chord* parent, ElementType type)
     m_playArpeggio = true;
     m_stretch = 1.0;
 
-    if (type == ElementType::ARPEGGIO) {
-        parent->setSpanArpeggio(this);
+    EngravingObject* p = parent;
+    if (type == ElementType::ARPEGGIO && p->isChord()) {
+        toChord(p)->setSpanArpeggio(this);
     }
 }
 

--- a/src/engraving/dom/arpeggio.h
+++ b/src/engraving/dom/arpeggio.h
@@ -117,7 +117,7 @@ public:
 protected:
     friend class Factory;
 
-    Arpeggio(Chord* parent, ElementType type = ElementType::ARPEGGIO);
+    Arpeggio(DummyParentOr<Chord> parent, ElementType type = ElementType::ARPEGGIO);
 
 private:
     void spatiumChanged(double /*oldValue*/, double /*newValue*/) override;

--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -56,7 +56,7 @@ static const ElementStyle articulationStyle {
 //   Articulation
 //---------------------------------------------------------
 
-Articulation::Articulation(ChordRest* parent, ElementType type)
+Articulation::Articulation(DummyParentOr<ChordRest> parent, ElementType type)
     : EngravingItem(type, parent, ElementFlag::MOVABLE)
 {
     m_symId         = SymId::noSym;

--- a/src/engraving/dom/articulation.h
+++ b/src/engraving/dom/articulation.h
@@ -208,7 +208,7 @@ public:
 
 protected:
     friend class mu::engraving::Factory;
-    Articulation(ChordRest* parent, ElementType type = ElementType::ARTICULATION);
+    Articulation(DummyParentOr<ChordRest> parent, ElementType type = ElementType::ARTICULATION);
 
 private:
 

--- a/src/engraving/dom/bagpembell.h
+++ b/src/engraving/dom/bagpembell.h
@@ -62,7 +62,7 @@ class BagpipeEmbellishment final : public EngravingItem
     DECLARE_CLASSOF(ElementType::BAGPIPE_EMBELLISHMENT)
 
 public:
-    BagpipeEmbellishment(EngravingItem* parent)
+    BagpipeEmbellishment(DummyParentOr<EngravingItem> parent)
         : EngravingItem(ElementType::BAGPIPE_EMBELLISHMENT, parent), m_embelType(EmbellishmentType(0)) { }
 
     BagpipeEmbellishment* clone() const override { return new BagpipeEmbellishment(*this); }

--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -84,7 +84,7 @@ String BarLine::translatedUserTypeName(BarLineType t)
 //   BarLine
 //---------------------------------------------------------
 
-BarLine::BarLine(Segment* parent)
+BarLine::BarLine(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::BAR_LINE, parent)
 {
     setHeight(4 * spatium());   // for use in palettes
@@ -109,7 +109,7 @@ BarLine::~BarLine()
     muse::DeleteAll(m_el);
 }
 
-void BarLine::setOwnershipParent(Segment* parent)
+void BarLine::setOwnershipParent(DummyParentOr<Segment> parent)
 {
     EngravingItem::setOwnershipParent(parent);
 }

--- a/src/engraving/dom/barline.h
+++ b/src/engraving/dom/barline.h
@@ -86,7 +86,7 @@ public:
 
     BarLine& operator=(const BarLine&) = delete;
 
-    void setOwnershipParent(Segment* parent);
+    void setOwnershipParent(DummyParentOr<Segment> parent);
 
     BarLine* clone() const override { return new BarLine(*this); }
     PointF canvasPos() const override;      ///< position in canvas coordinates
@@ -172,7 +172,7 @@ public:
 private:
 
     friend class Factory;
-    BarLine(Segment* parent);
+    BarLine(DummyParentOr<Segment> parent);
     BarLine(const BarLine&);
 
     bool m_spanStaff = false;         // span barline to next staff if true

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -34,6 +34,7 @@
 #include "chord.h"
 #include "groups.h"
 #include "measure.h"
+#include "rootitem.h"
 #include "score.h"
 #include "segment.h"
 #include "staff.h"
@@ -81,9 +82,7 @@ EngravingItem* Beam::accessibleParentItem() const
 {
     // The system a beam is drawn on does not own it and cannot list it, so in the
     // accessibility tree the beam stays where it is parked: on the dummy.
-    EngravingObject* parent = this->parent();
-
-    return parent && parent->isEngravingItem() ? toEngravingItem(parent) : nullptr;
+    return score()->dummy()->rootItem();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/beambase.cpp
+++ b/src/engraving/dom/beambase.cpp
@@ -23,7 +23,7 @@
 
 using namespace mu::engraving;
 
-BeamBase::BeamBase(const ElementType& type, EngravingItem* parent, ElementFlags flags)
+BeamBase::BeamBase(const ElementType& type, EngravingObject* parent, ElementFlags flags)
     : EngravingItem(type, parent, flags)
 {
 }

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -187,7 +187,7 @@ public:
     DECLARE_LAYOUTDATA_METHODS(BeamBase)
 
 protected:
-    BeamBase(const ElementType& type, EngravingItem* parent, ElementFlags flags = ElementFlag::ON_STAFF);
+    BeamBase(const ElementType& type, EngravingObject* parent, ElementFlags flags = ElementFlag::ON_STAFF);
     BeamBase(const BeamBase&);
     std::vector<BeamSegment*> m_beamSegments;
     PointF m_startAnchor;

--- a/src/engraving/dom/bend.cpp
+++ b/src/engraving/dom/bend.cpp
@@ -77,7 +77,7 @@ static const PitchValues PREBEND_RELEASE_CURVE = { PitchValue(0, 100),
 //   Bend
 //---------------------------------------------------------
 
-Bend::Bend(Note* parent)
+Bend::Bend(DummyParentOr<Note> parent)
     : EngravingItem(ElementType::BEND, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&bendStyle);

--- a/src/engraving/dom/bend.h
+++ b/src/engraving/dom/bend.h
@@ -96,7 +96,7 @@ public:
 private:
     friend class Factory;
 
-    Bend(Note* parent);
+    Bend(DummyParentOr<Note> parent);
 
     BendType parseBendTypeFromCurve() const;
     void updatePointsByBendType(const BendType bendType);

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -393,7 +393,6 @@ EngravingItem* Box::drop(Transaction&, EditData& data)
     case ElementType::STAFF_TEXT:
     {
         Text* text = Factory::createText(this, TextStyleType::FRAME);
-        text->setOwnershipParent(this);
         text->setXmlText(toStaffText(e)->xmlText());
         score()->undoAddElement(text);
         delete e;
@@ -966,7 +965,6 @@ TBox::TBox(Score* parent)
     resetProperty(Pid::BOX_HEIGHT);
     m_text  = Factory::createText(this, TextStyleType::FRAME);
     m_text->setLayoutToParentWidth(true);
-    m_text->setOwnershipParent(this);
 }
 
 TBox::TBox(const TBox& tbox)
@@ -1039,7 +1037,6 @@ void TBox::remove(EngravingItem* el)
         LOGD("TBox::remove() - replacing _text");
         m_text = Factory::createText(this, TextStyleType::FRAME);
         m_text->setLayoutToParentWidth(true);
-        m_text->setOwnershipParent(this);
         el->removed();
     } else {
         VBox::remove(el);

--- a/src/engraving/dom/bracket.cpp
+++ b/src/engraving/dom/bracket.cpp
@@ -41,7 +41,7 @@ using namespace muse::draw;
 //   Bracket
 //---------------------------------------------------------
 
-Bracket::Bracket(EngravingItem* parent)
+Bracket::Bracket(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::BRACKET, parent)
 {
     m_ay1          = 0;

--- a/src/engraving/dom/bracket.h
+++ b/src/engraving/dom/bracket.h
@@ -123,7 +123,7 @@ public:
 private:
     friend class Factory;
 
-    Bracket(EngravingItem* parent);
+    Bracket(DummyParentOr<EngravingItem> parent);
 
     BracketItem* m_bi = nullptr;
     double m_ay1 = 0.0;

--- a/src/engraving/dom/bracketitem.cpp
+++ b/src/engraving/dom/bracketitem.cpp
@@ -31,12 +31,12 @@
 using namespace mu;
 
 namespace mu::engraving {
-BracketItem::BracketItem(EngravingItem* parent)
+BracketItem::BracketItem(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::BRACKET_ITEM, parent)
 {
 }
 
-BracketItem::BracketItem(EngravingItem* parent, BracketType bracketType, size_t span)
+BracketItem::BracketItem(DummyParentOr<EngravingItem> parent, BracketType bracketType, size_t span)
     : EngravingItem(ElementType::BRACKET_ITEM, parent), m_bracketType(bracketType), m_bracketSpan(span)
 {
 }

--- a/src/engraving/dom/bracketitem.h
+++ b/src/engraving/dom/bracketitem.h
@@ -71,8 +71,8 @@ private:
 
     friend class Factory;
 
-    BracketItem(EngravingItem* parent);
-    BracketItem(EngravingItem* parent, BracketType bracketType, size_t span);
+    BracketItem(DummyParentOr<EngravingItem> parent);
+    BracketItem(DummyParentOr<EngravingItem> parent, BracketType bracketType, size_t span);
 
     BracketType m_bracketType = BracketType::NO_BRACKET;
     size_t m_column = 0;

--- a/src/engraving/dom/breath.cpp
+++ b/src/engraving/dom/breath.cpp
@@ -53,7 +53,7 @@ const std::vector<BreathType> Breath::BREATH_LIST {
 //   Breath
 //---------------------------------------------------------
 
-Breath::Breath(Segment* parent)
+Breath::Breath(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::BREATH, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     m_symId = SymId::breathMarkComma;

--- a/src/engraving/dom/breath.h
+++ b/src/engraving/dom/breath.h
@@ -79,7 +79,7 @@ public:
 private:
 
     friend class Factory;
-    Breath(Segment* parent);
+    Breath(DummyParentOr<Segment> parent);
 
     double m_pause = 0.0;
     SymId m_symId = SymId::breathMarkComma;

--- a/src/engraving/dom/bsymbol.cpp
+++ b/src/engraving/dom/bsymbol.cpp
@@ -42,7 +42,7 @@ namespace mu::engraving {
 //   BSymbol
 //---------------------------------------------------------
 
-BSymbol::BSymbol(const ElementType& type, EngravingItem* parent, ElementFlags f)
+BSymbol::BSymbol(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : EngravingItem(type, parent, f)
 {
     m_align = { AlignH::LEFT, AlignV::BASELINE };

--- a/src/engraving/dom/bsymbol.h
+++ b/src/engraving/dom/bsymbol.h
@@ -60,7 +60,7 @@ public:
     std::vector<LineF> dragAnchorLines() const override;
 
 protected:
-    BSymbol(const ElementType& type, EngravingItem* parent, ElementFlags f = ElementFlag::NOTHING);
+    BSymbol(const ElementType& type, EngravingObject* parent, ElementFlags f = ElementFlag::NOTHING);
     BSymbol(const BSymbol&);
 
 private:

--- a/src/engraving/dom/capo.cpp
+++ b/src/engraving/dom/capo.cpp
@@ -33,7 +33,7 @@ static const ElementStyle CAPO_STYLE {
     { Sid::staffTextMinDistance, Pid::MIN_DISTANCE },
 };
 
-Capo::Capo(Segment* parent, TextStyleType textStyleType)
+Capo::Capo(DummyParentOr<Segment> parent, TextStyleType textStyleType)
     : StaffTextBase(ElementType::CAPO, parent, textStyleType, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&CAPO_STYLE);

--- a/src/engraving/dom/capo.h
+++ b/src/engraving/dom/capo.h
@@ -31,7 +31,7 @@ class Capo final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::CAPO)
 
 public:
-    Capo(Segment* parent = nullptr, TextStyleType textStyleType = TextStyleType::STAFF);
+    Capo(DummyParentOr<Segment> parent, TextStyleType textStyleType = TextStyleType::STAFF);
 
     Capo* clone() const override;
 

--- a/src/engraving/dom/check.cpp
+++ b/src/engraving/dom/check.cpp
@@ -275,7 +275,7 @@ void Measure::fillGap(const Fraction& rtickStart, const Fraction& len, track_idx
 
     Fraction curTick = tick() + actualTicks(rtickStart, nullptr, stretch);
     for (TDuration d : durationList) {
-        Rest* rest = Factory::createRest(score()->dummy()->segment());
+        Rest* rest = Factory::createRest(score()->dummy());
         rest->setTicks(d.isMeasure() ? ticks() * stretch : d.fraction());
         rest->setDurationType(d);
         rest->setTrack(track);

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1042,7 +1042,7 @@ void Chord::resizeLedgerLinesTo(size_t newSize)
     int ledgerLineCountDiff = static_cast<int>(newSize - m_ledgerLines.size());
     if (ledgerLineCountDiff > 0) {
         for (int i = 0; i < ledgerLineCountDiff; ++i) {
-            m_ledgerLines.push_back(new LedgerLine(score()->dummy()));
+            m_ledgerLines.push_back(new LedgerLine(this));
         }
     } else {
         for (int i = 0; i < std::abs(ledgerLineCountDiff); ++i) {

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1784,7 +1784,7 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
             }
             auto splitSyms = splitArticulations({ artic->symId() });
             for (const SymId& id : splitSyms) {
-                Articulation* newArticulation = Factory::createArticulation(score()->dummy()->chord());
+                Articulation* newArticulation = Factory::createArticulation(score()->dummy());
                 newArticulation->setSymId(id);
                 newArticulation->setAnchor(artic->anchor());
                 newArticulation->setPropertyFlags(Pid::ARTICULATION_ANCHOR, artic->propertyFlags(Pid::ARTICULATION_ANCHOR));
@@ -1871,7 +1871,7 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
     } else {
         // add articulations from newArtics that are not found in m_articulations
         for (const SymId& id : newArtics) {
-            Articulation* newArticulation = Factory::createArticulation(score()->dummy()->chord());
+            Articulation* newArticulation = Factory::createArticulation(score()->dummy());
             newArticulation->setSymId(id);
             if (overallAnchor != ArticulationAnchor::AUTO) {
                 newArticulation->setAnchor(overallAnchor);

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -281,7 +281,7 @@ std::vector<int> Chord::noteDistances() const
 //   Chord
 //---------------------------------------------------------
 
-Chord::Chord(Segment* parent)
+Chord::Chord(DummyParentOr<Segment> parent)
     : ChordRest(ElementType::CHORD, parent)
 {
     m_stem             = 0;
@@ -2797,8 +2797,8 @@ Note* Chord::firstGraceOrNote()
 // GRACE NOTES
 //---------------------------------
 
-GraceNotesGroup::GraceNotesGroup(Chord* c)
-    : EngravingItem(ElementType::GRACE_NOTES_GROUP, c), _parent(c) {}
+GraceNotesGroup::GraceNotesGroup(DummyParentOr<Chord> c)
+    : EngravingItem(ElementType::GRACE_NOTES_GROUP, c), _parent(c.as<Chord>()) {}
 
 void GraceNotesGroup::setPos(double x, double y)
 {

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1087,7 +1087,6 @@ bool Chord::shouldHaveHook() const
 void Chord::createStem()
 {
     Stem* stem = Factory::createStem(this);
-    stem->setOwnershipParent(this);
     stem->setGenerated(true);
     //! score()->undoAddElement calls add(), which assigns this created stem to _stem
     score()->doUndoAddElement(stem);
@@ -1109,7 +1108,6 @@ void Chord::removeStem()
 void Chord::createHook()
 {
     Hook* hook = new Hook(this);
-    hook->setOwnershipParent(this);
     hook->setGenerated(true);
     score()->doUndoAddElement(hook);
 }

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -87,7 +87,7 @@ class GraceNotesGroup final : public std::vector<Chord*>, public EngravingItem
     OBJECT_ALLOCATOR(engraving, GraceNotesGroup)
 public:
     GraceNotesGroup* clone() const override { return new GraceNotesGroup(*this); }
-    GraceNotesGroup(Chord* c);
+    GraceNotesGroup(DummyParentOr<Chord> c);
 
     Chord* parent() const { return _parent; }
 
@@ -386,7 +386,7 @@ private:
 
     friend class Factory;
 
-    Chord(Segment* parent = 0);
+    Chord(DummyParentOr<Segment> parent);
     Chord(const Chord&, bool link = false);
 
     // `includeTemporarySiblings`: whether items that are deleted & recreated during every layout should also be processed

--- a/src/engraving/dom/chordbracket.cpp
+++ b/src/engraving/dom/chordbracket.cpp
@@ -7,7 +7,7 @@ static const ElementStyle chordBracketStyle {
     { Sid::chordBracketHookLen, Pid::BRACKET_HOOK_LEN },
 };
 
-ChordBracket::ChordBracket(Chord* parent)
+ChordBracket::ChordBracket(DummyParentOr<Chord> parent)
     : Arpeggio(parent, ElementType::CHORD_BRACKET)
 {
     setArpeggioType(ArpeggioType::BRACKET);

--- a/src/engraving/dom/chordbracket.h
+++ b/src/engraving/dom/chordbracket.h
@@ -47,7 +47,7 @@ public:
 private:
     friend class Factory;
 
-    ChordBracket(Chord* parent);
+    ChordBracket(DummyParentOr<Chord> parent);
 
     Spatium m_hookLength = Spatium(1);
     DirectionV m_hookPos = DirectionV::AUTO; // AUTO == both up and down hooks

--- a/src/engraving/dom/chordline.cpp
+++ b/src/engraving/dom/chordline.cpp
@@ -43,7 +43,7 @@ namespace mu::engraving {
 //   ChordLine
 //---------------------------------------------------------
 
-ChordLine::ChordLine(Chord* parent)
+ChordLine::ChordLine(DummyParentOr<Chord> parent)
     : EngravingItem(ElementType::CHORDLINE, parent, ElementFlag::MOVABLE)
 {
 }

--- a/src/engraving/dom/chordline.h
+++ b/src/engraving/dom/chordline.h
@@ -103,7 +103,7 @@ private:
 
     friend class Factory;
 
-    ChordLine(Chord* parent);
+    ChordLine(DummyParentOr<Chord> parent);
     ChordLine(const ChordLine&);
 
     bool m_straight = false;

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -314,7 +314,7 @@ EngravingItem* ChordRest::drop(Transaction& tx, EditData& data)
 
         Segment* seg = segment();
         score()->undoRemoveElement(this);
-        Chord* chord = Factory::createChord(score()->dummy()->segment());
+        Chord* chord = Factory::createChord(score()->dummy());
         chord->setTrack(track());
         chord->setDurationType(durationType());
         chord->setTicks(ticks());

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -77,7 +77,7 @@ namespace mu::engraving {
 //   ChordRest
 //---------------------------------------------------------
 
-ChordRest::ChordRest(const ElementType& type, Segment* parent)
+ChordRest::ChordRest(const ElementType& type, DummyParentOr<Segment> parent)
     : DurationElement(type, parent)
 {
     m_staffMove    = 0;

--- a/src/engraving/dom/chordrest.h
+++ b/src/engraving/dom/chordrest.h
@@ -60,7 +60,7 @@ class ChordRest : public DurationElement
     DECLARE_CLASSOF(ElementType::INVALID) // dummy
 
 public:
-    ChordRest(const ElementType& type, Segment* parent);
+    ChordRest(const ElementType& type, DummyParentOr<Segment> parent);
     ChordRest(const ChordRest&, bool link = false);
     ChordRest& operator=(const ChordRest&) = delete;
     ~ChordRest();

--- a/src/engraving/dom/chordtextlinebase.cpp
+++ b/src/engraving/dom/chordtextlinebase.cpp
@@ -37,7 +37,7 @@ namespace mu::engraving {
 //   ChordTextLineBase
 //---------------------------------------------------------
 
-ChordTextLineBase::ChordTextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags f)
+ChordTextLineBase::ChordTextLineBase(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : TextLineBase(type, parent, f)
 {
 }

--- a/src/engraving/dom/chordtextlinebase.h
+++ b/src/engraving/dom/chordtextlinebase.h
@@ -34,7 +34,7 @@ class ChordTextLineBase : public TextLineBase
 {
     OBJECT_ALLOCATOR(engraving, ChordTextLineBase)
 public:
-    ChordTextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
+    ChordTextLineBase(const ElementType& type, EngravingObject* parent, ElementFlags = ElementFlag::NOTHING);
 
     Anchor anchor() const override { return Anchor::SEGMENT; }
 

--- a/src/engraving/dom/clef.cpp
+++ b/src/engraving/dom/clef.cpp
@@ -150,7 +150,6 @@ EngravingItem* Clef::drop(Transaction& tx, EditData& data)
                 score()->undoRemoveElement(segm->element(track()));
             }
             Ambitus* r = Factory::createAmbitus(segm);
-            r->setOwnershipParent(segm);
             r->setTrack(track());
             score()->undoAddElement(r);
         }

--- a/src/engraving/dom/clef.cpp
+++ b/src/engraving/dom/clef.cpp
@@ -96,11 +96,12 @@ const ClefInfo ClefInfo::clefTable[] = {
 //   Clef
 //---------------------------------------------------------
 
-Clef::Clef(Segment* parent)
+Clef::Clef(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::CLEF, parent, ElementFlag::ON_STAFF)
 {
     m_clefToBarlinePosition = ClefToBarlinePosition::AUTO;
-    m_isHeader = parent->isHeaderClefType();
+    const Segment* segment = parent.as<Segment>();
+    m_isHeader = segment && segment->isHeaderClefType();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/clef.h
+++ b/src/engraving/dom/clef.h
@@ -166,7 +166,7 @@ public:
 private:
 
     friend class Factory;
-    Clef(Segment* parent);
+    Clef(DummyParentOr<Segment> parent);
 
     bool m_showCourtesy = true;
     bool m_isSmall = false;

--- a/src/engraving/dom/dom.cmake
+++ b/src/engraving/dom/dom.cmake
@@ -78,6 +78,8 @@ set(DOM_SRC
     ${CMAKE_CURRENT_LIST_DIR}/deadslapped.h
     ${CMAKE_CURRENT_LIST_DIR}/drumset.cpp
     ${CMAKE_CURRENT_LIST_DIR}/drumset.h
+    ${CMAKE_CURRENT_LIST_DIR}/dummyparent.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dummyparent.h
     ${CMAKE_CURRENT_LIST_DIR}/durationelement.cpp
     ${CMAKE_CURRENT_LIST_DIR}/durationelement.h
     ${CMAKE_CURRENT_LIST_DIR}/durationtype.cpp

--- a/src/engraving/dom/dummyparent.cpp
+++ b/src/engraving/dom/dummyparent.cpp
@@ -21,16 +21,8 @@
  */
 #include "dummyparent.h"
 
-#include "barline.h"
-#include "chord.h"
-#include "factory.h"
-#include "measure.h"
-#include "note.h"
-#include "page.h"
 #include "rootitem.h"
 #include "score.h"
-#include "segment.h"
-#include "system.h"
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY
 #include "../accessibility/accessibleitem.h"
@@ -45,12 +37,6 @@ DummyParent::DummyParent(EngravingObject* parent)
 
 DummyParent::~DummyParent()
 {
-    delete m_note;
-    delete m_chord;
-    delete m_segment;
-    delete m_measure;
-    delete m_system;
-    delete m_page;
     delete m_root;
 }
 
@@ -66,62 +52,11 @@ void DummyParent::init()
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     m_root->setupAccessible();
 #endif
-
-    // the dummy's chain is a fake hierarchy, so it deliberately bypasses the typed setters
-    m_page = Factory::createPage(score());
-    static_cast<EngravingItem*>(m_page)->setOwnershipParent(m_root);
-
-    m_system = Factory::createSystem(score());
-    static_cast<EngravingItem*>(m_system)->setOwnershipParent(m_page);
-    m_system->setPage(m_page);
-
-    m_measure = Factory::createMeasure(score());
-    static_cast<EngravingItem*>(m_measure)->setOwnershipParent(m_system);
-    m_measure->setSystem(m_system);
-
-    m_segment = Factory::createSegment(m_measure);
-    m_segment->setOwnershipParent(m_measure);
-
-    m_chord = Factory::createChord(m_segment);
-    m_chord->setOwnershipParent(m_segment);
-
-    m_note = Factory::createNote(m_chord);
-    m_note->setOwnershipParent(m_chord);
 }
 
 RootItem* DummyParent::rootItem()
 {
     return m_root;
-}
-
-Page* DummyParent::page()
-{
-    return m_page;
-}
-
-System* DummyParent::system()
-{
-    return m_system;
-}
-
-Measure* DummyParent::measure()
-{
-    return m_measure;
-}
-
-Segment* DummyParent::segment()
-{
-    return m_segment;
-}
-
-Chord* DummyParent::chord()
-{
-    return m_chord;
-}
-
-Note* DummyParent::note()
-{
-    return m_note;
 }
 
 EngravingItem* DummyParent::clone() const

--- a/src/engraving/dom/dummyparent.cpp
+++ b/src/engraving/dom/dummyparent.cpp
@@ -19,33 +19,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "dummyelement.h"
+#include "dummyparent.h"
 
-#include "dom/barline.h"
-#include "dom/factory.h"
-#include "dom/score.h"
-#include "dom/rootitem.h"
-#include "dom/page.h"
-#include "dom/system.h"
-#include "dom/measure.h"
-#include "dom/segment.h"
-#include "dom/chord.h"
-#include "dom/note.h"
-#include "dom/bracketitem.h"
+#include "barline.h"
+#include "bracketitem.h"
+#include "chord.h"
+#include "factory.h"
+#include "measure.h"
+#include "note.h"
+#include "page.h"
+#include "rootitem.h"
+#include "score.h"
+#include "segment.h"
+#include "system.h"
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY
-#include "accessibility/accessibleitem.h"
+#include "../accessibility/accessibleitem.h"
 #endif
 
 using namespace mu::engraving;
-using namespace mu::engraving::compat;
 
-DummyElement::DummyElement(EngravingObject* parent)
+DummyParent::DummyParent(EngravingObject* parent)
     : EngravingItem(ElementType::DUMMY, parent)
 {
 }
 
-DummyElement::~DummyElement()
+DummyParent::~DummyParent()
 {
     delete m_bracketItem;
     delete m_note;
@@ -57,7 +56,7 @@ DummyElement::~DummyElement()
     delete m_root;
 }
 
-void DummyElement::init()
+void DummyParent::init()
 {
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     setupAccessible();
@@ -95,53 +94,53 @@ void DummyElement::init()
     m_bracketItem->setOwnershipParent(m_system);
 }
 
-RootItem* DummyElement::rootItem()
+RootItem* DummyParent::rootItem()
 {
     return m_root;
 }
 
-Page* DummyElement::page()
+Page* DummyParent::page()
 {
     return m_page;
 }
 
-System* DummyElement::system()
+System* DummyParent::system()
 {
     return m_system;
 }
 
-Measure* DummyElement::measure()
+Measure* DummyParent::measure()
 {
     return m_measure;
 }
 
-Segment* DummyElement::segment()
+Segment* DummyParent::segment()
 {
     return m_segment;
 }
 
-Chord* DummyElement::chord()
+Chord* DummyParent::chord()
 {
     return m_chord;
 }
 
-Note* DummyElement::note()
+Note* DummyParent::note()
 {
     return m_note;
 }
 
-BracketItem* DummyElement::bracketItem()
+BracketItem* DummyParent::bracketItem()
 {
     return m_bracketItem;
 }
 
-EngravingItem* DummyElement::clone() const
+EngravingItem* DummyParent::clone() const
 {
     return nullptr;
 }
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY
-AccessibleItemPtr DummyElement::createAccessible()
+AccessibleItemPtr DummyParent::createAccessible()
 {
     using namespace muse::accessibility;
     return std::make_shared<AccessibleItem>(this, IAccessible::Group);

--- a/src/engraving/dom/dummyparent.cpp
+++ b/src/engraving/dom/dummyparent.cpp
@@ -24,14 +24,10 @@
 #include "rootitem.h"
 #include "score.h"
 
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-#include "../accessibility/accessibleitem.h"
-#endif
-
 using namespace mu::engraving;
 
-DummyParent::DummyParent(EngravingObject* parent)
-    : EngravingItem(ElementType::DUMMY, parent)
+DummyParent::DummyParent(Score* score)
+    : EngravingObject(ElementType::DUMMY, score)
 {
 }
 
@@ -42,33 +38,9 @@ DummyParent::~DummyParent()
 
 void DummyParent::init()
 {
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-    setupAccessible();
-#endif
-
-    m_root = new RootItem(score());
-    m_root->setOwnershipParent(this);
+    m_root = new RootItem(score(), RootItem::Kind::Dummy);
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     m_root->setupAccessible();
 #endif
 }
-
-RootItem* DummyParent::rootItem()
-{
-    return m_root;
-}
-
-EngravingItem* DummyParent::clone() const
-{
-    return nullptr;
-}
-
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-AccessibleItemPtr DummyParent::createAccessible()
-{
-    using namespace muse::accessibility;
-    return std::make_shared<AccessibleItem>(this, IAccessible::Group);
-}
-
-#endif

--- a/src/engraving/dom/dummyparent.cpp
+++ b/src/engraving/dom/dummyparent.cpp
@@ -22,7 +22,6 @@
 #include "dummyparent.h"
 
 #include "barline.h"
-#include "bracketitem.h"
 #include "chord.h"
 #include "factory.h"
 #include "measure.h"
@@ -46,7 +45,6 @@ DummyParent::DummyParent(EngravingObject* parent)
 
 DummyParent::~DummyParent()
 {
-    delete m_bracketItem;
     delete m_note;
     delete m_chord;
     delete m_segment;
@@ -89,9 +87,6 @@ void DummyParent::init()
 
     m_note = Factory::createNote(m_chord);
     m_note->setOwnershipParent(m_chord);
-
-    m_bracketItem = Factory::createBracketItem(m_system);
-    m_bracketItem->setOwnershipParent(m_system);
 }
 
 RootItem* DummyParent::rootItem()
@@ -127,11 +122,6 @@ Chord* DummyParent::chord()
 Note* DummyParent::note()
 {
     return m_note;
-}
-
-BracketItem* DummyParent::bracketItem()
-{
-    return m_bracketItem;
 }
 
 EngravingItem* DummyParent::clone() const

--- a/src/engraving/dom/dummyparent.h
+++ b/src/engraving/dom/dummyparent.h
@@ -41,12 +41,6 @@ public:
     void init();
 
     RootItem* rootItem();
-    Page* page();
-    System* system();
-    Measure* measure();
-    Segment* segment();
-    Chord* chord();
-    Note* note();
 
     EngravingItem* clone() const override;
 
@@ -59,11 +53,5 @@ private:
 #endif
 
     RootItem* m_root = nullptr;
-    Page* m_page = nullptr;
-    System* m_system = nullptr;
-    Measure* m_measure = nullptr;
-    Segment* m_segment = nullptr;
-    Chord* m_chord = nullptr;
-    Note* m_note = nullptr;
 };
 }

--- a/src/engraving/dom/dummyparent.h
+++ b/src/engraving/dom/dummyparent.h
@@ -21,37 +21,32 @@
  */
 #pragma once
 
-#include "engravingitem.h"
+#include "engravingobject.h"
 
 namespace mu::engraving {
 enum class Pid : short;
 
 class RootItem;
+class Score;
 
-//! The parent an object has while it is not attached to anything. Nothing is laid
-//! out in it and it takes no part in the score; it only keeps unattached objects
-//! reachable, and heads their accessibility tree.
-class DummyParent : public EngravingItem
+//! The parent an object has while it is not attached to anything. It is not part of
+//! the score and nothing is laid out in it - it is not even an item; it only keeps
+//! unattached objects reachable, and heads the accessibility tree they form.
+class DummyParent : public EngravingObject
 {
     OBJECT_ALLOCATOR(engraving, DummyParent)
 public:
-    DummyParent(EngravingObject* parent);
+    DummyParent(Score* score);
     ~DummyParent();
 
     void init();
 
-    RootItem* rootItem();
-
-    EngravingItem* clone() const override;
+    RootItem* rootItem() const { return m_root; }
 
     PropertyValue getProperty(Pid) const override { return PropertyValue(); }
     bool setProperty(Pid, const PropertyValue&) override { return false; }
 
 private:
-#ifndef ENGRAVING_NO_ACCESSIBILITY
-    AccessibleItemPtr createAccessible() override;
-#endif
-
     RootItem* m_root = nullptr;
 };
 }

--- a/src/engraving/dom/dummyparent.h
+++ b/src/engraving/dom/dummyparent.h
@@ -47,7 +47,6 @@ public:
     Segment* segment();
     Chord* chord();
     Note* note();
-    BracketItem* bracketItem();
 
     EngravingItem* clone() const override;
 
@@ -66,6 +65,5 @@ private:
     Segment* m_segment = nullptr;
     Chord* m_chord = nullptr;
     Note* m_note = nullptr;
-    BracketItem* m_bracketItem = nullptr;
 };
 }

--- a/src/engraving/dom/dummyparent.h
+++ b/src/engraving/dom/dummyparent.h
@@ -19,24 +19,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_DUMMYELEMENT_H
-#define MU_ENGRAVING_DUMMYELEMENT_H
+#pragma once
 
-#include "../dom/engravingitem.h"
+#include "engravingitem.h"
 
 namespace mu::engraving {
 enum class Pid : short;
 
 class RootItem;
-}
 
-namespace mu::engraving::compat {
-class DummyElement : public EngravingItem
+//! The parent an object has while it is not attached to anything. Nothing is laid
+//! out in it and it takes no part in the score; it only keeps unattached objects
+//! reachable, and heads their accessibility tree.
+class DummyParent : public EngravingItem
 {
-    OBJECT_ALLOCATOR(engraving, DummyElement)
+    OBJECT_ALLOCATOR(engraving, DummyParent)
 public:
-    DummyElement(EngravingObject* parent);
-    ~DummyElement();
+    DummyParent(EngravingObject* parent);
+    ~DummyParent();
 
     void init();
 
@@ -69,5 +69,3 @@ private:
     BracketItem* m_bracketItem = nullptr;
 };
 }
-
-#endif // MU_ENGRAVING_DUMMYELEMENT_H

--- a/src/engraving/dom/durationelement.cpp
+++ b/src/engraving/dom/durationelement.cpp
@@ -37,7 +37,7 @@ namespace mu::engraving {
 //   DurationElement
 //---------------------------------------------------------
 
-DurationElement::DurationElement(const ElementType& type, EngravingItem* parent, ElementFlags f)
+DurationElement::DurationElement(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : EngravingItem(type, parent, f)
 {
     m_tuplet = 0;

--- a/src/engraving/dom/durationelement.h
+++ b/src/engraving/dom/durationelement.h
@@ -68,7 +68,8 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue&) override;
 
 protected:
-    DurationElement(const ElementType& type, EngravingItem* parent = nullptr, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
+    DurationElement(const ElementType& type, EngravingObject* parent = nullptr,
+                    ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
     DurationElement(const DurationElement& e, bool link = false);
 
 private:

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -115,7 +115,7 @@ static const ElementStyle dynamicsStyle {
 //   Dynamic
 //---------------------------------------------------------
 
-Dynamic::Dynamic(Segment* parent)
+Dynamic::Dynamic(DummyParentOr<Segment> parent)
     : TextBase(ElementType::DYNAMIC, parent, TextStyleType::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     m_velocity    = -1;

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -59,7 +59,7 @@ public:
         const char* name = nullptr;
     };
 
-    Dynamic(Segment* parent);
+    Dynamic(DummyParentOr<Segment> parent);
     Dynamic(const Dynamic&);
     Dynamic* clone() const override { return new Dynamic(*this); }
     Segment* segment() const { return (Segment*)ownershipParent(); }

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -58,6 +58,7 @@
 #include "../editing/navigation.h"
 
 #include "chord.h"
+#include "dummyparent.h"
 #include "factory.h"
 #include "linkedobjects.h"
 #include "masterscore.h"

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2530,7 +2530,6 @@ void EngravingItem::setHasLeftParenthesis(bool v, bool addToLinked, bool generat
     if (v) {
         if (!m_leftParenthesis) {
             Parenthesis* paren = Factory::createParenthesis(this);
-            paren->setOwnershipParent(this);
             paren->setTrack(track());
             paren->setDirection(DirectionH::LEFT);
             paren->setGenerated(generated);
@@ -2559,7 +2558,6 @@ void EngravingItem::setHasRightParenthesis(bool v, bool addToLinked, bool genera
     if (v) {
         if (!m_rightParenthesis) {
             Parenthesis* paren = Factory::createParenthesis(this);
-            paren->setOwnershipParent(this);
             paren->setTrack(track());
             paren->setDirection(DirectionH::RIGHT);
             paren->setGenerated(generated);

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -174,11 +174,6 @@ EngravingItem* EngravingItem::accessibleParentItem() const
         return p;
     }
 
-    // embedded in an item without being owned by it, e.g. a grace notes group
-    if (EngravingObject* raw = parent(); raw && raw->isEngravingItem()) {
-        return toEngravingItem(raw);
-    }
-
     // not placed anywhere, so not in the score's tree: head of the dummy's tree instead
     return score() && score()->dummy() ? score()->dummy()->rootItem() : nullptr;
 }

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -174,7 +174,12 @@ EngravingItem* EngravingItem::accessibleParentItem() const
         return p;
     }
 
-    // not placed anywhere, so not in the score's tree: head of the dummy's tree instead
+    if (ownershipParent()) {
+        // attached to something, but not placed anywhere: in neither tree
+        return nullptr;
+    }
+
+    // not attached to anything: head of the tree those objects form
     return score() && score()->dummy() ? score()->dummy()->rootItem() : nullptr;
 }
 

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -68,6 +68,7 @@
 #include "page.h"
 #include "parenthesis.h"
 #include "part.h"
+#include "rootitem.h"
 #include "score.h"
 #include "segment.h"
 #include "shape.h"
@@ -169,18 +170,17 @@ void EngravingItem::setAccessibleEnabled(bool enabled)
 
 EngravingItem* EngravingItem::accessibleParentItem() const
 {
-    EngravingItem* p = layoutParent();
-    if (p) {
+    if (EngravingItem* p = layoutParent()) {
         return p;
     }
 
-    // fall back to the raw parent, so that e.g. palette items reach the dummy
-    EngravingObject* raw = parent();
-    if (raw && raw->isEngravingItem()) {
+    // embedded in an item without being owned by it, e.g. a grace notes group
+    if (EngravingObject* raw = parent(); raw && raw->isEngravingItem()) {
         return toEngravingItem(raw);
     }
 
-    return nullptr;
+    // not placed anywhere, so not in the score's tree: head of the dummy's tree instead
+    return score() && score()->dummy() ? score()->dummy()->rootItem() : nullptr;
 }
 
 EngravingItemList EngravingItem::accessibleChildren() const
@@ -201,26 +201,6 @@ EngravingItem* EngravingItem::ownershipParentItem() const
 EngravingItem* EngravingItem::layoutParent() const
 {
     return ownershipParentItem();
-}
-
-static void collectChildrenItems(const EngravingObject* item, EngravingItemList& list, bool all)
-{
-    for (EngravingObject* ch : item->children()) {
-        if (ch->isEngravingItem()) {
-            list.push_back(toEngravingItem(ch));
-
-            if (all) {
-                collectChildrenItems(ch, list, all);
-            }
-        }
-    }
-}
-
-EngravingItemList EngravingItem::childrenItems(bool all) const
-{
-    EngravingItemList list;
-    collectChildrenItems(this, list, all);
-    return list;
 }
 
 const std::shared_ptr<IEngravingConfiguration>& EngravingItem::configuration() const

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -146,8 +146,6 @@ enum class KerningType : unsigned char
     ALLOW_COLLISION,
 };
 
-using EngravingItemList = std::vector<EngravingItem*>;
-
 //-------------------------------------------------------------------
 //    @@ EngravingItem
 ///     \brief Base class of score layout elements
@@ -172,8 +170,6 @@ public:
     virtual EngravingItem* linkedClone();
 
     void deleteLater();
-
-    EngravingItemList childrenItems(bool all = false) const;
 
     //! Item-typed variant of ownershipParent(); additionally null when the
     //! owner is not an item.
@@ -488,8 +484,9 @@ public:
     bool accessibleEnabled() const;
     void setAccessibleEnabled(bool enabled);
 
-    //! Parent in the accessibility hierarchy: the layout parent when placed,
-    //! otherwise the raw parent (so that e.g. palette items reach the dummy).
+    //! Parent in the accessibility hierarchy: the layout parent when placed, otherwise
+    //! the item it is embedded in, otherwise the head of the tree the unattached
+    //! objects form.
     virtual EngravingItem* accessibleParentItem() const;
     //! Children in the accessibility hierarchy: the items that name this one as their
     //! accessibleParentItem(). Those are the children it owns, unless ownership and

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -484,8 +484,9 @@ public:
     bool accessibleEnabled() const;
     void setAccessibleEnabled(bool enabled);
 
-    //! Parent in the accessibility hierarchy: the layout parent when placed, otherwise
-    //! the head of the tree the unattached objects form.
+    //! Parent in the accessibility hierarchy: the layout parent when placed; the head of
+    //! the tree the unattached objects form when attached to nothing; null in between,
+    //! i.e. while attached to something that does not place it.
     virtual EngravingItem* accessibleParentItem() const;
     //! Children in the accessibility hierarchy: the items that name this one as their
     //! accessibleParentItem(). Those are the children it owns, unless ownership and

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -485,8 +485,7 @@ public:
     void setAccessibleEnabled(bool enabled);
 
     //! Parent in the accessibility hierarchy: the layout parent when placed, otherwise
-    //! the item it is embedded in, otherwise the head of the tree the unattached
-    //! objects form.
+    //! the head of the tree the unattached objects form.
     virtual EngravingItem* accessibleParentItem() const;
     //! Children in the accessibility hierarchy: the items that name this one as their
     //! accessibleParentItem(). Those are the children it owns, unless ownership and

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -32,6 +32,7 @@
 #include "types/typesconv.h"
 
 #include "bracketitem.h"
+#include "dummyparent.h"
 #include "linkedobjects.h"
 #include "masterscore.h"
 #include "score.h"

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -57,10 +57,13 @@ EngravingObject::EngravingObject(const ElementType& type, EngravingObject* paren
         assert(parent);
     }
 
+    // The parent an object is constructed with is its parent: it is attached to it
+    // right away. Passing the dummy means it is not attached to anything yet.
     doSetParent(parent);
     if (m_parent) {
         doSetScore(m_parent->score());
     }
+    m_isParentExplicitlySet = parent && !parent->isType(ElementType::DUMMY);
 
     if (type == ElementType::SCORE) {
         m_score = static_cast<Score*>(this);

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -112,7 +112,7 @@ EngravingObject::~EngravingObject()
         bool canMoveToDummy = !this->isType(ElementType::ROOT_ITEM)
                               && !this->isType(ElementType::DUMMY)
                               && !this->isType(ElementType::SCORE)
-                              && score()->rootItem() && score()->rootItem()->dummy();
+                              && score()->dummy();
 
         // copy because moveToDummy might modify children
         EngravingObjectList children = m_children;

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -63,7 +63,6 @@ EngravingObject::EngravingObject(const ElementType& type, EngravingObject* paren
     if (m_parent) {
         doSetScore(m_parent->score());
     }
-    m_isParentExplicitlySet = parent && !parent->isType(ElementType::DUMMY);
 
     if (type == ElementType::SCORE) {
         m_score = static_cast<Score*>(this);
@@ -82,7 +81,6 @@ EngravingObject::EngravingObject(const EngravingObject& se)
     m_type = se.m_type;
     doSetParent(se.m_parent);
     m_score = se.m_score;
-    m_isParentExplicitlySet = se.m_isParentExplicitlySet;
     m_elementStyle = se.m_elementStyle;
     if (m_elementStyle) {
         size_t n = m_elementStyle->size();
@@ -269,7 +267,7 @@ EngravingObject* EngravingObject::parent() const
 
 EngravingObject* EngravingObject::ownershipParent() const
 {
-    if (!m_isParentExplicitlySet) {
+    if (!m_parent || m_parent->isType(ElementType::DUMMY)) {
         return nullptr;
     }
     return m_parent;
@@ -290,8 +288,6 @@ void EngravingObject::setOwnershipParent(EngravingObject* p)
     if (m_parent) {
         doSetScore(m_parent->score());
     }
-
-    m_isParentExplicitlySet = p && !p->isType(ElementType::DUMMY);
 }
 
 Score* EngravingObject::score() const

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -188,6 +188,26 @@ void EngravingObject::moveToDummy()
     }
 }
 
+static void collectChildrenItems(const EngravingObject* item, EngravingItemList& list, bool all)
+{
+    for (EngravingObject* ch : item->children()) {
+        if (ch->isEngravingItem()) {
+            list.push_back(toEngravingItem(ch));
+
+            if (all) {
+                collectChildrenItems(ch, list, all);
+            }
+        }
+    }
+}
+
+EngravingItemList EngravingObject::childrenItems(bool all) const
+{
+    EngravingItemList list;
+    collectChildrenItems(this, list, all);
+    return list;
+}
+
 EngravingItemList EngravingObject::getChildren(bool includeInvisible) const
 {
     EngravingItemList childrenList;

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -22,6 +22,8 @@
 
 #include "engravingobject.h"
 
+#include <algorithm>
+
 #include "global/containers.h"
 
 #include "../editing/addremoveelement.h"
@@ -257,7 +259,16 @@ void EngravingObject::removeChild(EngravingObject* o)
         return;
     }
     o->m_parent = nullptr;
-    muse::remove(m_children, o);
+
+    // Search from the back: a child is most often unparented shortly after it was added,
+    // so it still sits at the end of the list. That matters for the dummy, whose child
+    // list is long-lived and large - it holds every object that has no owner, which
+    // includes all beams and spanners. Laying out goldberg.mscx walks 59M list entries
+    // searching from the front, and 65k searching from the back. Order is preserved.
+    auto it = std::find(m_children.rbegin(), m_children.rend(), o);
+    if (it != m_children.rend()) {
+        m_children.erase(std::next(it).base());
+    }
 }
 
 EngravingObject* EngravingObject::parent() const

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -212,6 +212,7 @@ enum class Pid : short;
 enum class PropertyFlags : char;
 
 using EngravingObjectList = std::vector<EngravingObject*>;
+using EngravingItemList = std::vector<EngravingItem*>;
 
 //! Parameter type for a parent that is either a real parent of one of the given types,
 //! or the dummy, i.e. no parent at all. It holds nothing but the pointer and makes no
@@ -279,6 +280,7 @@ public:
 
     const EngravingObjectList& children() const { return m_children; }
 
+    EngravingItemList childrenItems(bool all = false) const;
     std::vector<EngravingItem*> getChildren(bool includeInvisible = true) const;
     virtual void scanElements(std::function<void(EngravingItem*)>) {}
 

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -273,8 +273,8 @@ public:
     EngravingObject* parent() const;
 
     void setOwnershipParent(EngravingObject* p);
-    //! The parent this object has explicitly been attached to via setOwnershipParent().
-    //! Null while the object is merely constructed with a context parent, or parked on the dummy.
+    //! The parent this object is attached to. Null while it is parked on the dummy,
+    //! i.e. not attached to anything.
     EngravingObject* ownershipParent() const;
     void moveToDummy();
 
@@ -354,7 +354,6 @@ private:
     ElementType m_type = ElementType::INVALID;
 
     EngravingObject* m_parent = nullptr;
-    bool m_isParentExplicitlySet = false;
     EngravingObjectList m_children;
 
 public:

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <vector>
 
 #include "global/allocator.h"
@@ -59,6 +60,7 @@ class ChordRest;
 class Clef;
 class Capo;
 class DeadSlapped;
+class DummyParent;
 class DurationElement;
 class Dynamic;
 class Expression;
@@ -210,6 +212,34 @@ enum class Pid : short;
 enum class PropertyFlags : char;
 
 using EngravingObjectList = std::vector<EngravingObject*>;
+
+//! Parameter type for a parent that is either a real parent of one of the given types,
+//! or the dummy, i.e. no parent at all. It holds nothing but the pointer and makes no
+//! difference at runtime; the point is that "not attached to anything" has to be said
+//! rather than slipped in as a pointer of the wrong kind.
+//!
+//! Best-effort only: it narrows what a call site can pass, it does not prove anything.
+template<typename ... ParentTypes>
+class DummyParentOr
+{
+public:
+    template<typename T, std::enable_if_t<std::is_same_v<T, DummyParent>
+                                          || (std::is_base_of_v<ParentTypes, T> || ...), int> = 0>
+    DummyParentOr(T* parent)
+        : m_parent(parent) {}
+
+    operator EngravingObject*() const {
+        return m_parent;
+    }
+
+    //! The parent as one of the accepted types, or null when it is the dummy - i.e.
+    //! when there is no parent to speak to yet.
+    template<typename T>
+    T* as() const;
+
+private:
+    EngravingObject* m_parent = nullptr;
+};
 
 class EngravingObject
 {
@@ -595,6 +625,13 @@ public:
 
     bool isIndicatorIcon() const { return isSystemLockIndicator() || isPageLockIndicator() || isStaffVisibilityIndicator(); }
 };
+
+template<typename ... ParentTypes>
+template<typename T>
+T* DummyParentOr<ParentTypes...>::as() const
+{
+    return m_parent && !m_parent->isType(ElementType::DUMMY) ? static_cast<T*>(m_parent) : nullptr;
+}
 
 //---------------------------------------------------
 // safe casting of EngravingObject

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -241,6 +241,13 @@ private:
     EngravingObject* m_parent = nullptr;
 };
 
+//! The given parent if there is one, the dummy otherwise.
+template<typename T>
+DummyParentOr<T> parentOrDummy(T* parent, DummyParent* dummy)
+{
+    return parent ? DummyParentOr<T>(parent) : DummyParentOr<T>(dummy);
+}
+
 class EngravingObject
 {
 public:

--- a/src/engraving/dom/expression.cpp
+++ b/src/engraving/dom/expression.cpp
@@ -36,7 +36,7 @@ static const ElementStyle expressionStyle {
     { Sid::snapToDynamics, Pid::SNAP_TO_DYNAMICS },
 };
 
-Expression::Expression(Segment* parent)
+Expression::Expression(DummyParentOr<Segment> parent)
     : TextBase(ElementType::EXPRESSION, parent, TextStyleType::EXPRESSION, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&expressionStyle);

--- a/src/engraving/dom/expression.h
+++ b/src/engraving/dom/expression.h
@@ -33,7 +33,7 @@ class Expression final : public TextBase
     DECLARE_CLASSOF(ElementType::EXPRESSION)
 
 public:
-    Expression(Segment* parent);
+    Expression(DummyParentOr<Segment> parent);
     Expression(const Expression& expression);
 
     bool isEditAllowed(EditData&) const override;

--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -328,7 +328,7 @@ EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingI
 }
 
 #define CREATE_ITEM_IMPL(T, P, isAccessibleEnabled) \
-    T* Factory::create##T(P * parent, bool isAccessibleEnabled) \
+    T* Factory::create##T(P parent, bool isAccessibleEnabled) \
     { \
         T* e = new T(parent); \
         e->setAccessibleEnabled(isAccessibleEnabled); \
@@ -336,7 +336,7 @@ EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingI
     } \
 
 #define MAKE_ITEM_IMPL(T, P) \
-    std::shared_ptr<T> Factory::make##T(P * parent) \
+    std::shared_ptr<T> Factory::make##T(P parent) \
     { \
         return std::shared_ptr<T>(create##T(parent)); \
     } \
@@ -348,39 +348,39 @@ EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingI
         return copy; \
     } \
 
-CREATE_ITEM_IMPL(Accidental, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Accidental, EngravingItem)
+CREATE_ITEM_IMPL(Accidental, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Accidental, EngravingItem*)
 
-CREATE_ITEM_IMPL(Ambitus, Segment, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Ambitus, Segment)
+CREATE_ITEM_IMPL(Ambitus, DummyParentOr<Segment>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Ambitus, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(Arpeggio, Chord, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Arpeggio, Chord)
+CREATE_ITEM_IMPL(Arpeggio, DummyParentOr<Chord>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Arpeggio, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(ChordBracket, Chord, isAccessibleEnabled)
-MAKE_ITEM_IMPL(ChordBracket, Chord)
+CREATE_ITEM_IMPL(ChordBracket, DummyParentOr<Chord>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(ChordBracket, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(Articulation, ChordRest, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Articulation, ChordRest)
+CREATE_ITEM_IMPL(Articulation, DummyParentOr<ChordRest>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Articulation, DummyParentOr<ChordRest>)
 
-CREATE_ITEM_IMPL(Tapping, ChordRest, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Tapping, ChordRest)
+CREATE_ITEM_IMPL(Tapping, DummyParentOr<ChordRest>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Tapping, DummyParentOr<ChordRest>)
 
-CREATE_ITEM_IMPL(Ornament, ChordRest, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Ornament, ChordRest)
+CREATE_ITEM_IMPL(Ornament, DummyParentOr<ChordRest>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Ornament, DummyParentOr<ChordRest>)
 
-CREATE_ITEM_IMPL(BarLine, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(BarLine, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(BarLine)
-MAKE_ITEM_IMPL(BarLine, Segment)
+MAKE_ITEM_IMPL(BarLine, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(Beam, Score, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Beam, Score)
+CREATE_ITEM_IMPL(Beam, Score*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Beam, Score*)
 
-CREATE_ITEM_IMPL(Bend, Note, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Bend, Note)
+CREATE_ITEM_IMPL(Bend, DummyParentOr<Note>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Bend, DummyParentOr<Note>)
 
-CREATE_ITEM_IMPL(Bracket, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Bracket, EngravingItem)
+CREATE_ITEM_IMPL(Bracket, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Bracket, EngravingItem*)
 
 BracketItem* Factory::createBracketItem(EngravingItem * parent)
 {
@@ -394,10 +394,10 @@ BracketItem* Factory::createBracketItem(EngravingItem* parent, BracketType brack
     return bi;
 }
 
-CREATE_ITEM_IMPL(Breath, Segment, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Breath, Segment)
+CREATE_ITEM_IMPL(Breath, DummyParentOr<Segment>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Breath, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(Chord, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Chord, DummyParentOr<Segment>, isAccessibleEnabled)
 
 Chord* Factory::copyChord(const Chord& src, bool link)
 {
@@ -406,61 +406,61 @@ Chord* Factory::copyChord(const Chord& src, bool link)
 
     return copy;
 }
-MAKE_ITEM_IMPL(Chord, Segment)
+MAKE_ITEM_IMPL(Chord, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(ChordLine, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(ChordLine, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(ChordLine)
-MAKE_ITEM_IMPL(ChordLine, Chord)
+MAKE_ITEM_IMPL(ChordLine, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(Clef, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Clef, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Clef)
-MAKE_ITEM_IMPL(Clef, Segment)
+MAKE_ITEM_IMPL(Clef, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(DeadSlapped, Rest, isAccessibleEnabled)
+CREATE_ITEM_IMPL(DeadSlapped, Rest*, isAccessibleEnabled)
 COPY_ITEM_IMPL(DeadSlapped)
 
-CREATE_ITEM_IMPL(Fermata, Segment, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Fermata, Segment)
+CREATE_ITEM_IMPL(Fermata, DummyParentOr<Segment>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Fermata, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(FiguredBass, Segment, isAccessibleEnabled)
-MAKE_ITEM_IMPL(FiguredBass, Segment)
+CREATE_ITEM_IMPL(FiguredBass, DummyParentOr<Segment>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(FiguredBass, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(FretDiagram, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(FretDiagram, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(FretDiagram)
-MAKE_ITEM_IMPL(FretDiagram, Segment)
+MAKE_ITEM_IMPL(FretDiagram, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(HarpPedalDiagram, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(HarpPedalDiagram, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(HarpPedalDiagram)
-MAKE_ITEM_IMPL(HarpPedalDiagram, Segment);
+MAKE_ITEM_IMPL(HarpPedalDiagram, DummyParentOr<Segment>);
 
-CREATE_ITEM_IMPL(KeySig, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(KeySig, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(KeySig)
-MAKE_ITEM_IMPL(KeySig, Segment)
+MAKE_ITEM_IMPL(KeySig, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(LaissezVib, Note, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LaissezVib, DummyParentOr<Note>, isAccessibleEnabled)
 COPY_ITEM_IMPL(LaissezVib);
 
-CREATE_ITEM_IMPL(LayoutBreak, MeasureBase, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LayoutBreak, DummyParentOr<MeasureBase>, isAccessibleEnabled)
 COPY_ITEM_IMPL(LayoutBreak)
-MAKE_ITEM_IMPL(LayoutBreak, MeasureBase)
+MAKE_ITEM_IMPL(LayoutBreak, DummyParentOr<MeasureBase>)
 
-CREATE_ITEM_IMPL(Lyrics, ChordRest, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Lyrics, DummyParentOr<ChordRest>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Lyrics)
 
-CREATE_ITEM_IMPL(LyricsLine, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LyricsLine, EngravingItem*, isAccessibleEnabled)
 COPY_ITEM_IMPL(LyricsLine)
 
-CREATE_ITEM_IMPL(Measure, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Measure, Score*, isAccessibleEnabled)
 COPY_ITEM_IMPL(Measure)
 
-CREATE_ITEM_IMPL(MeasureRepeat, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(MeasureRepeat, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(MeasureRepeat)
 
-CREATE_ITEM_IMPL(StringTunings, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StringTunings, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(StringTunings)
-MAKE_ITEM_IMPL(StringTunings, Segment);
+MAKE_ITEM_IMPL(StringTunings, DummyParentOr<Segment>);
 
-CREATE_ITEM_IMPL(Note, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Note, DummyParentOr<Chord>, isAccessibleEnabled)
 Note* Factory::copyNote(const Note& src, bool link)
 {
     Note* copy = new Note(src, link);
@@ -468,18 +468,18 @@ Note* Factory::copyNote(const Note& src, bool link)
 
     return copy;
 }
-MAKE_ITEM_IMPL(Note, Chord)
+MAKE_ITEM_IMPL(Note, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(NoteDot, Note, isAccessibleEnabled)
-CREATE_ITEM_IMPL(NoteDot, Rest, isAccessibleEnabled)
+CREATE_ITEM_IMPL(NoteDot, DummyParentOr<Note>, isAccessibleEnabled)
+CREATE_ITEM_IMPL(NoteDot, Rest*, isAccessibleEnabled)
 COPY_ITEM_IMPL(NoteDot)
 
-CREATE_ITEM_IMPL(NoteLine, Note, isAccessibleEnabled)
-MAKE_ITEM_IMPL(NoteLine, Note);
+CREATE_ITEM_IMPL(NoteLine, DummyParentOr<Note>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(NoteLine, DummyParentOr<Note>);
 
-CREATE_ITEM_IMPL(Page, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Page, Score*, isAccessibleEnabled)
 
-PageLockIndicator* Factory::createPageLockIndicator(System * parent, const RangeLock * lock, bool isAccessibleEnabled)
+PageLockIndicator* Factory::createPageLockIndicator(DummyParentOr<System> parent, const RangeLock * lock, bool isAccessibleEnabled)
 {
     PageLockIndicator* pli = new PageLockIndicator(parent, lock);
     pli->setAccessibleEnabled(isAccessibleEnabled);
@@ -488,15 +488,15 @@ PageLockIndicator* Factory::createPageLockIndicator(System * parent, const Range
 
 COPY_ITEM_IMPL(PageLockIndicator)
 
-CREATE_ITEM_IMPL(PartialTie, Note, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PartialTie, DummyParentOr<Note>, isAccessibleEnabled)
 COPY_ITEM_IMPL(PartialTie)
 
-CREATE_ITEM_IMPL(PartialLyricsLine, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PartialLyricsLine, EngravingItem*, isAccessibleEnabled)
 COPY_ITEM_IMPL(PartialLyricsLine)
 
-CREATE_ITEM_IMPL(Rest, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Rest, DummyParentOr<Segment>, isAccessibleEnabled)
 
-Rest* Factory::createRest(Segment * parent, const TDuration& t, bool isAccessibleEnabled)
+Rest* Factory::createRest(DummyParentOr<Segment> parent, const TDuration& t, bool isAccessibleEnabled)
 {
     Rest* r = new Rest(parent, t);
     r->setAccessibleEnabled(isAccessibleEnabled);
@@ -512,9 +512,9 @@ Rest* Factory::copyRest(const Rest& src, bool link)
     return copy;
 }
 
-CREATE_ITEM_IMPL(Segment, Measure, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Segment, DummyParentOr<Measure>, isAccessibleEnabled)
 
-Segment* Factory::createSegment(Measure * parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled)
+Segment* Factory::createSegment(DummyParentOr<Measure> parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled)
 {
     Segment* s = new Segment(parent, type, t);
     s->setAccessibleEnabled(isAccessibleEnabled);
@@ -522,11 +522,11 @@ Segment* Factory::createSegment(Measure * parent, SegmentType type, const Fracti
     return s;
 }
 
-CREATE_ITEM_IMPL(Slur, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Slur, EngravingItem)
+CREATE_ITEM_IMPL(Slur, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Slur, EngravingItem*)
 
-CREATE_ITEM_IMPL(Spacer, Measure, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Spacer, Measure)
+CREATE_ITEM_IMPL(Spacer, DummyParentOr<Measure>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Spacer, DummyParentOr<Measure>)
 
 Staff* Factory::createStaff(Part * parent)
 {
@@ -535,15 +535,15 @@ Staff* Factory::createStaff(Part * parent)
     return staff;
 }
 
-CREATE_ITEM_IMPL(StaffLines, Measure, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StaffLines, DummyParentOr<Measure>, isAccessibleEnabled)
 COPY_ITEM_IMPL(StaffLines)
 
-CREATE_ITEM_IMPL(StaffState, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StaffState, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(StaffTypeChange, MeasureBase, isAccessibleEnabled)
-MAKE_ITEM_IMPL(StaffTypeChange, MeasureBase)
+CREATE_ITEM_IMPL(StaffTypeChange, DummyParentOr<MeasureBase>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(StaffTypeChange, DummyParentOr<MeasureBase>)
 
-StaffText* Factory::createStaffText(Segment * parent, TextStyleType textStyleType, bool isAccessibleEnabled)
+StaffText* Factory::createStaffText(DummyParentOr<Segment> parent, TextStyleType textStyleType, bool isAccessibleEnabled)
 {
     StaffText* staffText = new StaffText(parent, textStyleType);
     staffText->setAccessibleEnabled(isAccessibleEnabled);
@@ -551,28 +551,29 @@ StaffText* Factory::createStaffText(Segment * parent, TextStyleType textStyleTyp
     return staffText;
 }
 
-StaveSharingLabel* Factory::createStaveSharingLabel(Segment* parent, TextStyleType textStyleType, bool isAccessibleEnabled)
+StaveSharingLabel* Factory::createStaveSharingLabel(DummyParentOr<Segment> parent, TextStyleType textStyleType, bool isAccessibleEnabled)
 {
     StaveSharingLabel* staveSharingLabel = new StaveSharingLabel(parent, textStyleType);
     staveSharingLabel->setAccessibleEnabled(isAccessibleEnabled);
     return staveSharingLabel;
 }
 
-CREATE_ITEM_IMPL(SoundFlag, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(SoundFlag, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Expression, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Expression, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(RehearsalMark, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(RehearsalMark, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Stem, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Stem, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Stem)
 
-CREATE_ITEM_IMPL(StemSlash, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StemSlash, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(StemSlash)
 
-CREATE_ITEM_IMPL(System, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(System, Score*, isAccessibleEnabled)
 
-SystemText* Factory::createSystemText(Segment * parent, TextStyleType textStyleType, ElementType type, bool isAccessibleEnabled)
+SystemText* Factory::createSystemText(DummyParentOr<Segment> parent, TextStyleType textStyleType, ElementType type,
+                                      bool isAccessibleEnabled)
 {
     SystemText* systemText = new SystemText(parent, textStyleType, type);
     systemText->setAccessibleEnabled(isAccessibleEnabled);
@@ -580,9 +581,9 @@ SystemText* Factory::createSystemText(Segment * parent, TextStyleType textStyleT
     return systemText;
 }
 
-CREATE_ITEM_IMPL(InstrumentChange, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(InstrumentChange, DummyParentOr<Segment>, isAccessibleEnabled)
 
-InstrumentChange* Factory::createInstrumentChange(Segment * parent, const Instrument& instrument,
+InstrumentChange* Factory::createInstrumentChange(DummyParentOr<Segment> parent, const Instrument& instrument,
                                                   bool isAccessibleEnabled)
 {
     InstrumentChange* instrumentChange = new InstrumentChange(instrument, parent);
@@ -591,11 +592,11 @@ InstrumentChange* Factory::createInstrumentChange(Segment * parent, const Instru
     return instrumentChange;
 }
 
-CREATE_ITEM_IMPL(Sticking, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Sticking, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Fingering, Note, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Fingering, DummyParentOr<Note>, isAccessibleEnabled)
 
-Fingering* Factory::createFingering(Note * parent, TextStyleType textStyleType,
+Fingering* Factory::createFingering(DummyParentOr<Note> parent, TextStyleType textStyleType,
                                     bool isAccessibleEnabled)
 {
     Fingering* fingering = new Fingering(parent, textStyleType);
@@ -604,9 +605,9 @@ Fingering* Factory::createFingering(Note * parent, TextStyleType textStyleType,
     return fingering;
 }
 
-CREATE_ITEM_IMPL(Harmony, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Harmony, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(TempoText, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TempoText, DummyParentOr<Segment>, isAccessibleEnabled)
 
 Text* Factory::createText(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
 {
@@ -618,7 +619,7 @@ Text* Factory::createText(EngravingItem * parent, TextStyleType tid, bool isAcce
 
 COPY_ITEM_IMPL(Text)
 
-CREATE_ITEM_IMPL(Tie, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Tie, EngravingItem*, isAccessibleEnabled)
 Tie* Factory::copyTie(const Tie& src)
 {
     Tie* copy = src.isLaissezVib() ? new LaissezVib(*toLaissezVib(&src)) : new Tie(src);
@@ -627,41 +628,41 @@ Tie* Factory::copyTie(const Tie& src)
     return copy;
 }
 
-CREATE_ITEM_IMPL(TimeSig, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TimeSig, DummyParentOr<Segment>, isAccessibleEnabled)
 COPY_ITEM_IMPL(TimeSig)
-MAKE_ITEM_IMPL(TimeSig, Segment)
+MAKE_ITEM_IMPL(TimeSig, DummyParentOr<Segment>)
 
-CREATE_ITEM_IMPL(TremoloTwoChord, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TremoloTwoChord, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(TremoloTwoChord)
-MAKE_ITEM_IMPL(TremoloTwoChord, Chord)
+MAKE_ITEM_IMPL(TremoloTwoChord, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(TremoloSingleChord, Chord, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TremoloSingleChord, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(TremoloSingleChord)
-MAKE_ITEM_IMPL(TremoloSingleChord, Chord)
+MAKE_ITEM_IMPL(TremoloSingleChord, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(TremoloBar, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(TremoloBar, EngravingItem)
+CREATE_ITEM_IMPL(TremoloBar, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(TremoloBar, EngravingItem*)
 
-CREATE_ITEM_IMPL(Tuplet, Measure, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Tuplet, DummyParentOr<Measure>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Tuplet)
 
-CREATE_ITEM_IMPL(Hairpin, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Hairpin, EngravingItem)
+CREATE_ITEM_IMPL(Hairpin, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Hairpin, EngravingItem*)
 
-CREATE_ITEM_IMPL(HammerOnPullOff, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(HammerOnPullOff, EngravingItem)
+CREATE_ITEM_IMPL(HammerOnPullOff, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(HammerOnPullOff, EngravingItem*)
 
-CREATE_ITEM_IMPL(Glissando, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Glissando, EngravingItem)
+CREATE_ITEM_IMPL(Glissando, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Glissando, EngravingItem*)
 
-CREATE_ITEM_IMPL(GuitarBend, Note, isAccessibleEnabled)
-MAKE_ITEM_IMPL(GuitarBend, Note)
+CREATE_ITEM_IMPL(GuitarBend, DummyParentOr<Note>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(GuitarBend, DummyParentOr<Note>)
 
-CREATE_ITEM_IMPL(Jump, Measure, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Jump, DummyParentOr<Measure>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Trill, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Trill, EngravingItem*, isAccessibleEnabled)
 
-TripletFeel* Factory::createTripletFeel(Segment * parent, TripletFeelType type, bool isAccessibleEnabled)
+TripletFeel* Factory::createTripletFeel(DummyParentOr<Segment> parent, TripletFeelType type, bool isAccessibleEnabled)
 {
     TripletFeel* t = new TripletFeel(parent, type);
     t->setAccessibleEnabled(isAccessibleEnabled);
@@ -669,16 +670,16 @@ TripletFeel* Factory::createTripletFeel(Segment * parent, TripletFeelType type, 
     return t;
 }
 
-CREATE_ITEM_IMPL(Vibrato, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Vibrato, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(TextLine, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(TextLine, EngravingItem);
+CREATE_ITEM_IMPL(TextLine, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(TextLine, EngravingItem*);
 
-CREATE_ITEM_IMPL(Ottava, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Ottava, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(LetRing, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LetRing, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Marker, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Marker, EngravingItem*, isAccessibleEnabled)
 
 Marker* Factory::createMarker(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
 {
@@ -688,30 +689,30 @@ Marker* Factory::createMarker(EngravingItem * parent, TextStyleType tid, bool is
     return m;
 }
 
-MAKE_ITEM_IMPL(Marker, EngravingItem)
+MAKE_ITEM_IMPL(Marker, EngravingItem*)
 
-CREATE_ITEM_IMPL(GradualTempoChange, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(GradualTempoChange, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(PalmMute, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PalmMute, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(WhammyBar, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(WhammyBar, Segment)
+CREATE_ITEM_IMPL(WhammyBar, EngravingItem*, isAccessibleEnabled)
+MAKE_ITEM_IMPL(WhammyBar, EngravingItem*)
 
-CREATE_ITEM_IMPL(Rasgueado, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Rasgueado, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(HarmonicMark, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(HarmonicMark, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(PickScrape, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PickScrape, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Volta, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Volta, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Pedal, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Pedal, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Dynamic, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Dynamic, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(MMRest, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(MMRest, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(VBox, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(VBox, Score*, isAccessibleEnabled)
 
 VBox* Factory::createTitleVBox(Score * parent, bool isAccessibleEnabled)
 {
@@ -723,11 +724,11 @@ VBox* Factory::createTitleVBox(Score * parent, bool isAccessibleEnabled)
     return b;
 }
 
-CREATE_ITEM_IMPL(HBox, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(HBox, Score*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(TBox, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TBox, Score*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(FBox, Score, isAccessibleEnabled)
+CREATE_ITEM_IMPL(FBox, Score*, isAccessibleEnabled)
 
 Image* Factory::createImage(EngravingItem * parent)
 {
@@ -737,12 +738,13 @@ Image* Factory::createImage(EngravingItem * parent)
     return image;
 }
 
-CREATE_ITEM_IMPL(Symbol, EngravingItem, isAccessibleEnabled)
-CREATE_ITEM_IMPL(FSymbol, EngravingItem, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Symbol, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(FSymbol, EngravingItem*, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(PlayCountText, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PlayCountText, DummyParentOr<Segment>, isAccessibleEnabled)
 
-PlayTechAnnotation* Factory::createPlayTechAnnotation(Segment * parent, PlayingTechniqueType techniqueType, TextStyleType styleType,
+PlayTechAnnotation* Factory::createPlayTechAnnotation(DummyParentOr<Segment> parent, PlayingTechniqueType techniqueType,
+                                                      TextStyleType styleType,
                                                       bool isAccessibleEnabled)
 {
     PlayTechAnnotation* annotation = new PlayTechAnnotation(parent, techniqueType, styleType);
@@ -751,14 +753,14 @@ PlayTechAnnotation* Factory::createPlayTechAnnotation(Segment * parent, PlayingT
     return annotation;
 }
 
-CREATE_ITEM_IMPL(Capo, Segment, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Capo, Segment);
+CREATE_ITEM_IMPL(Capo, DummyParentOr<Segment>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Capo, DummyParentOr<Segment>);
 
-CREATE_ITEM_IMPL(TimeTickAnchor, Segment, isAccessibleEnabled)
+CREATE_ITEM_IMPL(TimeTickAnchor, DummyParentOr<Segment>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(StaffVisibilityIndicator, System, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StaffVisibilityIndicator, DummyParentOr<System>, isAccessibleEnabled)
 
-SystemLockIndicator* Factory::createSystemLockIndicator(System * parent, const RangeLock * lock, bool isAccessibleEnabled)
+SystemLockIndicator* Factory::createSystemLockIndicator(DummyParentOr<System> parent, const RangeLock * lock, bool isAccessibleEnabled)
 {
     SystemLockIndicator* sli = new SystemLockIndicator(parent, lock);
     sli->setAccessibleEnabled(isAccessibleEnabled);
@@ -767,5 +769,5 @@ SystemLockIndicator* Factory::createSystemLockIndicator(System * parent, const R
 
 COPY_ITEM_IMPL(SystemLockIndicator)
 
-CREATE_ITEM_IMPL(Parenthesis, EngravingItem, isAccessibleEnabled);
+CREATE_ITEM_IMPL(Parenthesis, EngravingItem*, isAccessibleEnabled);
 COPY_ITEM_IMPL(Parenthesis)

--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -140,6 +140,14 @@ EngravingItem* Factory::createItem(ElementType type, EngravingItem* parent, bool
     return item;
 }
 
+//! The parent if it is of the given type, the dummy otherwise: a parent of the wrong
+//! type is no parent at all.
+template<typename T>
+static DummyParentOr<T> parentOfTypeOrDummy(EngravingItem* parent, DummyParent* dummy)
+{
+    return parentOrDummy(dynamic_cast<T*>(parent), dummy);
+}
+
 EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
 {
     auto dummy = parent->score()->dummy();
@@ -159,97 +167,96 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::PICK_SCRAPE:       return new PickScrape(parent);
     case ElementType::PEDAL:             return new Pedal(parent);
     case ElementType::HAIRPIN:           return new Hairpin(parent);
-    case ElementType::CLEF:              return new Clef(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::KEYSIG:            return new KeySig(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::TIMESIG:           return new TimeSig(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::BAR_LINE:          return new BarLine(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::SYSTEM_DIVIDER:    return new SystemDivider(parent->isSystem() ? toSystem(parent) : dummy->system());
-    case ElementType::ARPEGGIO:          return new Arpeggio(parent->isChord() ? toChord(parent) : dummy->chord());
-    case ElementType::CHORD_BRACKET:     return new ChordBracket(parent->isChord() ? toChord(parent) : dummy->chord());
-    case ElementType::BREATH:            return new Breath(parent->isSegment() ? toSegment(parent) : dummy->segment());
+    case ElementType::CLEF:              return new Clef(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::KEYSIG:            return new KeySig(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::TIMESIG:           return new TimeSig(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::BAR_LINE:          return new BarLine(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::SYSTEM_DIVIDER:    return new SystemDivider(parentOfTypeOrDummy<System>(parent, dummy));
+    case ElementType::ARPEGGIO:          return new Arpeggio(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::CHORD_BRACKET:     return new ChordBracket(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::BREATH:            return new Breath(parentOfTypeOrDummy<Segment>(parent, dummy));
     case ElementType::GLISSANDO:         return new Glissando(parent);
     case ElementType::BRACKET:           return new Bracket(parent);
-    case ElementType::ARTICULATION:      return new Articulation(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
-    case ElementType::TAPPING:           return new Tapping(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
-    case ElementType::ORNAMENT:          return new Ornament(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
+    case ElementType::ARTICULATION:      return new Articulation(parentOfTypeOrDummy<ChordRest>(parent, dummy));
+    case ElementType::TAPPING:           return new Tapping(parentOfTypeOrDummy<ChordRest>(parent, dummy));
+    case ElementType::ORNAMENT:          return new Ornament(parentOfTypeOrDummy<ChordRest>(parent, dummy));
     case ElementType::FERMATA:           return new Fermata(parent);
-    case ElementType::CHORDLINE:         return new ChordLine(parent->isChord() ? toChord(parent) : dummy->chord());
+    case ElementType::CHORDLINE:         return new ChordLine(parentOfTypeOrDummy<Chord>(parent, dummy));
     case ElementType::ACCIDENTAL:        return new Accidental(parent);
-    case ElementType::DYNAMIC:           return new Dynamic(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::EXPRESSION:        return new Expression(parent->isSegment() ? toSegment(parent) : dummy->segment());
+    case ElementType::DYNAMIC:           return new Dynamic(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::EXPRESSION:        return new Expression(parentOfTypeOrDummy<Segment>(parent, dummy));
     case ElementType::TEXT:              return new Text(parent);
-    case ElementType::MEASURE_NUMBER:    return new MeasureNumber(parent->isMeasure() ? toMeasure(parent) : dummy->measure());
-    case ElementType::MMREST_RANGE:      return new MMRestRange(parent->isMeasure() ? toMeasure(parent) : dummy->measure());
-    case ElementType::INSTRUMENT_NAME:   return new InstrumentName(parent->isSystem() ? toSystem(parent) : dummy->system());
-    case ElementType::STAFF_TEXT:        return new StaffText(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::STAVE_SHARING_LABEL: return new StaveSharingLabel(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::PLAY_COUNT_TEXT:   return new PlayCountText(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::PLAYTECH_ANNOTATION: return new PlayTechAnnotation(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::CAPO:              return new Capo(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::SYSTEM_TEXT:       return new SystemText(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::REHEARSAL_MARK:    return new RehearsalMark(parent->isSegment() ? toSegment(parent) : dummy->segment());
+    case ElementType::MEASURE_NUMBER:    return new MeasureNumber(parentOfTypeOrDummy<Measure>(parent, dummy));
+    case ElementType::MMREST_RANGE:      return new MMRestRange(parentOfTypeOrDummy<Measure>(parent, dummy));
+    case ElementType::INSTRUMENT_NAME:   return new InstrumentName(parentOfTypeOrDummy<System>(parent, dummy));
+    case ElementType::STAFF_TEXT:        return new StaffText(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::STAVE_SHARING_LABEL: return new StaveSharingLabel(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::PLAY_COUNT_TEXT:   return new PlayCountText(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::PLAYTECH_ANNOTATION: return new PlayTechAnnotation(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::CAPO:              return new Capo(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::SYSTEM_TEXT:       return new SystemText(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::REHEARSAL_MARK:    return new RehearsalMark(parentOfTypeOrDummy<Segment>(parent, dummy));
     case ElementType::INSTRUMENT_CHANGE: return new InstrumentChange(parent);
     case ElementType::SOUND_FLAG:        return new SoundFlag(parent);
-    case ElementType::STAFFTYPE_CHANGE:  return new StaffTypeChange(parent->isMeasureBase() ? toMeasureBase(parent) : dummy->measure());
-    case ElementType::STAFF_VISIBILITY_INDICATOR: return new StaffVisibilityIndicator(parent->isSystem()
-                                                                                      ? toSystem(parent) : dummy->system());
-    case ElementType::NOTEHEAD:          return new NoteHead(parent->isNote() ? toNote(parent) : dummy->note());
+    case ElementType::STAFFTYPE_CHANGE:  return new StaffTypeChange(parentOfTypeOrDummy<MeasureBase>(parent, dummy));
+    case ElementType::STAFF_VISIBILITY_INDICATOR: return new StaffVisibilityIndicator(parentOfTypeOrDummy<System>(parent, dummy));
+    case ElementType::NOTEHEAD:          return new NoteHead(parentOfTypeOrDummy<Note>(parent, dummy));
     case ElementType::NOTEDOT: {
         if (parent->isNote()) {
             return new NoteDot(toNote(parent));
         } else if (parent->isRest()) {
             return new NoteDot(toRest(parent));
         } else {
-            return new NoteDot(dummy->note());
+            return new NoteDot(dummy);
         }
     }
-    case ElementType::TREMOLO_SINGLECHORD: return new TremoloSingleChord(parent->isChord() ? toChord(parent) : dummy->chord());
-    case ElementType::TREMOLO_TWOCHORD:  return new TremoloTwoChord(parent->isChord() ? toChord(parent) : dummy->chord());
-    case ElementType::LAYOUT_BREAK:      return new LayoutBreak(parent->isMeasureBase() ? toMeasureBase(parent) : dummy->measure());
+    case ElementType::TREMOLO_SINGLECHORD: return new TremoloSingleChord(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::TREMOLO_TWOCHORD:  return new TremoloTwoChord(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::LAYOUT_BREAK:      return new LayoutBreak(parentOfTypeOrDummy<MeasureBase>(parent, dummy));
     case ElementType::MARKER:            return new Marker(parent);
-    case ElementType::JUMP:              return new Jump(parent->isMeasure() ? toMeasure(parent) : dummy->measure());
-    case ElementType::MEASURE_REPEAT:    return new MeasureRepeat(parent->isSegment() ? toSegment(parent) : dummy->segment());
+    case ElementType::JUMP:              return new Jump(parentOfTypeOrDummy<Measure>(parent, dummy));
+    case ElementType::MEASURE_REPEAT:    return new MeasureRepeat(parentOfTypeOrDummy<Segment>(parent, dummy));
     case ElementType::ACTION_ICON:       return new ActionIcon(parent);
-    case ElementType::NOTE:              return new Note(parent->isChord() ? toChord(parent) : dummy->chord());
+    case ElementType::NOTE:              return new Note(parentOfTypeOrDummy<Chord>(parent, dummy));
     case ElementType::SYMBOL:            return new Symbol(parent);
     case ElementType::FSYMBOL:           return new FSymbol(parent);
-    case ElementType::CHORD:             return new Chord(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::REST:              return new Rest(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::MMREST:            return new MMRest(parent->isSegment() ? toSegment(parent) : dummy->segment());
+    case ElementType::CHORD:             return new Chord(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::REST:              return new Rest(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::MMREST:            return new MMRest(parentOfTypeOrDummy<Segment>(parent, dummy));
     case ElementType::DEAD_SLAPPED:      return new DeadSlapped(toRest(parent));
-    case ElementType::SPACER:            return new Spacer(parent->isMeasure() ? toMeasure(parent) : dummy->measure());
+    case ElementType::SPACER:            return new Spacer(parentOfTypeOrDummy<Measure>(parent, dummy));
     case ElementType::STAFF_STATE:       return new StaffState(parent);
-    case ElementType::TEMPO_TEXT:        return new TempoText(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::HARMONY:           return new Harmony(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::FRET_DIAGRAM:      return new FretDiagram(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::HARP_DIAGRAM:      return new HarpPedalDiagram(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::BEND:              return new Bend(parent->isNote() ? toNote(parent) : dummy->note());
-    case ElementType::GUITAR_BEND:       return new GuitarBend(parent->isNote() ? toNote(parent) : dummy->note());
+    case ElementType::TEMPO_TEXT:        return new TempoText(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::HARMONY:           return new Harmony(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::FRET_DIAGRAM:      return new FretDiagram(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::HARP_DIAGRAM:      return new HarpPedalDiagram(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::BEND:              return new Bend(parentOfTypeOrDummy<Note>(parent, dummy));
+    case ElementType::GUITAR_BEND:       return new GuitarBend(parentOfTypeOrDummy<Note>(parent, dummy));
     case ElementType::TREMOLOBAR:        return new TremoloBar(parent);
-    case ElementType::LYRICS:            return new Lyrics(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
+    case ElementType::LYRICS:            return new Lyrics(parentOfTypeOrDummy<ChordRest>(parent, dummy));
     case ElementType::LYRICSLINE:        return new LyricsLine(parent);
-    case ElementType::FIGURED_BASS:      return new FiguredBass(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::STEM:              return new Stem(parent->isChord() ? toChord(parent) : dummy->chord());
+    case ElementType::FIGURED_BASS:      return new FiguredBass(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::STEM:              return new Stem(parentOfTypeOrDummy<Chord>(parent, dummy));
     case ElementType::SLUR:              return new Slur(parent);
     case ElementType::HAMMER_ON_PULL_OFF: return new HammerOnPullOff(parent);
     case ElementType::TIE:               return new Tie(parent);
-    case ElementType::TUPLET:            return new Tuplet(parent->isMeasure() ? toMeasure(parent) : dummy->measure());
-    case ElementType::FINGERING:         return new Fingering(parent->isNote() ? toNote(parent) : dummy->note());
+    case ElementType::TUPLET:            return new Tuplet(parentOfTypeOrDummy<Measure>(parent, dummy));
+    case ElementType::FINGERING:         return new Fingering(parentOfTypeOrDummy<Note>(parent, dummy));
     case ElementType::HBOX:              return new HBox(parent->score());
     case ElementType::VBOX:              return new VBox(parent->score());
     case ElementType::TBOX:              return new TBox(parent->score());
     case ElementType::FBOX:              return new FBox(parent->score());
     case ElementType::MEASURE:           return new Measure(parent->score());
-    case ElementType::TAB_DURATION_SYMBOL: return new TabDurationSymbol(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
+    case ElementType::TAB_DURATION_SYMBOL: return new TabDurationSymbol(parentOfTypeOrDummy<ChordRest>(parent, dummy));
     case ElementType::IMAGE:             return new Image(parent);
     case ElementType::BAGPIPE_EMBELLISHMENT: return new BagpipeEmbellishment(parent);
-    case ElementType::AMBITUS:           return new Ambitus(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::STICKING:          return new Sticking(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::TRIPLET_FEEL:      return new TripletFeel(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::STRING_TUNINGS:      return new StringTunings(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::TIME_TICK_ANCHOR:  return new TimeTickAnchor(parent->isSegment() ? toSegment(parent) : dummy->segment());
-    case ElementType::LAISSEZ_VIB:       return new LaissezVib(parent->isNote() ? toNote(parent) : dummy->note());
-    case ElementType::PARTIAL_TIE:       return new PartialTie(parent->isNote() ? toNote(parent) : dummy->note());
+    case ElementType::AMBITUS:           return new Ambitus(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::STICKING:          return new Sticking(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::TRIPLET_FEEL:      return new TripletFeel(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::STRING_TUNINGS:      return new StringTunings(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::TIME_TICK_ANCHOR:  return new TimeTickAnchor(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::LAISSEZ_VIB:       return new LaissezVib(parentOfTypeOrDummy<Note>(parent, dummy));
+    case ElementType::PARTIAL_TIE:       return new PartialTie(parentOfTypeOrDummy<Note>(parent, dummy));
     case ElementType::PARTIAL_LYRICSLINE: return new PartialLyricsLine(parent);
     case ElementType::PARENTHESIS:       return new Parenthesis(parent);
 

--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -129,7 +129,7 @@
 using namespace mu;
 using namespace mu::engraving;
 
-EngravingItem* Factory::createItem(ElementType type, EngravingItem* parent, bool isAccessibleEnabled)
+EngravingItem* Factory::createItem(ElementType type, DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled)
 {
     EngravingItem* item = doCreateItem(type, parent);
 
@@ -148,9 +148,15 @@ static DummyParentOr<T> parentOfTypeOrDummy(EngravingItem* parent, DummyParent* 
     return parentOrDummy(dynamic_cast<T*>(parent), dummy);
 }
 
-EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
+EngravingItem* Factory::doCreateItem(ElementType type, DummyParentOr<EngravingItem> parent)
 {
-    auto dummy = parent->score()->dummy();
+    EngravingObject* parentObject = parent;
+    Score* score = parentObject->score();
+    DummyParent* dummy = score->dummy();
+    // null when the item is to be created unattached; the cases below that need a
+    // parent of a particular type fall back to the dummy either way
+    EngravingItem* parentItem = parent.as<EngravingItem>();
+
     switch (type) {
     case ElementType::VOLTA:             return new Volta(parent);
     case ElementType::OTTAVA:            return new Ottava(parent);
@@ -167,96 +173,96 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::PICK_SCRAPE:       return new PickScrape(parent);
     case ElementType::PEDAL:             return new Pedal(parent);
     case ElementType::HAIRPIN:           return new Hairpin(parent);
-    case ElementType::CLEF:              return new Clef(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::KEYSIG:            return new KeySig(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::TIMESIG:           return new TimeSig(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::BAR_LINE:          return new BarLine(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::SYSTEM_DIVIDER:    return new SystemDivider(parentOfTypeOrDummy<System>(parent, dummy));
-    case ElementType::ARPEGGIO:          return new Arpeggio(parentOfTypeOrDummy<Chord>(parent, dummy));
-    case ElementType::CHORD_BRACKET:     return new ChordBracket(parentOfTypeOrDummy<Chord>(parent, dummy));
-    case ElementType::BREATH:            return new Breath(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::CLEF:              return new Clef(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::KEYSIG:            return new KeySig(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::TIMESIG:           return new TimeSig(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::BAR_LINE:          return new BarLine(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::SYSTEM_DIVIDER:    return new SystemDivider(parentOfTypeOrDummy<System>(parentItem, dummy));
+    case ElementType::ARPEGGIO:          return new Arpeggio(parentOfTypeOrDummy<Chord>(parentItem, dummy));
+    case ElementType::CHORD_BRACKET:     return new ChordBracket(parentOfTypeOrDummy<Chord>(parentItem, dummy));
+    case ElementType::BREATH:            return new Breath(parentOfTypeOrDummy<Segment>(parentItem, dummy));
     case ElementType::GLISSANDO:         return new Glissando(parent);
     case ElementType::BRACKET:           return new Bracket(parent);
-    case ElementType::ARTICULATION:      return new Articulation(parentOfTypeOrDummy<ChordRest>(parent, dummy));
-    case ElementType::TAPPING:           return new Tapping(parentOfTypeOrDummy<ChordRest>(parent, dummy));
-    case ElementType::ORNAMENT:          return new Ornament(parentOfTypeOrDummy<ChordRest>(parent, dummy));
+    case ElementType::ARTICULATION:      return new Articulation(parentOfTypeOrDummy<ChordRest>(parentItem, dummy));
+    case ElementType::TAPPING:           return new Tapping(parentOfTypeOrDummy<ChordRest>(parentItem, dummy));
+    case ElementType::ORNAMENT:          return new Ornament(parentOfTypeOrDummy<ChordRest>(parentItem, dummy));
     case ElementType::FERMATA:           return new Fermata(parent);
-    case ElementType::CHORDLINE:         return new ChordLine(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::CHORDLINE:         return new ChordLine(parentOfTypeOrDummy<Chord>(parentItem, dummy));
     case ElementType::ACCIDENTAL:        return new Accidental(parent);
-    case ElementType::DYNAMIC:           return new Dynamic(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::EXPRESSION:        return new Expression(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::DYNAMIC:           return new Dynamic(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::EXPRESSION:        return new Expression(parentOfTypeOrDummy<Segment>(parentItem, dummy));
     case ElementType::TEXT:              return new Text(parent);
-    case ElementType::MEASURE_NUMBER:    return new MeasureNumber(parentOfTypeOrDummy<Measure>(parent, dummy));
-    case ElementType::MMREST_RANGE:      return new MMRestRange(parentOfTypeOrDummy<Measure>(parent, dummy));
-    case ElementType::INSTRUMENT_NAME:   return new InstrumentName(parentOfTypeOrDummy<System>(parent, dummy));
-    case ElementType::STAFF_TEXT:        return new StaffText(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::STAVE_SHARING_LABEL: return new StaveSharingLabel(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::PLAY_COUNT_TEXT:   return new PlayCountText(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::PLAYTECH_ANNOTATION: return new PlayTechAnnotation(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::CAPO:              return new Capo(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::SYSTEM_TEXT:       return new SystemText(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::REHEARSAL_MARK:    return new RehearsalMark(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::MEASURE_NUMBER:    return new MeasureNumber(parentOfTypeOrDummy<Measure>(parentItem, dummy));
+    case ElementType::MMREST_RANGE:      return new MMRestRange(parentOfTypeOrDummy<Measure>(parentItem, dummy));
+    case ElementType::INSTRUMENT_NAME:   return new InstrumentName(parentOfTypeOrDummy<System>(parentItem, dummy));
+    case ElementType::STAFF_TEXT:        return new StaffText(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::STAVE_SHARING_LABEL: return new StaveSharingLabel(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::PLAY_COUNT_TEXT:   return new PlayCountText(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::PLAYTECH_ANNOTATION: return new PlayTechAnnotation(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::CAPO:              return new Capo(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::SYSTEM_TEXT:       return new SystemText(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::REHEARSAL_MARK:    return new RehearsalMark(parentOfTypeOrDummy<Segment>(parentItem, dummy));
     case ElementType::INSTRUMENT_CHANGE: return new InstrumentChange(parent);
     case ElementType::SOUND_FLAG:        return new SoundFlag(parent);
-    case ElementType::STAFFTYPE_CHANGE:  return new StaffTypeChange(parentOfTypeOrDummy<MeasureBase>(parent, dummy));
-    case ElementType::STAFF_VISIBILITY_INDICATOR: return new StaffVisibilityIndicator(parentOfTypeOrDummy<System>(parent, dummy));
-    case ElementType::NOTEHEAD:          return new NoteHead(parentOfTypeOrDummy<Note>(parent, dummy));
+    case ElementType::STAFFTYPE_CHANGE:  return new StaffTypeChange(parentOfTypeOrDummy<MeasureBase>(parentItem, dummy));
+    case ElementType::STAFF_VISIBILITY_INDICATOR: return new StaffVisibilityIndicator(parentOfTypeOrDummy<System>(parentItem, dummy));
+    case ElementType::NOTEHEAD:          return new NoteHead(parentOfTypeOrDummy<Note>(parentItem, dummy));
     case ElementType::NOTEDOT: {
-        if (parent->isNote()) {
-            return new NoteDot(toNote(parent));
-        } else if (parent->isRest()) {
-            return new NoteDot(toRest(parent));
+        if (parentItem && parentItem->isNote()) {
+            return new NoteDot(toNote(parentItem));
+        } else if (parentItem && parentItem->isRest()) {
+            return new NoteDot(toRest(parentItem));
         } else {
             return new NoteDot(dummy);
         }
     }
-    case ElementType::TREMOLO_SINGLECHORD: return new TremoloSingleChord(parentOfTypeOrDummy<Chord>(parent, dummy));
-    case ElementType::TREMOLO_TWOCHORD:  return new TremoloTwoChord(parentOfTypeOrDummy<Chord>(parent, dummy));
-    case ElementType::LAYOUT_BREAK:      return new LayoutBreak(parentOfTypeOrDummy<MeasureBase>(parent, dummy));
+    case ElementType::TREMOLO_SINGLECHORD: return new TremoloSingleChord(parentOfTypeOrDummy<Chord>(parentItem, dummy));
+    case ElementType::TREMOLO_TWOCHORD:  return new TremoloTwoChord(parentOfTypeOrDummy<Chord>(parentItem, dummy));
+    case ElementType::LAYOUT_BREAK:      return new LayoutBreak(parentOfTypeOrDummy<MeasureBase>(parentItem, dummy));
     case ElementType::MARKER:            return new Marker(parent);
-    case ElementType::JUMP:              return new Jump(parentOfTypeOrDummy<Measure>(parent, dummy));
-    case ElementType::MEASURE_REPEAT:    return new MeasureRepeat(parentOfTypeOrDummy<Segment>(parent, dummy));
+    case ElementType::JUMP:              return new Jump(parentOfTypeOrDummy<Measure>(parentItem, dummy));
+    case ElementType::MEASURE_REPEAT:    return new MeasureRepeat(parentOfTypeOrDummy<Segment>(parentItem, dummy));
     case ElementType::ACTION_ICON:       return new ActionIcon(parent);
-    case ElementType::NOTE:              return new Note(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::NOTE:              return new Note(parentOfTypeOrDummy<Chord>(parentItem, dummy));
     case ElementType::SYMBOL:            return new Symbol(parent);
     case ElementType::FSYMBOL:           return new FSymbol(parent);
-    case ElementType::CHORD:             return new Chord(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::REST:              return new Rest(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::MMREST:            return new MMRest(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::DEAD_SLAPPED:      return new DeadSlapped(toRest(parent));
-    case ElementType::SPACER:            return new Spacer(parentOfTypeOrDummy<Measure>(parent, dummy));
+    case ElementType::CHORD:             return new Chord(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::REST:              return new Rest(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::MMREST:            return new MMRest(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::DEAD_SLAPPED:      return new DeadSlapped(toRest(parentItem));
+    case ElementType::SPACER:            return new Spacer(parentOfTypeOrDummy<Measure>(parentItem, dummy));
     case ElementType::STAFF_STATE:       return new StaffState(parent);
-    case ElementType::TEMPO_TEXT:        return new TempoText(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::HARMONY:           return new Harmony(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::FRET_DIAGRAM:      return new FretDiagram(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::HARP_DIAGRAM:      return new HarpPedalDiagram(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::BEND:              return new Bend(parentOfTypeOrDummy<Note>(parent, dummy));
-    case ElementType::GUITAR_BEND:       return new GuitarBend(parentOfTypeOrDummy<Note>(parent, dummy));
+    case ElementType::TEMPO_TEXT:        return new TempoText(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::HARMONY:           return new Harmony(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::FRET_DIAGRAM:      return new FretDiagram(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::HARP_DIAGRAM:      return new HarpPedalDiagram(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::BEND:              return new Bend(parentOfTypeOrDummy<Note>(parentItem, dummy));
+    case ElementType::GUITAR_BEND:       return new GuitarBend(parentOfTypeOrDummy<Note>(parentItem, dummy));
     case ElementType::TREMOLOBAR:        return new TremoloBar(parent);
-    case ElementType::LYRICS:            return new Lyrics(parentOfTypeOrDummy<ChordRest>(parent, dummy));
+    case ElementType::LYRICS:            return new Lyrics(parentOfTypeOrDummy<ChordRest>(parentItem, dummy));
     case ElementType::LYRICSLINE:        return new LyricsLine(parent);
-    case ElementType::FIGURED_BASS:      return new FiguredBass(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::STEM:              return new Stem(parentOfTypeOrDummy<Chord>(parent, dummy));
+    case ElementType::FIGURED_BASS:      return new FiguredBass(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::STEM:              return new Stem(parentOfTypeOrDummy<Chord>(parentItem, dummy));
     case ElementType::SLUR:              return new Slur(parent);
     case ElementType::HAMMER_ON_PULL_OFF: return new HammerOnPullOff(parent);
     case ElementType::TIE:               return new Tie(parent);
-    case ElementType::TUPLET:            return new Tuplet(parentOfTypeOrDummy<Measure>(parent, dummy));
-    case ElementType::FINGERING:         return new Fingering(parentOfTypeOrDummy<Note>(parent, dummy));
-    case ElementType::HBOX:              return new HBox(parent->score());
-    case ElementType::VBOX:              return new VBox(parent->score());
-    case ElementType::TBOX:              return new TBox(parent->score());
-    case ElementType::FBOX:              return new FBox(parent->score());
-    case ElementType::MEASURE:           return new Measure(parent->score());
-    case ElementType::TAB_DURATION_SYMBOL: return new TabDurationSymbol(parentOfTypeOrDummy<ChordRest>(parent, dummy));
+    case ElementType::TUPLET:            return new Tuplet(parentOfTypeOrDummy<Measure>(parentItem, dummy));
+    case ElementType::FINGERING:         return new Fingering(parentOfTypeOrDummy<Note>(parentItem, dummy));
+    case ElementType::HBOX:              return new HBox(score);
+    case ElementType::VBOX:              return new VBox(score);
+    case ElementType::TBOX:              return new TBox(score);
+    case ElementType::FBOX:              return new FBox(score);
+    case ElementType::MEASURE:           return new Measure(score);
+    case ElementType::TAB_DURATION_SYMBOL: return new TabDurationSymbol(parentOfTypeOrDummy<ChordRest>(parentItem, dummy));
     case ElementType::IMAGE:             return new Image(parent);
     case ElementType::BAGPIPE_EMBELLISHMENT: return new BagpipeEmbellishment(parent);
-    case ElementType::AMBITUS:           return new Ambitus(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::STICKING:          return new Sticking(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::TRIPLET_FEEL:      return new TripletFeel(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::STRING_TUNINGS:      return new StringTunings(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::TIME_TICK_ANCHOR:  return new TimeTickAnchor(parentOfTypeOrDummy<Segment>(parent, dummy));
-    case ElementType::LAISSEZ_VIB:       return new LaissezVib(parentOfTypeOrDummy<Note>(parent, dummy));
-    case ElementType::PARTIAL_TIE:       return new PartialTie(parentOfTypeOrDummy<Note>(parent, dummy));
+    case ElementType::AMBITUS:           return new Ambitus(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::STICKING:          return new Sticking(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::TRIPLET_FEEL:      return new TripletFeel(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::STRING_TUNINGS:      return new StringTunings(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::TIME_TICK_ANCHOR:  return new TimeTickAnchor(parentOfTypeOrDummy<Segment>(parentItem, dummy));
+    case ElementType::LAISSEZ_VIB:       return new LaissezVib(parentOfTypeOrDummy<Note>(parentItem, dummy));
+    case ElementType::PARTIAL_TIE:       return new PartialTie(parentOfTypeOrDummy<Note>(parentItem, dummy));
     case ElementType::PARTIAL_LYRICSLINE: return new PartialLyricsLine(parent);
     case ElementType::PARENTHESIS:       return new Parenthesis(parent);
 
@@ -324,7 +330,7 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     return nullptr;
 }
 
-EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingItem* parent, bool isAccessibleEnabled)
+EngravingItem* Factory::createItemByName(const AsciiStringView& name, DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled)
 {
     ElementType type = TConv::fromXml(name, ElementType::INVALID, isAccessibleEnabled);
     if (type == ElementType::INVALID) {
@@ -355,8 +361,8 @@ EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingI
         return copy; \
     } \
 
-CREATE_ITEM_IMPL(Accidental, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Accidental, EngravingItem*)
+CREATE_ITEM_IMPL(Accidental, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Accidental, DummyParentOr<EngravingItem>)
 
 CREATE_ITEM_IMPL(Ambitus, DummyParentOr<Segment>, isAccessibleEnabled)
 MAKE_ITEM_IMPL(Ambitus, DummyParentOr<Segment>)
@@ -386,16 +392,16 @@ MAKE_ITEM_IMPL(Beam, Score*)
 CREATE_ITEM_IMPL(Bend, DummyParentOr<Note>, isAccessibleEnabled)
 MAKE_ITEM_IMPL(Bend, DummyParentOr<Note>)
 
-CREATE_ITEM_IMPL(Bracket, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Bracket, EngravingItem*)
+CREATE_ITEM_IMPL(Bracket, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Bracket, DummyParentOr<EngravingItem>)
 
-BracketItem* Factory::createBracketItem(EngravingItem * parent)
+BracketItem* Factory::createBracketItem(DummyParentOr<EngravingItem> parent)
 {
     BracketItem* bi = new BracketItem(parent);
     return bi;
 }
 
-BracketItem* Factory::createBracketItem(EngravingItem* parent, BracketType bracketType, size_t span)
+BracketItem* Factory::createBracketItem(DummyParentOr<EngravingItem> parent, BracketType bracketType, size_t span)
 {
     BracketItem* bi = new BracketItem(parent, bracketType, span);
     return bi;
@@ -454,7 +460,7 @@ MAKE_ITEM_IMPL(LayoutBreak, DummyParentOr<MeasureBase>)
 CREATE_ITEM_IMPL(Lyrics, DummyParentOr<ChordRest>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Lyrics)
 
-CREATE_ITEM_IMPL(LyricsLine, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LyricsLine, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 COPY_ITEM_IMPL(LyricsLine)
 
 CREATE_ITEM_IMPL(Measure, Score*, isAccessibleEnabled)
@@ -498,7 +504,7 @@ COPY_ITEM_IMPL(PageLockIndicator)
 CREATE_ITEM_IMPL(PartialTie, DummyParentOr<Note>, isAccessibleEnabled)
 COPY_ITEM_IMPL(PartialTie)
 
-CREATE_ITEM_IMPL(PartialLyricsLine, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PartialLyricsLine, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 COPY_ITEM_IMPL(PartialLyricsLine)
 
 CREATE_ITEM_IMPL(Rest, DummyParentOr<Segment>, isAccessibleEnabled)
@@ -529,8 +535,8 @@ Segment* Factory::createSegment(DummyParentOr<Measure> parent, SegmentType type,
     return s;
 }
 
-CREATE_ITEM_IMPL(Slur, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Slur, EngravingItem*)
+CREATE_ITEM_IMPL(Slur, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Slur, DummyParentOr<EngravingItem>)
 
 CREATE_ITEM_IMPL(Spacer, DummyParentOr<Measure>, isAccessibleEnabled)
 MAKE_ITEM_IMPL(Spacer, DummyParentOr<Measure>)
@@ -545,7 +551,7 @@ Staff* Factory::createStaff(Part * parent)
 CREATE_ITEM_IMPL(StaffLines, DummyParentOr<Measure>, isAccessibleEnabled)
 COPY_ITEM_IMPL(StaffLines)
 
-CREATE_ITEM_IMPL(StaffState, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(StaffState, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(StaffTypeChange, DummyParentOr<MeasureBase>, isAccessibleEnabled)
 MAKE_ITEM_IMPL(StaffTypeChange, DummyParentOr<MeasureBase>)
@@ -565,7 +571,7 @@ StaveSharingLabel* Factory::createStaveSharingLabel(DummyParentOr<Segment> paren
     return staveSharingLabel;
 }
 
-CREATE_ITEM_IMPL(SoundFlag, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(SoundFlag, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(Expression, DummyParentOr<Segment>, isAccessibleEnabled)
 
@@ -612,11 +618,11 @@ Fingering* Factory::createFingering(DummyParentOr<Note> parent, TextStyleType te
     return fingering;
 }
 
-CREATE_ITEM_IMPL(Harmony, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Harmony, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(TempoText, DummyParentOr<Segment>, isAccessibleEnabled)
 
-Text* Factory::createText(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
+Text* Factory::createText(DummyParentOr<EngravingItem> parent, TextStyleType tid, bool isAccessibleEnabled)
 {
     Text* t = new Text(parent, tid);
     t->setAccessibleEnabled(isAccessibleEnabled);
@@ -626,7 +632,7 @@ Text* Factory::createText(EngravingItem * parent, TextStyleType tid, bool isAcce
 
 COPY_ITEM_IMPL(Text)
 
-CREATE_ITEM_IMPL(Tie, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Tie, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 Tie* Factory::copyTie(const Tie& src)
 {
     Tie* copy = src.isLaissezVib() ? new LaissezVib(*toLaissezVib(&src)) : new Tie(src);
@@ -647,27 +653,27 @@ CREATE_ITEM_IMPL(TremoloSingleChord, DummyParentOr<Chord>, isAccessibleEnabled)
 COPY_ITEM_IMPL(TremoloSingleChord)
 MAKE_ITEM_IMPL(TremoloSingleChord, DummyParentOr<Chord>)
 
-CREATE_ITEM_IMPL(TremoloBar, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(TremoloBar, EngravingItem*)
+CREATE_ITEM_IMPL(TremoloBar, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(TremoloBar, DummyParentOr<EngravingItem>)
 
 CREATE_ITEM_IMPL(Tuplet, DummyParentOr<Measure>, isAccessibleEnabled)
 COPY_ITEM_IMPL(Tuplet)
 
-CREATE_ITEM_IMPL(Hairpin, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Hairpin, EngravingItem*)
+CREATE_ITEM_IMPL(Hairpin, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Hairpin, DummyParentOr<EngravingItem>)
 
-CREATE_ITEM_IMPL(HammerOnPullOff, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(HammerOnPullOff, EngravingItem*)
+CREATE_ITEM_IMPL(HammerOnPullOff, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(HammerOnPullOff, DummyParentOr<EngravingItem>)
 
-CREATE_ITEM_IMPL(Glissando, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Glissando, EngravingItem*)
+CREATE_ITEM_IMPL(Glissando, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Glissando, DummyParentOr<EngravingItem>)
 
 CREATE_ITEM_IMPL(GuitarBend, DummyParentOr<Note>, isAccessibleEnabled)
 MAKE_ITEM_IMPL(GuitarBend, DummyParentOr<Note>)
 
 CREATE_ITEM_IMPL(Jump, DummyParentOr<Measure>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Trill, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Trill, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 TripletFeel* Factory::createTripletFeel(DummyParentOr<Segment> parent, TripletFeelType type, bool isAccessibleEnabled)
 {
@@ -677,18 +683,18 @@ TripletFeel* Factory::createTripletFeel(DummyParentOr<Segment> parent, TripletFe
     return t;
 }
 
-CREATE_ITEM_IMPL(Vibrato, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Vibrato, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(TextLine, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(TextLine, EngravingItem*);
+CREATE_ITEM_IMPL(TextLine, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(TextLine, DummyParentOr<EngravingItem>);
 
-CREATE_ITEM_IMPL(Ottava, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Ottava, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(LetRing, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(LetRing, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Marker, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Marker, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-Marker* Factory::createMarker(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
+Marker* Factory::createMarker(DummyParentOr<EngravingItem> parent, TextStyleType tid, bool isAccessibleEnabled)
 {
     Marker* m = new Marker(parent, tid);
     m->setAccessibleEnabled(isAccessibleEnabled);
@@ -696,24 +702,24 @@ Marker* Factory::createMarker(EngravingItem * parent, TextStyleType tid, bool is
     return m;
 }
 
-MAKE_ITEM_IMPL(Marker, EngravingItem*)
+MAKE_ITEM_IMPL(Marker, DummyParentOr<EngravingItem>)
 
-CREATE_ITEM_IMPL(GradualTempoChange, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(GradualTempoChange, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(PalmMute, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PalmMute, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(WhammyBar, EngravingItem*, isAccessibleEnabled)
-MAKE_ITEM_IMPL(WhammyBar, EngravingItem*)
+CREATE_ITEM_IMPL(WhammyBar, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+MAKE_ITEM_IMPL(WhammyBar, DummyParentOr<EngravingItem>)
 
-CREATE_ITEM_IMPL(Rasgueado, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Rasgueado, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(HarmonicMark, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(HarmonicMark, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(PickScrape, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(PickScrape, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Volta, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Volta, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
-CREATE_ITEM_IMPL(Pedal, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Pedal, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(Dynamic, DummyParentOr<Segment>, isAccessibleEnabled)
 
@@ -737,7 +743,7 @@ CREATE_ITEM_IMPL(TBox, Score*, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(FBox, Score*, isAccessibleEnabled)
 
-Image* Factory::createImage(EngravingItem * parent)
+Image* Factory::createImage(DummyParentOr<EngravingItem> parent)
 {
     Image* image = new Image(parent);
     image->setOwnershipParent(parent);
@@ -745,8 +751,8 @@ Image* Factory::createImage(EngravingItem * parent)
     return image;
 }
 
-CREATE_ITEM_IMPL(Symbol, EngravingItem*, isAccessibleEnabled)
-CREATE_ITEM_IMPL(FSymbol, EngravingItem*, isAccessibleEnabled)
+CREATE_ITEM_IMPL(Symbol, DummyParentOr<EngravingItem>, isAccessibleEnabled)
+CREATE_ITEM_IMPL(FSymbol, DummyParentOr<EngravingItem>, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(PlayCountText, DummyParentOr<Segment>, isAccessibleEnabled)
 
@@ -776,5 +782,5 @@ SystemLockIndicator* Factory::createSystemLockIndicator(DummyParentOr<System> pa
 
 COPY_ITEM_IMPL(SystemLockIndicator)
 
-CREATE_ITEM_IMPL(Parenthesis, EngravingItem*, isAccessibleEnabled);
+CREATE_ITEM_IMPL(Parenthesis, DummyParentOr<EngravingItem>, isAccessibleEnabled);
 COPY_ITEM_IMPL(Parenthesis)

--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -746,7 +746,6 @@ CREATE_ITEM_IMPL(FBox, Score*, isAccessibleEnabled)
 Image* Factory::createImage(DummyParentOr<EngravingItem> parent)
 {
     Image* image = new Image(parent);
-    image->setOwnershipParent(parent);
 
     return image;
 }

--- a/src/engraving/dom/factory.h
+++ b/src/engraving/dom/factory.h
@@ -44,85 +44,86 @@ public:
     static Accidental* createAccidental(EngravingItem* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Accidental> makeAccidental(EngravingItem* parent);
 
-    static Ambitus* createAmbitus(Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Ambitus> makeAmbitus(Segment* parent);
+    static Ambitus* createAmbitus(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Ambitus> makeAmbitus(DummyParentOr<Segment> parent);
 
-    static Arpeggio* createArpeggio(Chord* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Arpeggio> makeArpeggio(Chord* parent);
+    static Arpeggio* createArpeggio(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Arpeggio> makeArpeggio(DummyParentOr<Chord> parent);
 
-    static ChordBracket* createChordBracket(Chord* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<ChordBracket> makeChordBracket(Chord* parent);
+    static ChordBracket* createChordBracket(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<ChordBracket> makeChordBracket(DummyParentOr<Chord> parent);
 
-    static Articulation* createArticulation(ChordRest* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Articulation> makeArticulation(ChordRest* parent);
+    static Articulation* createArticulation(DummyParentOr<ChordRest> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Articulation> makeArticulation(DummyParentOr<ChordRest> parent);
 
-    static Tapping* createTapping(ChordRest* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Tapping> makeTapping(ChordRest* parent);
+    static Tapping* createTapping(DummyParentOr<ChordRest> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Tapping> makeTapping(DummyParentOr<ChordRest> parent);
 
-    static Ornament* createOrnament(ChordRest* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Ornament> makeOrnament(ChordRest* parent);
+    static Ornament* createOrnament(DummyParentOr<ChordRest> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Ornament> makeOrnament(DummyParentOr<ChordRest> parent);
 
-    static BarLine* createBarLine(Segment* parent, bool isAccessibleEnabled = true);
+    static BarLine* createBarLine(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static BarLine* copyBarLine(const BarLine& src);
-    static std::shared_ptr<BarLine> makeBarLine(Segment* parent);
+    static std::shared_ptr<BarLine> makeBarLine(DummyParentOr<Segment> parent);
 
     static Beam* createBeam(Score* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Beam> makeBeam(Score* parent);
 
-    static Bend* createBend(Note* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Bend> makeBend(Note* parent);
+    static Bend* createBend(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Bend> makeBend(DummyParentOr<Note> parent);
 
     static Bracket* createBracket(EngravingItem* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Bracket> makeBracket(EngravingItem* parent);
     static BracketItem* createBracketItem(EngravingItem* parent);
     static BracketItem* createBracketItem(EngravingItem* parent, BracketType bracketType, size_t span);
 
-    static Breath* createBreath(Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Breath> makeBreath(Segment* parent);
+    static Breath* createBreath(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Breath> makeBreath(DummyParentOr<Segment> parent);
 
-    static Chord* createChord(Segment* parent, bool isAccessibleEnabled = true);
+    static Chord* createChord(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static Chord* copyChord(const Chord& src, bool link = false);
-    static std::shared_ptr<Chord> makeChord(Segment* parent);
+    static std::shared_ptr<Chord> makeChord(DummyParentOr<Segment> parent);
 
-    static ChordLine* createChordLine(Chord* parent, bool isAccessibleEnabled = true);
+    static ChordLine* createChordLine(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
     static ChordLine* copyChordLine(const ChordLine& src);
-    static std::shared_ptr<ChordLine> makeChordLine(Chord* parent);
+    static std::shared_ptr<ChordLine> makeChordLine(DummyParentOr<Chord> parent);
 
-    static Clef* createClef(Segment* parent, bool isAccessibleEnabled = true);
+    static Clef* createClef(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static Clef* copyClef(const Clef& src);
-    static std::shared_ptr<Clef> makeClef(Segment* parent);
+    static std::shared_ptr<Clef> makeClef(DummyParentOr<Segment> parent);
 
-    static Fermata* createFermata(Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Fermata> makeFermata(Segment* parent);
+    static Fermata* createFermata(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Fermata> makeFermata(DummyParentOr<Segment> parent);
 
-    static FiguredBass* createFiguredBass(Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<FiguredBass> makeFiguredBass(Segment* parent);
+    static FiguredBass* createFiguredBass(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<FiguredBass> makeFiguredBass(DummyParentOr<Segment> parent);
 
-    static FretDiagram* createFretDiagram(Segment* parent, bool isAccessibleEnabled = true);
+    static FretDiagram* createFretDiagram(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static FretDiagram* copyFretDiagram(const FretDiagram& src);
-    static std::shared_ptr<FretDiagram> makeFretDiagram(Segment* parent);
+    static std::shared_ptr<FretDiagram> makeFretDiagram(DummyParentOr<Segment> parent);
 
-    static HarpPedalDiagram* createHarpPedalDiagram(Segment* parent, bool isAccessibleEnabled = true);
+    static HarpPedalDiagram* createHarpPedalDiagram(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static HarpPedalDiagram* copyHarpPedalDiagram(const HarpPedalDiagram& src);
-    static std::shared_ptr<HarpPedalDiagram> makeHarpPedalDiagram(Segment* parent);
+    static std::shared_ptr<HarpPedalDiagram> makeHarpPedalDiagram(DummyParentOr<Segment> parent);
 
-    static KeySig* createKeySig(Segment* parent, bool isAccessibleEnabled = true);
+    static KeySig* createKeySig(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static KeySig* copyKeySig(const KeySig& src);
-    static std::shared_ptr<KeySig> makeKeySig(Segment* parent);
+    static std::shared_ptr<KeySig> makeKeySig(DummyParentOr<Segment> parent);
 
-    static LaissezVib* createLaissezVib(Note* parent, bool isAccessibleEnabled = true);
+    static LaissezVib* createLaissezVib(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static LaissezVib* copyLaissezVib(const LaissezVib& src);
 
-    static LayoutBreak* createLayoutBreak(MeasureBase* parent, bool isAccessibleEnabled = true);
+    static LayoutBreak* createLayoutBreak(DummyParentOr<MeasureBase> parent, bool isAccessibleEnabled = true);
     static LayoutBreak* copyLayoutBreak(const LayoutBreak& src);
-    static std::shared_ptr<LayoutBreak> makeLayoutBreak(MeasureBase* parent);
+    static std::shared_ptr<LayoutBreak> makeLayoutBreak(DummyParentOr<MeasureBase> parent);
 
-    static StaffVisibilityIndicator* createStaffVisibilityIndicator(System* parent, bool isAccessibleEnabled = true);
+    static StaffVisibilityIndicator* createStaffVisibilityIndicator(DummyParentOr<System> parent, bool isAccessibleEnabled = true);
 
-    static SystemLockIndicator* createSystemLockIndicator(System* parent, const RangeLock* lock, bool isAccessibleEnabled = true);
+    static SystemLockIndicator* createSystemLockIndicator(DummyParentOr<System> parent, const RangeLock* lock,
+                                                          bool isAccessibleEnabled = true);
     static SystemLockIndicator* copySystemLockIndicator(const SystemLockIndicator& src);
 
-    static Lyrics* createLyrics(ChordRest* parent, bool isAccessibleEnabled = true);
+    static Lyrics* createLyrics(DummyParentOr<ChordRest> parent, bool isAccessibleEnabled = true);
     static Lyrics* copyLyrics(const Lyrics& src);
 
     static LyricsLine* createLyricsLine(EngravingItem* parent, bool isAccessibleEnabled = true);
@@ -131,92 +132,95 @@ public:
     static Measure* createMeasure(Score* parent, bool isAccessibleEnabled = true);
     static Measure* copyMeasure(const Measure& src);
 
-    static MeasureRepeat* createMeasureRepeat(Segment* parent, bool isAccessibleEnabled = true);
+    static MeasureRepeat* createMeasureRepeat(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static MeasureRepeat* copyMeasureRepeat(const MeasureRepeat& src);
 
-    static Note* createNote(Chord* parent, bool isAccessibleEnabled = true);
+    static Note* createNote(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
     static Note* copyNote(const Note& src, bool link = false);
-    static std::shared_ptr<Note> makeNote(Chord* parent);
+    static std::shared_ptr<Note> makeNote(DummyParentOr<Chord> parent);
 
-    static NoteDot* createNoteDot(Note* parent, bool isAccessibleEnabled = true);
+    static NoteDot* createNoteDot(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static NoteDot* createNoteDot(Rest* parent, bool isAccessibleEnabled = true);
     static NoteDot* copyNoteDot(const NoteDot& src);
 
-    static NoteLine* createNoteLine(Note* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<NoteLine> makeNoteLine(Note* parent);
+    static NoteLine* createNoteLine(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<NoteLine> makeNoteLine(DummyParentOr<Note> parent);
 
     static Page* createPage(Score* parent, bool isAccessibleEnabled = true);
 
-    static PageLockIndicator* createPageLockIndicator(System* parent, const RangeLock* lock, bool isAccessibleEnabled = true);
+    static PageLockIndicator* createPageLockIndicator(DummyParentOr<System> parent, const RangeLock* lock, bool isAccessibleEnabled = true);
     static PageLockIndicator* copyPageLockIndicator(const PageLockIndicator& src);
 
     static Parenthesis* createParenthesis(EngravingItem* parent, bool isAccessibleEnabled = true);
     static Parenthesis* copyParenthesis(const Parenthesis& src);
 
-    static PartialTie* createPartialTie(Note* parent, bool isAccessibleEnabled = true);
+    static PartialTie* createPartialTie(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static PartialTie* copyPartialTie(const PartialTie& src);
 
     static PartialLyricsLine* createPartialLyricsLine(EngravingItem* parent, bool isAccessibleEnabled = true);
     static PartialLyricsLine* copyPartialLyricsLine(const PartialLyricsLine& src);
 
-    static Rest* createRest(Segment* parent, bool isAccessibleEnabled = true);
-    static Rest* createRest(Segment* parent, const TDuration& t, bool isAccessibleEnabled = true);
+    static Rest* createRest(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static Rest* createRest(DummyParentOr<Segment> parent, const TDuration& t, bool isAccessibleEnabled = true);
     static Rest* copyRest(const Rest& src, bool link = false);
-    static MMRest* createMMRest(Segment* parent, bool isAccessibleEnabled = true);
+    static MMRest* createMMRest(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
     static DeadSlapped* createDeadSlapped(Rest* parent, bool isAccessibleEnabled = true);
     static DeadSlapped* copyDeadSlapped(const DeadSlapped& src);
 
-    static Segment* createSegment(Measure* parent, bool isAccessibleEnabled = true);
-    static Segment* createSegment(Measure* parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled = true);
+    static Segment* createSegment(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
+    static Segment* createSegment(DummyParentOr<Measure> parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled = true);
 
     static Slur* createSlur(EngravingItem* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Slur> makeSlur(EngravingItem* parent);
 
-    static Spacer* createSpacer(Measure* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Spacer> makeSpacer(Measure* parent);
+    static Spacer* createSpacer(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Spacer> makeSpacer(DummyParentOr<Measure> parent);
 
     static Staff* createStaff(Part* parent);
 
-    static StaffLines* createStaffLines(Measure* parent, bool isAccessibleEnabled = true);
+    static StaffLines* createStaffLines(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static StaffLines* copyStaffLines(const StaffLines& src);
 
     static StaffState* createStaffState(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static StaffTypeChange* createStaffTypeChange(MeasureBase* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<StaffTypeChange> makeStaffTypeChange(MeasureBase* parent);
+    static StaffTypeChange* createStaffTypeChange(DummyParentOr<MeasureBase> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<StaffTypeChange> makeStaffTypeChange(DummyParentOr<MeasureBase> parent);
 
-    static StaffText* createStaffText(Segment* parent, TextStyleType textStyleType = TextStyleType::STAFF, bool isAccessibleEnabled = true);
-    static StaveSharingLabel* createStaveSharingLabel(Segment* parent, TextStyleType textStyleType = TextStyleType::STAVE_SHARING,
+    static StaffText* createStaffText(DummyParentOr<Segment> parent, TextStyleType textStyleType = TextStyleType::STAFF,
+                                      bool isAccessibleEnabled = true);
+    static StaveSharingLabel* createStaveSharingLabel(DummyParentOr<Segment> parent,
+                                                      TextStyleType textStyleType = TextStyleType::STAVE_SHARING,
                                                       bool isAccessibleEnabled = true);
 
     static SoundFlag* createSoundFlag(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static Expression* createExpression(Segment* parent, bool isAccessibleEnabled = true);
+    static Expression* createExpression(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static RehearsalMark* createRehearsalMark(Segment* parent, bool isAccessibleEnabled = true);
+    static RehearsalMark* createRehearsalMark(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static Stem* createStem(Chord* parent, bool isAccessibleEnabled = true);
+    static Stem* createStem(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
     static Stem* copyStem(const Stem& src);
 
-    static StemSlash* createStemSlash(Chord* parent, bool isAccessibleEnabled = true);
+    static StemSlash* createStemSlash(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
     static StemSlash* copyStemSlash(const StemSlash& src);
 
     static System* createSystem(Score* parent, bool isAccessibleEnabled = true);
-    static SystemText* createSystemText(Segment* parent, TextStyleType textStyleType = TextStyleType::SYSTEM,
+    static SystemText* createSystemText(DummyParentOr<Segment> parent, TextStyleType textStyleType = TextStyleType::SYSTEM,
                                         ElementType type = ElementType::SYSTEM_TEXT, bool isAccessibleEnabled = true);
 
-    static InstrumentChange* createInstrumentChange(Segment* parent, bool isAccessibleEnabled = true);
-    static InstrumentChange* createInstrumentChange(Segment* parent, const Instrument& instrument, bool isAccessibleEnabled = true);
+    static InstrumentChange* createInstrumentChange(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static InstrumentChange* createInstrumentChange(DummyParentOr<Segment> parent, const Instrument& instrument,
+                                                    bool isAccessibleEnabled = true);
 
-    static Sticking* createSticking(Segment* parent, bool isAccessibleEnabled = true);
+    static Sticking* createSticking(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static Fingering* createFingering(Note* parent, bool isAccessibleEnabled = true);
-    static Fingering* createFingering(Note* parent, TextStyleType textStyleType, bool isAccessibleEnabled = true);
+    static Fingering* createFingering(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
+    static Fingering* createFingering(DummyParentOr<Note> parent, TextStyleType textStyleType, bool isAccessibleEnabled = true);
 
     static Harmony* createHarmony(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static TempoText* createTempoText(Segment* parent, bool isAccessibleEnabled = true);
+    static TempoText* createTempoText(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
     static Text* createText(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT, bool isAccessibleEnabled = true);
     static Text* copyText(const Text& src);
@@ -224,24 +228,24 @@ public:
     static Tie* createTie(EngravingItem* parent, bool isAccessibleEnabled = true);
     static Tie* copyTie(const Tie& src);
 
-    static TimeSig* createTimeSig(Segment* parent, bool isAccessibleEnabled = true);
+    static TimeSig* createTimeSig(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static TimeSig* copyTimeSig(const TimeSig& src);
-    static std::shared_ptr<TimeSig> makeTimeSig(Segment* parent);
+    static std::shared_ptr<TimeSig> makeTimeSig(DummyParentOr<Segment> parent);
 
-    static TremoloTwoChord* createTremoloTwoChord(Chord* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<TremoloTwoChord> makeTremoloTwoChord(Chord* parent);
+    static TremoloTwoChord* createTremoloTwoChord(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<TremoloTwoChord> makeTremoloTwoChord(DummyParentOr<Chord> parent);
     static TremoloTwoChord* copyTremoloTwoChord(const TremoloTwoChord& src);
 
-    static TremoloSingleChord* createTremoloSingleChord(Chord* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<TremoloSingleChord> makeTremoloSingleChord(Chord* parent);
+    static TremoloSingleChord* createTremoloSingleChord(DummyParentOr<Chord> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<TremoloSingleChord> makeTremoloSingleChord(DummyParentOr<Chord> parent);
     static TremoloSingleChord* copyTremoloSingleChord(const TremoloSingleChord& src);
 
     static TremoloBar* createTremoloBar(EngravingItem* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<TremoloBar> makeTremoloBar(EngravingItem* parent);
 
-    static TripletFeel* createTripletFeel(Segment* parent, TripletFeelType type, bool isAccessibleEnabled = true);
+    static TripletFeel* createTripletFeel(DummyParentOr<Segment> parent, TripletFeelType type, bool isAccessibleEnabled = true);
 
-    static Tuplet* createTuplet(Measure* parent, bool isAccessibleEnabled = true);
+    static Tuplet* createTuplet(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static Tuplet* copyTuplet(const Tuplet& src);
 
     static Hairpin* createHairpin(EngravingItem* parent, bool isAccessibleEnabled = true);
@@ -253,10 +257,10 @@ public:
     static Glissando* createGlissando(EngravingItem* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Glissando> makeGlissando(EngravingItem* parent);
 
-    static GuitarBend* createGuitarBend(Note* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<GuitarBend> makeGuitarBend(Note* parent);
+    static GuitarBend* createGuitarBend(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<GuitarBend> makeGuitarBend(DummyParentOr<Note> parent);
 
-    static Jump* createJump(Measure* parent, bool isAccessibleEnabled = true);
+    static Jump* createJump(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
 
     static Trill* createTrill(EngravingItem* parent, bool isAccessibleEnabled = true);
 
@@ -280,7 +284,7 @@ public:
     static PalmMute* createPalmMute(EngravingItem* parent, bool isAccessibleEnabled = true);
 
     static WhammyBar* createWhammyBar(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<WhammyBar> makeWhammyBar(Segment* parent);
+    static std::shared_ptr<WhammyBar> makeWhammyBar(EngravingItem* parent);
 
     static Rasgueado* createRasgueado(EngravingItem* parent, bool isAccessibleEnabled = true);
 
@@ -292,7 +296,7 @@ public:
 
     static Pedal* createPedal(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static Dynamic* createDynamic(Segment* parent, bool isAccessibleEnabled = true);
+    static Dynamic* createDynamic(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
     static VBox* createVBox(Score* parent, bool isAccessibleEnabled = true);
 
@@ -311,19 +315,19 @@ public:
     static Symbol* createSymbol(EngravingItem* parent, bool isAccessibleEnabled = true);
     static FSymbol* createFSymbol(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static PlayCountText* createPlayCountText(Segment* parent, bool isAccessibleEnabled = true);
+    static PlayCountText* createPlayCountText(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static PlayTechAnnotation* createPlayTechAnnotation(Segment* parent, PlayingTechniqueType techniqueType, TextStyleType styleType,
-                                                        bool isAccessibleEnabled = true);
+    static PlayTechAnnotation* createPlayTechAnnotation(DummyParentOr<Segment> parent, PlayingTechniqueType techniqueType,
+                                                        TextStyleType styleType, bool isAccessibleEnabled = true);
 
-    static Capo* createCapo(Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Capo> makeCapo(Segment* parent);
+    static Capo* createCapo(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Capo> makeCapo(DummyParentOr<Segment> parent);
 
-    static TimeTickAnchor* createTimeTickAnchor(Segment* parent, bool isAccessibleEnabled = true);
+    static TimeTickAnchor* createTimeTickAnchor(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static StringTunings* createStringTunings(Segment* parent, bool isAccessibleEnabled = true);
+    static StringTunings* createStringTunings(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static StringTunings* copyStringTunings(const StringTunings& src);
-    static std::shared_ptr<StringTunings> makeStringTunings(Segment* parent);
+    static std::shared_ptr<StringTunings> makeStringTunings(DummyParentOr<Segment> parent);
 
 private:
     static EngravingItem* doCreateItem(ElementType type, EngravingItem* parent);

--- a/src/engraving/dom/factory.h
+++ b/src/engraving/dom/factory.h
@@ -38,11 +38,12 @@ class Factory
 {
 public:
 
-    static EngravingItem* createItem(ElementType type, EngravingItem* parent, bool isAccessibleEnabled = true);
-    static EngravingItem* createItemByName(const AsciiStringView& name, EngravingItem* parent, bool isAccessibleEnabled = true);
+    static EngravingItem* createItem(ElementType type, DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static EngravingItem* createItemByName(const AsciiStringView& name, DummyParentOr<EngravingItem> parent,
+                                           bool isAccessibleEnabled = true);
 
-    static Accidental* createAccidental(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Accidental> makeAccidental(EngravingItem* parent);
+    static Accidental* createAccidental(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Accidental> makeAccidental(DummyParentOr<EngravingItem> parent);
 
     static Ambitus* createAmbitus(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Ambitus> makeAmbitus(DummyParentOr<Segment> parent);
@@ -72,10 +73,10 @@ public:
     static Bend* createBend(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Bend> makeBend(DummyParentOr<Note> parent);
 
-    static Bracket* createBracket(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Bracket> makeBracket(EngravingItem* parent);
-    static BracketItem* createBracketItem(EngravingItem* parent);
-    static BracketItem* createBracketItem(EngravingItem* parent, BracketType bracketType, size_t span);
+    static Bracket* createBracket(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Bracket> makeBracket(DummyParentOr<EngravingItem> parent);
+    static BracketItem* createBracketItem(DummyParentOr<EngravingItem> parent);
+    static BracketItem* createBracketItem(DummyParentOr<EngravingItem> parent, BracketType bracketType, size_t span);
 
     static Breath* createBreath(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Breath> makeBreath(DummyParentOr<Segment> parent);
@@ -126,7 +127,7 @@ public:
     static Lyrics* createLyrics(DummyParentOr<ChordRest> parent, bool isAccessibleEnabled = true);
     static Lyrics* copyLyrics(const Lyrics& src);
 
-    static LyricsLine* createLyricsLine(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static LyricsLine* createLyricsLine(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
     static LyricsLine* copyLyricsLine(const LyricsLine& src);
 
     static Measure* createMeasure(Score* parent, bool isAccessibleEnabled = true);
@@ -151,13 +152,13 @@ public:
     static PageLockIndicator* createPageLockIndicator(DummyParentOr<System> parent, const RangeLock* lock, bool isAccessibleEnabled = true);
     static PageLockIndicator* copyPageLockIndicator(const PageLockIndicator& src);
 
-    static Parenthesis* createParenthesis(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Parenthesis* createParenthesis(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
     static Parenthesis* copyParenthesis(const Parenthesis& src);
 
     static PartialTie* createPartialTie(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static PartialTie* copyPartialTie(const PartialTie& src);
 
-    static PartialLyricsLine* createPartialLyricsLine(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static PartialLyricsLine* createPartialLyricsLine(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
     static PartialLyricsLine* copyPartialLyricsLine(const PartialLyricsLine& src);
 
     static Rest* createRest(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
@@ -171,8 +172,8 @@ public:
     static Segment* createSegment(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static Segment* createSegment(DummyParentOr<Measure> parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled = true);
 
-    static Slur* createSlur(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Slur> makeSlur(EngravingItem* parent);
+    static Slur* createSlur(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Slur> makeSlur(DummyParentOr<EngravingItem> parent);
 
     static Spacer* createSpacer(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<Spacer> makeSpacer(DummyParentOr<Measure> parent);
@@ -182,7 +183,7 @@ public:
     static StaffLines* createStaffLines(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static StaffLines* copyStaffLines(const StaffLines& src);
 
-    static StaffState* createStaffState(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static StaffState* createStaffState(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
     static StaffTypeChange* createStaffTypeChange(DummyParentOr<MeasureBase> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<StaffTypeChange> makeStaffTypeChange(DummyParentOr<MeasureBase> parent);
@@ -193,7 +194,7 @@ public:
                                                       TextStyleType textStyleType = TextStyleType::STAVE_SHARING,
                                                       bool isAccessibleEnabled = true);
 
-    static SoundFlag* createSoundFlag(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static SoundFlag* createSoundFlag(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
     static Expression* createExpression(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
@@ -218,14 +219,15 @@ public:
     static Fingering* createFingering(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static Fingering* createFingering(DummyParentOr<Note> parent, TextStyleType textStyleType, bool isAccessibleEnabled = true);
 
-    static Harmony* createHarmony(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Harmony* createHarmony(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
     static TempoText* createTempoText(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
-    static Text* createText(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT, bool isAccessibleEnabled = true);
+    static Text* createText(DummyParentOr<EngravingItem> parent, TextStyleType tid = TextStyleType::DEFAULT,
+                            bool isAccessibleEnabled = true);
     static Text* copyText(const Text& src);
 
-    static Tie* createTie(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Tie* createTie(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
     static Tie* copyTie(const Tie& src);
 
     static TimeSig* createTimeSig(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
@@ -240,61 +242,61 @@ public:
     static std::shared_ptr<TremoloSingleChord> makeTremoloSingleChord(DummyParentOr<Chord> parent);
     static TremoloSingleChord* copyTremoloSingleChord(const TremoloSingleChord& src);
 
-    static TremoloBar* createTremoloBar(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<TremoloBar> makeTremoloBar(EngravingItem* parent);
+    static TremoloBar* createTremoloBar(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<TremoloBar> makeTremoloBar(DummyParentOr<EngravingItem> parent);
 
     static TripletFeel* createTripletFeel(DummyParentOr<Segment> parent, TripletFeelType type, bool isAccessibleEnabled = true);
 
     static Tuplet* createTuplet(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
     static Tuplet* copyTuplet(const Tuplet& src);
 
-    static Hairpin* createHairpin(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Hairpin> makeHairpin(EngravingItem* parent);
+    static Hairpin* createHairpin(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Hairpin> makeHairpin(DummyParentOr<EngravingItem> parent);
 
-    static HammerOnPullOff* createHammerOnPullOff(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<HammerOnPullOff> makeHammerOnPullOff(EngravingItem* parent);
+    static HammerOnPullOff* createHammerOnPullOff(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<HammerOnPullOff> makeHammerOnPullOff(DummyParentOr<EngravingItem> parent);
 
-    static Glissando* createGlissando(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Glissando> makeGlissando(EngravingItem* parent);
+    static Glissando* createGlissando(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Glissando> makeGlissando(DummyParentOr<EngravingItem> parent);
 
     static GuitarBend* createGuitarBend(DummyParentOr<Note> parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<GuitarBend> makeGuitarBend(DummyParentOr<Note> parent);
 
     static Jump* createJump(DummyParentOr<Measure> parent, bool isAccessibleEnabled = true);
 
-    static Trill* createTrill(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Trill* createTrill(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static Vibrato* createVibrato(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Vibrato* createVibrato(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static TextLine* createTextLine(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<TextLine> makeTextLine(EngravingItem* parent);
+    static TextLine* createTextLine(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<TextLine> makeTextLine(DummyParentOr<EngravingItem> parent);
 
-    static Ottava* createOttava(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Ottava* createOttava(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static LetRing* createLetRing(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static LetRing* createLetRing(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static Marker* createMarker(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Marker* createMarker(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static Marker* createMarker(EngravingItem* parent, TextStyleType tid, bool isAccessibleEnabled = true);
+    static Marker* createMarker(DummyParentOr<EngravingItem> parent, TextStyleType tid, bool isAccessibleEnabled = true);
 
-    static std::shared_ptr<Marker> makeMarker(EngravingItem* parent);
+    static std::shared_ptr<Marker> makeMarker(DummyParentOr<EngravingItem> parent);
 
-    static GradualTempoChange* createGradualTempoChange(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static GradualTempoChange* createGradualTempoChange(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static PalmMute* createPalmMute(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static PalmMute* createPalmMute(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static WhammyBar* createWhammyBar(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<WhammyBar> makeWhammyBar(EngravingItem* parent);
+    static WhammyBar* createWhammyBar(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<WhammyBar> makeWhammyBar(DummyParentOr<EngravingItem> parent);
 
-    static Rasgueado* createRasgueado(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Rasgueado* createRasgueado(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static HarmonicMark* createHarmonicMark(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static HarmonicMark* createHarmonicMark(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static PickScrape* createPickScrape(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static PickScrape* createPickScrape(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static Volta* createVolta(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Volta* createVolta(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
-    static Pedal* createPedal(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Pedal* createPedal(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
     static Dynamic* createDynamic(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
@@ -310,10 +312,10 @@ public:
 
     static FBox* createFBox(Score* parent, bool isAccessibleEnabled = true);
 
-    static Image* createImage(EngravingItem* parent);
+    static Image* createImage(DummyParentOr<EngravingItem> parent);
 
-    static Symbol* createSymbol(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static FSymbol* createFSymbol(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Symbol* createSymbol(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
+    static FSymbol* createFSymbol(DummyParentOr<EngravingItem> parent, bool isAccessibleEnabled = true);
 
     static PlayCountText* createPlayCountText(DummyParentOr<Segment> parent, bool isAccessibleEnabled = true);
 
@@ -330,6 +332,6 @@ public:
     static std::shared_ptr<StringTunings> makeStringTunings(DummyParentOr<Segment> parent);
 
 private:
-    static EngravingItem* doCreateItem(ElementType type, EngravingItem* parent);
+    static EngravingItem* doCreateItem(ElementType type, DummyParentOr<EngravingItem> parent);
 };
 }

--- a/src/engraving/dom/fermata.cpp
+++ b/src/engraving/dom/fermata.cpp
@@ -53,7 +53,7 @@ static const ElementStyle fermataStyle {
 //   Fermata
 //---------------------------------------------------------
 
-Fermata::Fermata(EngravingItem* parent)
+Fermata::Fermata(EngravingObject* parent)
     : EngravingItem(ElementType::FERMATA, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     setPlacement(PlacementV::ABOVE);

--- a/src/engraving/dom/fermata.h
+++ b/src/engraving/dom/fermata.h
@@ -85,7 +85,7 @@ public:
 private:
 
     friend class Factory;
-    Fermata(EngravingItem* parent);
+    Fermata(EngravingObject* parent);
 
     SymId m_symId = SymId::noSym;
     double m_timeStretch = -1.0;

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -973,7 +973,6 @@ FiguredBass* FiguredBass::addFiguredBassToSegment(Segment* seg, track_idx_t trac
     if (fb == 0) {                            // no FB at segment: create new
         fb = Factory::createFiguredBass(seg);
         fb->setTrack(track);
-        fb->setOwnershipParent(seg);
 
         // locate next SegChordRest in the same staff to estimate presumed duration of element
         endTick = Fraction::max();

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -644,7 +644,7 @@ bool FiguredBassItem::startsWithParenthesis() const
 //   F I G U R E D   B A S S
 //---------------------------------------------------------
 
-FiguredBass::FiguredBass(Segment* parent)
+FiguredBass::FiguredBass(DummyParentOr<Segment> parent)
     : TextBase(ElementType::FIGURED_BASS, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&figuredBassStyle);

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -198,7 +198,7 @@ private:
 
     friend class FiguredBass;
 
-    FiguredBassItem(FiguredBass* parent = 0, int line = 0);
+    FiguredBassItem(FiguredBass* parent, int line = 0);
     FiguredBassItem(const FiguredBassItem&);
 
     // part parsing

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -321,7 +321,7 @@ public:
 private:
 
     friend class Factory;
-    FiguredBass(Segment* parent = 0);
+    FiguredBass(DummyParentOr<Segment> parent);
     FiguredBass(const FiguredBass&);
 
     Sid getPropertyStyle(Pid) const override;

--- a/src/engraving/dom/fingering.cpp
+++ b/src/engraving/dom/fingering.cpp
@@ -51,14 +51,14 @@ static const ElementStyle fingeringStyle {
 //      EngravingItem(Score* = 0, ElementFlags = ElementFlag::NOTHING);
 //---------------------------------------------------------
 
-Fingering::Fingering(Note* parent, TextStyleType tid, ElementFlags ef)
+Fingering::Fingering(DummyParentOr<Note> parent, TextStyleType tid, ElementFlags ef)
     : TextBase(ElementType::FINGERING, parent, tid, ef)
 {
     setPlacement(PlacementV::ABOVE);
     initElementStyle(&fingeringStyle);
 }
 
-Fingering::Fingering(Note* parent, ElementFlags ef)
+Fingering::Fingering(DummyParentOr<Note> parent, ElementFlags ef)
     : Fingering(parent, TextStyleType::FINGERING, ef)
 {
 }

--- a/src/engraving/dom/fingering.h
+++ b/src/engraving/dom/fingering.h
@@ -40,8 +40,8 @@ class Fingering final : public TextBase
     DECLARE_CLASSOF(ElementType::FINGERING)
 
 public:
-    Fingering(Note* parent, TextStyleType tid, ElementFlags ef = ElementFlag::ON_STAFF);
-    Fingering(Note* parent, ElementFlags ef = ElementFlag::ON_STAFF);
+    Fingering(DummyParentOr<Note> parent, TextStyleType tid, ElementFlags ef = ElementFlag::ON_STAFF);
+    Fingering(DummyParentOr<Note> parent, ElementFlags ef = ElementFlag::ON_STAFF);
 
     Fingering* clone() const override { return new Fingering(*this); }
 

--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -1367,7 +1367,7 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
         fretDiagram->setOffset(PointF());
         if (!fretDiagram->harmony()) {
             //! generate from diagram and add harmony
-            fretDiagram->add(Factory::createHarmony(harmonyOrFretDiagram->score()->dummy()));
+            fretDiagram->add(Factory::createHarmony(fretDiagram));
         }
     }
 

--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -974,7 +974,7 @@ String FretDiagram::harmonyDisplayText() const
 void FretDiagram::setHarmony(String harmonyText)
 {
     if (!m_harmony) {
-        Harmony* h = new Harmony(this->score()->dummy()->segment());
+        Harmony* h = new Harmony(this->score()->dummy());
         add(h);
     }
 
@@ -1355,7 +1355,7 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
     if (harmonyOrFretDiagram->isHarmony() && !harmonyOrFretDiagram->ownershipParent()->isFretDiagram()) {
         Harmony* harmony = toHarmony(harmonyOrFretDiagram)->clone();
 
-        fretDiagram = Factory::createFretDiagram(harmonyOrFretDiagram->score()->dummy()->segment());
+        fretDiagram = Factory::createFretDiagram(harmonyOrFretDiagram->score()->dummy());
 
         fretDiagram->updateDiagram(harmony->plainText());
 
@@ -1367,7 +1367,7 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
         fretDiagram->setOffset(PointF());
         if (!fretDiagram->harmony()) {
             //! generate from diagram and add harmony
-            fretDiagram->add(Factory::createHarmony(harmonyOrFretDiagram->score()->dummy()->segment()));
+            fretDiagram->add(Factory::createHarmony(harmonyOrFretDiagram->score()->dummy()));
         }
     }
 

--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -170,7 +170,7 @@ static DiagramInfo resolveDiagram(const std::vector<DiagramInfo>& diagrams)
     return result;
 }
 
-FretDiagram::FretDiagram(Segment* parent)
+FretDiagram::FretDiagram(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::FRET_DIAGRAM, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initDefaultValues();

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -269,7 +269,7 @@ public:
 private:
     friend class Factory;
 
-    FretDiagram(Segment* parent = nullptr);
+    FretDiagram(DummyParentOr<Segment> parent);
     FretDiagram(const FretDiagram&);
 
     void readHarmonyToDiagramFile(const muse::io::path_t& filePath) const;

--- a/src/engraving/dom/glissando.cpp
+++ b/src/engraving/dom/glissando.cpp
@@ -104,7 +104,7 @@ EngravingObject* GlissandoSegment::propertyDelegate(Pid pid) const
 //   Glissando
 //=========================================================
 
-Glissando::Glissando(EngravingItem* parent)
+Glissando::Glissando(DummyParentOr<EngravingItem> parent)
     : SLine(ElementType::GLISSANDO, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&glissandoElementStyle);

--- a/src/engraving/dom/glissando.h
+++ b/src/engraving/dom/glissando.h
@@ -75,7 +75,7 @@ public:
     static constexpr double GLISS_PALETTE_WIDTH = 4.0;
     static constexpr double GLISS_PALETTE_HEIGHT = 4.0;
 
-    Glissando(EngravingItem* parent);
+    Glissando(DummyParentOr<EngravingItem> parent);
     Glissando(const Glissando&);
 
     Anchor anchor() const override { return Anchor::NOTE; }

--- a/src/engraving/dom/gradualtempochange.cpp
+++ b/src/engraving/dom/gradualtempochange.cpp
@@ -108,7 +108,7 @@ static const std::unordered_map<GradualTempoChangeType, double> DEFAULT_FACTORS_
     { GradualTempoChangeType::Stringendo, 1.5 }
 };
 
-GradualTempoChange::GradualTempoChange(EngravingItem* parent)
+GradualTempoChange::GradualTempoChange(DummyParentOr<EngravingItem> parent)
     : TextLineBase(ElementType::GRADUAL_TEMPO_CHANGE, parent, ElementFlag::SYSTEM)
 {
     initElementStyle(&tempoStyle);

--- a/src/engraving/dom/gradualtempochange.h
+++ b/src/engraving/dom/gradualtempochange.h
@@ -36,7 +36,7 @@ class GradualTempoChange : public TextLineBase
     DECLARE_CLASSOF(ElementType::GRADUAL_TEMPO_CHANGE)
 
 public:
-    GradualTempoChange(EngravingItem* parent);
+    GradualTempoChange(DummyParentOr<EngravingItem> parent);
 
     GradualTempoChange* clone() const override;
 

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -48,7 +48,7 @@ namespace mu::engraving {
  *              GuitarBend
  * **************************************/
 
-GuitarBend::GuitarBend(EngravingItem* parent)
+GuitarBend::GuitarBend(EngravingObject* parent)
     : SLine(ElementType::GUITAR_BEND, parent, ElementFlag::MOVABLE)
 {
 }

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -848,7 +848,6 @@ GuitarBendSegment::GuitarBendSegment(GuitarBend* sp)
     : LineSegment(ElementType::GUITAR_BEND_SEGMENT, sp, ElementFlag::MOVABLE)
 {
     m_text = new GuitarBendText(this);
-    m_text->setOwnershipParent(this);
     setFlag(ElementFlag::ON_STAFF, true);
 }
 
@@ -857,7 +856,6 @@ GuitarBendSegment::GuitarBendSegment(const GuitarBendSegment& s)
 {
     m_vertexPointOff = s.m_vertexPointOff;
     m_text = new GuitarBendText(this);
-    m_text->setOwnershipParent(this);
 }
 
 GuitarBendSegment::~GuitarBendSegment()

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -59,7 +59,7 @@ class GuitarBend final : public SLine
     M_PROPERTY2(float, endTimeFactor, setEndTimeFactor, 1.f)
 
 public:
-    GuitarBend(EngravingItem* parent);
+    GuitarBend(EngravingObject* parent);
     GuitarBend(const GuitarBend&);
     ~GuitarBend() override;
 

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -503,7 +503,7 @@ Sid Hairpin::getPropertyStyle(Pid pid) const
 //   Hairpin
 //---------------------------------------------------------
 
-Hairpin::Hairpin(EngravingItem* parent)
+Hairpin::Hairpin(DummyParentOr<EngravingItem> parent)
     : TextLineBase(ElementType::HAIRPIN, parent)
 {
     initElementStyle(&hairpinStyle);

--- a/src/engraving/dom/hairpin.h
+++ b/src/engraving/dom/hairpin.h
@@ -106,7 +106,7 @@ class Hairpin final : public TextLineBase
     DECLARE_CLASSOF(ElementType::HAIRPIN)
 
 public:
-    Hairpin(EngravingItem* parent);
+    Hairpin(DummyParentOr<EngravingItem> parent);
 
     Hairpin* clone() const override { return new Hairpin(*this); }
 

--- a/src/engraving/dom/hammeronpulloff.cpp
+++ b/src/engraving/dom/hammeronpulloff.cpp
@@ -32,7 +32,7 @@
 #include "system.h"
 
 namespace mu::engraving {
-HammerOnPullOff::HammerOnPullOff(EngravingItem* parent)
+HammerOnPullOff::HammerOnPullOff(DummyParentOr<EngravingItem> parent)
     : Slur(parent, ElementType::HAMMER_ON_PULL_OFF)
 {
 }

--- a/src/engraving/dom/hammeronpulloff.cpp
+++ b/src/engraving/dom/hammeronpulloff.cpp
@@ -134,7 +134,6 @@ void HammerOnPullOffSegment::updateHopoText()
             m_hopoText.push_back(curHopoText);
         }
 
-        curHopoText->setOwnershipParent(this);
         curHopoText->setTrack(track());
         curHopoText->setIsValid(curRegion.isValid);
         curHopoText->setIsHammerOn(curRegion.isHammerOn);

--- a/src/engraving/dom/hammeronpulloff.h
+++ b/src/engraving/dom/hammeronpulloff.h
@@ -119,7 +119,7 @@ public:
 
     friend class Factory;
 
-    HammerOnPullOff(EngravingItem* parent);
+    HammerOnPullOff(DummyParentOr<EngravingItem> parent);
     HammerOnPullOff(const HammerOnPullOff&);
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/harmonicmark.cpp
+++ b/src/engraving/dom/harmonicmark.cpp
@@ -75,7 +75,7 @@ HarmonicMarkSegment::HarmonicMarkSegment(HarmonicMark* sp)
 //   HarmonicMark
 //---------------------------------------------------------
 
-HarmonicMark::HarmonicMark(EngravingItem* parent)
+HarmonicMark::HarmonicMark(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::HARMONIC_MARK, parent)
 {
     initElementStyle(&harmonicMarkStyle);

--- a/src/engraving/dom/harmonicmark.h
+++ b/src/engraving/dom/harmonicmark.h
@@ -57,7 +57,7 @@ class HarmonicMark final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::HARMONIC_MARK)
 
 public:
-    HarmonicMark(EngravingItem* parent);
+    HarmonicMark(DummyParentOr<EngravingItem> parent);
 
     HarmonicMark* clone() const override { return new HarmonicMark(*this); }
 

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -326,10 +326,10 @@ const ElementStyle chordSymbolStyle {
 //   Harmony
 //---------------------------------------------------------
 
-Harmony::Harmony(EngravingItem* parent)
+Harmony::Harmony(EngravingObject* parent)
     : TextBase(ElementType::HARMONY, parent, TextStyleType::HARMONY_A, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
-    assert(!parent || parent->isSegment() || parent->isFretDiagram());
+    assert(!parent || parent->isSegment() || parent->isFretDiagram() || parent->isType(ElementType::DUMMY));
 
     m_rootCase   = NoteCaseType::CAPITAL;
     m_bassCase   = NoteCaseType::CAPITAL;

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -215,7 +215,7 @@ class Harmony final : public TextBase
     DECLARE_CLASSOF(ElementType::HARMONY)
 
 public:
-    Harmony(EngravingItem* parent = 0); // Segment or FretDiagram
+    Harmony(EngravingObject* parent = 0); // Segment or FretDiagram
     Harmony(const Harmony&);
     ~Harmony();
 

--- a/src/engraving/dom/harppedaldiagram.cpp
+++ b/src/engraving/dom/harppedaldiagram.cpp
@@ -100,7 +100,7 @@ void HarpPedalDiagram::setPlayableTpcs()
     m_playableTpcs = playableTpcs;
 }
 
-HarpPedalDiagram::HarpPedalDiagram(Segment* parent)
+HarpPedalDiagram::HarpPedalDiagram(DummyParentOr<Segment> parent)
     : TextBase(ElementType::HARP_DIAGRAM, parent, TextStyleType::HARP_PEDAL_DIAGRAM, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&harpPedalDiagramStyle);

--- a/src/engraving/dom/harppedaldiagram.h
+++ b/src/engraving/dom/harppedaldiagram.h
@@ -49,7 +49,7 @@ class HarpPedalDiagram final : public TextBase
     DECLARE_CLASSOF(ElementType::HARP_DIAGRAM)
 
 public:
-    HarpPedalDiagram(Segment* parent);
+    HarpPedalDiagram(DummyParentOr<Segment> parent);
     HarpPedalDiagram(const HarpPedalDiagram& h);
 
     HarpPedalDiagram* clone() const override { return new HarpPedalDiagram(*this); }

--- a/src/engraving/dom/hook.cpp
+++ b/src/engraving/dom/hook.cpp
@@ -31,7 +31,7 @@
 using namespace mu;
 using namespace mu::engraving;
 
-Hook::Hook(Chord* parent)
+Hook::Hook(DummyParentOr<Chord> parent)
     : Symbol(ElementType::HOOK, parent, ElementFlag::NOTHING)
 {
     setZ(int(type()) * 100);

--- a/src/engraving/dom/hook.h
+++ b/src/engraving/dom/hook.h
@@ -36,7 +36,7 @@ class Hook final : public Symbol
     DECLARE_CLASSOF(ElementType::HOOK)
 
 public:
-    Hook(Chord* parent = 0);
+    Hook(DummyParentOr<Chord> parent);
 
     Hook* clone() const override { return new Hook(*this); }
     double mag() const override { return layoutParent()->mag(); }

--- a/src/engraving/dom/image.cpp
+++ b/src/engraving/dom/image.cpp
@@ -57,7 +57,7 @@ static bool defaultSizeIsSpatium    = true;
 //   Image
 //---------------------------------------------------------
 
-Image::Image(EngravingItem* parent)
+Image::Image(DummyParentOr<EngravingItem> parent)
     : BSymbol(ElementType::IMAGE, parent, ElementFlag::MOVABLE)
 {
     m_imageType        = ImageType::NONE;

--- a/src/engraving/dom/image.h
+++ b/src/engraving/dom/image.h
@@ -57,7 +57,7 @@ class Image final : public BSymbol
     muse::GlobalInject<muse::draw::IImageProvider> imageProvider;
 
 public:
-    Image(EngravingItem* parent);
+    Image(DummyParentOr<EngravingItem> parent);
     Image(const Image&);
     ~Image();
 

--- a/src/engraving/dom/indicatoricon.cpp
+++ b/src/engraving/dom/indicatoricon.cpp
@@ -30,7 +30,7 @@
 using namespace mu::engraving;
 using namespace muse::draw;
 
-IndicatorIcon::IndicatorIcon(const ElementType& type, System* parent, ElementFlags flags)
+IndicatorIcon::IndicatorIcon(const ElementType& type, DummyParentOr<System> parent, ElementFlags flags)
     : EngravingItem(type, parent, flags)
 {
 }

--- a/src/engraving/dom/indicatoricon.h
+++ b/src/engraving/dom/indicatoricon.h
@@ -32,7 +32,7 @@ class IndicatorIcon : public EngravingItem
     OBJECT_ALLOCATOR(engraving, IndicatorIcon)
 
 public:
-    IndicatorIcon(const ElementType& type, System* parent = nullptr, ElementFlags = ElementFlag::NOTHING);
+    IndicatorIcon(const ElementType& type, DummyParentOr<System> parent, ElementFlags = ElementFlag::NOTHING);
     IndicatorIcon* clone() const override { return new IndicatorIcon(*this); }
 
     System* system() const { return toSystem(ownershipParent()); }

--- a/src/engraving/dom/instrchange.cpp
+++ b/src/engraving/dom/instrchange.cpp
@@ -56,14 +56,14 @@ static const ElementStyle instrumentChangeStyle {
 //   InstrumentChange
 //---------------------------------------------------------
 
-InstrumentChange::InstrumentChange(EngravingItem* parent)
+InstrumentChange::InstrumentChange(EngravingObject* parent)
     : TextBase(ElementType::INSTRUMENT_CHANGE, parent, TextStyleType::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);
     m_instrument = new Instrument();
 }
 
-InstrumentChange::InstrumentChange(const Instrument& i, EngravingItem* parent)
+InstrumentChange::InstrumentChange(const Instrument& i, EngravingObject* parent)
     : TextBase(ElementType::INSTRUMENT_CHANGE, parent, TextStyleType::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);

--- a/src/engraving/dom/instrchange.h
+++ b/src/engraving/dom/instrchange.h
@@ -40,8 +40,8 @@ class InstrumentChange final : public TextBase
     DECLARE_CLASSOF(ElementType::INSTRUMENT_CHANGE)
 
 public:
-    InstrumentChange(EngravingItem* parent);
-    InstrumentChange(const Instrument&, EngravingItem* parent);
+    InstrumentChange(EngravingObject* parent);
+    InstrumentChange(const Instrument&, EngravingObject* parent);
     InstrumentChange(const InstrumentChange&);
     ~InstrumentChange();
 

--- a/src/engraving/dom/instrumentname.cpp
+++ b/src/engraving/dom/instrumentname.cpp
@@ -53,7 +53,7 @@ static const ElementStyle shortInstrumentStyle {
 //   InstrumentName
 //---------------------------------------------------------
 
-InstrumentName::InstrumentName(System* s)
+InstrumentName::InstrumentName(DummyParentOr<System> s)
     : TextBase(ElementType::INSTRUMENT_NAME, s, TextStyleType::INSTRUMENT_LONG, ElementFlag::NOTHING)
 {
     setFlag(ElementFlag::MOVABLE, false);

--- a/src/engraving/dom/instrumentname.h
+++ b/src/engraving/dom/instrumentname.h
@@ -46,7 +46,7 @@ class InstrumentName final : public TextBase
     DECLARE_CLASSOF(ElementType::INSTRUMENT_NAME)
 
 public:
-    InstrumentName(System*);
+    InstrumentName(DummyParentOr<System>);
 
     InstrumentName* clone() const override { return new InstrumentName(*this); }
 

--- a/src/engraving/dom/jump.cpp
+++ b/src/engraving/dom/jump.cpp
@@ -66,7 +66,7 @@ const std::vector<JumpTypeTableItem> jumpTypeTable {
 //   Jump
 //---------------------------------------------------------
 
-Jump::Jump(Measure* parent)
+Jump::Jump(DummyParentOr<Measure> parent)
     : TextBase(ElementType::JUMP, parent, TextStyleType::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&jumpStyle);

--- a/src/engraving/dom/jump.h
+++ b/src/engraving/dom/jump.h
@@ -46,7 +46,7 @@ class Jump final : public TextBase
 
 public:
 
-    Jump(Measure* parent);
+    Jump(DummyParentOr<Measure> parent);
 
     void setJumpType(JumpType t);
     JumpType jumpType() const;

--- a/src/engraving/dom/keysig.cpp
+++ b/src/engraving/dom/keysig.cpp
@@ -45,7 +45,7 @@ namespace mu::engraving {
 //   KeySig
 //---------------------------------------------------------
 
-KeySig::KeySig(Segment* s)
+KeySig::KeySig(DummyParentOr<Segment> s)
     : EngravingItem(ElementType::KEYSIG, s, ElementFlag::ON_STAFF)
 {
     m_showCourtesy = true;

--- a/src/engraving/dom/keysig.h
+++ b/src/engraving/dom/keysig.h
@@ -101,7 +101,7 @@ public:
 private:
     friend class Factory;
 
-    KeySig(Segment* = 0);
+    KeySig(DummyParentOr<Segment>);
     KeySig(const KeySig&);
 
     void addLayout(SymId sym, int line);

--- a/src/engraving/dom/laissezvib.cpp
+++ b/src/engraving/dom/laissezvib.cpp
@@ -35,7 +35,7 @@ static const ElementStyle laissezVibStyle {
     { Sid::minLaissezVibLength, Pid::MIN_LENGTH }
 };
 
-LaissezVib::LaissezVib(Note* parent)
+LaissezVib::LaissezVib(DummyParentOr<Note> parent)
     : Tie(ElementType::LAISSEZ_VIB, parent)
 {
     initElementStyle(&laissezVibStyle);

--- a/src/engraving/dom/laissezvib.h
+++ b/src/engraving/dom/laissezvib.h
@@ -55,7 +55,7 @@ class LaissezVib : public Tie
     DECLARE_CLASSOF(ElementType::LAISSEZ_VIB);
 
 public:
-    LaissezVib(Note* parent);
+    LaissezVib(DummyParentOr<Note> parent);
 
     LaissezVib* clone() const override { return new LaissezVib(*this); }
 

--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -47,7 +47,7 @@ static const ElementStyle sectionBreakStyle {
 //   LayoutBreak
 //---------------------------------------------------------
 
-LayoutBreak::LayoutBreak(MeasureBase* parent)
+LayoutBreak::LayoutBreak(DummyParentOr<MeasureBase> parent)
     : EngravingItem(ElementType::LAYOUT_BREAK, parent, ElementFlag::SYSTEM)
 {
     m_pause = 0.;
@@ -77,7 +77,7 @@ LayoutBreak::LayoutBreak(const LayoutBreak& lb)
     m_showCourtesy           = lb.m_showCourtesy;
 }
 
-void LayoutBreak::setOwnershipParent(MeasureBase* parent)
+void LayoutBreak::setOwnershipParent(DummyParentOr<MeasureBase> parent)
 {
     EngravingItem::setOwnershipParent(parent);
 }

--- a/src/engraving/dom/layoutbreak.h
+++ b/src/engraving/dom/layoutbreak.h
@@ -40,7 +40,7 @@ class LayoutBreak final : public EngravingItem
 
 public:
 
-    void setOwnershipParent(MeasureBase* parent);
+    void setOwnershipParent(DummyParentOr<MeasureBase> parent);
 
     LayoutBreak* clone() const override { return new LayoutBreak(*this); }
     int subtype() const override { return static_cast<int>(m_layoutBreakType); }
@@ -82,7 +82,7 @@ public:
 private:
 
     friend class Factory;
-    LayoutBreak(MeasureBase* parent = 0);
+    LayoutBreak(DummyParentOr<MeasureBase> parent);
     LayoutBreak(const LayoutBreak&);
 
     double m_pause = 0.0;

--- a/src/engraving/dom/ledgerline.cpp
+++ b/src/engraving/dom/ledgerline.cpp
@@ -33,7 +33,7 @@ namespace mu::engraving {
 //   LedgerLine
 //---------------------------------------------------------
 
-LedgerLine::LedgerLine(EngravingItem* s)
+LedgerLine::LedgerLine(DummyParentOr<EngravingItem> s)
     : EngravingItem(ElementType::LEDGER_LINE, s, ElementFlag::ON_STAFF)
 {
     setSelectable(false);

--- a/src/engraving/dom/ledgerline.h
+++ b/src/engraving/dom/ledgerline.h
@@ -43,7 +43,7 @@ class LedgerLine final : public EngravingItem
     DECLARE_CLASSOF(ElementType::LEDGER_LINE)
 
 public:
-    LedgerLine(EngravingItem*);
+    LedgerLine(DummyParentOr<EngravingItem>);
     ~LedgerLine();
     LedgerLine& operator=(const LedgerLine&) = delete;
 

--- a/src/engraving/dom/letring.cpp
+++ b/src/engraving/dom/letring.cpp
@@ -76,7 +76,7 @@ LetRingSegment::LetRingSegment(LetRing* sp)
 //   LetRing
 //---------------------------------------------------------
 
-LetRing::LetRing(EngravingItem* parent)
+LetRing::LetRing(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::LET_RING, parent)
 {
     initElementStyle(&letRingStyle);

--- a/src/engraving/dom/letring.h
+++ b/src/engraving/dom/letring.h
@@ -57,7 +57,7 @@ class LetRing final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::LET_RING)
 
 public:
-    LetRing(EngravingItem* parent);
+    LetRing(DummyParentOr<EngravingItem> parent);
 
     LetRing* clone() const override { return new LetRing(*this); }
 

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -869,7 +869,7 @@ void LineSegment::undoMoveStartEndAndSnappedItems(EditData& ed, bool moveStart, 
 //   SLine
 //---------------------------------------------------------
 
-SLine::SLine(const ElementType& type, EngravingItem* parent, ElementFlags f)
+SLine::SLine(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : Spanner(type, parent, f)
 {
     setTrack(0);

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -102,7 +102,7 @@ class SLine : public Spanner
     OBJECT_ALLOCATOR(engraving, SLine)
 
 public:
-    SLine(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
+    SLine(const ElementType& type, EngravingObject* parent, ElementFlags = ElementFlag::NOTHING);
     SLine(const SLine&);
 
     virtual LineSegment* createLineSegment() = 0;

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -53,7 +53,7 @@ static const ElementStyle lyricsElementStyle {
 //   Lyrics
 //---------------------------------------------------------
 
-Lyrics::Lyrics(ChordRest* parent)
+Lyrics::Lyrics(DummyParentOr<ChordRest> parent)
     : TextBase(ElementType::LYRICS, parent, TextStyleType::LYRICS_ODD, ElementFlag::ON_STAFF)
 {
     m_separator  = 0;

--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -132,7 +132,7 @@ class LyricsLine : public SLine
     DECLARE_CLASSOF(ElementType::LYRICSLINE)
 
 public:
-    LyricsLine(EngravingItem* parent);
+    LyricsLine(DummyParentOr<EngravingItem> parent);
     LyricsLine(const LyricsLine&);
 
     LyricsLine* clone() const override { return new LyricsLine(*this); }
@@ -152,7 +152,7 @@ public:
     Sid getPropertyStyle(Pid) const override;
 
 protected:
-    LyricsLine(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
+    LyricsLine(const ElementType& type, DummyParentOr<EngravingItem> parent, ElementFlags = ElementFlag::NOTHING);
 
     bool isInSpannerMap() const override { return false; }
 
@@ -217,7 +217,7 @@ class PartialLyricsLine final : public LyricsLine
     DECLARE_CLASSOF(ElementType::PARTIAL_LYRICSLINE)
 
 public:
-    PartialLyricsLine(EngravingItem* parent);
+    PartialLyricsLine(DummyParentOr<EngravingItem> parent);
     PartialLyricsLine(const PartialLyricsLine&);
     PartialLyricsLine* clone() const override { return new PartialLyricsLine(*this); }
     LineSegment* createLineSegment() override;

--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -110,7 +110,7 @@ public:
 private:
 
     friend class Factory;
-    Lyrics(ChordRest* parent);
+    Lyrics(DummyParentOr<ChordRest> parent);
     Lyrics(const Lyrics&);
 
     int m_verse = 0;              // row index

--- a/src/engraving/dom/lyricsline.cpp
+++ b/src/engraving/dom/lyricsline.cpp
@@ -402,7 +402,7 @@ Lyrics* PartialLyricsLine::findAdjacentLyricsOrDefault() const
     }
 
     // If there are no adjacent lyrics, create dummy lyrics using the odd lyrics text style to get font information
-    Lyrics* dummyLyr = Factory::createLyrics(toChordRest(score()->dummy()->chord()));
+    Lyrics* dummyLyr = Factory::createLyrics(score()->dummy());
     dummyLyr->setTextStyleType(TextStyleType::LYRICS_ODD);
     return dummyLyr;
 }

--- a/src/engraving/dom/lyricsline.cpp
+++ b/src/engraving/dom/lyricsline.cpp
@@ -45,7 +45,7 @@ static const ElementStyle lyricsLineElementStyle {
     { Sid::lyricsDashLineThickness, Pid::LINE_WIDTH }
 };
 
-LyricsLine::LyricsLine(EngravingItem* parent)
+LyricsLine::LyricsLine(DummyParentOr<EngravingItem> parent)
     : SLine(ElementType::LYRICSLINE, parent)
 {
     setDiagonal(false);
@@ -53,7 +53,7 @@ LyricsLine::LyricsLine(EngravingItem* parent)
     m_nextLyrics = 0;
 }
 
-LyricsLine::LyricsLine(const ElementType& type, EngravingItem* parent, ElementFlags f)
+LyricsLine::LyricsLine(const ElementType& type, DummyParentOr<EngravingItem> parent, ElementFlags f)
     : SLine(type, parent, f)
 {
     setDiagonal(false);
@@ -222,7 +222,7 @@ EngravingObject* LyricsLineSegment::propertyDelegate(Pid propertyId) const
 //=========================================================
 //   PartialLyricsLine
 //=========================================================
-PartialLyricsLine::PartialLyricsLine(EngravingItem* parent)
+PartialLyricsLine::PartialLyricsLine(DummyParentOr<EngravingItem> parent)
     : LyricsLine(ElementType::PARTIAL_LYRICSLINE, parent)
 {
     setGenerated(false);

--- a/src/engraving/dom/marker.cpp
+++ b/src/engraving/dom/marker.cpp
@@ -65,13 +65,13 @@ const std::vector<MarkerTypeTableItem> markerTypeTable {
 //   Marker
 //---------------------------------------------------------
 
-Marker::Marker(EngravingItem* parent)
+Marker::Marker(DummyParentOr<EngravingItem> parent)
     : Marker(parent, TextStyleType::REPEAT_LEFT)
 {
     resetProperty(Pid::MUSIC_SYMBOL_SIZE);
 }
 
-Marker::Marker(EngravingItem* parent, TextStyleType tid)
+Marker::Marker(DummyParentOr<EngravingItem> parent, TextStyleType tid)
     : TextBase(ElementType::MARKER, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
 {
     initElementStyle(&markerStyle);

--- a/src/engraving/dom/marker.h
+++ b/src/engraving/dom/marker.h
@@ -38,8 +38,8 @@ class Marker final : public TextBase
     DECLARE_CLASSOF(ElementType::MARKER)
 
 public:
-    Marker(EngravingItem* parent);
-    Marker(EngravingItem* parent, TextStyleType);
+    Marker(DummyParentOr<EngravingItem> parent);
+    Marker(DummyParentOr<EngravingItem> parent, TextStyleType);
 
     void setMarkerType(MarkerType t);
     MarkerType markerType() const { return m_markerType; }

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -845,7 +845,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         // undoAddCR adds rest to linked staves as well
         for (size_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
             size_t track = staffIdx * VOICES;
-            Rest* rest = Factory::createRest(dummy()->segment(), TDuration(DurationType::V_MEASURE));
+            Rest* rest = Factory::createRest(dummy(), TDuration(DurationType::V_MEASURE));
             Fraction timeStretch(staff(staffIdx)->timeStretch(masterMeasure->tick()));
             rest->setTicks(masterMeasure->ticks() * timeStretch);
             rest->setTrack(track);

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -193,7 +193,6 @@ Measure::Measure(Score* parent)
         Staff* staff = score()->staff(staffIdx);
         ms->setLines(Factory::createStaffLines(this));
         ms->lines()->setTrack(staffIdx * VOICES);
-        ms->lines()->setOwnershipParent(this);
         ms->lines()->setVisible(!staff->isLinesInvisible(tick()));
         m_mstaves.push_back(ms);
     }
@@ -243,7 +242,6 @@ void Measure::createStaves(staff_idx_t staffIdx)
         Staff* staff = score()->staff(n);
         MStaff* s    = new MStaff;
         s->setLines(Factory::createStaffLines(this));
-        s->lines()->setOwnershipParent(this);
         s->lines()->setTrack(n * VOICES);
         s->lines()->setVisible(!staff->isLinesInvisible(tick()));
         m_mstaves.push_back(s);
@@ -1215,7 +1213,6 @@ void Measure::cmdAddStaves(staff_idx_t sStaff, staff_idx_t eStaff, bool createRe
         MStaff* ms   = new MStaff;
         ms->setLines(Factory::createStaffLines(this));
         ms->lines()->setTrack(i * VOICES);
-        ms->lines()->setOwnershipParent(this);
         ms->lines()->setVisible(!staff->isLinesInvisible(tick()));
         score()->undo(new InsertMStaff(this, ms, i));
     }
@@ -1336,7 +1333,6 @@ void Measure::insertStaff(Staff* staff, staff_idx_t staffIdx)
 
     MStaff* ms = new MStaff;
     ms->setLines(Factory::createStaffLines(this));
-    ms->lines()->setOwnershipParent(this);
     ms->lines()->setTrack(staffIdx * VOICES);
     ms->lines()->setVisible(!staff->isLinesInvisible(tick()));
     insertMStaff(ms, staffIdx);
@@ -1788,7 +1784,6 @@ EngravingItem* Measure::drop(Transaction& tx, EditData& data)
                 BarLine* staffBarLine = toBarLine(seg->element(stIdx * VOICES));
                 if (!staffBarLine) {
                     staffBarLine = Factory::createBarLine(seg);
-                    staffBarLine->setOwnershipParent(seg);
                     staffBarLine->setTrack(stIdx * VOICES);
                     undoAddElement(staffBarLine);
                 }
@@ -1828,7 +1823,6 @@ EngravingItem* Measure::drop(Transaction& tx, EditData& data)
                 return nullptr;
             }
             EngravingItem* stc = Factory::createStaffTypeChange(this);
-            stc->setOwnershipParent(this);
             stc->setTrack(trackZeroVoice(data.track));
             score()->undoAddElement(stc);
             break;
@@ -3579,7 +3573,6 @@ void Measure::setEndBarLineType(BarLineType val, track_idx_t track, bool visible
     if (!bl) {
         // no suitable bar line: create a new one
         bl = Factory::createBarLine(seg);
-        bl->setOwnershipParent(seg);
         bl->setTrack(track);
         Part* part = score()->staff(track / VOICES)->part();
         // by default, barlines for multi-staff parts should span across staves

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1261,7 +1261,7 @@ void Measure::cmdAddStaves(staff_idx_t sStaff, staff_idx_t eStaff, bool createRe
             }
             if (!ots) {
                 // no time signature found; use measure timesig to construct one
-                ots = Factory::createTimeSig(score()->dummy()->segment());
+                ots = Factory::createTimeSig(score()->dummy());
                 ots->setSig(timesig());
                 constructed = true;
             }
@@ -1949,7 +1949,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                 // add rests for any other duration list value
                 Fraction tickOffset = tick() + rest->actualTicks();
                 for (unsigned i = 1; i < durList.size(); i++) {
-                    Rest* newRest = Factory::createRest(s->dummy()->segment());
+                    Rest* newRest = Factory::createRest(s->dummy());
                     TDuration dur = durList.at(i);
                     newRest->setDurationType(dur);
                     newRest->setTicks(dur.isMeasure() ? ticks() : dur.fraction());

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -43,8 +43,6 @@ using namespace mu::engraving;
 MeasureBase::MeasureBase(const ElementType& type, Score* parent)
     : EngravingItem(type, parent)
 {
-    // Owned by its score right away; a system only places it later
-    setOwnershipParent(parent);
 }
 
 void MeasureBase::setOwnershipParent(Score* score)
@@ -527,7 +525,6 @@ void MeasureBase::undoSetBreak(bool v, LayoutBreakType type)
         LayoutBreak* lb = Factory::createLayoutBreak(mb);
         lb->setLayoutBreakType(type);
         lb->setTrack(0);
-        lb->setOwnershipParent(mb);
         score()->undoAddElement(lb);
     }
     cleanupLayoutBreaks(true);

--- a/src/engraving/dom/measurenumber.cpp
+++ b/src/engraving/dom/measurenumber.cpp
@@ -42,7 +42,7 @@ static const ElementStyle measureNumberStyle {
 //   MeasureNumber
 //---------------------------------------------------------
 
-MeasureNumber::MeasureNumber(Measure* parent, TextStyleType tid)
+MeasureNumber::MeasureNumber(DummyParentOr<Measure> parent, TextStyleType tid)
     : MeasureNumberBase(ElementType::MEASURE_NUMBER, parent, tid)
 {
     initElementStyle(&measureNumberStyle);

--- a/src/engraving/dom/measurenumber.h
+++ b/src/engraving/dom/measurenumber.h
@@ -36,7 +36,7 @@ class MeasureNumber : public MeasureNumberBase
     DECLARE_CLASSOF(ElementType::MEASURE_NUMBER)
 
 public:
-    MeasureNumber(Measure* parent = nullptr, TextStyleType tid = TextStyleType::MEASURE_NUMBER);
+    MeasureNumber(DummyParentOr<Measure> parent, TextStyleType tid = TextStyleType::MEASURE_NUMBER);
     MeasureNumber(const MeasureNumber& other);
 
     virtual MeasureNumber* clone() const override { return new MeasureNumber(*this); }

--- a/src/engraving/dom/measurenumberbase.cpp
+++ b/src/engraving/dom/measurenumberbase.cpp
@@ -36,7 +36,7 @@ namespace mu::engraving {
 //   MeasureNumberBase
 //---------------------------------------------------------
 
-MeasureNumberBase::MeasureNumberBase(const ElementType& type, Measure* parent, TextStyleType tid)
+MeasureNumberBase::MeasureNumberBase(const ElementType& type, DummyParentOr<Measure> parent, TextStyleType tid)
     : TextBase(type, parent, tid, ElementFlag::ON_STAFF)
 {
 }

--- a/src/engraving/dom/measurenumberbase.h
+++ b/src/engraving/dom/measurenumberbase.h
@@ -36,7 +36,7 @@ class MeasureNumberBase : public TextBase
 {
     OBJECT_ALLOCATOR(engraving, MeasureNumberBase)
 public:
-    MeasureNumberBase(const ElementType& type, Measure* parent = nullptr, TextStyleType = TextStyleType::DEFAULT);
+    MeasureNumberBase(const ElementType& type, DummyParentOr<Measure> parent, TextStyleType = TextStyleType::DEFAULT);
     MeasureNumberBase(const MeasureNumberBase& other);
 
     Measure* measure() const { return toMeasure(ownershipParent()); }

--- a/src/engraving/dom/measurerepeat.cpp
+++ b/src/engraving/dom/measurerepeat.cpp
@@ -43,7 +43,7 @@ static const ElementStyle measureRepeatStyle {
 //   MeasureRepeat
 //---------------------------------------------------------
 
-MeasureRepeat::MeasureRepeat(Segment* parent)
+MeasureRepeat::MeasureRepeat(DummyParentOr<Segment> parent)
     : Rest(ElementType::MEASURE_REPEAT, parent), m_numMeasures(0)
 {
     // however many measures the group, the element itself is always exactly the duration of its containing measure

--- a/src/engraving/dom/measurerepeat.h
+++ b/src/engraving/dom/measurerepeat.h
@@ -36,7 +36,7 @@ class MeasureRepeat final : public Rest
     DECLARE_CLASSOF(ElementType::MEASURE_REPEAT)
 
 public:
-    MeasureRepeat(Segment* parent);
+    MeasureRepeat(DummyParentOr<Segment> parent);
     MeasureRepeat(const MeasureRepeat&) = default;
     MeasureRepeat& operator=(const MeasureRepeat&) = delete;
 

--- a/src/engraving/dom/mmrest.cpp
+++ b/src/engraving/dom/mmrest.cpp
@@ -33,7 +33,7 @@ using namespace mu::engraving;
 //    MMRest
 //--------------------------------------------------------
 
-MMRest::MMRest(Segment* s)
+MMRest::MMRest(DummyParentOr<Segment> s)
     : Rest(ElementType::MMREST, s)
 {
     m_numberVisible = true;

--- a/src/engraving/dom/mmrest.h
+++ b/src/engraving/dom/mmrest.h
@@ -33,7 +33,7 @@ class MMRest final : public Rest
     DECLARE_CLASSOF(ElementType::MMREST)
 
 public:
-    MMRest(Segment* s = 0);
+    MMRest(DummyParentOr<Segment> s);
     MMRest(const MMRest&, bool link = false);
 
     MMRest* clone() const override { return new MMRest(*this, false); }

--- a/src/engraving/dom/mmrestrange.cpp
+++ b/src/engraving/dom/mmrestrange.cpp
@@ -44,7 +44,7 @@ static const ElementStyle mmRestRangeStyle {
     { Sid::mmRestRangeTextStyle, Pid::TEXT_STYLE }
 };
 
-MMRestRange::MMRestRange(Measure* parent)
+MMRestRange::MMRestRange(DummyParentOr<Measure> parent)
     : MeasureNumberBase(ElementType::MMREST_RANGE, parent, TextStyleType::MMREST_RANGE)
 {
     initElementStyle(&mmRestRangeStyle);

--- a/src/engraving/dom/mmrestrange.h
+++ b/src/engraving/dom/mmrestrange.h
@@ -40,7 +40,7 @@ class MMRestRange : public MeasureNumberBase
     M_PROPERTY(MMRestRangeBracketType, bracketType, setBracketType)
 
 public:
-    MMRestRange(Measure* parent = nullptr);
+    MMRestRange(DummyParentOr<Measure> parent);
     MMRestRange(const MMRestRange& other);
 
     MMRestRange* clone() const override { return new MMRestRange(*this); }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2254,7 +2254,6 @@ void Note::updateAccidental(AccidentalState* as)
         if (acci != AccidentalType::NONE && !m_hidden) {
             if (m_accidental == 0) {
                 Accidental* a = Factory::createAccidental(this);
-                a->setOwnershipParent(this);
                 a->setAccidentalType(acci);
                 a->setVisible(visible());
                 score()->undoAddElement(a);

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -629,7 +629,7 @@ SymId Note::noteHead(int direction, NoteHeadGroup group, NoteHeadType t, int tpc
     return noteHeads[direction][int(group)][int(t)];
 }
 
-NoteHead::NoteHead(Note* parent)
+NoteHead::NoteHead(DummyParentOr<Note> parent)
     : Symbol(ElementType::NOTEHEAD, parent) {}
 
 //---------------------------------------------------------
@@ -654,7 +654,7 @@ NoteHeadGroup NoteHead::headGroup() const
 //   Note
 //---------------------------------------------------------
 
-Note::Note(Chord* ch)
+Note::Note(DummyParentOr<Chord> ch)
     : EngravingItem(ElementType::NOTE, ch, ElementFlag::MOVABLE)
 {
     m_playEvents.push_back(NoteEvent());      // add default play event
@@ -800,7 +800,7 @@ Note::Note(const Note& n, bool link)
     setDropTarget(false);
 }
 
-void Note::setOwnershipParent(Chord* ch)
+void Note::setOwnershipParent(DummyParentOr<Chord> ch)
 {
     EngravingItem::setOwnershipParent(ch);
 }

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -84,7 +84,7 @@ class NoteHead final : public Symbol
     DECLARE_CLASSOF(ElementType::NOTEHEAD)
 
 public:
-    NoteHead(Note* parent = 0);
+    NoteHead(DummyParentOr<Note> parent);
     NoteHead(const NoteHead&) = default;
     NoteHead& operator=(const NoteHead&) = delete;
     NoteHead* clone() const override { return new NoteHead(*this); }
@@ -158,7 +158,7 @@ public:
     virtual Note* clone() const override { return new Note(*this, false); }
 
     Chord* chord() const { return (Chord*)ownershipParent(); }
-    void setOwnershipParent(Chord* ch);
+    void setOwnershipParent(DummyParentOr<Chord> ch);
 
     void undoUnlink() override;
 
@@ -466,7 +466,7 @@ public:
 private:
 
     friend class Factory;
-    Note(Chord* ch = 0);
+    Note(DummyParentOr<Chord> ch);
     Note(const Note&, bool link = false);
 
     void startDrag(EditData&) override;

--- a/src/engraving/dom/notedot.cpp
+++ b/src/engraving/dom/notedot.cpp
@@ -36,7 +36,7 @@ namespace mu::engraving {
 //   NoteDot
 //---------------------------------------------------------
 
-NoteDot::NoteDot(Note* parent)
+NoteDot::NoteDot(DummyParentOr<Note> parent)
     : EngravingItem(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);

--- a/src/engraving/dom/notedot.h
+++ b/src/engraving/dom/notedot.h
@@ -50,7 +50,7 @@ public:
 
 private:
     friend class Factory;
-    NoteDot(Note* parent);
+    NoteDot(DummyParentOr<Note> parent);
     NoteDot(Rest* parent);
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/noteline.cpp
+++ b/src/engraving/dom/noteline.cpp
@@ -79,7 +79,7 @@ EngravingObject* NoteLineSegment::propertyDelegate(Pid pid) const
     return TextLineBaseSegment::propertyDelegate(pid);
 }
 
-NoteLine::NoteLine(EngravingItem* parent)
+NoteLine::NoteLine(EngravingObject* parent)
     : TextLineBase(ElementType::NOTELINE, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&noteLineStyle);

--- a/src/engraving/dom/noteline.h
+++ b/src/engraving/dom/noteline.h
@@ -48,7 +48,7 @@ class NoteLine final : public TextLineBase
     DECLARE_CLASSOF(ElementType::NOTELINE)
 
 public:
-    NoteLine(EngravingItem* parent);
+    NoteLine(EngravingObject* parent);
     NoteLine(const NoteLine&);
     ~NoteLine() {}
 

--- a/src/engraving/dom/ornament.cpp
+++ b/src/engraving/dom/ornament.cpp
@@ -40,7 +40,7 @@
 
 using namespace mu::engraving;
 
-Ornament::Ornament(ChordRest* parent)
+Ornament::Ornament(DummyParentOr<ChordRest> parent)
     : Articulation(parent, ElementType::ORNAMENT)
 {
     _intervalAbove = DEFAULT_ORNAMENT_INTERVAL;

--- a/src/engraving/dom/ornament.h
+++ b/src/engraving/dom/ornament.h
@@ -32,7 +32,7 @@ class Ornament final : public Articulation
     DECLARE_CLASSOF(ElementType::ORNAMENT)
 
 public:
-    Ornament(ChordRest* parent);
+    Ornament(DummyParentOr<ChordRest> parent);
     Ornament* clone() const override { return new Ornament(*this); }
     Ornament(const Ornament& o);
     ~Ornament();

--- a/src/engraving/dom/ottava.cpp
+++ b/src/engraving/dom/ottava.cpp
@@ -227,7 +227,7 @@ Sid Ottava::getPropertyStyle(Pid pid) const
 //   Ottava
 //---------------------------------------------------------
 
-Ottava::Ottava(EngravingItem* parent)
+Ottava::Ottava(DummyParentOr<EngravingItem> parent)
     : TextLineBase(ElementType::OTTAVA, parent, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
 {
     m_ottavaType  = OttavaType::OTTAVA_8VA;

--- a/src/engraving/dom/ottava.h
+++ b/src/engraving/dom/ottava.h
@@ -111,7 +111,7 @@ class Ottava final : public TextLineBase
     DECLARE_CLASSOF(ElementType::OTTAVA)
 
 public:
-    Ottava(EngravingItem* parent);
+    Ottava(DummyParentOr<EngravingItem> parent);
     Ottava(const Ottava&);
 
     Ottava* clone() const override { return new Ottava(*this); }

--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -29,6 +29,7 @@
 #include "factory.h"
 #include "measurebase.h"
 #include "mscore.h"
+#include "rootitem.h"
 #include "score.h"
 #include "system.h"
 

--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -62,11 +62,9 @@ EngravingItem* Page::layoutParent() const
 EngravingItem* Page::accessibleParentItem() const
 {
     // Above the visual hierarchy sits the root item, which exists only to head the
-    // accessibility tree. (The dummy's page hangs off the dummy's own root item, which
-    // the base implementation finds as its raw parent.)
-    EngravingItem* parent = EngravingItem::accessibleParentItem();
-
-    return parent ? parent : score()->rootItem();
+    // accessibility tree. A page that is not in the score belongs to the dummy's tree,
+    // which the base implementation finds.
+    return ownershipParent() ? score()->rootItem() : EngravingItem::accessibleParentItem();
 }
 
 Page::~Page()

--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -42,9 +42,6 @@ using namespace mu::engraving;
 Page::Page(Score* parent)
     : EngravingItem(ElementType::PAGE, parent, ElementFlag::NOT_SELECTABLE)
 {
-    // Owned by its score right away; Score::m_pages manages page lifetime
-    setOwnershipParent(parent);
-
     m_bspTreeValid = false;
 }
 

--- a/src/engraving/dom/pagelockindicator.cpp
+++ b/src/engraving/dom/pagelockindicator.cpp
@@ -31,7 +31,7 @@
 #include "system.h"
 
 namespace mu::engraving {
-PageLockIndicator::PageLockIndicator(System* parent, const RangeLock* lock)
+PageLockIndicator::PageLockIndicator(DummyParentOr<System> parent, const RangeLock* lock)
     : IndicatorIcon(ElementType::PAGE_LOCK_INDICATOR, parent, ElementFlag::SYSTEM | ElementFlag::GENERATED), m_pageLock(lock) {}
 
 void PageLockIndicator::setSelected(bool v)

--- a/src/engraving/dom/pagelockindicator.h
+++ b/src/engraving/dom/pagelockindicator.h
@@ -33,7 +33,7 @@ class PageLockIndicator : public IndicatorIcon
     DECLARE_CLASSOF(ElementType::PAGE_LOCK_INDICATOR)
 
 public:
-    PageLockIndicator(System* parent, const RangeLock* lock);
+    PageLockIndicator(DummyParentOr<System> parent, const RangeLock* lock);
 
     void setSelected(bool v) override;
 

--- a/src/engraving/dom/palmmute.cpp
+++ b/src/engraving/dom/palmmute.cpp
@@ -88,7 +88,7 @@ PalmMuteSegment::PalmMuteSegment(PalmMute* sp)
 //   PalmMute
 //---------------------------------------------------------
 
-PalmMute::PalmMute(EngravingItem* parent)
+PalmMute::PalmMute(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::PALM_MUTE, parent)
 {
     initElementStyle(&palmMuteStyle);

--- a/src/engraving/dom/palmmute.h
+++ b/src/engraving/dom/palmmute.h
@@ -57,7 +57,7 @@ class PalmMute final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::PALM_MUTE)
 
 public:
-    PalmMute(EngravingItem* parent);
+    PalmMute(DummyParentOr<EngravingItem> parent);
 
     PalmMute* clone() const override { return new PalmMute(*this); }
 

--- a/src/engraving/dom/parenthesis.cpp
+++ b/src/engraving/dom/parenthesis.cpp
@@ -27,7 +27,7 @@
 
 using namespace mu::engraving;
 
-Parenthesis::Parenthesis(EngravingItem* parent)
+Parenthesis::Parenthesis(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::PARENTHESIS, parent, ElementFlag::MOVABLE)
 {
 }

--- a/src/engraving/dom/parenthesis.h
+++ b/src/engraving/dom/parenthesis.h
@@ -32,7 +32,7 @@ class Parenthesis : public EngravingItem
 public:
     static constexpr double PARENTHESIS_END_WIDTH = 0.1;
 
-    Parenthesis(EngravingItem* parent);
+    Parenthesis(DummyParentOr<EngravingItem> parent);
     Parenthesis(const Parenthesis& p);
 
     Parenthesis* clone() const override { return new Parenthesis(*this); }

--- a/src/engraving/dom/partialtie.cpp
+++ b/src/engraving/dom/partialtie.cpp
@@ -6,7 +6,7 @@
 #include "staff.h"
 
 namespace mu::engraving {
-PartialTie::PartialTie(Note* parent)
+PartialTie::PartialTie(DummyParentOr<Note> parent)
     : Tie(ElementType::PARTIAL_TIE, parent)
 {
 }

--- a/src/engraving/dom/partialtie.h
+++ b/src/engraving/dom/partialtie.h
@@ -49,7 +49,7 @@ class PartialTie : public Tie
     M_PROPERTY2(PartialSpannerDirection, partialSpannerDirection, setPartialSpannerDirection, PartialSpannerDirection::OUTGOING)
 
 public:
-    PartialTie(Note* parent);
+    PartialTie(DummyParentOr<Note> parent);
 
     Note* parentNote() const { return parent() ? toNote(parent()) : nullptr; }
 

--- a/src/engraving/dom/pedal.cpp
+++ b/src/engraving/dom/pedal.cpp
@@ -107,7 +107,7 @@ Sid Pedal::getPropertyStyle(Pid pid) const
 //   Pedal
 //---------------------------------------------------------
 
-Pedal::Pedal(EngravingItem* parent)
+Pedal::Pedal(DummyParentOr<EngravingItem> parent)
     : TextLineBase(ElementType::PEDAL, parent)
 {
     initElementStyle(&pedalStyle);

--- a/src/engraving/dom/pedal.h
+++ b/src/engraving/dom/pedal.h
@@ -65,7 +65,7 @@ public:
     static const String PEDAL_SYMBOL;
     static const String STAR_SYMBOL;
 
-    Pedal(EngravingItem* parent);
+    Pedal(DummyParentOr<EngravingItem> parent);
 
     Pedal* clone() const override { return new Pedal(*this); }
 

--- a/src/engraving/dom/pickscrape.cpp
+++ b/src/engraving/dom/pickscrape.cpp
@@ -74,7 +74,7 @@ PickScrapeSegment::PickScrapeSegment(PickScrape* sp)
 //   PickScrape
 //---------------------------------------------------------
 
-PickScrape::PickScrape(EngravingItem* parent)
+PickScrape::PickScrape(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::PICK_SCRAPE, parent)
 {
     initElementStyle(&pickScrapeStyle);

--- a/src/engraving/dom/pickscrape.h
+++ b/src/engraving/dom/pickscrape.h
@@ -57,7 +57,7 @@ class PickScrape final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::PICK_SCRAPE)
 
 public:
-    PickScrape(EngravingItem* parent);
+    PickScrape(DummyParentOr<EngravingItem> parent);
 
     PickScrape* clone() const override { return new PickScrape(*this); }
 

--- a/src/engraving/dom/playcounttext.cpp
+++ b/src/engraving/dom/playcounttext.cpp
@@ -36,7 +36,7 @@ static ElementStyle playCountStyle {
     { Sid::repeatPlayCountMinDistance, Pid::MIN_DISTANCE },
 };
 
-PlayCountText::PlayCountText(Segment* parent, TextStyleType tid)
+PlayCountText::PlayCountText(DummyParentOr<Segment> parent, TextStyleType tid)
     : TextBase(ElementType::PLAY_COUNT_TEXT, parent, tid, ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&playCountStyle);

--- a/src/engraving/dom/playcounttext.h
+++ b/src/engraving/dom/playcounttext.h
@@ -55,7 +55,7 @@ public:
 
 private:
     friend class Factory;
-    PlayCountText(Segment* parent, TextStyleType tid = TextStyleType::REPEAT_PLAY_COUNT);
+    PlayCountText(DummyParentOr<Segment> parent, TextStyleType tid = TextStyleType::REPEAT_PLAY_COUNT);
 
     AutoCustomHide m_playCountTextSetting = AutoCustomHide::AUTO;
     String m_playCountCustomText = u"";

--- a/src/engraving/dom/playtechannotation.cpp
+++ b/src/engraving/dom/playtechannotation.cpp
@@ -36,7 +36,7 @@ static const ElementStyle annotationStyle {
     { Sid::staffTextMinDistance, Pid::MIN_DISTANCE },
 };
 
-PlayTechAnnotation::PlayTechAnnotation(Segment* parent, PlayingTechniqueType techniqueType, TextStyleType tid)
+PlayTechAnnotation::PlayTechAnnotation(DummyParentOr<Segment> parent, PlayingTechniqueType techniqueType, TextStyleType tid)
     : StaffTextBase(ElementType::PLAYTECH_ANNOTATION, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF),
     m_techniqueType(techniqueType)
 {

--- a/src/engraving/dom/playtechannotation.h
+++ b/src/engraving/dom/playtechannotation.h
@@ -33,7 +33,7 @@ class PlayTechAnnotation final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::PLAYTECH_ANNOTATION)
 
 public:
-    PlayTechAnnotation(Segment* parent = nullptr, PlayingTechniqueType techniqueType = PlayingTechniqueType::Natural,
+    PlayTechAnnotation(DummyParentOr<Segment> parent, PlayingTechniqueType techniqueType = PlayingTechniqueType::Natural,
                        TextStyleType tid = TextStyleType::STAFF);
 
     PlayingTechniqueType techniqueType() const;

--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -338,7 +338,7 @@ void TrackList::appendGap(const Fraction& du, Score* score)
         m_duration   += du;
         rest->setTicks(dd);
     } else {
-        Rest* rest = Factory::createRest(score->dummy()->segment());
+        Rest* rest = Factory::createRest(score->dummy());
         rest->setTicks(du);
         std::vector<EngravingItem*>::push_back(rest);
         m_duration   += du;

--- a/src/engraving/dom/rasgueado.cpp
+++ b/src/engraving/dom/rasgueado.cpp
@@ -74,7 +74,7 @@ RasgueadoSegment::RasgueadoSegment(Rasgueado* sp)
 //   Rasgueado
 //---------------------------------------------------------
 
-Rasgueado::Rasgueado(EngravingItem* parent)
+Rasgueado::Rasgueado(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::RASGUEADO, parent)
 {
     initElementStyle(&rasgueadoStyle);

--- a/src/engraving/dom/rasgueado.h
+++ b/src/engraving/dom/rasgueado.h
@@ -57,7 +57,7 @@ class Rasgueado final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::RASGUEADO)
 
 public:
-    Rasgueado(EngravingItem* parent);
+    Rasgueado(DummyParentOr<EngravingItem> parent);
 
     Rasgueado* clone() const override { return new Rasgueado(*this); }
 

--- a/src/engraving/dom/rehearsalmark.cpp
+++ b/src/engraving/dom/rehearsalmark.cpp
@@ -54,7 +54,7 @@ static const ElementStyle additionalRehearsalMarkStyle {
 //   RehearsalMark
 //---------------------------------------------------------
 
-RehearsalMark::RehearsalMark(Segment* parent)
+RehearsalMark::RehearsalMark(DummyParentOr<Segment> parent)
     : TextBase(ElementType::REHEARSAL_MARK, parent, TextStyleType::REHEARSAL_MARK, ElementFlag::ON_STAFF)
 {
     initElementStyle(&rehearsalMarkStyle);

--- a/src/engraving/dom/rehearsalmark.h
+++ b/src/engraving/dom/rehearsalmark.h
@@ -41,7 +41,7 @@ public:
         Additional
     };
 
-    RehearsalMark(Segment* parent);
+    RehearsalMark(DummyParentOr<Segment> parent);
 
     bool isEditAllowed(EditData&) const override;
     bool allowTimeAnchor() const override { return false; }

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -58,23 +58,23 @@ namespace mu::engraving {
 //    Rest
 //--------------------------------------------------------
 
-Rest::Rest(Segment* parent)
+Rest::Rest(DummyParentOr<Segment> parent)
     : Rest(ElementType::REST, parent)
 {
 }
 
-Rest::Rest(const ElementType& type, Segment* parent)
+Rest::Rest(const ElementType& type, DummyParentOr<Segment> parent)
     : ChordRest(type, parent)
 {
     m_beamMode  = BeamMode::NONE;
 }
 
-Rest::Rest(Segment* parent, const TDuration& d)
+Rest::Rest(DummyParentOr<Segment> parent, const TDuration& d)
     : Rest(ElementType::REST, parent, d)
 {
 }
 
-Rest::Rest(const ElementType& type, Segment* parent, const TDuration& d)
+Rest::Rest(const ElementType& type, DummyParentOr<Segment> parent, const TDuration& d)
     : ChordRest(type, parent)
 {
     m_beamMode  = BeamMode::NONE;

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -310,7 +310,6 @@ void Rest::checkDots()
     int n = dots() - int(m_dots.size());
     for (int i = 0; i < n; ++i) {
         NoteDot* dot = Factory::createNoteDot(this);
-        dot->setOwnershipParent(this);
         dot->setVisible(visible());
         score()->undoAddElement(dot);
     }

--- a/src/engraving/dom/rest.h
+++ b/src/engraving/dom/rest.h
@@ -139,8 +139,8 @@ public:
     double symWidthNoLedgerLines(LayoutData* ldata) const;
 
 protected:
-    Rest(const ElementType& type, Segment* parent = 0);
-    Rest(const ElementType& type, Segment* parent, const TDuration&);
+    Rest(const ElementType& type, DummyParentOr<Segment> parent);
+    Rest(const ElementType& type, DummyParentOr<Segment> parent, const TDuration&);
     Rest(const Rest&, bool link = false);
 
     Sid getPropertyStyle(Pid pid) const override;
@@ -149,8 +149,8 @@ protected:
 private:
 
     friend class Factory;
-    Rest(Segment* parent);
-    Rest(Segment* parent, const TDuration&);
+    Rest(DummyParentOr<Segment> parent);
+    Rest(DummyParentOr<Segment> parent, const TDuration&);
 
     RectF drag(EditData&) override;
     double upPos() const override;

--- a/src/engraving/dom/rootitem.cpp
+++ b/src/engraving/dom/rootitem.cpp
@@ -21,6 +21,7 @@
  */
 #include "rootitem.h"
 
+#include "dummyparent.h"
 #include "page.h"
 #include "score.h"
 
@@ -30,23 +31,28 @@
 
 using namespace mu::engraving;
 
-RootItem::RootItem(Score* score)
-    : EngravingItem(ElementType::ROOT_ITEM, score)
+RootItem::RootItem(Score* score, Kind kind)
+    : EngravingItem(ElementType::ROOT_ITEM, score), m_kind(kind)
 {
 }
 
 EngravingItemList RootItem::accessibleChildren() const
 {
-    EngravingItemList children = EngravingItem::accessibleChildren();
-
-    if (this == score()->rootItem()) {
+    switch (m_kind) {
+    case Kind::Score: {
+        EngravingItemList children = EngravingItem::accessibleChildren();
         // The pages are owned by the score, but this is the top of the accessibility
-        // tree, so this is where they are listed. (The dummy has a root item of its
-        // own, which heads the tree of the items parked on it and has no pages.)
+        // tree, so this is where they are listed.
         children.insert(children.end(), score()->pages().begin(), score()->pages().end());
+        return children;
+    }
+    case Kind::Dummy:
+        // The objects parked on the dummy are not part of the score, so they form a
+        // tree of their own, headed by this.
+        return score()->dummy()->childrenItems();
     }
 
-    return children;
+    return EngravingItemList();
 }
 
 void RootItem::init()

--- a/src/engraving/dom/rootitem.cpp
+++ b/src/engraving/dom/rootitem.cpp
@@ -33,19 +33,6 @@ using namespace mu::engraving;
 RootItem::RootItem(Score* score)
     : EngravingItem(ElementType::ROOT_ITEM, score)
 {
-    m_dummy = new compat::DummyElement(this);
-}
-
-RootItem::~RootItem()
-{
-    compat::DummyElement* d = m_dummy;
-    m_dummy = nullptr;
-    delete d;
-}
-
-compat::DummyElement* RootItem::dummy() const
-{
-    return m_dummy;
 }
 
 EngravingItemList RootItem::accessibleChildren() const
@@ -67,9 +54,6 @@ void RootItem::init()
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     setupAccessible();
 #endif
-
-    m_dummy->setOwnershipParent(this);
-    m_dummy->init();
 }
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY

--- a/src/engraving/dom/rootitem.h
+++ b/src/engraving/dom/rootitem.h
@@ -24,8 +24,6 @@
 
 #include "engravingitem.h"
 
-#include "../compat/dummyelement.h"
-
 namespace mu::engraving {
 class Score;
 
@@ -37,9 +35,7 @@ class RootItem : public EngravingItem
     OBJECT_ALLOCATOR(engraving, RootItem)
 public:
     RootItem(Score* score);
-    ~RootItem() override;
 
-    compat::DummyElement* dummy() const;
     void init();
 
     EngravingItemList accessibleChildren() const override;
@@ -53,7 +49,5 @@ private:
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     AccessibleItemPtr createAccessible() override;
 #endif
-
-    compat::DummyElement* m_dummy = nullptr;
 };
 }

--- a/src/engraving/dom/rootitem.h
+++ b/src/engraving/dom/rootitem.h
@@ -28,16 +28,25 @@ namespace mu::engraving {
 class Score;
 
 //! Sits above the pages, which are the top of the visual hierarchy. It takes no part in
-//! that hierarchy - nothing is laid out inside it - and exists only to head the
+//! that hierarchy - nothing is laid out inside it - and exists only to head an
 //! accessibility tree; see EngravingItem::accessibleChildren().
 class RootItem : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, RootItem)
 public:
-    RootItem(Score* score);
+    //! Which tree this one heads: the score's own, or the one formed by the objects
+    //! parked on the dummy, which are not part of the score.
+    enum class Kind {
+        Score,
+        Dummy
+    };
+
+    RootItem(Score* score, Kind kind);
 
     void init();
 
+    //! The top of a tree has no parent within it.
+    EngravingItem* accessibleParentItem() const override { return nullptr; }
     EngravingItemList accessibleChildren() const override;
 
     EngravingItem* clone() const override { return nullptr; }
@@ -49,5 +58,7 @@ private:
 #ifndef ENGRAVING_NO_ACCESSIBILITY
     AccessibleItemPtr createAccessible() override;
 #endif
+
+    Kind m_kind = Kind::Score;
 };
 }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -52,7 +52,6 @@
 
 #include "style/style.h"
 #include "style/defaultstyle.h"
-#include "compat/dummyelement.h"
 
 #include "iengravingfont.h"
 #include "types/translatablestring.h"
@@ -65,6 +64,7 @@
 #include "capo.h"
 #include "chord.h"
 #include "clef.h"
+#include "dummyparent.h"
 #include "excerpt.h"
 #include "factory.h"
 #include "glissando.h"
@@ -184,7 +184,7 @@ Score::Score(const modularity::ContextPtr& iocCtx)
     m_rootItem = new RootItem(this);
     m_rootItem->init();
 
-    m_dummy = new compat::DummyElement(this);
+    m_dummy = new DummyParent(this);
     m_dummy->init();
 
     createPaddingTable();

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -367,14 +367,19 @@ bool Score::isPaletteScore() const
     return this == paletteScore();
 }
 
-static void onBracketItemDestruction(const Score* score, const BracketItem* item)
+//! A bracket is a rendering of its bracket item, rebuilt from it on every layout, so
+//! one whose item is gone has nothing left to represent.
+static void onBracketItemDestruction(Score* score, const BracketItem* item)
 {
-    BracketItem* dummy = score->dummy()->bracketItem();
-
-    for (const System* system : score->systems()) {
-        for (Bracket* bracket : system->brackets()) {
+    for (System* system : score->systems()) {
+        std::vector<Bracket*>& brackets = system->brackets();
+        for (auto it = brackets.begin(); it != brackets.end();) {
+            Bracket* bracket = *it;
             if (bracket && bracket->bracketItem() == item) {
-                bracket->setBracketItem(dummy);
+                it = brackets.erase(it);
+                delete bracket;
+            } else {
+                ++it;
             }
         }
     }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -91,6 +91,7 @@
 #include "rehearsalmark.h"
 #include "repeatlist.h"
 #include "rest.h"
+#include "rootitem.h"
 #include "scoreorder.h"
 #include "segment.h"
 #include "select.h"
@@ -182,6 +183,9 @@ Score::Score(const modularity::ContextPtr& iocCtx)
 
     m_rootItem = new RootItem(this);
     m_rootItem->init();
+
+    m_dummy = new compat::DummyElement(this);
+    m_dummy->init();
 
     createPaddingTable();
 
@@ -295,6 +299,10 @@ Score::~Score()
 
     delete m_rootItem;
     m_rootItem = nullptr;
+
+    // last: everything that is deleted above may park children on it on its way out
+    delete m_dummy;
+    m_dummy = nullptr;
 }
 
 muse::async::Channel<LoopBoundaryType, unsigned> Score::loopBoundaryTickChanged() const

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1930,7 +1930,6 @@ void Score::splitStaff(staff_idx_t staffIdx, int splitPoint)
     Clef* clef = Factory::createClef(seg);
     clef->setClefType(ClefType::F);
     clef->setTrack((staffIdx + 1) * VOICES);
-    clef->setOwnershipParent(seg);
     clef->setIsHeader(true);
     undoAddElement(clef);
 
@@ -2347,7 +2346,6 @@ void Score::adjustKeySigs(track_idx_t sidx, track_idx_t eidx, KeyList km)
 
             Segment* s = measure->getSegment(SegmentType::KeySig, tick);
             KeySig* keysig = Factory::createKeySig(s);
-            keysig->setOwnershipParent(s);
             keysig->setTrack(staffIdx * VOICES);
             keysig->setKeySigEvent(key);
             doUndoAddElement(keysig);

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -181,7 +181,7 @@ Score::Score(const modularity::ContextPtr& iocCtx)
     m_fileDivision = Constants::DIVISION;
     m_style = DefaultStyle::defaultStyle();
 
-    m_rootItem = new RootItem(this);
+    m_rootItem = new RootItem(this, RootItem::Kind::Score);
     m_rootItem->init();
 
     m_dummy = new DummyParent(this);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -45,11 +45,10 @@
 #include "../style/style.h"
 #include "../style/pagestyle.h"
 
-#include "../compat/dummyelement.h"
-
 #include "../editing/cmd.h"
 
 #include "chordlist.h"
+#include "dummyparent.h"
 #include "guitarbend.h"
 #include "input.h"
 #include "mscore.h"
@@ -304,7 +303,7 @@ public:
     void scanElements(std::function<void(EngravingItem*)> func) override;
 
     RootItem* rootItem() const { return m_rootItem; }
-    compat::DummyElement* dummy() const { return m_dummy; }
+    DummyParent* dummy() const { return m_dummy; }
 
     ShadowNote* shadowNote() const;
 
@@ -1007,7 +1006,7 @@ private:
     SelectionFilter m_selectionFilter;
 
     RootItem* m_rootItem = nullptr;
-    compat::DummyElement* m_dummy = nullptr;
+    DummyParent* m_dummy = nullptr;
     LayoutOptions m_layoutOptions;
 
     muse::async::Channel<EngravingItem*> m_elementDestroyed;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -45,6 +45,8 @@
 #include "../style/style.h"
 #include "../style/pagestyle.h"
 
+#include "../compat/dummyelement.h"
+
 #include "../editing/cmd.h"
 
 #include "chordlist.h"
@@ -52,7 +54,6 @@
 #include "input.h"
 #include "mscore.h"
 #include "property.h"
-#include "rootitem.h"
 #include "scoreorder.h"
 #include "segment.h"
 #include "select.h"
@@ -125,6 +126,7 @@ class RehearsalMark;
 class RepeatList;
 struct RepeatSegmentInfo;
 class Rest;
+class RootItem;
 class Score;
 class IEngravingFont;
 class Segment;
@@ -302,7 +304,7 @@ public:
     void scanElements(std::function<void(EngravingItem*)> func) override;
 
     RootItem* rootItem() const { return m_rootItem; }
-    compat::DummyElement* dummy() const { return m_rootItem->dummy(); }
+    compat::DummyElement* dummy() const { return m_dummy; }
 
     ShadowNote* shadowNote() const;
 
@@ -1005,6 +1007,7 @@ private:
     SelectionFilter m_selectionFilter;
 
     RootItem* m_rootItem = nullptr;
+    compat::DummyElement* m_dummy = nullptr;
     LayoutOptions m_layoutOptions;
 
     muse::async::Channel<EngravingItem*> m_elementDestroyed;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -149,14 +149,12 @@ void Segment::removeElement(track_idx_t track)
 Segment::Segment(DummyParentOr<Measure> m)
     : EngravingItem(ElementType::SEGMENT, m, ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
-    setOwnershipParent(m);
     init();
 }
 
 Segment::Segment(DummyParentOr<Measure> m, SegmentType st, const Fraction& t)
     : EngravingItem(ElementType::SEGMENT, m, ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
-    setOwnershipParent(m);
 //      assert(t >= Fraction(0,1));
 //      assert(t <= m->ticks());
     m_segmentType = st;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -146,15 +146,15 @@ void Segment::removeElement(track_idx_t track)
 //   Segment
 //---------------------------------------------------------
 
-Segment::Segment(Measure* m)
-    : EngravingItem(ElementType::SEGMENT, m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
+Segment::Segment(DummyParentOr<Measure> m)
+    : EngravingItem(ElementType::SEGMENT, m, ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
     setOwnershipParent(m);
     init();
 }
 
-Segment::Segment(Measure* m, SegmentType st, const Fraction& t)
-    : EngravingItem(ElementType::SEGMENT, m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
+Segment::Segment(DummyParentOr<Measure> m, SegmentType st, const Fraction& t)
+    : EngravingItem(ElementType::SEGMENT, m, ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
     setOwnershipParent(m);
 //      assert(t >= Fraction(0,1));
@@ -191,7 +191,7 @@ Segment::Segment(const Segment& s)
     m_shapes  = s.m_shapes;
 }
 
-void Segment::setOwnershipParent(Measure* parent)
+void Segment::setOwnershipParent(DummyParentOr<Measure> parent)
 {
     EngravingItem::setOwnershipParent(parent);
 }

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -128,7 +128,7 @@ public:
 
     ~Segment();
 
-    void setOwnershipParent(Measure* parent);
+    void setOwnershipParent(DummyParentOr<Measure> parent);
 
     Segment* clone() const override { return new Segment(*this); }
 
@@ -352,8 +352,8 @@ private:
     void addArticulationsToShape(const Chord* chord, Shape& shape);
 
     friend class Factory;
-    Segment(Measure* m = 0);
-    Segment(Measure*, SegmentType, const Fraction&);
+    Segment(DummyParentOr<Measure> m);
+    Segment(DummyParentOr<Measure>, SegmentType, const Fraction&);
     Segment(const Segment&);
 
     void init();

--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -380,7 +380,7 @@ Slur::Slur(const Slur& s)
 //   Slur
 //---------------------------------------------------------
 
-Slur::Slur(EngravingItem* parent, ElementType type)
+Slur::Slur(DummyParentOr<EngravingItem> parent, ElementType type)
     : SlurTie(type, parent)
 {
 }

--- a/src/engraving/dom/slur.h
+++ b/src/engraving/dom/slur.h
@@ -76,7 +76,7 @@ class Slur : public SlurTie
     DECLARE_CLASSOF(ElementType::SLUR)
 
 public:
-    Slur(EngravingItem* parent, ElementType type = ElementType::SLUR);
+    Slur(DummyParentOr<EngravingItem> parent, ElementType type = ElementType::SLUR);
     Slur(const Slur&);
 
     Anchor anchor() const override { return Anchor::CHORDREST; }

--- a/src/engraving/dom/slurtie.cpp
+++ b/src/engraving/dom/slurtie.cpp
@@ -346,7 +346,7 @@ void SlurTieSegment::undoChangeProperty(Pid pid, const PropertyValue& val, Prope
 //   SlurTie
 //---------------------------------------------------------
 
-SlurTie::SlurTie(const ElementType& type, EngravingItem* parent)
+SlurTie::SlurTie(const ElementType& type, EngravingObject* parent)
     : Spanner(type, parent)
 {
     m_slurDirection = DirectionV::AUTO;

--- a/src/engraving/dom/slurtie.h
+++ b/src/engraving/dom/slurtie.h
@@ -159,7 +159,7 @@ class SlurTie : public Spanner
     OBJECT_ALLOCATOR(engraving, SlurTie)
 
 public:
-    SlurTie(const ElementType& type, EngravingItem* parent);
+    SlurTie(const ElementType& type, EngravingObject* parent);
     SlurTie(const SlurTie&);
     ~SlurTie();
 

--- a/src/engraving/dom/soundflag.cpp
+++ b/src/engraving/dom/soundflag.cpp
@@ -34,7 +34,7 @@
 using namespace muse::draw;
 using namespace mu::engraving;
 
-SoundFlag::SoundFlag(EngravingItem* parent)
+SoundFlag::SoundFlag(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::SOUND_FLAG, parent)
 {
     String fontFamily = configuration()->iconsFontFamily();

--- a/src/engraving/dom/soundflag.h
+++ b/src/engraving/dom/soundflag.h
@@ -33,7 +33,7 @@ class SoundFlag final : public EngravingItem
     DECLARE_CLASSOF(ElementType::SOUND_FLAG)
 
 public:
-    explicit SoundFlag(EngravingItem* parent = nullptr);
+    explicit SoundFlag(DummyParentOr<EngravingItem> parent);
 
     SoundFlag* clone() const override;
     bool isEditable() const override;

--- a/src/engraving/dom/spacer.cpp
+++ b/src/engraving/dom/spacer.cpp
@@ -38,7 +38,7 @@ namespace mu::engraving {
 //   LayoutBreak
 //---------------------------------------------------------
 
-Spacer::Spacer(Measure* parent)
+Spacer::Spacer(DummyParentOr<Measure> parent)
     : EngravingItem(ElementType::SPACER, parent)
 {
     m_spacerType = SpacerType::UP;

--- a/src/engraving/dom/spacer.h
+++ b/src/engraving/dom/spacer.h
@@ -85,7 +85,7 @@ public:
 private:
 
     friend class Factory;
-    Spacer(Measure* parent);
+    Spacer(DummyParentOr<Measure> parent);
     Spacer(const Spacer&);
 
     SpacerType m_spacerType = SpacerType::UP;

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -86,6 +86,19 @@ EngravingItem* SpannerSegment::layoutParent() const
     return m_system;
 }
 
+EngravingItem* SpannerSegment::accessibleParentItem() const
+{
+    // Not placed on a system yet, so it is the spanner that lists it;
+    // see Spanner::accessibleChildren().
+    if (!m_system) {
+        if (EngravingItem* owner = ownershipParentItem()) {
+            return owner;
+        }
+    }
+
+    return EngravingItem::accessibleParentItem();
+}
+
 //---------------------------------------------------------
 //   mag
 //---------------------------------------------------------

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -52,7 +52,6 @@ namespace mu::engraving {
 SpannerSegment::SpannerSegment(const ElementType& type, Spanner* sp, ElementFlags f)
     : EngravingItem(type, sp, f)
 {
-    setOwnershipParent(sp);
     setSpannerSegmentType(SpannerSegmentType::SINGLE);
 }
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -443,7 +443,7 @@ TranslatableString SpannerSegment::subtypeUserName() const
 //   Spanner
 //---------------------------------------------------------
 
-Spanner::Spanner(const ElementType& type, EngravingItem* parent, ElementFlags f)
+Spanner::Spanner(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : EngravingItem(type, parent, f)
 {
 }

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -76,6 +76,7 @@ public:
     //! Detach from the current system's segment list and attach to the given one.
     void moveToSystem(System* s);
     EngravingItem* layoutParent() const override;
+    EngravingItem* accessibleParentItem() const override;
 
     //! A segment is owned by its spanner; a system merely places it, see
     //! setSystem()/moveToSystem(). This overload hides EngravingItem::setOwnershipParent,

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -284,7 +284,7 @@ public:
 
 protected:
 
-    Spanner(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
+    Spanner(const ElementType& type, EngravingObject* parent, ElementFlags = ElementFlag::NOTHING);
     Spanner(const Spanner&);
 
     virtual void doComputeStartElement();

--- a/src/engraving/dom/stafflines.cpp
+++ b/src/engraving/dom/stafflines.cpp
@@ -48,7 +48,7 @@ namespace mu::engraving {
 //   StaffLines
 //---------------------------------------------------------
 
-StaffLines::StaffLines(Measure* parent)
+StaffLines::StaffLines(DummyParentOr<Measure> parent)
     : EngravingItem(ElementType::STAFF_LINES, parent)
 {
     setSelectable(false);

--- a/src/engraving/dom/stafflines.h
+++ b/src/engraving/dom/stafflines.h
@@ -62,7 +62,7 @@ public:
 
 private:
     friend class Factory;
-    StaffLines(Measure* parent);
+    StaffLines(DummyParentOr<Measure> parent);
 
     double m_lw = 0.0;
     std::vector<LineF> m_lines;

--- a/src/engraving/dom/staffstate.cpp
+++ b/src/engraving/dom/staffstate.cpp
@@ -37,7 +37,7 @@ namespace mu::engraving {
 //   StaffState
 //---------------------------------------------------------
 
-StaffState::StaffState(EngravingItem* parent)
+StaffState::StaffState(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::STAFF_STATE, parent)
 {
     m_staffStateType = StaffStateType::INSTRUMENT;

--- a/src/engraving/dom/staffstate.h
+++ b/src/engraving/dom/staffstate.h
@@ -74,7 +74,7 @@ public:
 private:
 
     friend class Factory;
-    StaffState(EngravingItem* parent);
+    StaffState(DummyParentOr<EngravingItem> parent);
     StaffState(const StaffState&);
 
     StaffStateType m_staffStateType = StaffStateType::INVISIBLE;

--- a/src/engraving/dom/stafftext.cpp
+++ b/src/engraving/dom/stafftext.cpp
@@ -34,7 +34,7 @@ static const ElementStyle STAFF_STYLE {
     { Sid::staffTextMinDistance, Pid::MIN_DISTANCE },
 };
 
-StaffText::StaffText(Segment* parent, TextStyleType tid)
+StaffText::StaffText(DummyParentOr<Segment> parent, TextStyleType tid)
     : StaffTextBase(ElementType::STAFF_TEXT, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&STAFF_STYLE);

--- a/src/engraving/dom/stafftext.h
+++ b/src/engraving/dom/stafftext.h
@@ -32,7 +32,7 @@ class StaffText final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::STAFF_TEXT)
 
 public:
-    StaffText(Segment* parent = nullptr, TextStyleType = TextStyleType::STAFF);
+    StaffText(DummyParentOr<Segment> parent, TextStyleType = TextStyleType::STAFF);
     StaffText(const StaffText&);
 
     bool isEditAllowed(EditData&) const override;

--- a/src/engraving/dom/stafftextbase.cpp
+++ b/src/engraving/dom/stafftextbase.cpp
@@ -30,7 +30,7 @@
 
 using namespace mu::engraving;
 
-StaffTextBase::StaffTextBase(const ElementType& type, Segment* parent, TextStyleType tid, ElementFlags flags)
+StaffTextBase::StaffTextBase(const ElementType& type, DummyParentOr<Segment> parent, TextStyleType tid, ElementFlags flags)
     : TextBase(type, parent, tid, flags)
 {
     setSwingParameters(Constants::DIVISION / 2, 60);

--- a/src/engraving/dom/stafftextbase.h
+++ b/src/engraving/dom/stafftextbase.h
@@ -43,7 +43,7 @@ class StaffTextBase : public TextBase
     OBJECT_ALLOCATOR(engraving, StaffTextBase)
 
 public:
-    StaffTextBase(const ElementType& type, Segment* parent, TextStyleType tid, ElementFlags = ElementFlag::ON_STAFF);
+    StaffTextBase(const ElementType& type, DummyParentOr<Segment> parent, TextStyleType tid, ElementFlags = ElementFlag::ON_STAFF);
 
     void clear();
 

--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -35,7 +35,7 @@ using namespace mu::engraving;
 //   StaffTypeChange
 //---------------------------------------------------------
 
-StaffTypeChange::StaffTypeChange(MeasureBase* parent)
+StaffTypeChange::StaffTypeChange(DummyParentOr<MeasureBase> parent)
     : EngravingItem(ElementType::STAFFTYPE_CHANGE, parent)
 {
     m_lw = spatium() * 0.3;

--- a/src/engraving/dom/stafftypechange.h
+++ b/src/engraving/dom/stafftypechange.h
@@ -56,7 +56,7 @@ public:
 private:
 
     friend class Factory;
-    StaffTypeChange(MeasureBase* parent = 0);
+    StaffTypeChange(DummyParentOr<MeasureBase> parent);
     StaffTypeChange(const StaffTypeChange&);
 
     void spatiumChanged(double oldValue, double newValue) override;

--- a/src/engraving/dom/staffvisibilityindicator.cpp
+++ b/src/engraving/dom/staffvisibilityindicator.cpp
@@ -24,7 +24,7 @@
 
 using namespace mu::engraving;
 
-StaffVisibilityIndicator::StaffVisibilityIndicator(System* parent)
+StaffVisibilityIndicator::StaffVisibilityIndicator(DummyParentOr<System> parent)
     : IndicatorIcon(ElementType::STAFF_VISIBILITY_INDICATOR, parent, ElementFlag::SYSTEM | ElementFlag::GENERATED)
 {
 }

--- a/src/engraving/dom/staffvisibilityindicator.h
+++ b/src/engraving/dom/staffvisibilityindicator.h
@@ -31,7 +31,7 @@ class StaffVisibilityIndicator : public IndicatorIcon
     DECLARE_CLASSOF(ElementType::STAFF_VISIBILITY_INDICATOR)
 
 public:
-    StaffVisibilityIndicator(System* parent);
+    StaffVisibilityIndicator(DummyParentOr<System> parent);
 
     char16_t iconCode() const override { return 0xF4AE; }
 };

--- a/src/engraving/dom/stavesharinglabel.cpp
+++ b/src/engraving/dom/stavesharinglabel.cpp
@@ -27,7 +27,7 @@ static const ElementStyle STAVE_SHARING_LABEL_STYLE {
     { Sid::staveSharingLabelMinDistance, Pid::MIN_DISTANCE },
 };
 
-StaveSharingLabel::StaveSharingLabel(Segment* parent, TextStyleType tid)
+StaveSharingLabel::StaveSharingLabel(DummyParentOr<Segment> parent, TextStyleType tid)
     : StaffTextBase(ElementType::STAVE_SHARING_LABEL, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&STAVE_SHARING_LABEL_STYLE);

--- a/src/engraving/dom/stavesharinglabel.h
+++ b/src/engraving/dom/stavesharinglabel.h
@@ -30,7 +30,7 @@ class StaveSharingLabel final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::STAVE_SHARING_LABEL)
 
 public:
-    StaveSharingLabel(Segment* parent = nullptr, TextStyleType tid = TextStyleType::STAVE_SHARING);
+    StaveSharingLabel(DummyParentOr<Segment> parent, TextStyleType tid = TextStyleType::STAVE_SHARING);
 
     bool isEditAllowed(EditData&) const override { return false; }
 

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -39,7 +39,7 @@ static const ElementStyle stemStyle {
     { Sid::stemWidth, Pid::LINE_WIDTH }
 };
 
-Stem::Stem(Chord* parent)
+Stem::Stem(DummyParentOr<Chord> parent)
     : EngravingItem(ElementType::STEM, parent)
 {
     initElementStyle(&stemStyle);

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -87,7 +87,7 @@ public:
 
 private:
     friend class Factory;
-    Stem(Chord* parent = 0);
+    Stem(DummyParentOr<Chord> parent);
 
     Spatium m_baseLength = 0.0_sp;
 

--- a/src/engraving/dom/stemslash.cpp
+++ b/src/engraving/dom/stemslash.cpp
@@ -29,7 +29,7 @@
 using namespace mu;
 
 namespace mu::engraving {
-StemSlash::StemSlash(Chord* parent)
+StemSlash::StemSlash(DummyParentOr<Chord> parent)
     : EngravingItem(ElementType::STEM_SLASH, parent)
 {
 }

--- a/src/engraving/dom/stemslash.h
+++ b/src/engraving/dom/stemslash.h
@@ -55,7 +55,7 @@ public:
 private:
 
     friend class Factory;
-    StemSlash(Chord* parent = 0);
+    StemSlash(DummyParentOr<Chord> parent);
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/dom/sticking.cpp
+++ b/src/engraving/dom/sticking.cpp
@@ -42,7 +42,7 @@ static const ElementStyle stickingStyle {
 //   Sticking
 //---------------------------------------------------------
 
-Sticking::Sticking(Segment* parent)
+Sticking::Sticking(DummyParentOr<Segment> parent)
     : TextBase(ElementType::STICKING, parent, TextStyleType::STICKING, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&stickingStyle);

--- a/src/engraving/dom/sticking.h
+++ b/src/engraving/dom/sticking.h
@@ -39,7 +39,7 @@ class Sticking final : public TextBase
     PropertyValue propertyDefault(Pid id) const override;
 
 public:
-    Sticking(Segment* parent);
+    Sticking(DummyParentOr<Segment> parent);
 
     Sticking* clone() const override { return new Sticking(*this); }
 

--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -43,7 +43,7 @@ static const ElementStyle STRING_TUNINGS_STYLE {
     { Sid::staffTextMinDistance, Pid::MIN_DISTANCE },
 };
 
-StringTunings::StringTunings(Segment* parent, TextStyleType textStyleType)
+StringTunings::StringTunings(DummyParentOr<Segment> parent, TextStyleType textStyleType)
     : StaffTextBase(ElementType::STRING_TUNINGS, parent, textStyleType, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&STRING_TUNINGS_STYLE);

--- a/src/engraving/dom/stringtunings.h
+++ b/src/engraving/dom/stringtunings.h
@@ -33,7 +33,7 @@ class StringTunings final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::STRING_TUNINGS)
 
 public:
-    explicit StringTunings(Segment* parent, TextStyleType textStyleType = TextStyleType::STRING_TUNINGS);
+    explicit StringTunings(DummyParentOr<Segment> parent, TextStyleType textStyleType = TextStyleType::STRING_TUNINGS);
     StringTunings(const StringTunings& s);
 
     StringTunings* clone() const override;

--- a/src/engraving/dom/symbol.cpp
+++ b/src/engraving/dom/symbol.cpp
@@ -186,7 +186,7 @@ void Symbol::reset()
 //   FSymbol
 //---------------------------------------------------------
 
-FSymbol::FSymbol(EngravingItem* parent)
+FSymbol::FSymbol(DummyParentOr<EngravingItem> parent)
     : BSymbol(ElementType::FSYMBOL, parent)
 {
     m_code = 0;

--- a/src/engraving/dom/symbol.cpp
+++ b/src/engraving/dom/symbol.cpp
@@ -43,13 +43,13 @@ namespace mu::engraving {
 //   Symbol
 //---------------------------------------------------------
 
-Symbol::Symbol(const ElementType& type, EngravingItem* parent, ElementFlags f)
+Symbol::Symbol(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : BSymbol(type, parent, f)
 {
     m_sym = SymId::accidentalSharp;          // arbitrary valid default
 }
 
-Symbol::Symbol(EngravingItem* parent, ElementFlags f)
+Symbol::Symbol(EngravingObject* parent, ElementFlags f)
     : Symbol(ElementType::SYMBOL, parent, f)
 {
 }

--- a/src/engraving/dom/symbol.h
+++ b/src/engraving/dom/symbol.h
@@ -96,7 +96,7 @@ class FSymbol final : public BSymbol
     DECLARE_CLASSOF(ElementType::FSYMBOL)
 
 public:
-    FSymbol(EngravingItem* parent);
+    FSymbol(DummyParentOr<EngravingItem> parent);
     FSymbol(const FSymbol&);
 
     FSymbol* clone() const override { return new FSymbol(*this); }

--- a/src/engraving/dom/symbol.h
+++ b/src/engraving/dom/symbol.h
@@ -49,8 +49,8 @@ class Symbol : public BSymbol
     DECLARE_CLASSOF(ElementType::SYMBOL)
 
 public:
-    Symbol(const ElementType& type, EngravingItem* parent, ElementFlags f = ElementFlag::MOVABLE);
-    Symbol(EngravingItem* parent, ElementFlags f = ElementFlag::MOVABLE);
+    Symbol(const ElementType& type, EngravingObject* parent, ElementFlags f = ElementFlag::MOVABLE);
+    Symbol(EngravingObject* parent, ElementFlags f = ElementFlag::MOVABLE);
     Symbol(const Symbol&);
 
     Symbol& operator=(const Symbol&) = delete;

--- a/src/engraving/dom/system.cpp
+++ b/src/engraving/dom/system.cpp
@@ -141,8 +141,6 @@ void SysStaff::removeInstrumentName(InstrumentNameRole role)
 System::System(Score* parent)
     : EngravingItem(ElementType::SYSTEM, parent)
 {
-    // Owned by its score right away; a page only places it later
-    setOwnershipParent(parent);
 }
 
 void System::setOwnershipParent(Score* score)
@@ -333,7 +331,6 @@ void System::setHasStaffVisibilityIndicator(bool has)
 {
     if (has && !m_staffVisibilityIndicator) {
         m_staffVisibilityIndicator = Factory::createStaffVisibilityIndicator(this);
-        m_staffVisibilityIndicator->setOwnershipParent(this);
     } else if (!has && m_staffVisibilityIndicator) {
         delete m_staffVisibilityIndicator;
         m_staffVisibilityIndicator = nullptr;

--- a/src/engraving/dom/systemdivider.cpp
+++ b/src/engraving/dom/systemdivider.cpp
@@ -40,7 +40,7 @@ static const ElementStyle dividerStyle {
     { Sid::musicalSymbolFont, Pid::SCORE_FONT }
 };
 
-SystemDivider::SystemDivider(System* parent)
+SystemDivider::SystemDivider(DummyParentOr<System> parent)
     : Symbol(ElementType::SYSTEM_DIVIDER, parent, ElementFlag::SYSTEM | ElementFlag::MOVABLE)
 {
     // default value, but not valid until setDividerType()

--- a/src/engraving/dom/systemdivider.h
+++ b/src/engraving/dom/systemdivider.h
@@ -39,7 +39,7 @@ class SystemDivider final : public Symbol
     DECLARE_CLASSOF(ElementType::SYSTEM_DIVIDER)
 
 public:
-    SystemDivider(System* parent = 0);
+    SystemDivider(DummyParentOr<System> parent);
     SystemDivider(const SystemDivider&);
 
     SystemDivider* clone() const override { return new SystemDivider(*this); }

--- a/src/engraving/dom/systemlockindicator.cpp
+++ b/src/engraving/dom/systemlockindicator.cpp
@@ -31,7 +31,7 @@
 #include "system.h"
 
 namespace mu::engraving {
-SystemLockIndicator::SystemLockIndicator(System* parent, const RangeLock* lock)
+SystemLockIndicator::SystemLockIndicator(DummyParentOr<System> parent, const RangeLock* lock)
     : IndicatorIcon(ElementType::SYSTEM_LOCK_INDICATOR, parent, ElementFlag::SYSTEM | ElementFlag::GENERATED), m_systemLock(lock) {}
 
 void SystemLockIndicator::setSelected(bool v)

--- a/src/engraving/dom/systemlockindicator.h
+++ b/src/engraving/dom/systemlockindicator.h
@@ -33,7 +33,7 @@ class SystemLockIndicator : public IndicatorIcon
     DECLARE_CLASSOF(ElementType::SYSTEM_LOCK_INDICATOR)
 
 public:
-    SystemLockIndicator(System* parent, const RangeLock* lock);
+    SystemLockIndicator(DummyParentOr<System> parent, const RangeLock* lock);
 
     void setSelected(bool v) override;
 

--- a/src/engraving/dom/systemtext.cpp
+++ b/src/engraving/dom/systemtext.cpp
@@ -38,7 +38,7 @@ static const ElementStyle systemStyle {
 //   SystemText
 //---------------------------------------------------------
 
-SystemText::SystemText(Segment* parent, TextStyleType tid, ElementType type)
+SystemText::SystemText(DummyParentOr<Segment> parent, TextStyleType tid, ElementType type)
     : StaffTextBase(type, parent, tid, ElementFlag::SYSTEM | ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&systemStyle);

--- a/src/engraving/dom/systemtext.h
+++ b/src/engraving/dom/systemtext.h
@@ -36,7 +36,7 @@ class SystemText : public StaffTextBase
     DECLARE_CLASSOF(ElementType::SYSTEM_TEXT)
 
 public:
-    SystemText(Segment* parent, TextStyleType = TextStyleType::SYSTEM, ElementType type = ElementType::SYSTEM_TEXT);
+    SystemText(DummyParentOr<Segment> parent, TextStyleType = TextStyleType::SYSTEM, ElementType type = ElementType::SYSTEM_TEXT);
 
     bool isEditAllowed(EditData&) const override;
 

--- a/src/engraving/dom/tabdurationsymbol.cpp
+++ b/src/engraving/dom/tabdurationsymbol.cpp
@@ -27,7 +27,7 @@
 
 using namespace mu::engraving;
 
-TabDurationSymbol::TabDurationSymbol(ChordRest* parent)
+TabDurationSymbol::TabDurationSymbol(DummyParentOr<ChordRest> parent)
     : EngravingItem(ElementType::TAB_DURATION_SYMBOL, parent, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
@@ -35,7 +35,7 @@ TabDurationSymbol::TabDurationSymbol(ChordRest* parent)
     m_text       = String();
 }
 
-TabDurationSymbol::TabDurationSymbol(ChordRest* parent, const StaffType* tab, DurationType type, int dots)
+TabDurationSymbol::TabDurationSymbol(DummyParentOr<ChordRest> parent, const StaffType* tab, DurationType type, int dots)
     : EngravingItem(ElementType::TAB_DURATION_SYMBOL, parent, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);

--- a/src/engraving/dom/tabdurationsymbol.h
+++ b/src/engraving/dom/tabdurationsymbol.h
@@ -43,8 +43,8 @@ class TabDurationSymbol final : public EngravingItem
     DECLARE_CLASSOF(ElementType::TAB_DURATION_SYMBOL)
 
 public:
-    TabDurationSymbol(ChordRest* parent);
-    TabDurationSymbol(ChordRest* parent, const StaffType* tab, DurationType type, int dots);
+    TabDurationSymbol(DummyParentOr<ChordRest> parent);
+    TabDurationSymbol(DummyParentOr<ChordRest> parent, const StaffType* tab, DurationType type, int dots);
     TabDurationSymbol(const TabDurationSymbol&);
     TabDurationSymbol* clone() const override { return new TabDurationSymbol(*this); }
 

--- a/src/engraving/dom/tapping.cpp
+++ b/src/engraving/dom/tapping.cpp
@@ -27,7 +27,7 @@
 #include "types/typesconv.h"
 
 namespace mu::engraving {
-Tapping::Tapping(ChordRest* parent)
+Tapping::Tapping(DummyParentOr<ChordRest> parent)
     : Articulation(parent, ElementType::TAPPING)
 {
 }

--- a/src/engraving/dom/tapping.h
+++ b/src/engraving/dom/tapping.h
@@ -72,7 +72,7 @@ public:
 
 protected:
     friend class mu::engraving::Factory;
-    Tapping(ChordRest* parent);
+    Tapping(DummyParentOr<ChordRest> parent);
 
 private:
     TappingHand m_hand = TappingHand::INVALID;

--- a/src/engraving/dom/tempotext.cpp
+++ b/src/engraving/dom/tempotext.cpp
@@ -57,7 +57,7 @@ static const ElementStyle tempoStyle {
 //   TempoText
 //---------------------------------------------------------
 
-TempoText::TempoText(Segment* parent)
+TempoText::TempoText(DummyParentOr<Segment> parent)
     : TextBase(ElementType::TEMPO_TEXT, parent, TextStyleType::TEMPO, ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tempoStyle);

--- a/src/engraving/dom/tempotext.h
+++ b/src/engraving/dom/tempotext.h
@@ -48,7 +48,7 @@ class TempoText final : public TextBase
     DECLARE_CLASSOF(ElementType::TEMPO_TEXT)
 
 public:
-    TempoText(Segment* parent);
+    TempoText(DummyParentOr<Segment> parent);
 
     TempoText* clone() const override { return new TempoText(*this); }
 

--- a/src/engraving/dom/text.cpp
+++ b/src/engraving/dom/text.cpp
@@ -57,7 +57,7 @@ static bool styleIsSelectable(TextStyleType style)
 //   Text
 //---------------------------------------------------------
 
-Text::Text(EngravingItem* parent, TextStyleType tid)
+Text::Text(DummyParentOr<EngravingItem> parent, TextStyleType tid)
     : TextBase(ElementType::TEXT, parent, tid, styleIsSelectable(tid) ? ElementFlag::NOTHING : ElementFlag::NOT_SELECTABLE)
 {
     initElementStyle(&defaultStyle);

--- a/src/engraving/dom/text.h
+++ b/src/engraving/dom/text.h
@@ -36,7 +36,7 @@ class Text final : public TextBase
     DECLARE_CLASSOF(ElementType::TEXT)
 
 public:
-    Text(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT);
+    Text(DummyParentOr<EngravingItem> parent, TextStyleType tid = TextStyleType::DEFAULT);
     Text* clone() const override { return new Text(*this); }
 
     EngravingObject* propertyDelegate(Pid) const override;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1547,7 +1547,7 @@ String TextBlock::text(int col1, int len, bool withFormat) const
 //   Text
 //---------------------------------------------------------
 
-TextBase::TextBase(const ElementType& type, EngravingItem* parent, TextStyleType tid, ElementFlags f)
+TextBase::TextBase(const ElementType& type, EngravingObject* parent, TextStyleType tid, ElementFlags f)
     : EngravingItem(type, parent, f | ElementFlag::MOVABLE)
 {
     m_textLineSpacing        = 1.0;
@@ -1564,7 +1564,7 @@ TextBase::TextBase(const ElementType& type, EngravingItem* parent, TextStyleType
     m_cursor->init();
 }
 
-TextBase::TextBase(const ElementType& type, EngravingItem* parent, ElementFlags f)
+TextBase::TextBase(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : TextBase(type, parent, TextStyleType::DEFAULT, f)
 {
 }

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -524,9 +524,9 @@ public:
     PointF defaultPos() const override;
 
 protected:
-    TextBase(const ElementType& type, EngravingItem* parent = 0, TextStyleType tid = TextStyleType::DEFAULT,
+    TextBase(const ElementType& type, EngravingObject* parent = 0, TextStyleType tid = TextStyleType::DEFAULT,
              ElementFlags = ElementFlag::NOTHING);
-    TextBase(const ElementType& type, EngravingItem* parent, ElementFlags);
+    TextBase(const ElementType& type, EngravingObject* parent, ElementFlags);
     TextBase(const TextBase&);
 
     bool nudge(const EditData& ed);

--- a/src/engraving/dom/textline.cpp
+++ b/src/engraving/dom/textline.cpp
@@ -151,7 +151,7 @@ EngravingObject* TextLineSegment::propertyDelegate(Pid pid) const
 //   TextLine
 //---------------------------------------------------------
 
-TextLine::TextLine(EngravingItem* parent, bool system)
+TextLine::TextLine(DummyParentOr<EngravingItem> parent, bool system)
     : TextLineBase(ElementType::TEXTLINE, parent)
 {
     setSystemFlag(system);

--- a/src/engraving/dom/textline.h
+++ b/src/engraving/dom/textline.h
@@ -59,7 +59,7 @@ class TextLine final : public TextLineBase
     DECLARE_CLASSOF(ElementType::TEXTLINE)
 
 public:
-    TextLine(EngravingItem* parent, bool system=false);
+    TextLine(DummyParentOr<EngravingItem> parent, bool system=false);
     TextLine(const TextLine&);
     ~TextLine() {}
 

--- a/src/engraving/dom/textlinebase.cpp
+++ b/src/engraving/dom/textlinebase.cpp
@@ -214,7 +214,7 @@ EngravingObject* TextLineBaseSegment::propertyDelegate(Pid pid) const
 //   TextLineBase
 //---------------------------------------------------------
 
-TextLineBase::TextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags f)
+TextLineBase::TextLineBase(const ElementType& type, EngravingObject* parent, ElementFlags f)
     : SLine(type, parent, f)
 {
     setBeginHookHeight(1.9_sp);

--- a/src/engraving/dom/textlinebase.cpp
+++ b/src/engraving/dom/textlinebase.cpp
@@ -44,8 +44,6 @@ TextLineBaseSegment::TextLineBaseSegment(const ElementType& type, TextLineBase* 
 {
     m_text    = Factory::createText(this, TextStyleType::DEFAULT, false);
     m_endText = Factory::createText(this, TextStyleType::DEFAULT, false);
-    m_text->setOwnershipParent(this);
-    m_endText->setOwnershipParent(this);
     m_text->setFlag(ElementFlag::MOVABLE, false);
     m_endText->setFlag(ElementFlag::MOVABLE, false);
 }

--- a/src/engraving/dom/textlinebase.h
+++ b/src/engraving/dom/textlinebase.h
@@ -140,7 +140,7 @@ class TextLineBase : public SLine
     M_PROPERTY(bool,       textSizeSpatiumDependent, setTextSizeSpatiumDependent)
 
 public:
-    TextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
+    TextLineBase(const ElementType& type, EngravingObject* parent, ElementFlags = ElementFlag::NOTHING);
 
     void spatiumChanged(double /*oldValue*/, double /*newValue*/) override;
 

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -516,7 +516,7 @@ void Tie::changeTieType(Tie* oldTie, Note* endNote)
         return;
     }
 
-    Tie* newTie = addPartialTie ? Factory::createPartialTie(score->dummy()->note()) : Factory::createTie(score->dummy()->note());
+    Tie* newTie = addPartialTie ? Factory::createPartialTie(score->dummy()) : Factory::createTie(score->dummy());
 
     score->undoRemoveElement(oldTie);
 

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -516,11 +516,10 @@ void Tie::changeTieType(Tie* oldTie, Note* endNote)
         return;
     }
 
-    Tie* newTie = addPartialTie ? Factory::createPartialTie(score->dummy()) : Factory::createTie(score->dummy());
+    Tie* newTie = addPartialTie ? Factory::createPartialTie(startNote) : Factory::createTie(startNote);
 
     score->undoRemoveElement(oldTie);
 
-    newTie->setOwnershipParent(startNote);
     newTie->setStartNote(startNote);
     newTie->setTick(startNote->tick());
     newTie->setTrack(startNote->track());

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -221,7 +221,7 @@ double TieSegment::dottedWidth() const
 //   Tie
 //---------------------------------------------------------
 
-Tie::Tie(const ElementType& type, EngravingItem* parent)
+Tie::Tie(const ElementType& type, EngravingObject* parent)
     : SlurTie(type, parent)
 {
 }
@@ -371,7 +371,7 @@ const TieJumpPointList* Tie::tieJumpPoints() const
     return startNote() ? startNote()->tieJumpPoints() : nullptr;
 }
 
-Tie::Tie(EngravingItem* parent)
+Tie::Tie(EngravingObject* parent)
     : SlurTie(ElementType::TIE, parent)
 {
 }

--- a/src/engraving/dom/tie.h
+++ b/src/engraving/dom/tie.h
@@ -88,7 +88,7 @@ class Tie : public SlurTie
     DECLARE_CLASSOF(ElementType::TIE)
 
 public:
-    Tie(EngravingItem* parent = 0);
+    Tie(EngravingObject* parent = 0);
     Tie(const Tie& t);
 
     Tie* clone() const override { return new Tie(*this); }
@@ -143,7 +143,7 @@ public:
     static void changeTieType(Tie* oldTie, Note* endNote = nullptr);
 
 protected:
-    Tie(const ElementType& type, EngravingItem* parent = nullptr);
+    Tie(const ElementType& type, EngravingObject* parent = nullptr);
 
     bool isInSpannerMap() const override { return false; }
 

--- a/src/engraving/dom/tiejumppointlist.cpp
+++ b/src/engraving/dom/tiejumppointlist.cpp
@@ -246,7 +246,6 @@ void TieJumpPointList::undoAddTieToScore(TieJumpPoint* jumpPoint)
     }
     // Otherwise create incoming partial tie on note
     PartialTie* pt = Factory::createPartialTie(note);
-    pt->setOwnershipParent(note);
     pt->setEndNote(note);
     pt->setJumpPoint(jumpPoint);
     score->undoAddElement(pt);

--- a/src/engraving/dom/timesig.cpp
+++ b/src/engraving/dom/timesig.cpp
@@ -52,7 +52,7 @@ static const ElementStyle tsStyle {
 //    Layout() is static and called in setSig().
 //---------------------------------------------------------
 
-TimeSig::TimeSig(Segment* parent)
+TimeSig::TimeSig(DummyParentOr<Segment> parent)
     : EngravingItem(ElementType::TIMESIG, parent, ElementFlag::ON_STAFF | ElementFlag::MOVABLE | ElementFlag::PLACE_ABOVE)
 {
     initElementStyle(&tsStyle);
@@ -65,7 +65,7 @@ TimeSig::TimeSig(Segment* parent)
     setMinDistance(0.5_sp); // TODO: style
 }
 
-void TimeSig::setOwnershipParent(Segment* parent)
+void TimeSig::setOwnershipParent(DummyParentOr<Segment> parent)
 {
     EngravingItem::setOwnershipParent(parent);
 }

--- a/src/engraving/dom/timesig.h
+++ b/src/engraving/dom/timesig.h
@@ -56,7 +56,7 @@ class TimeSig final : public EngravingItem
 
 public:
 
-    void setOwnershipParent(Segment* parent);
+    void setOwnershipParent(DummyParentOr<Segment> parent);
 
     String ssig() const;
     void setSSig(const String&);
@@ -149,7 +149,7 @@ protected:
 private:
 
     friend class Factory;
-    TimeSig(Segment* parent = 0);
+    TimeSig(DummyParentOr<Segment> parent);
 
     String m_numeratorString;       // calculated from actualSig() if !customText
     String m_denominatorString;

--- a/src/engraving/dom/tremolobar.cpp
+++ b/src/engraving/dom/tremolobar.cpp
@@ -64,7 +64,7 @@ static const PitchValues RELEASE_DOWN_CURVE = { PitchValue(0, 150),
 //   TremoloBar
 //---------------------------------------------------------
 
-TremoloBar::TremoloBar(EngravingItem* parent)
+TremoloBar::TremoloBar(DummyParentOr<EngravingItem> parent)
     : EngravingItem(ElementType::TREMOLOBAR, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tremoloBarStyle);

--- a/src/engraving/dom/tremolobar.h
+++ b/src/engraving/dom/tremolobar.h
@@ -78,7 +78,7 @@ public:
 private:
 
     friend class Factory;
-    TremoloBar(EngravingItem* parent);
+    TremoloBar(DummyParentOr<EngravingItem> parent);
 
     TremoloBarType parseTremoloBarTypeFromCurve(const PitchValues& curve) const;
     void updatePointsByTremoloBarType(const TremoloBarType type);

--- a/src/engraving/dom/tremolosinglechord.cpp
+++ b/src/engraving/dom/tremolosinglechord.cpp
@@ -43,7 +43,7 @@ using namespace muse::draw;
 using namespace mu::engraving;
 
 namespace mu::engraving {
-TremoloSingleChord::TremoloSingleChord(Chord* parent)
+TremoloSingleChord::TremoloSingleChord(DummyParentOr<Chord> parent)
     : EngravingItem(ElementType::TREMOLO_SINGLECHORD, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
 }

--- a/src/engraving/dom/tremolosinglechord.h
+++ b/src/engraving/dom/tremolosinglechord.h
@@ -93,7 +93,7 @@ public:
 private:
     friend class Factory;
 
-    TremoloSingleChord(Chord* parent);
+    TremoloSingleChord(DummyParentOr<Chord> parent);
     TremoloSingleChord(const TremoloSingleChord&);
 
     TremoloType m_tremoloType = TremoloType::INVALID_TREMOLO;

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -54,7 +54,7 @@ static const ElementStyle TREMOLO_STYLE {
 //   Tremolo
 //---------------------------------------------------------
 
-TremoloTwoChord::TremoloTwoChord(Chord* parent)
+TremoloTwoChord::TremoloTwoChord(DummyParentOr<Chord> parent)
     : BeamBase(ElementType::TREMOLO_TWOCHORD, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&TREMOLO_STYLE);

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -126,7 +126,7 @@ public:
 private:
     friend class Factory;
 
-    TremoloTwoChord(Chord* parent);
+    TremoloTwoChord(DummyParentOr<Chord> parent);
     TremoloTwoChord(const TremoloTwoChord&);
 
     void setBeamPos(const PairF& bp);

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -158,7 +158,7 @@ EngravingObject* TrillSegment::propertyDelegate(Pid pid) const
 //   Trill
 //---------------------------------------------------------
 
-Trill::Trill(EngravingItem* parent)
+Trill::Trill(DummyParentOr<EngravingItem> parent)
     : SLine(ElementType::TRILL, parent)
 {
     m_trillType     = TrillType::TRILL_LINE;

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -315,7 +315,7 @@ void Trill::setTrillType(TrillType tt)
     m_trillType = tt;
     if (!m_ornament) {
         // ornament parent will be explicitely set at layout stage
-        m_ornament = Factory::createOrnament((ChordRest*)score()->dummy()->chord());
+        m_ornament = Factory::createOrnament((ChordRest*)score()->dummy());
     }
     m_ornament->setTrack(track());
     m_ornament->setSymId(Ornament::fromTrillType(tt));

--- a/src/engraving/dom/trill.h
+++ b/src/engraving/dom/trill.h
@@ -75,7 +75,7 @@ class Trill final : public SLine
     DECLARE_CLASSOF(ElementType::TRILL)
 
 public:
-    Trill(EngravingItem* parent);
+    Trill(DummyParentOr<EngravingItem> parent);
     Trill(const Trill& t);
 
     Trill* clone() const override { return new Trill(*this); }

--- a/src/engraving/dom/tripletfeel.cpp
+++ b/src/engraving/dom/tripletfeel.cpp
@@ -114,7 +114,7 @@ static const std::map<TripletFeelType, TranslatableString> tripletFeelNames =
     { TripletFeelType::NONE,            TranslatableString("engraving/tripletfeel", "No triplet feel") }
 };
 
-TripletFeel::TripletFeel(Segment* parent, TripletFeelType tripletFillType)
+TripletFeel::TripletFeel(DummyParentOr<Segment> parent, TripletFeelType tripletFillType)
     : SystemText(parent, TextStyleType::SYSTEM, ElementType::TRIPLET_FEEL)
 {
     m_tripletFeelType = tripletFillType;

--- a/src/engraving/dom/tripletfeel.h
+++ b/src/engraving/dom/tripletfeel.h
@@ -45,7 +45,7 @@ class TripletFeel final : public SystemText
     DECLARE_CLASSOF(ElementType::TRIPLET_FEEL)
 
 public:
-    TripletFeel(Segment* parent = nullptr, TripletFeelType tripletFillType = TripletFeelType::NONE);
+    TripletFeel(DummyParentOr<Segment> parent, TripletFeelType tripletFillType = TripletFeelType::NONE);
     void setTripletProperty();
 
     TripletFeel* clone() const override { return new TripletFeel(*this); }

--- a/src/engraving/dom/tuplet.cpp
+++ b/src/engraving/dom/tuplet.cpp
@@ -63,7 +63,7 @@ static const ElementStyle tupletStyle {
 //   Tuplet
 //---------------------------------------------------------
 
-Tuplet::Tuplet(Measure* parent)
+Tuplet::Tuplet(DummyParentOr<Measure> parent)
     : DurationElement(ElementType::TUPLET, parent)
 {
     m_direction    = DirectionV::AUTO;
@@ -114,7 +114,7 @@ Tuplet::~Tuplet()
     delete m_number;
 }
 
-void Tuplet::setOwnershipParent(Measure* parent)
+void Tuplet::setOwnershipParent(DummyParentOr<Measure> parent)
 {
     EngravingItem::setOwnershipParent(parent);
 }

--- a/src/engraving/dom/tuplet.h
+++ b/src/engraving/dom/tuplet.h
@@ -99,11 +99,11 @@ class Tuplet final : public DurationElement
     DECLARE_CLASSOF(ElementType::TUPLET)
 
 public:
-    Tuplet(Measure* parent);
+    Tuplet(DummyParentOr<Measure> parent);
     Tuplet(const Tuplet&);
     ~Tuplet();
 
-    void setOwnershipParent(Measure* parent);
+    void setOwnershipParent(DummyParentOr<Measure> parent);
 
     Tuplet* clone() const override { return new Tuplet(*this); }
     void setTrack(track_idx_t val) override;

--- a/src/engraving/dom/vibrato.cpp
+++ b/src/engraving/dom/vibrato.cpp
@@ -112,7 +112,7 @@ static const ElementStyle vibratoStyle {
 //   Vibrato
 //---------------------------------------------------------
 
-Vibrato::Vibrato(EngravingItem* parent)
+Vibrato::Vibrato(DummyParentOr<EngravingItem> parent)
     : SLine(ElementType::VIBRATO, parent)
 {
     initElementStyle(&vibratoStyle);

--- a/src/engraving/dom/vibrato.h
+++ b/src/engraving/dom/vibrato.h
@@ -66,7 +66,7 @@ class Vibrato final : public SLine
     DECLARE_CLASSOF(ElementType::VIBRATO)
 
 public:
-    Vibrato(EngravingItem* parent);
+    Vibrato(DummyParentOr<EngravingItem> parent);
     ~Vibrato();
 
     Vibrato* clone() const override { return new Vibrato(*this); }

--- a/src/engraving/dom/volta.cpp
+++ b/src/engraving/dom/volta.cpp
@@ -100,7 +100,7 @@ EngravingObject* VoltaSegment::propertyDelegate(Pid pid) const
 //   Volta
 //---------------------------------------------------------
 
-Volta::Volta(EngravingItem* parent)
+Volta::Volta(DummyParentOr<EngravingItem> parent)
     : TextLineBase(ElementType::VOLTA, parent, ElementFlag::SYSTEM)
 {
     setPlacement(PlacementV::ABOVE);

--- a/src/engraving/dom/volta.h
+++ b/src/engraving/dom/volta.h
@@ -65,7 +65,7 @@ public:
         OPEN, CLOSED
     };
 
-    Volta(EngravingItem* parent);
+    Volta(DummyParentOr<EngravingItem> parent);
 
     Volta* clone() const override { return new Volta(*this); }
 

--- a/src/engraving/dom/whammybar.cpp
+++ b/src/engraving/dom/whammybar.cpp
@@ -75,7 +75,7 @@ WhammyBarSegment::WhammyBarSegment(WhammyBar* sp)
 //   WhammyBar
 //---------------------------------------------------------
 
-WhammyBar::WhammyBar(EngravingItem* parent)
+WhammyBar::WhammyBar(DummyParentOr<EngravingItem> parent)
     : ChordTextLineBase(ElementType::WHAMMY_BAR, parent)
 {
     initElementStyle(&whammyBarStyle);

--- a/src/engraving/dom/whammybar.h
+++ b/src/engraving/dom/whammybar.h
@@ -57,7 +57,7 @@ class WhammyBar final : public ChordTextLineBase
     DECLARE_CLASSOF(ElementType::WHAMMY_BAR)
 
 public:
-    WhammyBar(EngravingItem* parent);
+    WhammyBar(DummyParentOr<EngravingItem> parent);
 
     WhammyBar* clone() const override { return new WhammyBar(*this); }
 

--- a/src/engraving/editing/clonevoice.cpp
+++ b/src/engraving/editing/clonevoice.cpp
@@ -224,7 +224,7 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
 
         Segment* tst = dm->segments().firstCRSegment();
         if (srcTrack % VOICES && !(dstTrack % VOICES) && (!tst || (!tst->element(dstTrack)))) {
-            Rest* rest = Factory::createRest(destScore->dummy()->segment());
+            Rest* rest = Factory::createRest(destScore->dummy());
             rest->setTicks(dm->ticks());
             rest->setDurationType(DurationType::V_MEASURE);
             rest->setTrack(dstTrack);

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -600,7 +600,6 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
         }
 
         Note* note = Factory::createNote(chord);
-        note->setOwnershipParent(chord);
         note->setTrack(chord->track());
         note->setNval(nval, tick);
         undoAddElement(note);
@@ -609,7 +608,6 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
             Accidental* a = Factory::createAccidental(note);
             a->setAccidentalType(m_is.accidentalType());
             a->setRole(AccidentalRole::USER);
-            a->setOwnershipParent(note);
             undoAddElement(a);
         }
         if (on->tieBack() && prevTied) {

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -623,7 +623,7 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
 
         Tie* tieFor = on->tieFor();
         if (tieFor) {
-            Tie* tie = tieFor->isLaissezVib() ? Factory::createLaissezVib(this->dummy()->note()) : Factory::createTie(this->dummy());
+            Tie* tie = tieFor->isLaissezVib() ? Factory::createLaissezVib(this->dummy()) : Factory::createTie(this->dummy());
             tie->setStartNote(note);
             tie->setTick(note->tick());
             tie->setTrack(note->track());
@@ -663,7 +663,7 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
 
 Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
 {
-    Chord* chord = Factory::createChord(this->dummy()->segment());
+    Chord* chord = Factory::createChord(this->dummy());
     Note* note = Factory::createNote(chord);
 
     // allow grace notes to be added to other grace notes
@@ -766,7 +766,7 @@ GuitarBend* Score::addGuitarBend(GuitarBendType type, Note* note, Note* endNote)
         }
     }
 
-    GuitarBend* bend = new GuitarBend(score()->dummy()->note());
+    GuitarBend* bend = new GuitarBend(score()->dummy());
     bend->setTick(chord->tick());
     bend->setTrack(chord->track());
 
@@ -954,19 +954,19 @@ Segment* Score::setNoteRest(Segment* segment, track_idx_t track, NoteVal nval, F
             Note* note = nullptr;
             Tie* addTie = nullptr;
             if (isRest) {
-                nr = ncr = Factory::createRest(this->dummy()->segment());
+                nr = ncr = Factory::createRest(this->dummy());
                 nr->setTrack(track);
                 ncr->setDurationType(d);
                 ncr->setTicks(d.isMeasure() ? measure->ticks() * timeStretch : d.fraction());
             } else {
-                nr = note = Factory::createNote(this->dummy()->chord());
+                nr = note = Factory::createNote(this->dummy());
 
                 if (tie) {
                     tie->setEndNote(note);
                     note->setTieBack(tie);
                     addTie = tie;
                 }
-                Chord* chord = Factory::createChord(this->dummy()->segment());
+                Chord* chord = Factory::createChord(this->dummy());
                 chord->setTrack(track);
                 chord->setDurationType(d);
                 chord->setTicks(d.fraction());

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -277,7 +277,7 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
         return nullptr;
     }
 
-    Tuplet* tuplet = Factory::createTuplet(this->dummy()->measure());
+    Tuplet* tuplet = Factory::createTuplet(this->dummy());
     tuplet->setRatio(_ratio);
 
     tuplet->setNumberType(numberType);
@@ -335,7 +335,7 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
 Rest* Score::addRest(const Fraction& tick, track_idx_t track, TDuration d, Tuplet* tuplet)
 {
     Measure* measure = tick2measure(tick);
-    Rest* rest = Factory::createRest(this->dummy()->segment(), d);
+    Rest* rest = Factory::createRest(this->dummy(), d);
     if (d.type() == DurationType::V_MEASURE) {
         rest->setTicks(measure->stretchedLen(staff(track2staff(track))));
     } else {
@@ -382,7 +382,7 @@ Chord* Score::addChord(const Fraction& tick, TDuration d, Chord* oc, bool genTie
         return 0;
     }
 
-    Chord* chord = Factory::createChord(this->dummy()->segment());
+    Chord* chord = Factory::createChord(this->dummy());
     chord->setTuplet(tuplet);
     chord->setTrack(oc->track());
     chord->setDurationType(d);
@@ -680,7 +680,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createStaffText(dummy()->segment(), TextStyleType::STAFF);
+        textBox = Factory::createStaffText(dummy(), TextStyleType::STAFF);
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -689,7 +689,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createSystemText(dummy()->segment(), TextStyleType::SYSTEM);
+        textBox = Factory::createSystemText(dummy(), TextStyleType::SYSTEM);
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -698,7 +698,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createDynamic(dummy()->segment());
+        textBox = Factory::createDynamic(dummy());
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -707,7 +707,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createExpression(dummy()->segment());
+        textBox = Factory::createExpression(dummy());
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -716,7 +716,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createInstrumentChange(dummy()->segment());
+        textBox = Factory::createInstrumentChange(dummy());
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -725,7 +725,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createSticking(dummy()->segment());
+        textBox = Factory::createSticking(dummy());
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -900,7 +900,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createHarpPedalDiagram(this->dummy()->segment());
+        textBox = Factory::createHarpPedalDiagram(this->dummy());
         chordRest->undoAddAnnotation(textBox);
         break;
     }
@@ -1161,7 +1161,7 @@ void Score::deleteItem(EngravingItem* el)
 
         // replace with rest
         if (chord->noteType() == NoteType::NORMAL) {
-            Rest* rest = Factory::createRest(this->dummy()->segment(), chord->durationType());
+            Rest* rest = Factory::createRest(this->dummy(), chord->durationType());
             rest->setDurationType(chord->durationType());
             rest->setTicks(chord->ticks());
 
@@ -1201,7 +1201,7 @@ void Score::deleteItem(EngravingItem* el)
     {
         MeasureRepeat* mr = toMeasureRepeat(el);
         removeChordRest(mr, false);
-        Rest* rest = Factory::createRest(this->dummy()->segment());
+        Rest* rest = Factory::createRest(this->dummy());
         rest->setDurationType(DurationType::V_MEASURE);
         rest->setTicks(mr->measure()->stretchedLen(mr->staff()));
         rest->setTrack(mr->track());
@@ -1319,7 +1319,7 @@ void Score::deleteItem(EngravingItem* el)
 
                     Fraction curTick = stick;
                     for (const TDuration& d : dList) {
-                        Rest* rr = Factory::createRest(this->dummy()->segment());
+                        Rest* rr = Factory::createRest(this->dummy());
                         rr->setTicks(d.fraction());
                         rr->setDurationType(d);
                         rr->setTrack(track);
@@ -2550,7 +2550,7 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
 
     ChordRest* cr;
     if (ocr->isChord()) {
-        cr = Factory::createChord(this->dummy()->segment());
+        cr = Factory::createChord(this->dummy());
         toChord(cr)->setStemDirection(toChord(ocr)->stemDirection());
         for (Note* oldNote : toChord(ocr)->notes()) {
             Note* note = Factory::createNote(toChord(cr));
@@ -2560,7 +2560,7 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
             cr->add(note);
         }
     } else {
-        cr = Factory::createRest(this->dummy()->segment());
+        cr = Factory::createRest(this->dummy());
     }
 
     int actualNotes = an.numerator() / an.denominator();
@@ -2577,7 +2577,7 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
 
     for (int i = 0; i < (actualNotes - 1); ++i) {
         tick += ticks;
-        Rest* rest = Factory::createRest(this->dummy()->segment());
+        Rest* rest = Factory::createRest(this->dummy());
         rest->setTuplet(tuplet);
         rest->setTrack(track);
         rest->setDurationType(tuplet->baseLen());

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -360,7 +360,6 @@ Rest* Score::addRest(Segment* s, track_idx_t track, TDuration d, Tuplet* tuplet)
         rest->setTicks(d.fraction());
     }
     rest->setTrack(track);
-    rest->setOwnershipParent(s);
     rest->setTuplet(tuplet);
     undoAddCR(rest, tick2measure(s->tick()), s->tick());
     return rest;
@@ -649,7 +648,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         }
 
         textBox = Factory::createText(frame, type);
-        textBox->setOwnershipParent(frame);
         undoAddElement(textBox);
         break;
     }
@@ -658,7 +656,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
             break;
         }
         textBox = Factory::createText(destinationElement, type);
-        textBox->setOwnershipParent(destinationElement);
         undoAddElement(textBox);
         break;
     }
@@ -668,7 +665,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
             break;
         }
         textBox = Factory::createRehearsalMark(chordRest->segment());
-        textBox->setOwnershipParent(chordRest->segment());
         textBox->setTrack(0);
         RehearsalMark* r = toRehearsalMark(textBox);
         textBox->setXmlText(EditRehearsalMark::createRehearsalMarkText(this, r));
@@ -746,7 +742,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
 
         textBox = Factory::createFingering(toNote(destinationElement), type);
         textBox->setTrack(destinationElement->track());
-        textBox->setOwnershipParent(destinationElement);
         undoAddElement(textBox);
         break;
     }
@@ -773,7 +768,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
 
         Harmony* harmony = Factory::createHarmony(newParent);
         harmony->setTrack(track);
-        harmony->setOwnershipParent(newParent);
 
         static const std::map<TextStyleType, HarmonyType> harmonyTypes = {
             { TextStyleType::HARMONY_A, HarmonyType::STANDARD },
@@ -818,7 +812,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         // Also check how many partial lines there are
         Lyrics* lyrics = Factory::createLyrics(chordRest);
         lyrics->setTrack(chordRest->track());
-        lyrics->setOwnershipParent(chordRest);
         lyrics->setProperty(Pid::VERSE, no);
 
         textBox = lyrics;
@@ -884,7 +877,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         }
 
         TempoText* tempoText = Factory::createTempoText(chordRest->segment());
-        tempoText->setOwnershipParent(chordRest->segment());
         tempoText->setTrack(0);
         tempoText->setXmlText(text);
         tempoText->setFollowText(true);
@@ -1043,7 +1035,6 @@ void Score::addNoteLine()
     }
 
     NoteLine* line = Factory::createNoteLine(startNote);
-    line->setOwnershipParent(startNote);
     line->setStartElement(startNote);
     line->setTick(startNote->chord()->tick());
     line->setEndElement(endNote);
@@ -1697,7 +1688,6 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
 
                 TimeSig* nts = Factory::createTimeSig(s);
                 nts->setTrack(staffIdx * VOICES);
-                nts->setOwnershipParent(s);
                 nts->setFrom(lastDeletedForThisStaff);
                 nts->setStretch(nts->sig() / mAfterSel->timesig());
                 score->undoAddElement(nts);
@@ -1742,7 +1732,6 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
                 KeySig* nks = (KeySig*)s->element(staff2track(staffIdx));
                 if (!nks) {
                     nks = Factory::createKeySig(s);
-                    nks->setOwnershipParent(s);
                     nks->setTrack(staffIdx * VOICES);
                     nks->setKeySigEvent(nkse);
                     score->undoAddElement(nks);
@@ -3428,7 +3417,6 @@ void Score::undoUpdatePlayCountText(Measure* m)
         if (!topPlayCountText) {
             topPlayCountText = Factory::createPlayCountText(endBarSeg);
             topPlayCountText->setTrack(0);
-            topPlayCountText->setOwnershipParent(endBarSeg);
             topPlayCountText->setSelected(topBl->selected());
             undoAddElement(topPlayCountText);
         }
@@ -3577,7 +3565,6 @@ void Score::undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                     BarLine* lbl = toBarLine(lsegment->element(ltrack));
                     if (!lbl) {
                         lbl = Factory::createBarLine(lsegment);
-                        lbl->setOwnershipParent(lsegment);
                         lbl->setTrack(ltrack);
                         lbl->setSpanStaff(lstaff->barLineSpan());
                         lbl->setSpanFrom(lstaff->barLineFrom());

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -277,7 +277,7 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
         return nullptr;
     }
 
-    Tuplet* tuplet = Factory::createTuplet(this->dummy());
+    Tuplet* tuplet = Factory::createTuplet(measure);
     tuplet->setRatio(_ratio);
 
     tuplet->setNumberType(numberType);
@@ -299,7 +299,6 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
 
     tuplet->setTrack(destinationChordRest->track());
     tuplet->setTick(destinationChordRest->tick());
-    tuplet->setOwnershipParent(measure);
 
     if (ot) {
         tuplet->setTuplet(ot);
@@ -1152,14 +1151,11 @@ void Score::deleteItem(EngravingItem* el)
 
         // replace with rest
         if (chord->noteType() == NoteType::NORMAL) {
-            Rest* rest = Factory::createRest(this->dummy(), chord->durationType());
-            rest->setDurationType(chord->durationType());
-            rest->setTicks(chord->ticks());
-
-            rest->setTrack(el->track());
-            rest->setOwnershipParent(chord->ownershipParent());
-
             Segment* segment = chord->segment();
+            Rest* rest = Factory::createRest(segment, chord->durationType());
+            rest->setTicks(chord->ticks());
+            rest->setTrack(el->track());
+
             undoAddCR(rest, segment->measure(), segment->tick());
 
             Tuplet* tuplet = chord->tuplet();
@@ -1192,12 +1188,11 @@ void Score::deleteItem(EngravingItem* el)
     {
         MeasureRepeat* mr = toMeasureRepeat(el);
         removeChordRest(mr, false);
-        Rest* rest = Factory::createRest(this->dummy());
+        Segment* segment = mr->segment();
+        Rest* rest = Factory::createRest(segment);
         rest->setDurationType(DurationType::V_MEASURE);
         rest->setTicks(mr->measure()->stretchedLen(mr->staff()));
         rest->setTrack(mr->track());
-        rest->setOwnershipParent(mr->ownershipParent());
-        Segment* segment = mr->segment();
         undoAddCR(rest, segment->measure(), segment->tick());
 
         // tell measures they're not part of measure repeat group anymore

--- a/src/engraving/editing/editchord.cpp
+++ b/src/engraving/editing/editchord.cpp
@@ -61,7 +61,7 @@ void EditChord::toggleArticulation(Score* score, SymId attr)
                     continue;
                 }
             }
-            Articulation* na = Factory::createArticulation(score->dummy()->chord());
+            Articulation* na = Factory::createArticulation(score->dummy());
             na->setSymId(attr);
             if (!EditChord::toggleArticulation(score, el, na)) {
                 delete na;

--- a/src/engraving/editing/editchord.cpp
+++ b/src/engraving/editing/editchord.cpp
@@ -189,12 +189,10 @@ void EditChord::undoAddParenthesesToNotes(Chord* chord, std::vector<Note*> notes
 {
     track_idx_t track = chord->track();
     Parenthesis* leftParen = Factory::createParenthesis(chord);
-    leftParen->setOwnershipParent(chord);
     leftParen->setTrack(track);
     leftParen->setDirection(DirectionH::LEFT);
     leftParen->setGenerated(generated);
     Parenthesis* rightParen = Factory::createParenthesis(chord);
-    rightParen->setOwnershipParent(chord);
     rightParen->setTrack(track);
     rightParen->setDirection(DirectionH::RIGHT);
     rightParen->setGenerated(generated);

--- a/src/engraving/editing/editclef.cpp
+++ b/src/engraving/editing/editclef.cpp
@@ -251,7 +251,7 @@ void EditClef::undoChangeClef(Transaction&, Score* score, Staff* ostaff, Engravi
                 clef = toClef(gclef->linkedClone());
                 clef->setScore(staffScore);
             } else {
-                clef = Factory::createClef(staffScore->dummy()->segment());
+                clef = Factory::createClef(staffScore->dummy());
                 clef->setClefType(ct);
                 gclef = clef;
             }

--- a/src/engraving/editing/editclef.cpp
+++ b/src/engraving/editing/editclef.cpp
@@ -250,13 +250,13 @@ void EditClef::undoChangeClef(Transaction&, Score* score, Staff* ostaff, Engravi
             if (gclef) {
                 clef = toClef(gclef->linkedClone());
                 clef->setScore(staffScore);
+                clef->setOwnershipParent(destSeg);
             } else {
-                clef = Factory::createClef(staffScore->dummy());
+                clef = Factory::createClef(destSeg);
                 clef->setClefType(ct);
                 gclef = clef;
             }
             clef->setTrack(track);
-            clef->setOwnershipParent(destSeg);
             clef->setIsHeader(st == SegmentType::HeaderClef);
             staffScore->doUndoAddElement(clef);
         }

--- a/src/engraving/editing/edithairpin.cpp
+++ b/src/engraving/editing/edithairpin.cpp
@@ -76,7 +76,7 @@ Hairpin* EditHairpin::addHairpin(Transaction& tx, Score* score, HairpinType type
         return nullptr;
     }
 
-    Hairpin* hairpin = Factory::createHairpin(score->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(score->dummy());
     hairpin->setHairpinType(type);
     if (type == HairpinType::CRESC_LINE) {
         hairpin->setBeginText(u"cresc.");
@@ -93,7 +93,7 @@ Hairpin* EditHairpin::addHairpin(Transaction& tx, Score* score, HairpinType type
 
 Hairpin* EditHairpin::addHairpin(Transaction&, Score* score, HairpinType type, Fraction sTick, Fraction eTick, track_idx_t track)
 {
-    Hairpin* hairpin = Factory::createHairpin(score->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(score->dummy());
     hairpin->setHairpinType(type);
     if (type == HairpinType::CRESC_LINE) {
         hairpin->setBeginText(u"cresc.");
@@ -207,7 +207,7 @@ Hairpin* EditHairpin::addHairpinToDynamicOnGripDrag(Transaction&, Score* score, 
         return nullptr;
     }
 
-    Hairpin* hairpin = Factory::createHairpin(score->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(score->dummy());
     hairpin->setHairpinType(isLeftGrip ? HairpinType::DIM_HAIRPIN : HairpinType::CRESC_HAIRPIN);
 
     hairpin->setTrack(track);

--- a/src/engraving/editing/editkeysig.cpp
+++ b/src/engraving/editing/editkeysig.cpp
@@ -122,7 +122,6 @@ void EditKeySig::undoChangeKeySig(Transaction& tx, Score* score, Staff* ostaff, 
             tx.push(new ChangeKeySig(ks, nkey, ks->showCourtesy()));
         } else {
             KeySig* nks = Factory::createKeySig(s);
-            nks->setOwnershipParent(s);
             nks->setTrack(track);
             nks->setKeySigEvent(nkey);
             staffScore->doUndoAddElement(nks);

--- a/src/engraving/editing/editmeasurerepeat.cpp
+++ b/src/engraving/editing/editmeasurerepeat.cpp
@@ -169,7 +169,7 @@ MeasureRepeat* EditMeasureRepeat::addMeasureRepeat(Transaction&, Score* score, c
                                                    int numMeasures)
 {
     Measure* measure = score->tick2measure(tick);
-    MeasureRepeat* mr = Factory::createMeasureRepeat(score->dummy()->segment());
+    MeasureRepeat* mr = Factory::createMeasureRepeat(score->dummy());
     mr->setNumMeasures(numMeasures);
     mr->setTicks(measure->stretchedLen(score->staff(track2staff(track))));
     mr->setTrack(track);

--- a/src/engraving/editing/editnote.cpp
+++ b/src/engraving/editing/editnote.cpp
@@ -410,7 +410,6 @@ void EditNote::changeAccidental(Score* score, Note* note, AccidentalType acciden
                 score->undoRemoveElement(a);
             }
             Accidental* a1 = Factory::createAccidental(ln);
-            a1->setOwnershipParent(ln);
             a1->setAccidentalType(accidental);
             a1->setRole(AccidentalRole::USER);
             lns->undoAddElement(a1);

--- a/src/engraving/editing/editnote.cpp
+++ b/src/engraving/editing/editnote.cpp
@@ -167,7 +167,7 @@ void EditNote::toggleOrnament(Score* score, SymId attr)
                     continue;
                 }
             }
-            Ornament* na = Factory::createOrnament(score->dummy()->chord());
+            Ornament* na = Factory::createOrnament(score->dummy());
             na->setSymId(attr);
             if (!EditChord::toggleArticulation(score, el, na)) {
                 delete na;

--- a/src/engraving/editing/edittie.cpp
+++ b/src/engraving/editing/edittie.cpp
@@ -363,7 +363,6 @@ void EditTie::cmdToggleLaissezVib(Score* score)
             continue;
         } else {
             LaissezVib* lvTie = Factory::createLaissezVib(note);
-            lvTie->setOwnershipParent(note);
             score->undoAddElement(lvTie);
         }
     }

--- a/src/engraving/editing/editvoice.cpp
+++ b/src/engraving/editing/editvoice.cpp
@@ -133,7 +133,6 @@ void EditVoice::changeSelectedElementsVoice(Transaction&, Score* score, voice_id
                     dstChord->setDurationType(chord->durationType());
                     dstChord->setTicks(chord->ticks());
                     dstChord->setTuplet(dstCR->tuplet());
-                    dstChord->setOwnershipParent(s);
                     elementScore->undoRemoveElement(dstCR);
                 }
             } else if (!chord->tuplet()) {
@@ -189,7 +188,6 @@ void EditVoice::changeSelectedElementsVoice(Transaction&, Score* score, voice_id
                 dstChord->setTrack(dstTrack);
                 dstChord->setDurationType(chord->durationType());
                 dstChord->setTicks(chord->ticks());
-                dstChord->setOwnershipParent(s);
                 // makeGapVoice will not back-fill an empty voice
                 if (voice && !dstCR) {
                     elementScore->expandVoice(s, /*m->first(SegmentType::ChordRest,*/ dstTrack);
@@ -294,7 +292,6 @@ void EditVoice::changeSelectedElementsVoice(Transaction&, Score* score, voice_id
                 r->setDurationType(chord->durationType());
                 r->setTicks(chord->ticks());
                 r->setTuplet(chord->tuplet());
-                r->setOwnershipParent(s);
                 // if there were grace notes, move them
                 while (!chord->graceNotes().empty()) {
                     Chord* gc = chord->graceNotes().front();

--- a/src/engraving/editing/noteinput.cpp
+++ b/src/engraving/editing/noteinput.cpp
@@ -311,7 +311,6 @@ Note* NoteInput::addNote(Transaction&, Score* score, Chord* chord, const NoteVal
     InputState& is = externalInputState ? (*externalInputState) : score->inputState();
 
     Note* note = Factory::createNote(chord);
-    note->setOwnershipParent(chord);
     note->setTrack(chord->track());
     note->setNval(noteVal);
     score->undoAddElement(note);
@@ -322,7 +321,6 @@ Note* NoteInput::addNote(Transaction&, Score* score, Chord* chord, const NoteVal
         Accidental* a = Factory::createAccidental(note);
         a->setAccidentalType(at);
         a->setRole(AccidentalRole::USER);
-        a->setOwnershipParent(note);
         score->undoAddElement(a);
     }
 
@@ -628,7 +626,6 @@ std::pair<Note*, Note*> NoteInput::repitchReplaceNote(Transaction&, Score* score
                                                       bool forceAccidental)
 {
     Note* note = Factory::createNote(chord);
-    note->setOwnershipParent(chord);
     note->setTrack(chord->track());
     note->setNval(nval);
 
@@ -705,7 +702,6 @@ std::pair<Note*, Note*> NoteInput::repitchReplaceNote(Transaction&, Score* score
         Accidental* a = Factory::createAccidental(note);
         a->setAccidentalType(at);
         a->setRole(AccidentalRole::USER);
-        a->setOwnershipParent(note);
         score->undoAddElement(a);
     }
     score->setPlayNote(true);

--- a/src/engraving/editing/paste.cpp
+++ b/src/engraving/editing/paste.cpp
@@ -244,7 +244,7 @@ void Paste::pasteChordRest(Transaction& tx, Score* score, ChordRest* cr, const F
         MeasureRepeat* mr = toMeasureRepeat(cr);
         std::vector<TDuration> list = toDurationList(mr->ticks(), true);
         for (auto dur : list) {
-            Rest* r = Factory::createRest(score->dummy()->segment(), dur);
+            Rest* r = Factory::createRest(score->dummy(), dur);
             r->setTrack(cr->track());
             Fraction rest = r->ticks();
             while (!rest.isZero()) {

--- a/src/engraving/editing/realizechordsymbols.cpp
+++ b/src/engraving/editing/realizechordsymbols.cpp
@@ -241,7 +241,7 @@ void RealizeChordSymbols::realizeChordSymbols(Transaction&, Score* score, bool l
         Fraction duration = r.getActualDuration(tick.ticks(), durationType) * h->staff()->timeStretch(tick);
         bool concertPitch = score->style().styleB(Sid::concertPitch);
 
-        Chord* chord = Factory::createChord(score->dummy()->segment());     //chord template
+        Chord* chord = Factory::createChord(score->dummy());     //chord template
         chord->setTrack(h->track());     //set track so notes have a track to sit on
 
         //create chord from notes

--- a/src/engraving/editing/splitjoinmeasure.cpp
+++ b/src/engraving/editing/splitjoinmeasure.cpp
@@ -176,7 +176,6 @@ void SplitJoinMeasure::splitMeasure(Transaction& tx, MasterScore* masterScore, c
         Staff* staff = masterScore->staves().at(staffIdx);
         if (staff->isStaffTypeStartFrom(stick)) {
             StaffTypeChange* stc = Factory::createStaffTypeChange(m1);
-            stc->setOwnershipParent(m1);
             stc->setTrack(staffIdx * VOICES);
             masterScore->addElement(stc);
         }
@@ -270,7 +269,6 @@ void SplitJoinMeasure::joinMeasures(Transaction& tx, MasterScore* masterScore, c
         Staff* staff = masterScore->staves().at(staffIdx);
         if (staff->isStaffTypeStartFrom(tick1)) {
             StaffTypeChange* stc = engraving::Factory::createStaffTypeChange(joinedMeasure);
-            stc->setOwnershipParent(joinedMeasure);
             stc->setTrack(staffIdx * VOICES);
             masterScore->addElement(stc);
         }

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -291,7 +291,6 @@ bool Transpose::transpose(Transaction& tx, Score* score, TransposeMode mode, Tra
                 ks->setTrack(track);
                 Key nKey = transposeKey(Key::C, interval);
                 ks->setKey(nKey);
-                ks->setOwnershipParent(seg);
                 score->undoAddElement(ks);
             }
         }
@@ -365,7 +364,6 @@ void Transpose::transposeKeys(Transaction& tx, Score* score, staff_idx_t staffSt
                 nKey = cKey;
             }
             ks->setKey(cKey, nKey);
-            ks->setOwnershipParent(seg);
             score->undoAddElement(ks);
         }
     }

--- a/src/engraving/editing/transpose.cpp
+++ b/src/engraving/editing/transpose.cpp
@@ -643,7 +643,7 @@ void Transpose::transposeFretDiagram(Transaction& tx, FretDiagram* diagram, Scor
 
 String Transpose::transposedChordName(Score* score, const String& name, const std::function<int(int tpc)>& transformTpc)
 {
-    Harmony h(score->dummy()->segment());
+    Harmony h(score->dummy());
     h.setHarmony(name);
     for (HarmonyInfo* info : h.chords()) {
         info->setRootTpc(transformTpc(info->rootTpc()));

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -520,7 +520,7 @@ void BeamLayout::breakCrossMeasureBeams(Measure* measure, LayoutContext& ctx)
 
         Beam* newBeam = nullptr;
         if (nextElements.size() > 1) {
-            newBeam = Factory::createBeam(ctx.mutDom().dummyParent()->score());
+            newBeam = Factory::createBeam(ctx.mutDom().score());
             newBeam->setGenerated(true);
             newBeam->setTrack(track);
         }
@@ -601,7 +601,7 @@ void BeamLayout::beamGraceNotes(LayoutContext& ctx, Chord* mainNote, bool after)
             } else {
                 beam = a1->beam();
                 if (beam == 0 || beam->elements().front() != a1) {
-                    beam = Factory::createBeam(ctx.mutDom().dummyParent()->score());
+                    beam = Factory::createBeam(ctx.mutDom().score());
                     beam->setGenerated(true);
                     beam->setTrack(mainNote->track());
                     a1->replaceBeam(beam);
@@ -775,7 +775,7 @@ void BeamLayout::createBeams(LayoutContext& ctx, Measure* measure)
                 } else {
                     beam = a1->beam();
                     if (beam == 0 || beam->elements().front() != a1) {
-                        beam = Factory::createBeam(ctx.mutDom().dummyParent()->score());
+                        beam = Factory::createBeam(ctx.mutDom().score());
                         beam->setGenerated(true);
                         beam->setTrack(track);
                         a1->replaceBeam(beam);

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -441,7 +441,6 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         double llX         = stemX - (headWidth + extraLen) * 0.5;
         for (int i = 0; i < ledgerLines; i++) {
             LedgerLine* ldgLin = item->ledgerLines()[i];
-            ldgLin->setOwnershipParent(item);
             ldgLin->setTrack(item->track());
             ldgLin->setVisible(item->visible());
             ldgLin->setLen(headWidth + extraLen);
@@ -546,7 +545,6 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
             } else {
                 item->tabDur()->setDuration(item->durationType().type(), item->dots(), tab);
             }
-            item->tabDur()->setOwnershipParent(item);
             item->tabDur()->setRepeat(repeat);
 //                  _tabDur->setMag(mag());           // useless to set grace mag: graces have no dur. symbol
             TLayout::layoutTabDurationSymbol(item->tabDur(), item->tabDur()->mutldata());
@@ -1421,7 +1419,6 @@ void ChordLayout::updateLedgerLines(Chord* item, LayoutContext& ctx)
     for (size_t i = 0; i < ledgerLineData.size(); ++i) {
         LedgerLineData lld = ledgerLineData[i];
         LedgerLine* h = item->ledgerLines()[i];
-        h->setOwnershipParent(item);
         h->setTrack(track);
         h->setVisible(lld.visible && staffVisible);
         h->setLen(lld.maxX - lld.minX);

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -468,7 +468,6 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         // set stem position (stem length is set in Chord:layoutStem() )
         if (!item->stem()) {
             Stem* stem = Factory::createStem(item);
-            stem->setOwnershipParent(item);
             stem->setGenerated(true);
             ctx.mutDom().addElement(stem);
         }
@@ -2592,7 +2591,6 @@ void ChordLayout::setDotRelativeLine(Note* note, int dotMove, LayoutContext& ctx
     int n = cdots - ndots;
     for (int i = 0; i < n; ++i) {
         NoteDot* dot = Factory::createNoteDot(note);
-        dot->setOwnershipParent(note);
         dot->setTrack(note->track());      // needed to know the staff it belongs to (and detect tablature)
         dot->setVisible(note->visible());
         ctx.mutDom().undoAddElement(dot);

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -859,7 +859,6 @@ void HarmonyLayout::renderActionScale(const RenderActionScalePtr& a, HarmonyRend
 void HarmonyLayout::renderActionParen(Harmony* item, const RenderActionParenPtr& a, HarmonyRenderCtx& harmonyCtx)
 {
     Parenthesis* p = Factory::createParenthesis(item);
-    p->setOwnershipParent(item);
     p->setDirection(a->direction());
     p->setColor(item->color());
     p->setFollowParentColor(true);

--- a/src/engraving/rendering/score/headerfooterlayout.cpp
+++ b/src/engraving/rendering/score/headerfooterlayout.cpp
@@ -76,7 +76,6 @@ void HeaderFooterLayout::createUpdateHeaderText(LayoutContext& ctx, Page* page, 
     Text* text = page->headerText(area);
     if (!text) {
         text = Factory::createText(page, TextStyleType::HEADER);
-        text->setOwnershipParent(page);
         text->setFlag(ElementFlag::MOVABLE, false);
         text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
         text->setLayoutToParentWidth(true);
@@ -115,7 +114,6 @@ void HeaderFooterLayout::createUpdateFooterText(LayoutContext& ctx, Page* page, 
     Text* text = page->footerText(area);
     if (!text) {
         text = Factory::createText(page, TextStyleType::FOOTER);
-        text->setOwnershipParent(page);
         text->setFlag(ElementFlag::MOVABLE, false);
         text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
         text->setLayoutToParentWidth(true);

--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -419,7 +419,7 @@ MeasureBase* DomAccessor::first()
     return score()->first();
 }
 
-compat::DummyElement* DomAccessor::dummyParent() const
+DummyParent* DomAccessor::dummyParent() const
 {
     IF_ASSERT_FAILED(score()) {
         return nullptr;

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -54,6 +54,7 @@
 #endif
 
 namespace mu::engraving {
+class DummyParent;
 class EngravingItem;
 class MeasureBase;
 class Part;
@@ -74,10 +75,6 @@ class UndoableCommand;
 class EditData;
 
 class Selection;
-}
-
-namespace mu::engraving::compat {
-class DummyElement;
 }
 
 namespace mu::engraving::rendering::score {
@@ -201,7 +198,7 @@ public:
     // Create/Remove
     const Score* score() const;
     Score* score();
-    compat::DummyElement* dummyParent() const;
+    DummyParent* dummyParent() const;
     void doUndoAddElement(EngravingItem*);
     void undoAddElement(EngravingItem* item, bool addToLinkedStaves = true, bool ctrlModifier = false);
     void doUndoRemoveElement(EngravingItem* item);

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -598,7 +598,6 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
                 measureNumber = new MeasureNumber(m);
                 measureNumber->setTrack(staff2track(staffIdx));
                 measureNumber->setGenerated(true);
-                measureNumber->setOwnershipParent(m);
                 m->add(measureNumber);
             }
 
@@ -785,7 +784,6 @@ void MeasureLayout::barLinesSetSpan(Segment* seg, LayoutContext& ctx)
             }
         } else {
             bl = Factory::createBarLine(seg);
-            bl->setOwnershipParent(seg);
             bl->setTrack(track);
             bl->setGenerated(true);
             bl->setSpanStaff(staff->barLineSpan());
@@ -923,7 +921,6 @@ void MeasureLayout::createEndBarLines(Measure* m, bool isLastMeasureInSystem, La
             const Staff* staff = ctx.dom().staff(staffIdx);
             if (!barLine) {
                 barLine = Factory::createBarLine(barlineSeg);
-                barLine->setOwnershipParent(barlineSeg);
                 barLine->setTrack(track);
                 barLine->setGenerated(true);
                 barLine->setSpanStaff(staff->barLineSpan());
@@ -1105,7 +1102,6 @@ void MeasureLayout::setCourtesyTimeSig(Measure* m, const Fraction& refSigTick, c
             courtesyTimeSig = Factory::createTimeSig(courtesySigSeg);
             courtesyTimeSig->setTrack(track);
             courtesyTimeSig->setGenerated(true);
-            courtesyTimeSig->setOwnershipParent(courtesySigSeg);
             courtesyTimeSig->setIsCourtesy(true);
             courtesySigSeg->add(courtesyTimeSig);
         }
@@ -1230,7 +1226,6 @@ void MeasureLayout::setCourtesyKeySig(Measure* m, const Fraction& refSigTick, co
             courtesyKeySig = Factory::createKeySig(courtesySigSeg);
             courtesyKeySig->setTrack(track);
             courtesyKeySig->setGenerated(true);
-            courtesyKeySig->setOwnershipParent(courtesySigSeg);
             courtesyKeySig->setIsCourtesy(true);
             courtesySigSeg->add(courtesyKeySig);
         }
@@ -1344,7 +1339,6 @@ void MeasureLayout::setCourtesyClef(Measure* m, const Fraction& refClefTick, con
             courtesyClef->setTrack(track);
             courtesyClef->setGenerated(true);
             courtesyClef->setSmall(true);
-            courtesyClef->setOwnershipParent(courtesyClefSeg);
             courtesyClef->setClefType(actualClef->clefType());
             courtesyClef->setIsCourtesy(true);
             courtesyClefSeg->add(courtesyClef);
@@ -1788,7 +1782,6 @@ Segment* MeasureLayout::addHeaderClef(Measure* m, bool isFirstClef, const Staff*
             clef = Factory::createClef(cSegment);
             clef->setTrack(track);
             clef->setGenerated(true);
-            clef->setOwnershipParent(cSegment);
             clef->setIsHeader(true);
             clef->setShowCourtesy(showCourtesy);
             cSegment->add(clef);
@@ -1858,7 +1851,6 @@ Segment* MeasureLayout::addHeaderKeySig(Measure* m, bool isFirstKeysig, const St
             keysig = Factory::createKeySig(kSegment);
             keysig->setTrack(track);
             keysig->setGenerated(true);
-            keysig->setOwnershipParent(kSegment);
             kSegment->add(keysig);
         }
         keysig->setKeySigEvent(keyIdx);
@@ -2082,7 +2074,6 @@ void MeasureLayout::createSystemBeginBarLine(Measure* m, LayoutContext& ctx)
                 bl = Factory::createBarLine(s);
                 bl->setTrack(track);
                 bl->setGenerated(true);
-                bl->setOwnershipParent(s);
                 bl->setBarLineType(BarLineType::NORMAL);
                 bl->setSpanStaff(true);
                 s->add(bl);

--- a/src/engraving/rendering/score/mmrestlayout.cpp
+++ b/src/engraving/rendering/score/mmrestlayout.cpp
@@ -206,7 +206,6 @@ void MMRestLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Measu
             mmr->setDurationType(DurationType::V_MEASURE);
             mmr->setTicks(mmrMeasure->ticks());
             mmr->setTrack(track);
-            mmr->setOwnershipParent(chordRestSeg);
             ctx.mutDom().doUndoAddElement(mmr);
         }
     }
@@ -811,7 +810,6 @@ void MMRestLayout::layoutMMRestRange(Measure* m, LayoutContext& ctx)
             rr = new MMRestRange(m);
             rr->setTrack(staffIdx * VOICES);
             rr->setGenerated(true);
-            rr->setOwnershipParent(m);
             m->add(rr);
         }
         // setXmlText is reimplemented to take care of brackets

--- a/src/engraving/rendering/score/mmrestlayout.cpp
+++ b/src/engraving/rendering/score/mmrestlayout.cpp
@@ -110,7 +110,7 @@ void MMRestLayout::reuseExistingMMRest(LayoutContext& ctx, Measure* mmrMeasure, 
             nextLastMeasure = nextLastMeasure ? nextLastMeasure : ctx.mutDom().lastMeasure();
             const int numMeasuresInNewMMRest = nextLastMeasure->measureIndex() - nextFirstMeasure->measureIndex() + 1;
 
-            Measure* nextMMRMeasure = Factory::createMeasure(ctx.mutDom().dummyParent()->score());
+            Measure* nextMMRMeasure = Factory::createMeasure(ctx.mutDom().score());
             nextMMRMeasure->setTicks(remainingMMRDuration);
             nextMMRMeasure->setTick(nextFirstMeasure->tick());
             ctx.mutDom().undo(new ChangeMMRest(nextFirstMeasure, nextMMRMeasure));
@@ -183,7 +183,7 @@ void MMRestLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Measu
     if (mmrMeasure) {
         reuseExistingMMRest(ctx, mmrMeasure, lastMeasure, len);
     } else {
-        mmrMeasure = Factory::createMeasure(ctx.mutDom().dummyParent()->score());
+        mmrMeasure = Factory::createMeasure(ctx.mutDom().score());
         mmrMeasure->setTicks(len);
         mmrMeasure->setTick(firstMeasure->tick());
         ctx.mutDom().undo(new ChangeMMRest(firstMeasure, mmrMeasure));

--- a/src/engraving/rendering/score/passlayoutindependentitems.cpp
+++ b/src/engraving/rendering/score/passlayoutindependentitems.cpp
@@ -31,7 +31,7 @@ using namespace mu::engraving::rendering::score;
 void PassLayoutIndependentItems::doRun(Score* score, LayoutContext& ctx)
 {
     for (EngravingObject* child : score->children()) {
-        if (child->isEngravingItem() && !child->isType(ElementType::DUMMY)) {
+        if (child->isEngravingItem()) {
             scan(toEngravingItem(child), ctx);
         }
     }
@@ -68,9 +68,6 @@ void PassLayoutIndependentItems::scan(EngravingItem* item, LayoutContext& ctx)
     }
 
     for (EngravingItem* ch : item->childrenItems()) {
-        if (ch->isType(ElementType::DUMMY)) {
-            continue;
-        }
         scan(ch, ctx);
     }
 }

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -100,7 +100,6 @@ void RestLayout::layoutRest(const Rest* item, Rest::LayoutData* ldata, const Lay
             } else {
                 item->tabDur()->setDuration(type, dots, stt);
             }
-            item->tabDur()->setOwnershipParent(const_cast<Rest*>(item));
 // needed?        _tabDur->setTrack(track());
             TLayout::layoutTabDurationSymbol(item->tabDur(), item->tabDur()->mutldata());
             ldata->setBbox(item->tabDur()->ldata()->bbox());

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -277,7 +277,6 @@ void ScoreHorizontalViewLayout::layoutSystemLockIndicators(System* system)
     for (const RangeLock* lock : systemLocks) {
         SystemLockIndicator* lockIndicator = Factory::createSystemLockIndicator(system, lock);
         lockIndicator->setTrack(0);
-        lockIndicator->setOwnershipParent(system);
         system->addSystemLockIndicator(lockIndicator);
         TLayout::layoutIndicatorIcon(lockIndicator, lockIndicator->mutldata());
     }

--- a/src/engraving/rendering/score/systemheaderlayout.cpp
+++ b/src/engraving/rendering/score/systemheaderlayout.cpp
@@ -997,7 +997,6 @@ InstrumentName* SystemHeaderLayout::updateName(System* system, staff_idx_t staff
     if (!iname) {
         iname = new InstrumentName(system);
         iname->setGenerated(true);
-        iname->setOwnershipParent(system);
         iname->setSysStaff(sysStaff);
         iname->setTrack(staffIdx * VOICES);
         iname->setInstrumentNameType(type);

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -568,7 +568,7 @@ System* SystemLayout::getNextSystem(LayoutContext& ctx)
     bool isVBox = ctx.state().curMeasure()->isVBox();
     System* system = nullptr;
     if (ctx.state().systemList().empty()) {
-        system = Factory::createSystem(ctx.mutDom().dummyParent()->score());
+        system = Factory::createSystem(ctx.mutDom().score());
         ctx.mutState().setSystemOldMeasure(nullptr);
     } else {
         system = muse::takeFirst(ctx.mutState().systemList());

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -531,7 +531,6 @@ void SystemLayout::layoutSystemLockIndicators(System* system, LayoutContext& ctx
 
     SystemLockIndicator* lockIndicator = Factory::createSystemLockIndicator(system, lock);
     lockIndicator->setTrack(0);
-    lockIndicator->setOwnershipParent(system);
     system->addSystemLockIndicator(lockIndicator);
 
     TLayout::layoutIndicatorIcon(lockIndicator, lockIndicator->mutldata());
@@ -553,7 +552,6 @@ void SystemLayout::layoutPageLockIndicators(System* system)
 
     PageLockIndicator* lockIndicator = Factory::createPageLockIndicator(system, lock);
     lockIndicator->setTrack(0);
-    lockIndicator->setOwnershipParent(system);
     system->setPageLockIndicator(lockIndicator);
 
     TLayout::layoutPageLockIndicator(lockIndicator, lockIndicator->mutldata());

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1542,7 +1542,6 @@ void TLayout::layoutGroupBracket(const Bracket* item, Bracket::LayoutData* ldata
 
     if (!item->text()) {
         Text* bracketText = new Text(const_cast<Bracket*>(item), TextStyleType::GROUP_BRACKET);
-        bracketText->setOwnershipParent(const_cast<Bracket*>(item));
         bracketText->setSelected(item->selected());
         bracketText->setGenerated(true);
         const_cast<Bracket*>(item)->setText(bracketText);

--- a/src/engraving/rendering/score/tupletlayout.cpp
+++ b/src/engraving/rendering/score/tupletlayout.cpp
@@ -166,7 +166,6 @@ void TupletLayout::createNumber(Tuplet* item, LayoutContext& ctx)
         Text* number = Factory::createText(item, TextStyleType::TUPLET);
         number->setComposition(true);
         number->setTrack(item->track());
-        number->setOwnershipParent(item);
         number->setVisible(item->visible());
         number->setColor(item->color());
         item->setNumber(number);

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -1112,7 +1112,6 @@ void SingleLayout::layout(HammerOnPullOffSegment* item, const Context& ctx)
     }
 
     HammerOnPullOffText* hopoText = hopoTexts.front();
-    hopoText->setOwnershipParent(item);
     hopoText->setXmlText("H/P");
 
     Align align;

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -28,7 +28,7 @@
 #include "types/typesconv.h"
 #include "types/symnames.h"
 
-#include "compat/dummyelement.h"
+#include "dom/dummyparent.h"
 
 #include "dom/factory.h"
 
@@ -312,7 +312,7 @@ std::shared_ptr<IEngravingFont> SingleLayout::Context::engravingFont() const
     return m_score->engravingFont();
 }
 
-compat::DummyElement* SingleLayout::Context::dummyParent() const
+DummyParent* SingleLayout::Context::dummyParent() const
 {
     return m_score->dummy();
 }

--- a/src/engraving/rendering/single/singlelayout.h
+++ b/src/engraving/rendering/single/singlelayout.h
@@ -49,6 +49,7 @@ class Chord;
 class ChordLine;
 class Clef;
 
+class DummyParent;
 class Dynamic;
 
 class Expression;
@@ -130,10 +131,6 @@ class Volta;
 class VoltaSegment;
 }
 
-namespace mu::engraving::compat {
-class DummyElement;
-}
-
 namespace mu::engraving::rendering::single {
 class SingleLayout
 {
@@ -148,7 +145,7 @@ public:
 
         const engraving::MStyle& style() const;
         std::shared_ptr<engraving::IEngravingFont> engravingFont() const;
-        engraving::compat::DummyElement* dummyParent() const;
+        engraving::DummyParent* dummyParent() const;
 
         //! NOTE Temporarily, do not use
         engraving::Score* dontUseScore() const { return m_score; }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -355,7 +355,7 @@ void CompatUtils::replaceOldWithNewOrnaments(MasterScore* score)
     for (Articulation* oldOrnament : oldOrnaments) {
         Chord* parentChord = toChord(oldOrnament->chordRest());
 
-        Ornament* newOrnament = Factory::createOrnament(score->dummy()->chord());
+        Ornament* newOrnament = Factory::createOrnament(score->dummy());
         newOrnament->setOwnershipParent(parentChord);
         newOrnament->setTrack(oldOrnament->track());
         newOrnament->setSymId(oldOrnament->symId());
@@ -402,7 +402,7 @@ void CompatUtils::replaceOldWithNewExpressions(MasterScore* score)
     for (StaffText* oldExpression : oldExpressions) {
         Segment* parentSegment = oldExpression->segment();
 
-        Expression* newExpression = Factory::createExpression(score->dummy()->segment());
+        Expression* newExpression = Factory::createExpression(score->dummy());
         newExpression->setOwnershipParent(parentSegment);
         newExpression->setTrack(oldExpression->track());
         newExpression->setXmlText(oldExpression->xmlText());
@@ -482,7 +482,7 @@ void CompatUtils::splitArticulations(MasterScore* masterScore)
         auto components = mu::engraving::splitArticulations({ combinedArtic->symId() });
         Chord* parentChord = toChord(combinedArtic->chordRest());
         for (SymId id : components) {
-            Articulation* newArtic = Factory::createArticulation(masterScore->dummy()->chord());
+            Articulation* newArtic = Factory::createArticulation(masterScore->dummy());
             newArtic->setSymId(id);
             if (parentChord->hasArticulation(newArtic)) {
                 delete newArtic;

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -355,8 +355,7 @@ void CompatUtils::replaceOldWithNewOrnaments(MasterScore* score)
     for (Articulation* oldOrnament : oldOrnaments) {
         Chord* parentChord = toChord(oldOrnament->chordRest());
 
-        Ornament* newOrnament = Factory::createOrnament(score->dummy());
-        newOrnament->setOwnershipParent(parentChord);
+        Ornament* newOrnament = Factory::createOrnament(parentChord);
         newOrnament->setTrack(oldOrnament->track());
         newOrnament->setSymId(oldOrnament->symId());
         newOrnament->setPos(oldOrnament->pos());
@@ -402,8 +401,7 @@ void CompatUtils::replaceOldWithNewExpressions(MasterScore* score)
     for (StaffText* oldExpression : oldExpressions) {
         Segment* parentSegment = oldExpression->segment();
 
-        Expression* newExpression = Factory::createExpression(score->dummy());
-        newExpression->setOwnershipParent(parentSegment);
+        Expression* newExpression = Factory::createExpression(parentSegment);
         newExpression->setTrack(oldExpression->track());
         newExpression->setXmlText(oldExpression->xmlText());
         newExpression->mapPropertiesFromOldExpressions(oldExpression);
@@ -482,13 +480,12 @@ void CompatUtils::splitArticulations(MasterScore* masterScore)
         auto components = mu::engraving::splitArticulations({ combinedArtic->symId() });
         Chord* parentChord = toChord(combinedArtic->chordRest());
         for (SymId id : components) {
-            Articulation* newArtic = Factory::createArticulation(masterScore->dummy());
+            Articulation* newArtic = Factory::createArticulation(parentChord);
             newArtic->setSymId(id);
             if (parentChord->hasArticulation(newArtic)) {
                 delete newArtic;
                 continue;
             }
-            newArtic->setOwnershipParent(parentChord);
             newArtic->setTrack(combinedArtic->track());
             newArtic->setPos(combinedArtic->pos());
             newArtic->setDirection(combinedArtic->direction());

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -836,7 +836,6 @@ NoteLine* CompatUtils::createNoteLineFromTextLine(TextLine* textLine)
     Note* endNote = toNote(textLine->endElement());
 
     NoteLine* noteLine = Factory::createNoteLine(startNote);
-    noteLine->setOwnershipParent(startNote);
     noteLine->setStartElement(startNote);
     noteLine->setTrack(textLine->track());
     noteLine->setTick(textLine->tick());
@@ -965,7 +964,6 @@ void CompatUtils::convertLaissezVibArticToTie(MasterScore* masterScore)
         parentChord->remove(oldArtic);
 
         LaissezVib* lv = Factory::createLaissezVib(parentNote);
-        lv->setOwnershipParent(parentNote);
         parentNote->add(lv);
 
         delete oldArtic;

--- a/src/engraving/rw/ireader.h
+++ b/src/engraving/rw/ireader.h
@@ -98,7 +98,7 @@ public:
     virtual void pasteSymbols(XmlReader& e, ChordRest* dst) = 0;
 
     // compat
-    virtual void readTremoloCompat(engraving::compat::TremoloCompat* item, XmlReader& xml) = 0;
+    virtual void readTremoloCompat(engraving::compat::TremoloCompat* item, engraving::Score* score, XmlReader& xml) = 0;
 
 private:
     virtual void doReadItem(EngravingItem* item, XmlReader& xml) = 0;

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -987,7 +987,6 @@ static void readChord(Measure* m, Chord* chord, XmlReader& e, ReadContext& ctx)
             Note* note = Factory::createNote(chord);
             // the note needs to know the properties of the track it belongs to
             note->setTrack(chord->track());
-            note->setOwnershipParent(chord);
             readNote(note, e, ctx);
             chord->add(note);
         } else if (tag == "Attribute" || tag == "Articulation") {
@@ -1654,7 +1653,6 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             if (m->isMMRest()) {
                 segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
-                mmr->setOwnershipParent(segment);
                 mmr->setTrack(ctx.track());
                 read400::TRead::read(mmr, e, ctx);
                 mmr->setTicks(m->ticks());
@@ -2079,7 +2077,6 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             Tuplet* tuplet = Factory::createTuplet(m);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(m);
             readTuplet(tuplet, e, ctx);
             ctx.addTuplet(tupletId, tuplet);
         } else if (tag == "startRepeat") {
@@ -2131,7 +2128,6 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             MeasureNumber* noText = new MeasureNumber(m);
             readText114(e, ctx, noText, m);
             noText->setTrack(ctx.track());
-            noText->setOwnershipParent(m);
             m->setMeasureNumber(noText->staffIdx(), noText);
         } else if (tag == "multiMeasureRest") {
             m->setMMRestCount(e.readInt());
@@ -2986,7 +2982,6 @@ muse::Ret Read114::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
                 KeySigEvent ke = i->second;
                 KeySig* ks = Factory::createKeySig(seg);
                 ks->setKeySigEvent(ke);
-                ks->setOwnershipParent(seg);
                 ks->setTrack(track);
                 ks->setGenerated(false);
                 seg->add(ks);

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1589,7 +1589,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             segment = m->getSegment(st, ctx.tick());
             segment->add(barLine);
         } else if (tag == "Chord") {
-            Chord* chord = Factory::createChord(m->getSegment(SegmentType::ChordRest, ctx.tick()));
+            // where the chord belongs is only known once it has been read: a grace note
+            // goes on the chord it decorates rather than on a segment of its own, and
+            // reading moves the tick the segment is looked up by
+            Chord* chord = Factory::createChord(ctx.score()->dummy());
             chord->setTrack(ctx.track());
             readChord(m, chord, e, ctx);
             if (!chord->segment()) {
@@ -1725,7 +1728,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             }
             e.readNext();
         } else if (tag == "Slur") {
-            Slur* sl = Factory::createSlur(m);
+            Slur* sl = Factory::createSlur(ctx.score()->dummy());
             sl->setTick(ctx.tick());
             Read206::readSlur206(e, ctx, sl);
             //

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1530,7 +1530,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
             lastTick = ctx.tick();
         } else if (tag == "BarLine") {
-            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* barLine = Factory::createBarLine(ctx.dummy());
             barLine->setTrack(ctx.track());
             // initialize span properties with values from staff
             barLine->resetProperty(Pid::BARLINE_SPAN_FROM);
@@ -1659,7 +1659,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 lastTick = ctx.tick();
                 ctx.incTick(mmr->actualTicks());
             } else {
-                Rest* rest = Factory::createRest(ctx.score()->dummy()->segment());
+                Rest* rest = Factory::createRest(ctx.score()->dummy());
                 rest->setDurationType(DurationType::V_MEASURE);
                 rest->setTicks(m->timesig() / timeStretch);
                 rest->setTrack(ctx.track());
@@ -1844,7 +1844,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 m->setTimesig(ts->sig() / timeStretch);
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             read400::TRead::read(ks, e, ctx);
             Fraction curTick = ctx.tick();
@@ -1854,7 +1854,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             segment->add(ks);
             staff->setKey(curTick, ks->keySigEvent());
         } else if (tag == "Lyrics") {
-            Lyrics* l = Factory::createLyrics(ctx.dummy()->chord());
+            Lyrics* l = Factory::createLyrics(ctx.dummy());
             l->setTrack(ctx.track());
 
             int iEndTick = 0;                 // used for backward compatibility
@@ -2774,7 +2774,7 @@ muse::Ret Read114::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
         if (tag == "Staff") {
             readStaffContent(masterScore, e, ctx);
         } else if (tag == "KeySig") {                 // not supported
-            KeySig* ks = Factory::createKeySig(masterScore->dummy()->segment());
+            KeySig* ks = Factory::createKeySig(masterScore->dummy());
             read400::TRead::read(ks, e, ctx);
             delete ks;
         } else if (tag == "siglist") {
@@ -2886,7 +2886,7 @@ muse::Ret Read114::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
             } else if (tag == "Pedal") {
                 readPedal114(e, ctx, toPedal(s));
             } else if (tag == "Trill") {
-                Ornament* ornament = Factory::createOrnament(score->dummy()->chord());
+                Ornament* ornament = Factory::createOrnament(score->dummy());
                 toTrill(s)->setOrnament(ornament);
                 Read206::readTrill206(e, ctx, toTrill(s));
             } else {
@@ -3118,7 +3118,7 @@ muse::Ret Read114::readScoreFile(Score* score, XmlReader& e, ReadInOutData* out)
             continue;
         }
 
-        TempoText* tt = Factory::createTempoText(masterScore->dummy()->segment());
+        TempoText* tt = Factory::createTempoText(masterScore->dummy());
         tt->setXmlText(String(u"<sym>metNoteQuarterUp</sym> = %1").arg(std::round(tempo.toBPM().val)));
         tt->setTempo(tempo);
         tt->setTrack(0);
@@ -3223,7 +3223,7 @@ void Read114::pasteSymbols(XmlReader&, ChordRest*)
     UNREACHABLE;
 }
 
-void Read114::readTremoloCompat(TremoloCompat*, XmlReader&)
+void Read114::readTremoloCompat(TremoloCompat*, Score*, XmlReader&)
 {
     UNREACHABLE;
 }

--- a/src/engraving/rw/read114/read114.h
+++ b/src/engraving/rw/read114/read114.h
@@ -45,7 +45,7 @@ public:
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
 
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
     static void setBarLineSpanToStaves(Score*, const read400::ReadContext&);
 

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -88,6 +88,7 @@
 #include "dom/stafftext.h"
 #include "dom/stem.h"
 #include "dom/stemslash.h"
+#include "dom/system.h"
 #include "dom/systemdivider.h"
 #include "dom/systemtext.h"
 #include "dom/tempotext.h"

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2510,12 +2510,12 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
             case SymId::fermataLongBelow:
             case SymId::fermataVeryLongAbove:
             case SymId::fermataVeryLongBelow: {
-                Fermata* fe = Factory::createFermata(ctx.dummy()->segment());
+                Fermata* fe = Factory::createFermata(ctx.dummy());
                 fe->setSymIdAndTimeStretch(sym);
                 el = fe;
             } break;
             default:
-                Articulation* ar = Factory::createArticulation(ctx.dummy()->chord());
+                Articulation* ar = Factory::createArticulation(ctx.dummy());
                 ar->setSymId(sym);
                 ar->setDirection(direction);
                 el = ar;
@@ -2548,7 +2548,7 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
     }
     // Special case for "no type" = ufermata, with missing subtype tag
     if (!el) {
-        Fermata* f = Factory::createFermata(ctx.dummy()->segment());
+        Fermata* f = Factory::createFermata(ctx.dummy());
         f->setSymIdAndTimeStretch(sym);
         el = f;
     }
@@ -2683,7 +2683,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
         } else if (tag == "BarLine") {
             Fermata* fermataAbove = nullptr;
             Fermata* fermataBelow = nullptr;
-            BarLine* bl = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* bl = Factory::createBarLine(ctx.dummy());
             bl->setTrack(ctx.track());
             while (e.readNextStartElement()) {
                 const AsciiStringView t(e.name());
@@ -2800,7 +2800,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 ctx.incTick(rest->actualTicks());
             }
         } else if (tag == "Breath") {
-            Breath* breath = Factory::createBreath(ctx.dummy()->segment());
+            Breath* breath = Factory::createBreath(ctx.dummy());
             breath->setTrack(ctx.track());
             breath->setPlacement(PlacementV::ABOVE);
             Fraction tick = ctx.tick();
@@ -2882,7 +2882,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             } else if (tag == "HairPin") {
                 Read206::readHairpin206(e, ctx, toHairpin(sp));
             } else if (tag == "Trill") {
-                Ornament* ornament = Factory::createOrnament(m->score()->dummy()->chord());
+                Ornament* ornament = Factory::createOrnament(m->score()->dummy());
                 toTrill(sp)->setOrnament(ornament);
                 Read206::readTrill206(e, ctx, toTrill(sp));
             } else {
@@ -2909,7 +2909,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             lastTick = ctx.tick();
             ctx.incTick(m->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            Clef* clef = Factory::createClef(ctx.dummy());
             clef->setTrack(ctx.track());
             read400::TRead::read(clef, e, ctx);
             clef->setGenerated(false);
@@ -2972,7 +2972,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
 
             segment->add(clef);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy());
             ts->setTrack(ctx.track());
             read400::TRead::read(ts, e, ctx);
             // if time sig not at beginning of measure => courtesy time sig
@@ -2999,7 +2999,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 }
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             read400::TRead::read(ks, e, ctx);
             Fraction curTick = ctx.tick();
@@ -3018,9 +3018,9 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             if (styleName == "System" || styleName == "Tempo"
                 || styleName == "Marker" || styleName == "Jump"
                 || styleName == "Volta") {    // TODO: is it possible to get it from style?
-                t = Factory::createSystemText(ctx.dummy()->segment());
+                t = Factory::createSystemText(ctx.dummy());
             } else {
-                t = Factory::createStaffText(ctx.dummy()->segment());
+                t = Factory::createStaffText(ctx.dummy());
             }
             t->setTrack(ctx.track());
             readTextPropertyStyle206(tctx.tag(), ctx, t, t);
@@ -3175,7 +3175,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             noText->setOwnershipParent(m);
             m->setMeasureNumber(noText->staffIdx(), noText);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            SystemDivider* sd = new SystemDivider(ctx.dummy());
             read400::TRead::read(sd, e, ctx);
             m->add(sd);
         } else if (tag == "Ambitus") {
@@ -3725,7 +3725,7 @@ void Read206::pasteSymbols(XmlReader&, ChordRest*)
     UNREACHABLE;
 }
 
-void Read206::readTremoloCompat(compat::TremoloCompat*, XmlReader&)
+void Read206::readTremoloCompat(compat::TremoloCompat*, Score*, XmlReader&)
 {
     UNREACHABLE;
 }

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3171,7 +3171,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             segment = m->getSegment(SegmentType::Ambitus, ctx.tick());
             Ambitus* range = Factory::createAmbitus(segment);
             readAmbitus(range, e, ctx);
-            range->setOwnershipParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(ctx.track()));
             segment->add(range);
         } else if (tag == "multiMeasureRest") {

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -1130,7 +1130,6 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e, ReadContext& ctx)
         note->add(a);
     } else if (tag == "Tie") {
         Tie* tie = Factory::createTie(note);
-        tie->setOwnershipParent(note);
         tie->setTrack(note->track());
         readTie206(e, ctx, tie);
         tie->setStartNote(note);
@@ -1605,7 +1604,6 @@ static void readTuplet206(Tuplet* tuplet, XmlReader& e, ReadContext& ctx)
         const AsciiStringView tag(e.name());
         if (tag == "Number") {
             Text* _number = Factory::createText(tuplet);
-            _number->setOwnershipParent(tuplet);
             _number->setComposition(true);
             tuplet->setNumber(_number);
             // _number reads property defaults from parent tuplet as "composition" is set:
@@ -1716,7 +1714,6 @@ bool Read206::readTupletProperties206(XmlReader& e, ReadContext& ctx, Tuplet* de
         Text* _number = Factory::createText(de);
         de->setNumber(_number);
         _number->setComposition(true);
-        _number->setOwnershipParent(de);
 //            _number->setSubStyleId(SubStyleId::TUPLET);
 //            initSubStyle(SubStyleId::TUPLET);   // hack: initialize number
         for (auto p : { Pid::FONT_FACE, Pid::FONT_SIZE, Pid::FONT_STYLE, Pid::ALIGN }) {
@@ -1967,7 +1964,6 @@ bool Read206::readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch)
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());
         read400::TRead::read(arpeggio, e, ctx);
-        arpeggio->setOwnershipParent(ch);
         ch->add(arpeggio);
     }
     // old glissando format, chord-to-chord, attached to its final chord
@@ -2114,7 +2110,6 @@ static void readChord(Chord* chord, XmlReader& e, ReadContext& ctx)
             Note* note = Factory::createNote(chord);
             // the note needs to know the properties of the track it belongs to
             note->setTrack(chord->track());
-            note->setOwnershipParent(chord);
             readNote206(note, e, ctx);
             chord->add(note);
         } else if (tag == "Stem") {
@@ -2359,7 +2354,6 @@ void Read206::readTrill206(XmlReader& e, ReadContext& ctx, Trill* t)
         } else if (tag == "Accidental") {
             Accidental* _accidental = Factory::createAccidental(t);
             readAccidental206(_accidental, e, ctx);
-            _accidental->setOwnershipParent(t);
             t->setAccidental(_accidental);
             if (t->ornament()) {
                 t->ornament()->setTrillOldCompatAccidental(_accidental);
@@ -2755,7 +2749,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
             Chord* chord = Factory::createChord(segment);
             chord->setTrack(ctx.track());
-            chord->setOwnershipParent(segment);
             readChord(chord, e, ctx);
             if (chord->noteType() != NoteType::NORMAL) {
                 graceNotes.push_back(chord);
@@ -2775,7 +2768,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             if (m->isMMRest()) {
                 segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
-                mmr->setOwnershipParent(segment);
                 mmr->setTrack(ctx.track());
                 read400::TRead::read(mmr, e, ctx);
                 mmr->setTicks(m->ticks());
@@ -2788,7 +2780,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 rest->setDurationType(DurationType::V_MEASURE);
                 rest->setTicks(m->timesig() / timeStretch);
                 rest->setTrack(ctx.track());
-                rest->setOwnershipParent(segment);
                 readRest(rest, e, ctx);
                 segment->add(rest);
 
@@ -3127,7 +3118,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             Tuplet* tuplet = Factory::createTuplet(m);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(m);
             readTuplet206(tuplet, e, ctx);
             ctx.addTuplet(tupletId, tuplet);
         } else if (tag == "startRepeat") {
@@ -3172,7 +3162,6 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
             MeasureNumber* noText = new MeasureNumber(m);
             readText206(e, ctx, noText, m);
             noText->setTrack(ctx.track());
-            noText->setOwnershipParent(m);
             m->setMeasureNumber(noText->staffIdx(), noText);
         } else if (tag == "SystemDivider") {
             SystemDivider* sd = new SystemDivider(ctx.dummy());

--- a/src/engraving/rw/read206/read206.h
+++ b/src/engraving/rw/read206/read206.h
@@ -65,7 +65,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
     static void readTimeSigMap(TimeSigMap* map, XmlReader& xml, read400::ReadContext& ctx);
 

--- a/src/engraving/rw/read302/read302.cpp
+++ b/src/engraving/rw/read302/read302.cpp
@@ -344,7 +344,7 @@ void Read302::pasteSymbols(XmlReader&, ChordRest*)
     UNREACHABLE;
 }
 
-void Read302::readTremoloCompat(compat::TremoloCompat*, XmlReader&)
+void Read302::readTremoloCompat(compat::TremoloCompat*, Score*, XmlReader&)
 {
     UNREACHABLE;
 }

--- a/src/engraving/rw/read302/read302.h
+++ b/src/engraving/rw/read302/read302.h
@@ -49,7 +49,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
 private:
     void doReadItem(EngravingItem* item, XmlReader& xml) override;

--- a/src/engraving/rw/read400/measurerw.cpp
+++ b/src/engraving/rw/read400/measurerw.cpp
@@ -172,7 +172,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         } else if (tag == "measureRepeatCount") {
             measure->setMeasureRepeatCount(e.readInt(), staffIdx);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            SystemDivider* sd = new SystemDivider(ctx.dummy());
             TRead::read(sd, e, ctx);
             //! TODO Looks like a bug.
             //! The SystemDivider parent must be System
@@ -231,7 +231,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             LOGD() << "read midi tick";
             ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
         } else if (tag == "BarLine") {
-            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* barLine = Factory::createBarLine(ctx.dummy());
             barLine->setTrack(ctx.track());
             TRead::read(barLine, e, ctx);
             //
@@ -264,7 +264,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 fermata = nullptr;
             }
         } else if (tag == "Chord") {
-            Chord* chord = Factory::createChord(ctx.dummy()->segment());
+            Chord* chord = Factory::createChord(ctx.dummy());
             chord->setTrack(ctx.track());
             TRead::read(chord, e, ctx);
             if (startingBeam) {
@@ -353,7 +353,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment->add(mr);
             ctx.incTick(measure->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            Clef* clef = Factory::createClef(ctx.dummy());
             clef->setTrack(ctx.track());
             TRead::read(clef, e, ctx);
             clef->setGenerated(false);
@@ -395,7 +395,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment->add(clef);
             clef->setIsHeader(header);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy());
             ts->setTrack(ctx.track());
             TRead::read(ts, e, ctx);
             // if time sig not at beginning of measure => courtesy time sig
@@ -418,7 +418,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 }
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             TRead::read(ks, e, ctx);
             Fraction curTick = ctx.tick();
@@ -570,7 +570,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 }
             }
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy()->segment());
+            fermata = Factory::createFermata(ctx.dummy());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/engraving/rw/read400/measurerw.cpp
+++ b/src/engraving/rw/read400/measurerw.cpp
@@ -48,6 +48,7 @@
 #include "../dom/staff.h"
 #include "../dom/stafflines.h"
 #include "../dom/stafftext.h"
+#include "../dom/system.h"
 #include "../dom/systemdivider.h"
 #include "../dom/timesig.h"
 #include "../dom/tuplet.h"

--- a/src/engraving/rw/read400/measurerw.cpp
+++ b/src/engraving/rw/read400/measurerw.cpp
@@ -81,7 +81,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         Staff* staff = ctx.staff(n);
         MStaff* s = new MStaff;
         s->setLines(Factory::createStaffLines(measure));
-        s->lines()->setOwnershipParent(measure);
         s->lines()->setTrack(n * VOICES);
         s->lines()->setVisible(!staff->isLinesInvisible(measure->tick()));
         measure->mstaves().push_back(s);
@@ -298,7 +297,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 segment = measure->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
                 mmr->setTrack(ctx.track());
-                mmr->setOwnershipParent(segment);
                 TRead::read(mmr, e, ctx);
                 segment->add(mmr);
                 ctx.incTick(mmr->actualTicks());
@@ -591,7 +589,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             tuplet = Factory::createTuplet(measure);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(measure);
             TRead::read(tuplet, e, ctx);
             if (oldTuplet) {
                 oldTuplet->add(tuplet);
@@ -628,7 +625,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(SegmentType::Ambitus, ctx.tick());
             Ambitus* range = Factory::createAmbitus(segment);
             TRead::read(range, e, ctx);
-            range->setOwnershipParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(ctx.track()));
             segment->add(range);
         } else {

--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -716,7 +716,6 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     Clef* clef = Factory::createClef(segment);
                     TRead::read(clef, e, ctx);
                     clef->setTrack(ctx.track());
-                    clef->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), clef);
                 } else if (tag == "Breath") {
                     Fraction tick = doScale ? (ctx.tick() - dstTick) * scale + dstTick : ctx.tick();
@@ -729,7 +728,6 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     breath->setTrack(ctx.track());
                     breath->setPlacement(breath->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
                     TRead::read(breath, e, ctx);
-                    breath->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), breath);
                 } else if (tag == "Beam") {
                     Beam* beam = Factory::createBeam(score);
@@ -947,7 +945,6 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                         el->setTrack(trackZeroVoice(destTrack));
                         TRead::read(el, e, ctx);
                         el->setTrack(trackZeroVoice(destTrack));
-                        el->setOwnershipParent(harmSegm);
                         score->undoAddElement(el);
                     }
                 } else if (tag == "Dynamic") {
@@ -960,7 +957,6 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                     d->setTrack(destTrack);
                     TRead::read(d, e, ctx);
                     d->setTrack(destTrack);
-                    d->setOwnershipParent(destCR->segment());
                     score->undoAddElement(d);
                 } else if (tag == "HairPin") {
                     if (destTrack >= maxTrack) {
@@ -1000,7 +996,6 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                         Articulation* el = Factory::createArticulation(cr);
                         TRead::read(el, e, ctx);
                         el->setTrack(destTrack);
-                        el->setOwnershipParent(cr);
                         if (!el->isFermata() && cr->isRest()) {
                             delete el;
                         } else {
@@ -1122,7 +1117,6 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                         el->setTrack(destTrack);
                         TRead::read(el, e, ctx);
                         el->setTrack(destTrack);
-                        el->setOwnershipParent(cr);
                         score->undoAddElement(el);
                     } else {
                         LOGD("PasteSymbols: element %s not handled", tag.ascii());

--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -968,7 +968,7 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                         e.skipCurrentElement();
                         continue;
                     }
-                    Hairpin* h = Factory::createHairpin(score->dummy()->segment());
+                    Hairpin* h = Factory::createHairpin(score->dummy());
                     h->setTrack(destTrack);
                     TRead::read(h, e, ctx);
                     h->setTrack(destTrack);
@@ -1134,7 +1134,7 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
     }                                     // inner while readNextstartElement()
 }                                         // pasteSymbolList()
 
-void Read400::readTremoloCompat(compat::TremoloCompat*, XmlReader&)
+void Read400::readTremoloCompat(compat::TremoloCompat*, Score*, XmlReader&)
 {
     UNREACHABLE;
 }

--- a/src/engraving/rw/read400/read400.h
+++ b/src/engraving/rw/read400/read400.h
@@ -40,7 +40,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
 private:
     bool preparePasteDurationElement(Score* score, const Fraction& tick, const Fraction& ticks, const track_idx_t track);

--- a/src/engraving/rw/read400/readcontext.cpp
+++ b/src/engraving/rw/read400/readcontext.cpp
@@ -112,7 +112,7 @@ void ReadContext::setSpatium(double v)
     m_score->style().set(Sid::spatium, v);
 }
 
-compat::DummyElement* ReadContext::dummy() const
+DummyParent* ReadContext::dummy() const
 {
     return m_score->dummy();
 }

--- a/src/engraving/rw/read400/readcontext.h
+++ b/src/engraving/rw/read400/readcontext.h
@@ -45,6 +45,7 @@
 namespace mu::engraving {
 class BarLine;
 class Beam;
+class DummyParent;
 class EngravingObject;
 class LinkedObjects;
 class Measure;
@@ -53,10 +54,6 @@ class Spanner;
 class Staff;
 class Tuplet;
 class MStyle;
-}
-
-namespace mu::engraving::compat {
-class DummyElement;
 }
 
 namespace mu::engraving::read400 {
@@ -107,7 +104,7 @@ public:
     bool forcePageMode() const { return m_forcePageMode; }
     void setForcePageMode(bool v) { m_forcePageMode = v; }
 
-    compat::DummyElement* dummy() const;
+    DummyParent* dummy() const;
 
     Staff* staff(staff_idx_t n);
 

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -703,7 +703,7 @@ void TRead::read(FretDiagram* d, XmlReader& e, ReadContext& ctx)
         } else if (tag == "mag") {
             TRead::readProperty(d, e, ctx, Pid::MAG);
         } else if (tag == "Harmony") {
-            Harmony* h = new Harmony(d->score()->dummy()->segment());
+            Harmony* h = new Harmony(d->score()->dummy());
             read(h, e, ctx);
             if (h->chords().empty()) {
                 // Invalid harmony
@@ -1786,7 +1786,7 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
-        Chord* chord = Factory::createChord(ctx.score()->dummy()->segment());
+        Chord* chord = Factory::createChord(ctx.score()->dummy());
         TRead::read(chord, xml, ctx);
         chord->setTrack(ctx.track());
         o->setCueNoteChord(chord);
@@ -1900,7 +1900,7 @@ void TRead::read(BarLine* b, XmlReader& e, ReadContext& ctx)
         } else if (tag == "spanToOffset") {
             b->setSpanTo(e.readInt());
         } else if (tag == "Articulation") {
-            Articulation* a = Factory::createArticulation(b->score()->dummy()->chord());
+            Articulation* a = Factory::createArticulation(b->score()->dummy());
             TRead::read(a, e, ctx);
             b->add(a);
         } else if (tag == "Symbol") {
@@ -2070,7 +2070,7 @@ bool TRead::readProperties(Box* b, XmlReader& e, ReadContext& ctx)
             b->add(image);
         }
     } else if (tag == "FretDiagram") {
-        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy()->segment());
+        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy());
         TRead::read(f, e, ctx);
         //! TODO Looks like a bug.
         //! The FretDiagram parent must be Segment

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -1500,7 +1500,6 @@ void TRead::read(Tuplet* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Number") {
             number = Factory::createText(t, TextStyleType::TUPLET);
             number->setComposition(true);
-            number->setOwnershipParent(t);
             Tuplet::resetNumberProperty(number);
             TRead::read(number, e, ctx);
             number->setVisible(t->visible());         //?? override saved property
@@ -1783,7 +1782,6 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
     } else if (tag == "Accidental") {
         Accidental* accidental = Factory::createAccidental(o);
         TRead::read(accidental, xml, ctx);
-        accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
         Chord* chord = Factory::createChord(ctx.score()->dummy());
@@ -2145,7 +2143,6 @@ bool TRead::readProperties(MeasureBase* b, XmlReader& e, ReadContext& ctx)
     } else if (tag == "StaffTypeChange") {
         StaffTypeChange* stc = Factory::createStaffTypeChange(b);
         stc->setTrack(ctx.track());
-        stc->setOwnershipParent(b);
         TRead::read(stc, e, ctx);
         b->add(stc);
     } else if (readItemProperties(b, e, ctx)) {
@@ -2331,7 +2328,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Note* note = Factory::createNote(ch);
         // the note needs to know the properties of the track it belongs to
         note->setTrack(ch->track());
-        note->setOwnershipParent(ch);
         TRead::read(note, e, ctx);
         ch->add(note);
     } else if (TRead::readProperties(toChordRest(ch), e, ctx)) {
@@ -2379,7 +2375,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());
         TRead::read(arpeggio, e, ctx);
-        arpeggio->setOwnershipParent(ch);
         ch->setArpeggio(arpeggio);
     } else if (tag == "Tremolo") {
         TremoloCompat tcompat;
@@ -4336,7 +4331,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Accidental") {
             Accidental* accidental = Factory::createAccidental(t);
             TRead::read(accidental, e, ctx);
-            accidental->setOwnershipParent(t);
             t->setAccidental(accidental);
             if (t->ornament()) {
                 t->ornament()->setTrillOldCompatAccidental(accidental);

--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -78,7 +78,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         Staff* staff = ctx.staff(n);
         MStaff* s = new MStaff;
         s->setLines(Factory::createStaffLines(measure));
-        s->lines()->setOwnershipParent(measure);
         s->lines()->setTrack(n * VOICES);
         s->lines()->setVisible(!staff->isLinesInvisible(measure->tick()));
         measure->mstaves().push_back(s);
@@ -291,7 +290,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 segment = measure->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
                 mmr->setTrack(ctx.track());
-                mmr->setOwnershipParent(segment);
                 TRead::read(mmr, e, ctx);
                 segment->add(mmr);
                 ctx.incTick(mmr->actualTicks());
@@ -557,7 +555,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             tuplet = Factory::createTuplet(measure);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(measure);
             TRead::read(tuplet, e, ctx);
             if (oldTuplet) {
                 oldTuplet->add(tuplet);
@@ -594,7 +591,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(SegmentType::Ambitus, ctx.tick());
             Ambitus* range = Factory::createAmbitus(segment);
             TRead::read(range, e, ctx);
-            range->setOwnershipParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(ctx.track()));
             segment->add(range);
         } else {

--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -162,7 +162,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         } else if (tag == "measureRepeatCount") {
             measure->setMeasureRepeatCount(e.readInt(), staffIdx);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            SystemDivider* sd = new SystemDivider(ctx.dummy());
             TRead::read(sd, e, ctx);
             //! TODO Looks like a bug.
             //! The SystemDivider parent must be System
@@ -224,7 +224,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             LOGD() << "read midi tick";
             ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
         } else if (tag == "BarLine") {
-            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* barLine = Factory::createBarLine(ctx.dummy());
             barLine->setTrack(ctx.track());
             TRead::read(barLine, e, ctx);
             //
@@ -257,7 +257,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 fermata = nullptr;
             }
         } else if (tag == "Chord") {
-            Chord* chord = Factory::createChord(ctx.dummy()->segment());
+            Chord* chord = Factory::createChord(ctx.dummy());
             chord->setTrack(ctx.track());
             TRead::read(chord, e, ctx);
             if (startingBeam) {
@@ -346,7 +346,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment->add(mr);
             ctx.incTick(measure->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            Clef* clef = Factory::createClef(ctx.dummy());
             clef->setTrack(ctx.track());
             TRead::read(clef, e, ctx);
             clef->setGenerated(false);
@@ -364,7 +364,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(header ? SegmentType::HeaderClef : SegmentType::Clef, ctx.tick());
             segment->add(clef);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy());
             ts->setTrack(ctx.track());
             TRead::read(ts, e, ctx);
 
@@ -393,7 +393,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 ctx.setTimeSigForNextMeasure(ts->sig() / ts->stretch().reduced());
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             TRead::read(ks, e, ctx);
 
@@ -536,7 +536,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             }
             segment->add(el);
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy()->segment());
+            fermata = Factory::createFermata(ctx.dummy());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -47,6 +47,7 @@
 #include "../dom/staff.h"
 #include "../dom/stafflines.h"
 #include "../dom/stafftext.h"
+#include "../dom/system.h"
 #include "../dom/systemdivider.h"
 #include "../dom/timesig.h"
 #include "../dom/tuplet.h"

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -959,7 +959,7 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Fermata* b = Factory::createFermata(score->dummy()->segment());
+                Fermata* b = Factory::createFermata(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -979,7 +979,7 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Breath* b = Factory::createBreath(score->dummy()->segment());
+                Breath* b = Factory::createBreath(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -1214,7 +1214,7 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
     } // inner while readNextstartElement()
 }
 
-void Read410::readTremoloCompat(compat::TremoloCompat* tc, XmlReader& xml)
+void Read410::readTremoloCompat(compat::TremoloCompat* tc, Score* score, XmlReader& xml)
 {
     IF_ASSERT_FAILED(tc->parent) {
         return;

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -725,7 +725,6 @@ bool Read410::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     Clef* clef = Factory::createClef(segment);
                     TRead::read(clef, e, ctx);
                     clef->setTrack(ctx.track());
-                    clef->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), clef);
                 } else if (tag == "Breath") {
                     Fraction tick = doScale ? (ctx.tick() - dstTick) * scale + dstTick : ctx.tick();
@@ -738,7 +737,6 @@ bool Read410::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     breath->setTrack(ctx.track());
                     breath->setPlacement(breath->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
                     TRead::read(breath, e, ctx);
-                    breath->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), breath);
                 } else if (tag == "Beam") {
                     Beam* beam = Factory::createBeam(score);
@@ -1072,7 +1070,6 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(trackZeroVoice(destTrack));
                     TRead::read(el, e, ctx);
                     el->setTrack(trackZeroVoice(destTrack));
-                    el->setOwnershipParent(seg);
                     score->undoAddElement(el);
                 }
             } else if (tag == "Lyrics" || tag == "FiguredBass") {
@@ -1121,7 +1118,6 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(destTrack);
                     TRead::read(el, e, ctx);
                     el->setTrack(destTrack);
-                    el->setOwnershipParent(cr);
                     score->undoAddElement(el);
                 } else if (tag == "FiguredBass") {
                     // FiguredBass always belongs to first staff voice

--- a/src/engraving/rw/read410/read410.h
+++ b/src/engraving/rw/read410/read410.h
@@ -40,7 +40,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
 private:
     bool preparePasteDurationElement(Score* score, const Fraction& tick, const Fraction& ticks, const track_idx_t track);

--- a/src/engraving/rw/read410/readcontext.cpp
+++ b/src/engraving/rw/read410/readcontext.cpp
@@ -106,7 +106,7 @@ void ReadContext::setSpatium(double v)
     m_score->style().set(Sid::spatium, v);
 }
 
-compat::DummyElement* ReadContext::dummy() const
+DummyParent* ReadContext::dummy() const
 {
     return m_score->dummy();
 }

--- a/src/engraving/rw/read410/readcontext.h
+++ b/src/engraving/rw/read410/readcontext.h
@@ -40,6 +40,7 @@
 
 namespace mu::engraving {
 class Beam;
+class DummyParent;
 class EngravingObject;
 class LinkedObjects;
 class Measure;
@@ -48,10 +49,6 @@ class Spanner;
 class Staff;
 class Tuplet;
 class MStyle;
-}
-
-namespace mu::engraving::compat {
-class DummyElement;
 }
 
 namespace mu::engraving::read410 {
@@ -91,7 +88,7 @@ public:
     bool forcePageMode() const { return m_forcePageMode; }
     void setForcePageMode(bool v) { m_forcePageMode = v; }
 
-    compat::DummyElement* dummy() const;
+    DummyParent* dummy() const;
 
     Staff* staff(staff_idx_t n);
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1601,7 +1601,6 @@ void TRead::read(Tuplet* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Number") {
             number = Factory::createText(t, TextStyleType::TUPLET);
             number->setComposition(true);
-            number->setOwnershipParent(t);
             Tuplet::resetNumberProperty(number);
             TRead::read(number, e, ctx);
             number->setVisible(t->visible());         //?? override saved property
@@ -1925,7 +1924,6 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         Accidental* accidental = Factory::createAccidental(o);
         TRead::read(accidental, xml, ctx);
         accidental->setTrack(ctx.track());
-        accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
         Chord* chord = Factory::createChord(ctx.score()->dummy());
@@ -2271,7 +2269,6 @@ bool TRead::readProperties(MeasureBase* b, XmlReader& e, ReadContext& ctx)
     } else if (tag == "StaffTypeChange") {
         StaffTypeChange* stc = Factory::createStaffTypeChange(b);
         stc->setTrack(ctx.track());
-        stc->setOwnershipParent(b);
         TRead::read(stc, e, ctx);
         b->add(stc);
     } else if (readItemProperties(b, e, ctx)) {
@@ -2448,7 +2445,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Note* note = Factory::createNote(ch);
         // the note needs to know the properties of the track it belongs to
         note->setTrack(ch->track());
-        note->setOwnershipParent(ch);
         TRead::read(note, e, ctx);
         ch->add(note);
     } else if (TRead::readProperties(toChordRest(ch), e, ctx)) {
@@ -2498,7 +2494,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());
         TRead::read(arpeggio, e, ctx);
-        arpeggio->setOwnershipParent(ch);
         ch->setArpeggio(arpeggio);
     } else if (tag == "Tremolo") { // compat
         compat::TremoloCompat tcompat;
@@ -2519,14 +2514,12 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         TremoloSingleChord* trem = Factory::createTremoloSingleChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloSingleChord(trem);
     } else if (tag == "TremoloTwoChord") {
         TremoloTwoChord* trem = Factory::createTremoloTwoChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloTwoChord(trem, false);
     } else if (tag == "ChordLine") {
@@ -2842,7 +2835,6 @@ void TRead::read(GuitarBend* g, XmlReader& e, ReadContext& ctx)
         } else if (tag == "GuitarBendHold") {
             GuitarBendHold* hold = new GuitarBendHold(g);
             TRead::read(hold, e, ctx);
-            hold->setOwnershipParent(g);
             g->setHoldLine(hold);
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::DIRECTION)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::BEND_SHOW_HOLD_LINE)) {
@@ -2872,7 +2864,6 @@ bool TRead::readProperties(GuitarBendSegment* g, const AsciiStringView& tag, Xml
         g->setVertexPointOff(xml.readPoint() * g->style().spatium());
     } else if (tag == "GuitarBendText") {
         GuitarBendText* bendText = new GuitarBendText(g);
-        bendText->setOwnershipParent(g);
         read(toTextBase(bendText), xml, ctx);
         g->setBendText(bendText);
     } else {
@@ -3357,7 +3348,6 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
     } else if (tag == "LaissezVib") {
         LaissezVib* lv = Factory::createLaissezVib(n);
         TRead::read(lv, e, ctx);
-        lv->setOwnershipParent(n);
         n->add(lv);
     } else if (tag == "PartialTie") {
         PartialTie* pt = Factory::createPartialTie(n);
@@ -4442,7 +4432,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Accidental") {
             Accidental* accidental = Factory::createAccidental(t);
             TRead::read(accidental, e, ctx);
-            accidental->setOwnershipParent(t);
             t->setAccidental(accidental);
             if (t->ornament()) {
                 t->ornament()->setTrillOldCompatAccidental(accidental);

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -886,7 +886,7 @@ void TRead::read(FretDiagram* d, XmlReader& e, ReadContext& ctx)
         } else if (tag == "mag") {
             TRead::readProperty(d, e, ctx, Pid::MAG);
         } else if (tag == "Harmony") {
-            Harmony* h = new Harmony(d->score()->dummy()->segment());
+            Harmony* h = new Harmony(d->score()->dummy());
             read(h, e, ctx);
             if (h->chords().empty()) {
                 // Invalid harmony
@@ -1928,7 +1928,7 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
-        Chord* chord = Factory::createChord(ctx.score()->dummy()->segment());
+        Chord* chord = Factory::createChord(ctx.score()->dummy());
         TRead::read(chord, xml, ctx);
         chord->setTrack(ctx.track());
         chord->setIsTrillCueNote(true);
@@ -2020,7 +2020,7 @@ void TRead::read(BarLine* b, XmlReader& e, ReadContext& ctx)
         } else if (tag == "spanToOffset") {
             b->setSpanTo(e.readInt());
         } else if (tag == "Articulation") {
-            Articulation* a = Factory::createArticulation(b->score()->dummy()->chord());
+            Articulation* a = Factory::createArticulation(b->score()->dummy());
             TRead::read(a, e, ctx);
             b->add(a);
         } else if (tag == "Symbol") {
@@ -2196,7 +2196,7 @@ bool TRead::readProperties(Box* b, XmlReader& e, ReadContext& ctx)
             b->add(image);
         }
     } else if (tag == "FretDiagram") {
-        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy()->segment());
+        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy());
         TRead::read(f, e, ctx);
         //! TODO Looks like a bug.
         //! The FretDiagram parent must be Segment
@@ -4246,20 +4246,24 @@ void TRead::read(compat::TremoloCompat* tc, XmlReader& e, ReadContext& ctx)
         return tc->single;
     };
 
+    // read on its own, e.g. into a palette, there is no chord to belong to
+    const DummyParentOr<Chord> parent = parentOrDummy(tc->parent, ctx.dummy());
+    const track_idx_t track = tc->parent ? tc->parent->track() : 0;
+
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "subtype") {
             TremoloType type = TConv::fromXml(e.readAsciiText(), TremoloType::INVALID_TREMOLO);
             if (isTremoloTwoChord(type)) {
                 if (!tc->two) {
-                    tc->two = Factory::createTremoloTwoChord(tc->parent);
-                    tc->two->setTrack(tc->parent->track());
+                    tc->two = Factory::createTremoloTwoChord(parent);
+                    tc->two->setTrack(track);
                 }
                 tc->two->setTremoloType(type);
             } else {
                 if (!tc->single) {
-                    tc->single = Factory::createTremoloSingleChord(tc->parent);
-                    tc->single->setTrack(tc->parent->track());
+                    tc->single = Factory::createTremoloSingleChord(parent);
+                    tc->single->setTrack(track);
                 }
                 tc->single->setTremoloType(type);
             }

--- a/src/engraving/rw/read460/measureread.cpp
+++ b/src/engraving/rw/read460/measureread.cpp
@@ -79,7 +79,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         Staff* staff = ctx.staff(n);
         MStaff* s = new MStaff;
         s->setLines(Factory::createStaffLines(measure));
-        s->lines()->setOwnershipParent(measure);
         s->lines()->setTrack(n * VOICES);
         s->lines()->setVisible(!staff->isLinesInvisible(measure->tick()));
         measure->mstaves().push_back(s);
@@ -294,7 +293,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 segment = measure->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
                 mmr->setTrack(ctx.track());
-                mmr->setOwnershipParent(segment);
                 TRead::read(mmr, e, ctx);
                 segment->add(mmr);
                 ctx.incTick(mmr->actualTicks());
@@ -548,7 +546,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             tuplet = Factory::createTuplet(measure);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(measure);
             TRead::read(tuplet, e, ctx);
             if (oldTuplet) {
                 oldTuplet->add(tuplet);
@@ -585,7 +582,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(SegmentType::Ambitus, ctx.tick());
             Ambitus* range = Factory::createAmbitus(segment);
             TRead::read(range, e, ctx);
-            range->setOwnershipParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(ctx.track()));
             segment->add(range);
         } else {

--- a/src/engraving/rw/read460/measureread.cpp
+++ b/src/engraving/rw/read460/measureread.cpp
@@ -165,7 +165,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         } else if (tag == "measureRepeatCount") {
             measure->setMeasureRepeatCount(e.readInt(), staffIdx);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            SystemDivider* sd = new SystemDivider(ctx.dummy());
             TRead::read(sd, e, ctx);
             //! TODO Looks like a bug.
             //! The SystemDivider parent must be System
@@ -227,7 +227,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             LOGD() << "read midi tick";
             ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
         } else if (tag == "BarLine") {
-            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* barLine = Factory::createBarLine(ctx.dummy());
             barLine->setTrack(ctx.track());
             TRead::read(barLine, e, ctx);
             //
@@ -260,7 +260,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 fermata = nullptr;
             }
         } else if (tag == "Chord") {
-            Chord* chord = Factory::createChord(ctx.dummy()->segment());
+            Chord* chord = Factory::createChord(ctx.dummy());
             chord->setTrack(ctx.track());
             TRead::read(chord, e, ctx);
             if (startingBeam) {
@@ -349,7 +349,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment->add(mr);
             ctx.incTick(measure->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            Clef* clef = Factory::createClef(ctx.dummy());
             clef->setTrack(ctx.track());
             TRead::read(clef, e, ctx);
             clef->setGenerated(false);
@@ -357,7 +357,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(clef->isHeader() ? SegmentType::HeaderClef : SegmentType::Clef, ctx.tick());
             segment->add(clef);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy());
             ts->setTrack(ctx.track());
             TRead::read(ts, e, ctx);
 
@@ -386,7 +386,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 }
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             TRead::read(ks, e, ctx);
 
@@ -517,7 +517,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             }
             segment->add(el);
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy()->segment());
+            fermata = Factory::createFermata(ctx.dummy());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/engraving/rw/read460/measureread.cpp
+++ b/src/engraving/rw/read460/measureread.cpp
@@ -47,6 +47,7 @@
 #include "../dom/staff.h"
 #include "../dom/stafflines.h"
 #include "../dom/stafftext.h"
+#include "../dom/system.h"
 #include "../dom/systemdivider.h"
 #include "../dom/timesig.h"
 #include "../dom/tuplet.h"

--- a/src/engraving/rw/read460/read460.cpp
+++ b/src/engraving/rw/read460/read460.cpp
@@ -732,7 +732,6 @@ bool Read460::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     Clef* clef = Factory::createClef(segment);
                     TRead::read(clef, e, ctx);
                     clef->setTrack(ctx.track());
-                    clef->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), clef);
                 } else if (tag == "Breath") {
                     Fraction tick = doScale ? (ctx.tick() - dstTick) * scale + dstTick : ctx.tick();
@@ -745,7 +744,6 @@ bool Read460::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     breath->setTrack(ctx.track());
                     breath->setPlacement(breath->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
                     TRead::read(breath, e, ctx);
-                    breath->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), breath);
                 } else if (tag == "Beam") {
                     Beam* beam = Factory::createBeam(score);
@@ -1079,7 +1077,6 @@ void Read460::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(trackZeroVoice(destTrack));
                     TRead::read(el, e, ctx);
                     el->setTrack(trackZeroVoice(destTrack));
-                    el->setOwnershipParent(seg);
                     score->undoAddElement(el);
                 }
             } else if (tag == "Lyrics" || tag == "FiguredBass") {
@@ -1128,7 +1125,6 @@ void Read460::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(destTrack);
                     TRead::read(el, e, ctx);
                     el->setTrack(destTrack);
-                    el->setOwnershipParent(cr);
                     score->undoAddElement(el);
                 } else if (tag == "FiguredBass") {
                     // FiguredBass always belongs to first staff voice

--- a/src/engraving/rw/read460/read460.cpp
+++ b/src/engraving/rw/read460/read460.cpp
@@ -966,7 +966,7 @@ void Read460::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Fermata* b = Factory::createFermata(score->dummy()->segment());
+                Fermata* b = Factory::createFermata(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -986,7 +986,7 @@ void Read460::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Breath* b = Factory::createBreath(score->dummy()->segment());
+                Breath* b = Factory::createBreath(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -1221,7 +1221,7 @@ void Read460::pasteSymbols(XmlReader& e, ChordRest* dst)
     } // inner while readNextstartElement()
 }
 
-void Read460::readTremoloCompat(compat::TremoloCompat* tc, XmlReader& xml)
+void Read460::readTremoloCompat(compat::TremoloCompat* tc, Score* score, XmlReader& xml)
 {
     IF_ASSERT_FAILED(tc->parent) {
         return;

--- a/src/engraving/rw/read460/read460.h
+++ b/src/engraving/rw/read460/read460.h
@@ -40,7 +40,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
 private:
     bool preparePasteDurationElement(Score* score, const Fraction& tick, const Fraction& ticks, const track_idx_t track);

--- a/src/engraving/rw/read460/readcontext.cpp
+++ b/src/engraving/rw/read460/readcontext.cpp
@@ -106,7 +106,7 @@ void ReadContext::setSpatium(double v)
     m_score->style().set(Sid::spatium, v);
 }
 
-compat::DummyElement* ReadContext::dummy() const
+DummyParent* ReadContext::dummy() const
 {
     return m_score->dummy();
 }

--- a/src/engraving/rw/read460/readcontext.h
+++ b/src/engraving/rw/read460/readcontext.h
@@ -36,6 +36,7 @@
 
 namespace mu::engraving {
 class Beam;
+class DummyParent;
 class EngravingObject;
 class LinkedObjects;
 class Measure;
@@ -44,10 +45,6 @@ class Spanner;
 class Staff;
 class Tuplet;
 class MStyle;
-}
-
-namespace mu::engraving::compat {
-class DummyElement;
 }
 
 namespace mu::engraving::read460 {
@@ -87,7 +84,7 @@ public:
     bool forcePageMode() const { return m_forcePageMode; }
     void setForcePageMode(bool v) { m_forcePageMode = v; }
 
-    compat::DummyElement* dummy() const;
+    DummyParent* dummy() const;
 
     Staff* staff(staff_idx_t n);
 

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -575,7 +575,6 @@ bool TRead::readItemProperties(EngravingItem* item, XmlReader& e, ReadContext& c
     } else if (tag == "Parenthesis") {
         Parenthesis* p = Factory::createParenthesis(item);
         TRead::read(p, e, ctx);
-        p->setOwnershipParent(item);
         p->setTrack(ctx.track());
         item->add(p);
     } else {
@@ -1571,7 +1570,6 @@ void TRead::read(Tuplet* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Number") {
             number = Factory::createText(t, TextStyleType::TUPLET);
             number->setComposition(true);
-            number->setOwnershipParent(t);
             Tuplet::resetNumberProperty(number);
             TRead::read(number, e, ctx);
             number->setVisible(t->visible());         //?? override saved property
@@ -1926,7 +1924,6 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         Accidental* accidental = Factory::createAccidental(o);
         TRead::read(accidental, xml, ctx);
         accidental->setTrack(ctx.track());
-        accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
         Chord* chord = Factory::createChord(ctx.score()->dummy());
@@ -1994,7 +1991,6 @@ void TRead::read(Tapping* t, XmlReader& xml, ReadContext& ctx)
         } else if (tag == TConv::toXml(ElementType::TAPPING_HALF_SLUR)) {
             TappingHalfSlur* tappingHalfSlur = new TappingHalfSlur(t);
             read(tappingHalfSlur, xml, ctx);
-            tappingHalfSlur->setOwnershipParent(t);
             if (tappingHalfSlur->isHalfSlurAbove()) {
                 t->setHalfSlurAbove(tappingHalfSlur);
             } else {
@@ -2291,7 +2287,6 @@ bool TRead::readProperties(MeasureBase* b, XmlReader& e, ReadContext& ctx)
     } else if (tag == "StaffTypeChange") {
         StaffTypeChange* stc = Factory::createStaffTypeChange(b);
         stc->setTrack(ctx.track());
-        stc->setOwnershipParent(b);
         TRead::read(stc, e, ctx);
         b->add(stc);
     } else if (readItemProperties(b, e, ctx)) {
@@ -2463,7 +2458,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Note* note = Factory::createNote(ch);
         // the note needs to know the properties of the track it belongs to
         note->setTrack(ch->track());
-        note->setOwnershipParent(ch);
         TRead::read(note, e, ctx);
         ch->add(note);
     } else if (TRead::readProperties(toChordRest(ch), e, ctx)) {
@@ -2513,13 +2507,11 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());
         TRead::read(arpeggio, e, ctx);
-        arpeggio->setOwnershipParent(ch);
         ch->setArpeggio(arpeggio);
     } else if (tag == "ChordBracket") {
         ChordBracket* bracket = Factory::createChordBracket(ch);
         bracket->setTrack(ch->track());
         TRead::read(bracket, e, ctx);
-        bracket->setOwnershipParent(ch);
         ch->add(bracket);
     } else if (tag == "Tremolo") { // compat
         compat::TremoloCompat tcompat;
@@ -2540,14 +2532,12 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         TremoloSingleChord* trem = Factory::createTremoloSingleChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloSingleChord(trem);
     } else if (tag == "TremoloTwoChord") {
         TremoloTwoChord* trem = Factory::createTremoloTwoChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloTwoChord(trem, false);
     } else if (tag == "ChordLine") {
@@ -2864,7 +2854,6 @@ void TRead::read(GuitarBend* g, XmlReader& e, ReadContext& ctx)
         } else if (tag == "GuitarBendHold") {
             GuitarBendHold* hold = new GuitarBendHold(g);
             TRead::read(hold, e, ctx);
-            hold->setOwnershipParent(g);
             g->setHoldLine(hold);
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::DIRECTION)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::BEND_SHOW_HOLD_LINE)) {
@@ -2899,7 +2888,6 @@ bool TRead::readProperties(GuitarBendSegment* g, const AsciiStringView& tag, Xml
         g->setVertexPointOff(xml.readPoint() * g->style().spatium());
     } else if (tag == "GuitarBendText") {
         GuitarBendText* bendText = new GuitarBendText(g);
-        bendText->setOwnershipParent(g);
         read(toTextBase(bendText), xml, ctx);
         g->setBendText(bendText);
     } else {
@@ -3207,7 +3195,6 @@ bool TRead::readProperties(Lyrics* l, XmlReader& e, ReadContext& ctx)
     } else if (tag == "LyricsLine") {
         LyricsLine* ll = Factory::createLyricsLine(l);
         TRead::read(ll, e, ctx);
-        ll->setOwnershipParent(l);
         ll->setTick(ctx.tick());
         l->setSeparator(ll);
         ctx.score()->addUnmanagedSpanner(ll);
@@ -3405,7 +3392,6 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
     } else if (tag == "LaissezVib") {
         LaissezVib* lv = Factory::createLaissezVib(n);
         TRead::read(lv, e, ctx);
-        lv->setOwnershipParent(n);
         n->add(lv);
     } else if (tag == "PartialTie") {
         PartialTie* pt = Factory::createPartialTie(n);
@@ -3850,7 +3836,6 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
         if (t == "Parenthesis") {
             Parenthesis* paren = Factory::createParenthesis(ch);
             TRead::read(paren, e, ctx);
-            paren->setOwnershipParent(ch);
             paren->setTrack(ctx.track());
 
             if (paren->direction() == DirectionH::LEFT) {
@@ -3898,14 +3883,12 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
 
     if (!leftParen) {
         leftParen = Factory::createParenthesis(ch);
-        leftParen->setOwnershipParent(ch);
         leftParen->setTrack(ctx.track());
     }
 
     if (!rightParen) {
         rightParen = Factory::createParenthesis(ch);
         rightParen->setDirection(DirectionH::RIGHT);
-        rightParen->setOwnershipParent(ch);
         rightParen->setTrack(ctx.track());
     }
 
@@ -4585,7 +4568,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Accidental") {
             Accidental* accidental = Factory::createAccidental(t);
             TRead::read(accidental, e, ctx);
-            accidental->setOwnershipParent(t);
             t->setAccidental(accidental);
             if (t->ornament()) {
                 t->ornament()->setTrillOldCompatAccidental(accidental);

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -863,7 +863,7 @@ void TRead::read(FretDiagram* d, XmlReader& e, ReadContext& ctx)
         } else if (tag == "mag") {
             TRead::readProperty(d, e, ctx, Pid::MAG);
         } else if (tag == "Harmony") {
-            Harmony* h = new Harmony(d->score()->dummy()->segment());
+            Harmony* h = new Harmony(d->score()->dummy());
             read(h, e, ctx);
             if (h->chords().empty()) {
                 // Invalid harmony
@@ -1929,7 +1929,7 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
-        Chord* chord = Factory::createChord(ctx.score()->dummy()->segment());
+        Chord* chord = Factory::createChord(ctx.score()->dummy());
         TRead::read(chord, xml, ctx);
         chord->setTrack(ctx.track());
         chord->setIsTrillCueNote(true);
@@ -2047,7 +2047,7 @@ void TRead::read(BarLine* b, XmlReader& e, ReadContext& ctx)
         } else if (tag == "spanToOffset") {
             b->setSpanTo(e.readInt());
         } else if (tag == "Articulation") {
-            Articulation* a = Factory::createArticulation(b->score()->dummy()->chord());
+            Articulation* a = Factory::createArticulation(b->score()->dummy());
             TRead::read(a, e, ctx);
             b->add(a);
         } else if (tag == "Symbol") {
@@ -2214,7 +2214,7 @@ bool TRead::readProperties(Box* b, XmlReader& e, ReadContext& ctx)
             b->add(image);
         }
     } else if (tag == "FretDiagram") {
-        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy()->segment());
+        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy());
         TRead::read(f, e, ctx);
         //! TODO Looks like a bug.
         //! The FretDiagram parent must be Segment
@@ -4386,20 +4386,24 @@ void TRead::read(compat::TremoloCompat* tc, XmlReader& e, ReadContext& ctx)
         return tc->single;
     };
 
+    // read on its own, e.g. into a palette, there is no chord to belong to
+    const DummyParentOr<Chord> parent = parentOrDummy(tc->parent, ctx.dummy());
+    const track_idx_t track = tc->parent ? tc->parent->track() : 0;
+
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "subtype") {
             TremoloType type = TConv::fromXml(e.readAsciiText(), TremoloType::INVALID_TREMOLO);
             if (isTremoloTwoChord(type)) {
                 if (!tc->two) {
-                    tc->two = Factory::createTremoloTwoChord(tc->parent);
-                    tc->two->setTrack(tc->parent->track());
+                    tc->two = Factory::createTremoloTwoChord(parent);
+                    tc->two->setTrack(track);
                 }
                 tc->two->setTremoloType(type);
             } else {
                 if (!tc->single) {
-                    tc->single = Factory::createTremoloSingleChord(tc->parent);
-                    tc->single->setTrack(tc->parent->track());
+                    tc->single = Factory::createTremoloSingleChord(parent);
+                    tc->single->setTrack(track);
                 }
                 tc->single->setTremoloType(type);
             }
@@ -4691,7 +4695,7 @@ void TRead::readSystemDividers(Score* score, XmlReader& e, ReadContext& ctx)
             size_t systemIdx = e.intAttribute("idx");
             while (e.readNextStartElement()) {
                 if (e.name() == "SystemDivider") {
-                    SystemDivider* divider = new SystemDivider(score->dummy()->system());
+                    SystemDivider* divider = new SystemDivider(score->dummy());
                     read(divider, e, ctx);
                     score->addSystemDivider(systemIdx, divider);
                 } else {

--- a/src/engraving/rw/read500/measureread.cpp
+++ b/src/engraving/rw/read500/measureread.cpp
@@ -79,7 +79,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         Staff* staff = ctx.staff(n);
         MStaff* s = new MStaff;
         s->setLines(Factory::createStaffLines(measure));
-        s->lines()->setOwnershipParent(measure);
         s->lines()->setTrack(n * VOICES);
         s->lines()->setVisible(!staff->isLinesInvisible(measure->tick()));
         measure->mstaves().push_back(s);
@@ -298,7 +297,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 segment = measure->getSegment(SegmentType::ChordRest, ctx.tick());
                 MMRest* mmr = Factory::createMMRest(segment);
                 mmr->setTrack(ctx.track());
-                mmr->setOwnershipParent(segment);
                 TRead::read(mmr, e, ctx);
                 segment->add(mmr);
                 ctx.incTick(mmr->actualTicks());
@@ -550,7 +548,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             tuplet = Factory::createTuplet(measure);
             tuplet->setTrack(ctx.track());
             tuplet->setTick(ctx.tick());
-            tuplet->setOwnershipParent(measure);
             TRead::read(tuplet, e, ctx);
             if (oldTuplet) {
                 oldTuplet->add(tuplet);
@@ -587,7 +584,6 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(SegmentType::Ambitus, ctx.tick());
             Ambitus* range = Factory::createAmbitus(segment);
             TRead::read(range, e, ctx);
-            range->setOwnershipParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(ctx.track()));
             segment->add(range);
         } else {

--- a/src/engraving/rw/read500/measureread.cpp
+++ b/src/engraving/rw/read500/measureread.cpp
@@ -47,6 +47,7 @@
 #include "../dom/staff.h"
 #include "../dom/stafflines.h"
 #include "../dom/stafftext.h"
+#include "../dom/system.h"
 #include "../dom/systemdivider.h"
 #include "../dom/timesig.h"
 #include "../dom/tuplet.h"

--- a/src/engraving/rw/read500/measureread.cpp
+++ b/src/engraving/rw/read500/measureread.cpp
@@ -165,7 +165,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         } else if (tag == "measureRepeatCount") {
             measure->setMeasureRepeatCount(e.readInt(), staffIdx);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            SystemDivider* sd = new SystemDivider(ctx.dummy());
             TRead::read(sd, e, ctx);
             //! TODO Looks like a bug.
             //! The SystemDivider parent must be System
@@ -231,7 +231,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             LOGD() << "read midi tick";
             ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
         } else if (tag == "BarLine") {
-            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            BarLine* barLine = Factory::createBarLine(ctx.dummy());
             barLine->setTrack(ctx.track());
             TRead::read(barLine, e, ctx);
             //
@@ -264,7 +264,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 fermata = nullptr;
             }
         } else if (tag == "Chord") {
-            Chord* chord = Factory::createChord(ctx.dummy()->segment());
+            Chord* chord = Factory::createChord(ctx.dummy());
             chord->setTrack(ctx.track());
             TRead::read(chord, e, ctx);
             if (startingBeam) {
@@ -351,7 +351,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment->add(mr);
             ctx.incTick(measure->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            Clef* clef = Factory::createClef(ctx.dummy());
             clef->setTrack(ctx.track());
             TRead::read(clef, e, ctx);
             clef->setGenerated(false);
@@ -359,7 +359,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             segment = measure->getSegment(clef->isHeader() ? SegmentType::HeaderClef : SegmentType::Clef, ctx.tick());
             segment->add(clef);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy());
             ts->setTrack(ctx.track());
             TRead::read(ts, e, ctx);
 
@@ -388,7 +388,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 }
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            KeySig* ks = Factory::createKeySig(ctx.dummy());
             ks->setTrack(ctx.track());
             TRead::read(ks, e, ctx);
 
@@ -519,7 +519,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             }
             segment->add(el);
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy()->segment());
+            fermata = Factory::createFermata(ctx.dummy());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -965,7 +965,7 @@ void Read500::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Fermata* b = Factory::createFermata(score->dummy()->segment());
+                Fermata* b = Factory::createFermata(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -985,7 +985,7 @@ void Read500::pasteSymbols(XmlReader& e, ChordRest* dst)
                     continue;
                 }
 
-                Breath* b = Factory::createBreath(score->dummy()->segment());
+                Breath* b = Factory::createBreath(score->dummy());
                 b->setTrack(destTrack);
                 TRead::read(b, e, ctx);
                 b->setTrack(destTrack);
@@ -1220,13 +1220,9 @@ void Read500::pasteSymbols(XmlReader& e, ChordRest* dst)
     } // inner while readNextstartElement()
 }
 
-void Read500::readTremoloCompat(compat::TremoloCompat* tc, XmlReader& xml)
+void Read500::readTremoloCompat(compat::TremoloCompat* tc, Score* score, XmlReader& xml)
 {
-    IF_ASSERT_FAILED(tc->parent) {
-        return;
-    }
-
-    ReadContext ctx(tc->parent->score(), /* pasteMode = */ true);
+    ReadContext ctx(score, /* pasteMode = */ true);
     TRead::read(tc, xml, ctx);
 }
 

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -731,7 +731,6 @@ bool Read500::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     Clef* clef = Factory::createClef(segment);
                     TRead::read(clef, e, ctx);
                     clef->setTrack(ctx.track());
-                    clef->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), clef);
                 } else if (tag == "Breath") {
                     Fraction tick = doScale ? (ctx.tick() - dstTick) * scale + dstTick : ctx.tick();
@@ -744,7 +743,6 @@ bool Read500::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                     breath->setTrack(ctx.track());
                     breath->setPlacement(breath->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
                     TRead::read(breath, e, ctx);
-                    breath->setOwnershipParent(segment);
                     score->undoChangeElement(segment->element(ctx.track()), breath);
                 } else if (tag == "Beam") {
                     Beam* beam = Factory::createBeam(score);
@@ -1078,7 +1076,6 @@ void Read500::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(trackZeroVoice(destTrack));
                     TRead::read(el, e, ctx);
                     el->setTrack(trackZeroVoice(destTrack));
-                    el->setOwnershipParent(seg);
                     score->undoAddElement(el);
                 }
             } else if (tag == "Lyrics" || tag == "FiguredBass") {
@@ -1127,7 +1124,6 @@ void Read500::pasteSymbols(XmlReader& e, ChordRest* dst)
                     el->setTrack(destTrack);
                     TRead::read(el, e, ctx);
                     el->setTrack(destTrack);
-                    el->setOwnershipParent(cr);
                     score->undoAddElement(el);
                 } else if (tag == "FiguredBass") {
                     // FiguredBass always belongs to first staff voice

--- a/src/engraving/rw/read500/read500.h
+++ b/src/engraving/rw/read500/read500.h
@@ -40,7 +40,7 @@ public:
 
     bool pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fraction scale) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst) override;
-    void readTremoloCompat(compat::TremoloCompat* item, XmlReader& xml) override;
+    void readTremoloCompat(compat::TremoloCompat* item, Score* score, XmlReader& xml) override;
 
 private:
     bool preparePasteDurationElement(Score* score, const Fraction& tick, const Fraction& ticks, const track_idx_t track);

--- a/src/engraving/rw/read500/readcontext.cpp
+++ b/src/engraving/rw/read500/readcontext.cpp
@@ -98,7 +98,7 @@ void ReadContext::setSpatium(double v)
     m_score->style().set(Sid::spatium, v);
 }
 
-compat::DummyElement* ReadContext::dummy() const
+DummyParent* ReadContext::dummy() const
 {
     return m_score->dummy();
 }

--- a/src/engraving/rw/read500/readcontext.h
+++ b/src/engraving/rw/read500/readcontext.h
@@ -34,6 +34,7 @@
 
 namespace mu::engraving {
 class Beam;
+class DummyParent;
 class EngravingObject;
 class LinkedObjects;
 class Measure;
@@ -42,10 +43,6 @@ class Score;
 class Spanner;
 class Staff;
 class Tuplet;
-}
-
-namespace mu::engraving::compat {
-class DummyElement;
 }
 
 namespace mu::engraving::read500 {
@@ -83,7 +80,7 @@ public:
     bool forcePageMode() const { return m_forcePageMode; }
     void setForcePageMode(bool v) { m_forcePageMode = v; }
 
-    compat::DummyElement* dummy() const;
+    DummyParent* dummy() const;
 
     Staff* staff(staff_idx_t n);
 

--- a/src/engraving/rw/read500/tread.cpp
+++ b/src/engraving/rw/read500/tread.cpp
@@ -579,7 +579,6 @@ bool TRead::readItemProperties(EngravingItem* item, XmlReader& e, ReadContext& c
     } else if (tag == "Parenthesis") {
         Parenthesis* p = Factory::createParenthesis(item);
         TRead::read(p, e, ctx);
-        p->setOwnershipParent(item);
         p->setTrack(ctx.track());
         item->add(p);
     } else {
@@ -1633,7 +1632,6 @@ void TRead::read(Tuplet* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Number") {
             number = Factory::createText(t, TextStyleType::TUPLET);
             number->setComposition(true);
-            number->setOwnershipParent(t);
             Tuplet::resetNumberProperty(number);
             TRead::read(number, e, ctx);
             number->setVisible(t->visible());         //?? override saved property
@@ -1984,7 +1982,6 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         Accidental* accidental = Factory::createAccidental(o);
         TRead::read(accidental, xml, ctx);
         accidental->setTrack(ctx.track());
-        accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
         Chord* chord = Factory::createChord(ctx.score()->dummy());
@@ -2052,7 +2049,6 @@ void TRead::read(Tapping* t, XmlReader& xml, ReadContext& ctx)
         } else if (tag == TConv::toXml(ElementType::TAPPING_HALF_SLUR)) {
             TappingHalfSlur* tappingHalfSlur = new TappingHalfSlur(t);
             read(tappingHalfSlur, xml, ctx);
-            tappingHalfSlur->setOwnershipParent(t);
             if (tappingHalfSlur->isHalfSlurAbove()) {
                 t->setHalfSlurAbove(tappingHalfSlur);
             } else {
@@ -2349,7 +2345,6 @@ bool TRead::readProperties(MeasureBase* b, XmlReader& e, ReadContext& ctx)
     } else if (tag == "StaffTypeChange") {
         StaffTypeChange* stc = Factory::createStaffTypeChange(b);
         stc->setTrack(ctx.track());
-        stc->setOwnershipParent(b);
         TRead::read(stc, e, ctx);
         b->add(stc);
     } else if (readItemProperties(b, e, ctx)) {
@@ -2521,7 +2516,6 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Note* note = Factory::createNote(ch);
         // the note needs to know the properties of the track it belongs to
         note->setTrack(ch->track());
-        note->setOwnershipParent(ch);
         TRead::read(note, e, ctx);
         ch->add(note);
     } else if (TRead::readProperties(toChordRest(ch), e, ctx)) {
@@ -2571,13 +2565,11 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());
         TRead::read(arpeggio, e, ctx);
-        arpeggio->setOwnershipParent(ch);
         ch->setArpeggio(arpeggio);
     } else if (tag == "ChordBracket") {
         ChordBracket* bracket = Factory::createChordBracket(ch);
         bracket->setTrack(ch->track());
         TRead::read(bracket, e, ctx);
-        bracket->setOwnershipParent(ch);
         ch->add(bracket);
     } else if (tag == "Tremolo") { // compat
         compat::TremoloCompat tcompat;
@@ -2598,14 +2590,12 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         TremoloSingleChord* trem = Factory::createTremoloSingleChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloSingleChord(trem);
     } else if (tag == "TremoloTwoChord") {
         TremoloTwoChord* trem = Factory::createTremoloTwoChord(ch);
         trem->setTrack(ch->track());
         TRead::read(trem, e, ctx);
-        trem->setOwnershipParent(ch);
         trem->setDurationType(ch->durationType());
         ch->setTremoloTwoChord(trem, false);
     } else if (tag == "ChordLine") {
@@ -2920,7 +2910,6 @@ void TRead::read(GuitarBend* g, XmlReader& e, ReadContext& ctx)
         } else if (tag == "GuitarBendHold") {
             GuitarBendHold* hold = new GuitarBendHold(g);
             TRead::read(hold, e, ctx);
-            hold->setOwnershipParent(g);
             g->setHoldLine(hold);
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::DIRECTION)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::BEND_SHOW_HOLD_LINE)) {
@@ -2955,7 +2944,6 @@ bool TRead::readProperties(GuitarBendSegment* g, const AsciiStringView& tag, Xml
         g->setVertexPointOff(xml.readPoint() * g->style().spatium());
     } else if (tag == "GuitarBendText") {
         GuitarBendText* bendText = new GuitarBendText(g);
-        bendText->setOwnershipParent(g);
         read(toTextBase(bendText), xml, ctx);
         g->setBendText(bendText);
     } else {
@@ -3263,7 +3251,6 @@ bool TRead::readProperties(Lyrics* l, XmlReader& e, ReadContext& ctx)
     } else if (tag == "LyricsLine") {
         LyricsLine* ll = Factory::createLyricsLine(l);
         TRead::read(ll, e, ctx);
-        ll->setOwnershipParent(l);
         ll->setTick(ctx.tick());
         l->setSeparator(ll);
         ctx.score()->addUnmanagedSpanner(ll);
@@ -3459,7 +3446,6 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
     } else if (tag == "LaissezVib") {
         LaissezVib* lv = Factory::createLaissezVib(n);
         TRead::read(lv, e, ctx);
-        lv->setOwnershipParent(n);
         n->add(lv);
     } else if (tag == "PartialTie") {
         PartialTie* pt = Factory::createPartialTie(n);
@@ -3916,7 +3902,6 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
         if (t == "Parenthesis") {
             Parenthesis* paren = Factory::createParenthesis(ch);
             TRead::read(paren, e, ctx);
-            paren->setOwnershipParent(ch);
             paren->setTrack(ctx.track());
 
             if (paren->direction() == DirectionH::LEFT) {
@@ -3953,14 +3938,12 @@ void TRead::readNoteParenGroup(Chord* ch, XmlReader& e, ReadContext& ctx)
 
     if (!leftParen) {
         leftParen = Factory::createParenthesis(ch);
-        leftParen->setOwnershipParent(ch);
         leftParen->setTrack(ctx.track());
     }
 
     if (!rightParen) {
         rightParen = Factory::createParenthesis(ch);
         rightParen->setDirection(DirectionH::RIGHT);
-        rightParen->setOwnershipParent(ch);
         rightParen->setTrack(ctx.track());
     }
 
@@ -4810,7 +4793,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Accidental") {
             Accidental* accidental = Factory::createAccidental(t);
             TRead::read(accidental, e, ctx);
-            accidental->setOwnershipParent(t);
             t->setAccidental(accidental);
             if (t->ornament()) {
                 t->ornament()->setTrillOldCompatAccidental(accidental);

--- a/src/engraving/rw/read500/tread.cpp
+++ b/src/engraving/rw/read500/tread.cpp
@@ -923,7 +923,7 @@ void TRead::read(FretDiagram* d, XmlReader& e, ReadContext& ctx)
         } else if (tag == "mag") {
             TRead::readProperty(d, e, ctx, Pid::MAG);
         } else if (tag == "Harmony") {
-            Harmony* h = new Harmony(d->score()->dummy()->segment());
+            Harmony* h = new Harmony(d->score()->dummy());
             read(h, e, ctx);
             if (h->chords().empty()) {
                 // Invalid harmony
@@ -1987,7 +1987,7 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         accidental->setOwnershipParent(o);
         accidental->placement() == PlacementV::ABOVE ? o->setAccidentalAbove(accidental) : o->setAccidentalBelow(accidental);
     } else if (tag == "Chord") {
-        Chord* chord = Factory::createChord(ctx.score()->dummy()->segment());
+        Chord* chord = Factory::createChord(ctx.score()->dummy());
         TRead::read(chord, xml, ctx);
         chord->setTrack(ctx.track());
         chord->setIsTrillCueNote(true);
@@ -2105,7 +2105,7 @@ void TRead::read(BarLine* b, XmlReader& e, ReadContext& ctx)
         } else if (tag == "spanToOffset") {
             b->setSpanTo(e.readInt());
         } else if (tag == "Articulation") {
-            Articulation* a = Factory::createArticulation(b->score()->dummy()->chord());
+            Articulation* a = Factory::createArticulation(b->score()->dummy());
             TRead::read(a, e, ctx);
             b->add(a);
         } else if (tag == "Symbol") {
@@ -2272,7 +2272,7 @@ bool TRead::readProperties(Box* b, XmlReader& e, ReadContext& ctx)
             b->add(image);
         }
     } else if (tag == "FretDiagram") {
-        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy()->segment());
+        FretDiagram* f = Factory::createFretDiagram(b->score()->dummy());
         TRead::read(f, e, ctx);
         //! TODO Looks like a bug.
         //! The FretDiagram parent must be Segment
@@ -4611,20 +4611,24 @@ void TRead::read(compat::TremoloCompat* tc, XmlReader& e, ReadContext& ctx)
         return tc->single;
     };
 
+    // read on its own, e.g. into a palette, there is no chord to belong to
+    const DummyParentOr<Chord> parent = parentOrDummy(tc->parent, ctx.dummy());
+    const track_idx_t track = tc->parent ? tc->parent->track() : 0;
+
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "subtype") {
             TremoloType type = TConv::fromXml(e.readAsciiText(), TremoloType::INVALID_TREMOLO);
             if (isTremoloTwoChord(type)) {
                 if (!tc->two) {
-                    tc->two = Factory::createTremoloTwoChord(tc->parent);
-                    tc->two->setTrack(tc->parent->track());
+                    tc->two = Factory::createTremoloTwoChord(parent);
+                    tc->two->setTrack(track);
                 }
                 tc->two->setTremoloType(type);
             } else {
                 if (!tc->single) {
-                    tc->single = Factory::createTremoloSingleChord(tc->parent);
-                    tc->single->setTrack(tc->parent->track());
+                    tc->single = Factory::createTremoloSingleChord(parent);
+                    tc->single->setTrack(track);
                 }
                 tc->single->setTremoloType(type);
             }
@@ -4941,7 +4945,7 @@ void TRead::readSystemDividers(Score* score, XmlReader& e, ReadContext& ctx)
             size_t systemIdx = e.intAttribute("idx");
             while (e.readNextStartElement()) {
                 if (e.name() == "SystemDivider") {
-                    SystemDivider* divider = new SystemDivider(score->dummy()->system());
+                    SystemDivider* divider = new SystemDivider(score->dummy());
                     read(divider, e, ctx);
                     score->addSystemDivider(systemIdx, divider);
                 } else {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3586,7 +3586,7 @@ static bool writeVoiceMove(XmlWriter& xml, WriteContext& ctx, Segment* seg, cons
 static void writeTimeSig(Score* score, const Fraction& tick, XmlWriter& xml, WriteContext& ctx)
 {
     Fraction tsf = score->sigmap()->timesig(tick).nominal();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(tsf);
     TWrite::write(ts, xml, ctx);
     ts->masterScore()->eidRegister()->removeItem(ts);
@@ -3718,7 +3718,7 @@ void TWrite::writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t strack
                 if (!keySigWritten) {
                     Key ck = score->staff(track2staff(track))->concertKey(segment->tick());
                     Key tk = score->staff(track2staff(track))->key(segment->tick());
-                    KeySig* ks = Factory::createKeySig(score->dummy()->segment());
+                    KeySig* ks = Factory::createKeySig(score->dummy());
                     ks->setKey(ck, tk);
                     TWrite::write(ks, xml, ctx);
                     ks->masterScore()->eidRegister()->removeItem(ks);

--- a/src/engraving/tests/barline_tests.cpp
+++ b/src/engraving/tests/barline_tests.cpp
@@ -122,7 +122,7 @@ TEST_F(Engraving_BarlineTests, barline02)
     EXPECT_TRUE(score);
 
     Measure* msr = score->firstMeasure()->nextMeasure();
-    TimeSig* ts  = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts  = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, msr, 0, ts, false);
@@ -320,7 +320,7 @@ TEST_F(Engraving_BarlineTests, barline06)
 void dropNormalBarline(EngravingItem* e)
 {
     EditData dropData(0);
-    BarLine* barLine = Factory::createBarLine(e->score()->dummy()->segment());
+    BarLine* barLine = Factory::createBarLine(e->score()->dummy());
     barLine->setBarLineType(BarLineType::NORMAL);
     dropData.dropElement = barLine;
     dropData.track = 0;

--- a/src/engraving/tests/barline_tests.cpp
+++ b/src/engraving/tests/barline_tests.cpp
@@ -242,7 +242,6 @@ TEST_F(Engraving_BarlineTests, barline05)
     LayoutBreak* lb = Factory::createLayoutBreak(msr);
     lb->setLayoutBreakType(LayoutBreakType::LINE);
     lb->setTrack(0);
-    lb->setOwnershipParent(msr);
     score->undoAddElement(lb);
     score->doLayout();
 

--- a/src/engraving/tests/breath_tests.cpp
+++ b/src/engraving/tests/breath_tests.cpp
@@ -57,7 +57,7 @@ TEST_F(Engraving_BreathTests, breath)
         score->cmdSelectAll();
         for (EngravingItem* e : score->selection().elements()) {
             EditData dd(0);
-            Breath* b = Factory::createBreath(score->dummy()->segment());
+            Breath* b = Factory::createBreath(score->dummy());
             b->setSymId(SymId::breathMarkComma);
             dd.dropElement = b;
             if (e->acceptDrop(dd)) {

--- a/src/engraving/tests/chordsymbol_tests.cpp
+++ b/src/engraving/tests/chordsymbol_tests.cpp
@@ -136,7 +136,6 @@ TEST_F(Engraving_ChordSymbolTests, testAddLink)
     Harmony* harmony = new Harmony(cr->segment());
     harmony->setHarmony(u"C7");
     harmony->setTrack(cr->track());
-    harmony->setOwnershipParent(cr->segment());
     score->undoAddElement(harmony);
     score->doLayout();
     test_post(score, u"add-link");
@@ -150,7 +149,6 @@ TEST_F(Engraving_ChordSymbolTests, testAddPart)
     Harmony* harmony = new Harmony(cr->segment());
     harmony->setHarmony(u"C7");
     harmony->setTrack(cr->track());
-    harmony->setOwnershipParent(cr->segment());
     score->undoAddElement(harmony);
     score->doLayout();
     test_post(score, u"add-part");

--- a/src/engraving/tests/clef_courtesy_tests.cpp
+++ b/src/engraving/tests/clef_courtesy_tests.cpp
@@ -50,7 +50,7 @@ static Measure* getMeasure(Score* score, int idx)
 
 static void dropClef(EngravingItem* m, ClefType t)
 {
-    Clef* clef = Factory::createClef(m->score()->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = Factory::createClef(m->score()->dummy());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(t);
     EditData dropData(0);
     dropData.dropElement = clef;
@@ -147,7 +147,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy02)
         m1 = m1->nextMeasure();
     }
     // make a clef-drop object and drop it to the measure
-    Clef* clef = Factory::createClef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = Factory::createClef(score->dummy());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G8_VA);
     EditData dropData(0);
     dropData.dropElement = clef;
@@ -160,7 +160,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy02)
         m2 = m2->nextMeasure();
     }
     // make a clef-drop object and drop it to the measure
-    clef = Factory::createClef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
+    clef = Factory::createClef(score->dummy());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G);
     dropData.dropElement = clef;
     dropData.track = 0;
@@ -204,7 +204,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy03)
     Measure* m2 = m1->nextMeasure();
 
     // make a clef-drop object and drop it to the 2nd measure
-    Clef* clef = Factory::createClef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = Factory::createClef(score->dummy());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G8_VA);
     EditData dropData(0);
     dropData.dropElement = clef;

--- a/src/engraving/tests/clef_tests.cpp
+++ b/src/engraving/tests/clef_tests.cpp
@@ -66,7 +66,7 @@ TEST_F(Engraving_ClefTests, clef2)
         Measure* m = score->firstMeasure();
         m = m->nextMeasure();
         m = m->nextMeasure();
-        TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+        TimeSig* ts = Factory::createTimeSig(score->dummy());
         ts->setSig(Fraction(2, 4));
         EditTimeSig::addTimeSig(tx, score, m, 0, ts, false);
     });

--- a/src/engraving/tests/dynamic_tests.cpp
+++ b/src/engraving/tests/dynamic_tests.cpp
@@ -42,7 +42,7 @@ TEST_F(Engraving_DynamicTests, test1)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
 
-    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
+    Dynamic* dynamic = new Dynamic(score->dummy());
     dynamic->setDynamicType(DynamicType(1));
 
     Dynamic* d;

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -65,7 +65,7 @@ TEST_F(Engraving_EIDTests, deletedItemIsUnregistered)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
 
-    EngravingItem* item = new Dynamic(score->dummy()->segment());
+    EngravingItem* item = new Dynamic(score->dummy());
     EID eid = item->assignNewEID();
     EXPECT_TRUE(eid.isValid());
     EXPECT_EQ(score->eidRegister()->itemFromEID(eid), item);
@@ -105,7 +105,7 @@ TEST_F(Engraving_EIDTests, writeReadElementDoesNotLeakRegisterEntries)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
 
-    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
+    Dynamic* dynamic = new Dynamic(score->dummy());
     dynamic->setDynamicType(DynamicType(1));
 
     // writeReadElement round trips through clipboard write and paste read,

--- a/src/engraving/tests/fretbox_tests.cpp
+++ b/src/engraving/tests/fretbox_tests.cpp
@@ -56,7 +56,7 @@ public:
         for (const String& chord : chords) {
             Segment* segment = measure->first(SegmentType::ChordRest);
 
-            FretDiagram* diagram = Factory::createFretDiagram(score->dummy()->segment());
+            FretDiagram* diagram = Factory::createFretDiagram(score->dummy());
 
             diagram->setHarmony(chord);
             diagram->updateDiagram(chord);
@@ -87,7 +87,7 @@ public:
 
         Segment* segment = measure->first(SegmentType::ChordRest);
 
-        FretDiagram* diagram = Factory::createFretDiagram(score->dummy()->segment());
+        FretDiagram* diagram = Factory::createFretDiagram(score->dummy());
 
         diagram->setHarmony(chord);
         diagram->updateDiagram(chord);

--- a/src/engraving/tests/fretdiagram_tests.cpp
+++ b/src/engraving/tests/fretdiagram_tests.cpp
@@ -53,7 +53,7 @@ void Engraving_FretDiagramTests::testChordSymToFretDiagram(MasterScore* score)
         Harmony* harmony = toHarmony(s1->findAnnotation(ElementType::HARMONY, 0, 0));
         EXPECT_TRUE(harmony);
 
-        FretDiagram* diagram = Factory::createFretDiagram(score->dummy()->segment());
+        FretDiagram* diagram = Factory::createFretDiagram(score->dummy());
         EXPECT_TRUE(diagram);
         diagram->updateDiagram(harmony->harmonyName());
         String pattern = diagram->patternFromDiagram();
@@ -84,7 +84,7 @@ TEST_F(Engraving_FretDiagramTests, harmonyToFretDiagramSolfeggio)
 TEST_F(Engraving_FretDiagramTests, enharmonicFallbackRootAndBass)
 {
     MasterScore* score = ScoreRW::readScore(FRETDIAGRAM_DATA_DIR + u"harmonytofrettest.mscx");
-    FretDiagram* fd = Factory::createFretDiagram(score->dummy()->segment());
+    FretDiagram* fd = Factory::createFretDiagram(score->dummy());
 
     // Root fallback: Fbdim7 -> Edim7 (Fb->E)
     ASSERT_FALSE(fd->patternsFromHarmony(String(u"Edim7")).empty());

--- a/src/engraving/tests/hairpin_tests.cpp
+++ b/src/engraving/tests/hairpin_tests.cpp
@@ -37,7 +37,7 @@ class Engraving_HairpinTests : public ::testing::Test
 TEST_F(Engraving_HairpinTests, hairpin)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
-    Hairpin* hp = new Hairpin(score->dummy()->segment());
+    Hairpin* hp = new Hairpin(score->dummy());
 
     // subtype
     hp->setHairpinType(HairpinType::DIM_HAIRPIN);

--- a/src/engraving/tests/harpdiagram_tests.cpp
+++ b/src/engraving/tests/harpdiagram_tests.cpp
@@ -48,7 +48,7 @@ TEST_F(Engraving_HarpDiagramTests, harpdiagram)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
 
-    HarpPedalDiagram* diagram = Factory::createHarpPedalDiagram(score->dummy()->segment());
+    HarpPedalDiagram* diagram = Factory::createHarpPedalDiagram(score->dummy());
 
     HarpPedalDiagram* d;
 

--- a/src/engraving/tests/instrumentchange_tests.cpp
+++ b/src/engraving/tests/instrumentchange_tests.cpp
@@ -71,7 +71,6 @@ TEST_F(Engraving_InstrumentChangeTests, testAdd)
     Measure* m = score->firstMeasure()->nextMeasure();
     Segment* s = m->first(SegmentType::ChordRest);
     InstrumentChange* ic = new InstrumentChange(s);
-    ic->setOwnershipParent(s);
     ic->setTrack(0);
     ic->setXmlText("Instrument");
     score->startCmd(TranslatableString::untranslatable("Instrument change tests"));

--- a/src/engraving/tests/measure_tests.cpp
+++ b/src/engraving/tests/measure_tests.cpp
@@ -747,7 +747,7 @@ TEST_F(Engraving_MeasureTests, breathInPart)
         EXPECT_TRUE(m);
         ChordRest* cr = m->findChordRest(m->tick(), 0);
         EXPECT_TRUE(cr);
-        Breath* b = Factory::createBreath(score->dummy()->segment());
+        Breath* b = Factory::createBreath(score->dummy());
         b->setSymId(SymId::breathMarkComma);
         EditData dd(nullptr);
         dd.dropElement = b;
@@ -773,7 +773,7 @@ TEST_F(Engraving_MeasureTests, breathInPart)
         EXPECT_TRUE(m);
         ChordRest* cr = m->findChordRest(m->tick(), 0);
         EXPECT_TRUE(cr);
-        Breath* b = Factory::createBreath(score->dummy()->segment());
+        Breath* b = Factory::createBreath(score->dummy());
         b->setSymId(SymId::breathMarkTick);
         EditData dd(nullptr);
         dd.dropElement = b;

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -325,7 +325,6 @@ TEST_F(Engraving_NoteTests, grace)
     score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     TremoloSingleChord* tr = Factory::createTremoloSingleChord(gc);
     tr->setTremoloType(TremoloType::R16);
-    tr->setOwnershipParent(gc);
     tr->setTrack(gc->track());
     score->undoAddElement(tr);
     score->endCmd();
@@ -337,7 +336,6 @@ TEST_F(Engraving_NoteTests, grace)
     score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     Articulation* ar = Factory::createArticulation(gc);
     ar->setSymId(SymId::articAccentAbove);
-    ar->setOwnershipParent(gc);
     ar->setTrack(gc->track());
     score->undoAddElement(ar);
     score->endCmd();

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -67,7 +67,7 @@ static ChordRest* chordRestAtTick(Score* score, const Fraction& tick, track_idx_
 TEST_F(Engraving_NoteTests, note)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore(nullptr);
-    Chord* chord = Factory::createChord(score->dummy()->segment());
+    Chord* chord = Factory::createChord(score->dummy());
     Note* note = Factory::createNote(chord);
     chord->add(note);
 

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -177,9 +177,9 @@ TEST_F(Engraving_ParentTests, deletingOwnerParksChildrenOnDummy)
     delete note;
 }
 
-//! Accessibility walks the layout hierarchy, but unattached items (e.g. palette
-//! items) must still reach the dummy so that they get an accessible ancestor.
-TEST_F(Engraving_ParentTests, accessibleParentFallsBackToTheDummy)
+//! Accessibility walks the layout hierarchy, but unattached items are not placed in
+//! it: they form a tree of their own, headed by the dummy's root item.
+TEST_F(Engraving_ParentTests, accessibleParentFallsBackToTheDummysRoot)
 {
     Segment* segment = someSegment();
     ASSERT_TRUE(segment);
@@ -192,7 +192,7 @@ TEST_F(Engraving_ParentTests, accessibleParentFallsBackToTheDummy)
     dynamic->moveToDummy();
 
     EXPECT_EQ(dynamic->layoutParent(), nullptr);
-    EXPECT_EQ(dynamic->accessibleParentItem(), m_score->dummy());
+    EXPECT_EQ(dynamic->accessibleParentItem(), m_score->dummy()->rootItem());
 
     delete dynamic;
 }
@@ -495,7 +495,7 @@ TEST_F(Engraving_ParentTests, accessibilityTreeAgreesInBothDirections)
     EXPECT_GT(checkedItems, 0u);
 
     // Downwards: whatever a parent lists must name it back. This is the direction a
-    // screen reader descends, starting from the root item.
+    // screen reader descends, starting from a root item.
     constexpr int MAX_DEPTH = 64;
     size_t checkedChildren = 0;
 
@@ -511,7 +511,13 @@ TEST_F(Engraving_ParentTests, accessibilityTreeAgreesInBothDirections)
         }
     };
 
-    checkChildren(m_score->rootItem(), 0);
+    auto checkTree = [&](const EngravingItem* root, const char* what) {
+        const size_t before = checkedChildren;
+        checkChildren(root, 0);
+        EXPECT_GT(checkedChildren, before) << "nothing is reachable through the " << what << " root";
+    };
 
-    EXPECT_GT(checkedChildren, 0u);
+    checkTree(m_score->rootItem(), "score");
+    // the objects that are not in the score are reached through the other root
+    checkTree(m_score->dummy()->rootItem(), "dummy");
 }

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -107,10 +107,8 @@ public:
 // score-editing API, because the parent link itself is what is under test.
 // ---------------------------------------------------------------------------
 
-//! A freshly constructed item is not attached to anything: the constructor
-//! argument only supplies context (above all, the score). It does leave the item
-//! in that parent's child list, but the item does not report it as its parent.
-TEST_F(Engraving_ParentTests, newItemIsNotAttached)
+//! An item is attached to the parent it is constructed with.
+TEST_F(Engraving_ParentTests, newItemIsAttachedToItsConstructorParent)
 {
     Segment* segment = someSegment();
     ASSERT_TRUE(segment);
@@ -121,6 +119,23 @@ TEST_F(Engraving_ParentTests, newItemIsNotAttached)
 
     EXPECT_EQ(dynamic->parent(), segment);
     EXPECT_TRUE(isChildOf(dynamic, segment));
+
+    EXPECT_EQ(dynamic->ownershipParent(), segment);
+    EXPECT_EQ(dynamic->ownershipParentItem(), segment);
+    EXPECT_EQ(dynamic->layoutParent(), segment);
+
+    delete dynamic;
+}
+
+//! Constructing an item with the dummy means it is not attached to anything yet.
+TEST_F(Engraving_ParentTests, newItemOnTheDummyIsNotAttached)
+{
+    Dynamic* dynamic = Factory::createDynamic(m_score->dummy(), false /*isAccessibleEnabled*/);
+
+    EXPECT_EQ(dynamic->score(), m_score);
+
+    EXPECT_EQ(dynamic->parent(), m_score->dummy());
+    EXPECT_TRUE(isChildOf(dynamic, m_score->dummy()));
 
     EXPECT_EQ(dynamic->ownershipParent(), nullptr);
     EXPECT_EQ(dynamic->ownershipParentItem(), nullptr);

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-#include "engraving/compat/dummyelement.h"
+#include "engraving/dom/dummyparent.h"
 
 #include "engraving/dom/beam.h"
 #include "engraving/dom/box.h"

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -151,8 +151,6 @@ TEST_F(Engraving_ParentTests, attachingAndDetaching)
 
     Dynamic* dynamic = Factory::createDynamic(segment, false /*isAccessibleEnabled*/);
 
-    dynamic->setOwnershipParent(segment);
-
     EXPECT_EQ(dynamic->parent(), segment);
     EXPECT_EQ(dynamic->ownershipParent(), segment);
     EXPECT_EQ(dynamic->ownershipParentItem(), segment);
@@ -181,7 +179,6 @@ TEST_F(Engraving_ParentTests, deletingOwnerParksChildrenOnDummy)
 
     Chord* chord = Factory::createChord(segment, false /*isAccessibleEnabled*/);
     Note* note = Factory::createNote(chord, false /*isAccessibleEnabled*/);
-    note->setOwnershipParent(chord);
     ASSERT_EQ(note->ownershipParent(), chord);
 
     delete chord;
@@ -201,7 +198,6 @@ TEST_F(Engraving_ParentTests, accessibleParentFallsBackToTheDummysRoot)
 
     Dynamic* dynamic = Factory::createDynamic(segment, false /*isAccessibleEnabled*/);
 
-    dynamic->setOwnershipParent(segment);
     EXPECT_EQ(dynamic->accessibleParentItem(), segment);
 
     dynamic->moveToDummy();

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -285,7 +285,7 @@ TEST_F(Engraving_ParentTests, deletingASegmentUnplacesItFromItsSystem)
     ASSERT_FALSE(m_score->systems().empty());
     System* system = m_score->systems().front();
 
-    Hairpin* hairpin = Factory::createHairpin(m_score->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(m_score->dummy());
     hairpin->setTrack(0);
     hairpin->setTrack2(0);
 
@@ -308,7 +308,7 @@ TEST_F(Engraving_ParentTests, deletingASpannerDeletesItsSegments)
 {
     const size_t dummyChildrenBefore = m_score->dummy()->children().size();
 
-    Hairpin* hairpin = Factory::createHairpin(m_score->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(m_score->dummy());
     hairpin->setTrack(0);
     hairpin->setTrack2(0);
 

--- a/src/engraving/tests/parent_tests.cpp
+++ b/src/engraving/tests/parent_tests.cpp
@@ -40,6 +40,8 @@
 #include "engraving/dom/spanner.h"
 #include "engraving/dom/system.h"
 
+#include "engraving/style/style.h"
+
 #include "utils/scorerw.h"
 
 using namespace mu::engraving;
@@ -458,6 +460,37 @@ TEST_F(Engraving_ParentTests, ancestorWalksAgreeWithAttachment)
     }
 
     EXPECT_GT(checkedChordRests, 0u);
+}
+
+//! A multi-measure rest takes the measures it covers off their system, leaving them
+//! attached to the score but placed nowhere. Neither tree holds them then: the score's
+//! tree reaches items through their placement, and the dummy's tree only holds what is
+//! not attached to anything.
+TEST_F(Engraving_ParentTests, aMeasureThatIsPlacedNowhereIsInNeitherTree)
+{
+    m_score->startCmd(TranslatableString::untranslatable("Engraving parent tests"));
+    // enough empty measures at the end for a multi-measure rest to be made of them
+    for (int i = 0; i < 4; ++i) {
+        m_score->insertMeasure();
+    }
+    m_score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
+    m_score->setLayoutAll();
+    m_score->endCmd();
+
+    size_t unplacedMeasures = 0;
+
+    for (MeasureBase* measure = m_score->first(); measure; measure = measure->next()) {
+        if (measure->system()) {
+            EXPECT_EQ(measure->accessibleParentItem(), measure->system());
+            continue;
+        }
+
+        ++unplacedMeasures;
+        EXPECT_EQ(measure->accessibleParentItem(), nullptr)
+            << "a " << measure->typeName() << " that is placed nowhere names a parent that cannot list it";
+    }
+
+    EXPECT_GT(unplacedMeasures, 0u) << "no multi-measure rest was made, so nothing was left unplaced";
 }
 
 //! The accessibility tree mirrors the visual hierarchy, and a screen reader walks it in

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -371,7 +371,7 @@ MasterScore* Engraving_PartsTests::doAddBreath()
     Chord* chord = toChord(s->element(0));
     Note* note   = chord->upNote();
     EditData dd(0);
-    Breath* b = Factory::createBreath(score->dummy()->segment());
+    Breath* b = Factory::createBreath(score->dummy());
     b->setSymId(SymId::breathMarkComma);
     dd.dropElement = b;
 

--- a/src/engraving/tests/remove_tests.cpp
+++ b/src/engraving/tests/remove_tests.cpp
@@ -22,10 +22,15 @@
 
 #include <gtest/gtest.h>
 
+#include "global/containers.h"
+
+#include "engraving/dom/bracket.h"
+#include "engraving/dom/bracketitem.h"
 #include "engraving/dom/excerpt.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/measure.h"
 #include "engraving/dom/spanner.h"
+#include "engraving/dom/system.h"
 
 #include "utils/scorerw.h"
 
@@ -113,4 +118,32 @@ TEST_F(Engraving_RemoveTests, removeStaffWithCourtesyClefs)
     EXPECT_TRUE(courtesyClef);
     EXPECT_TRUE(courtesyClef->leftParen());
     EXPECT_TRUE(courtesyClef->rightParen());
+}
+
+//! A bracket is only a rendering of its bracket item, so it must not outlive it:
+//! otherwise the system is left holding a bracket that points at freed memory.
+TEST_F(Engraving_RemoveTests, removingABracketItemRemovesItsBrackets)
+{
+    MasterScore* score = ScoreRW::readScore(REMOVE_DATA_DIR + u"remove_staff.mscx");
+    ASSERT_TRUE(score);
+
+    System* system = nullptr;
+    for (System* s : score->systems()) {
+        if (!s->brackets().empty()) {
+            system = s;
+            break;
+        }
+    }
+    ASSERT_TRUE(system);
+
+    const size_t bracketsBefore = system->brackets().size();
+
+    BracketItem* bracketItem = system->brackets().front()->bracketItem();
+    ASSERT_TRUE(bracketItem);
+    muse::remove(score->brackets(bracketItem->startStaffIdx()), bracketItem);
+    delete bracketItem;
+
+    EXPECT_EQ(system->brackets().size(), bracketsBefore - 1);
+
+    delete score;
 }

--- a/src/engraving/tests/spanners_tests.cpp
+++ b/src/engraving/tests/spanners_tests.cpp
@@ -508,7 +508,7 @@ TEST_F(Engraving_SpannersTests, DISABLED_spanners13)
     // DROP A BREAK AT FIRST MEASURE AND VERIFY
     Measure* msr   = score->firstMeasure();
     EXPECT_TRUE(msr);
-    brk = Factory::createLayoutBreak(score->dummy()->measure());
+    brk = Factory::createLayoutBreak(score->dummy());
     brk->setLayoutBreakType(LayoutBreakType::LINE);
 
     EditData dropData(0);

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -52,7 +52,7 @@ public:
 
 Dynamic* Engraving_TextBaseTests::addDynamic(MasterScore* score)
 {
-    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
+    Dynamic* dynamic = new Dynamic(score->dummy());
     dynamic->setXmlText("<sym>dynamicForte</sym>");
     ChordRest* chordRest = score->firstSegment(SegmentType::ChordRest)->nextChordRest(0);
     EditData ed;
@@ -112,7 +112,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextNoItalic)
 
 StaffText* Engraving_TextBaseTests::addStaffText(MasterScore* score)
 {
-    StaffText* staffText = new StaffText(score->dummy()->segment());
+    StaffText* staffText = new StaffText(score->dummy());
     ChordRest* chordRest = score->firstSegment(SegmentType::ChordRest)->nextChordRest(0);
     EditData ed;
     ed.dropElement = staffText;

--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -54,7 +54,7 @@ TEST_F(Engraving_TimesigTests, timesig01)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig01.mscx");
     EXPECT_TRUE(score);
     Measure* m  = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
@@ -78,7 +78,7 @@ TEST_F(Engraving_TimesigTests, timesig02)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig-02.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
@@ -104,7 +104,7 @@ TEST_F(Engraving_TimesigTests, timesig03)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + u"timesig-03.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, m, 0, ts, false);
@@ -125,7 +125,7 @@ TEST_F(Engraving_TimesigTests, timesig04)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig-04.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(6, 4), TimeSigType::NORMAL);
 
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, m, 0, ts, false);
@@ -149,7 +149,7 @@ TEST_F(Engraving_TimesigTests, timesig05)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig-05.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, m, 0, ts, false);
@@ -169,7 +169,7 @@ TEST_F(Engraving_TimesigTests, timesig06)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig-06.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(5, 4), TimeSigType::NORMAL);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
@@ -195,7 +195,7 @@ TEST_F(Engraving_TimesigTests, timesig07)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + u"timesig-07.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
@@ -240,7 +240,7 @@ TEST_F(Engraving_TimesigTests, DISABLED_timesig09)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + "timesig-09.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(9, 8), TimeSigType::NORMAL);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
@@ -267,16 +267,16 @@ TEST_F(Engraving_TimesigTests, timesig10)
     MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + u"timesig-10.mscx");
 
     Measure* m1 = score->firstMeasure();
-    TimeSig* ts1 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts1 = Factory::createTimeSig(score->dummy());
     ts1->setSig(Fraction(2, 2), TimeSigType::ALLA_BREVE);
 
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, m1, 0, ts1, false);
 
     Measure* m2 = m1->nextMeasure();
-    TimeSig* ts2 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts2 = Factory::createTimeSig(score->dummy());
     ts2->setSig(Fraction(2, 2), TimeSigType::NORMAL);
-    TimeSig* ts3 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts3 = Factory::createTimeSig(score->dummy());
     ts3->setSig(Fraction(4, 4), TimeSigType::FOUR_FOUR);
 
     EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, m2, 0, ts2, false);
@@ -317,13 +317,13 @@ TEST_F(Engraving_TimesigTests, timesig_11)
     EXPECT_TRUE(score);
     score->doLayout();
 
-    TimeSig* timeSig1 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* timeSig1 = Factory::createTimeSig(score->dummy());
     timeSig1->setSig(Fraction(5, 4));
 
-    TimeSig* timeSig2 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* timeSig2 = Factory::createTimeSig(score->dummy());
     timeSig2->setSig(Fraction(7, 8));
 
-    TimeSig* timeSig3 = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* timeSig3 = Factory::createTimeSig(score->dummy());
     timeSig3->setSig(Fraction(3, 4));
 
     Measure* secondMeas = score->firstMeasure()->nextMeasure();
@@ -481,7 +481,7 @@ TEST_F(Engraving_TimesigTests, endOfMeasureMMRTimeSigChange)
     EXPECT_TRUE(endBl);
 
     EditData dropData(0);
-    BarLine* barLine = Factory::createBarLine(score->dummy()->segment());
+    BarLine* barLine = Factory::createBarLine(score->dummy());
     barLine->setBarLineType(BarLineType::END_REPEAT);
     dropData.dropElement = barLine;
     dropData.track = 0;
@@ -532,7 +532,7 @@ TEST_F(Engraving_TimesigTests, endOfMeasureTie) {
     EXPECT_TRUE(tie->endNote());
 
     score->transactionManager()->transaction(TranslatableString::untranslatable("TimesigTests"), [&](Transaction& tx) {
-        TimeSig* newSig = Factory::createTimeSig(score->dummy()->segment());
+        TimeSig* newSig = Factory::createTimeSig(score->dummy());
         newSig->setSig(Fraction(3, 4));
         EditTimeSig::addTimeSig(tx, score, m1, 0, newSig, false);
     });

--- a/src/engraving/tests/tuplet_tests.cpp
+++ b/src/engraving/tests/tuplet_tests.cpp
@@ -64,7 +64,7 @@ bool Engraving_TupletTests::createTuplet(int n, ChordRest* cr)
         fr    *= Fraction(1, 2);
     }
 
-    Tuplet* tuplet = Factory::createTuplet(cr->score()->dummy()->measure());
+    Tuplet* tuplet = Factory::createTuplet(cr->score()->dummy());
     tuplet->setRatio(ratio);
 
     //
@@ -124,7 +124,7 @@ void Engraving_TupletTests::split(const char16_t* p1, const char16_t* p2)
 {
     MasterScore* score = ScoreRW::readScore(TUPLET_DATA_DIR + p1);
     Measure* m         = score->firstMeasure();
-    TimeSig* ts        = Factory::createTimeSig(score->dummy()->segment());
+    TimeSig* ts        = Factory::createTimeSig(score->dummy());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->transactionManager()->transaction(TranslatableString::untranslatable("Engraving tuplet tests"), [&](Transaction& tx) {

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -354,7 +354,7 @@ void MsScWriter::note(const QString pitch, const QVector<Bww::BeamType> beamList
     mu::engraving::DirectionV sd = mu::engraving::DirectionV::AUTO;
 
     // create chord
-    mu::engraving::Chord* cr = Factory::createChord(score->dummy()->segment());
+    mu::engraving::Chord* cr = Factory::createChord(score->dummy());
     //ws cr->setTick(tick);
     cr->setBeamMode(bm);
     cr->setTrack(0);

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -680,7 +680,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                               tick.ticks(), o->tupletDenominator, o->tripartite, o->isProlonging, ticks.ticks(), o->objects.size());
             }
 
-            Chord* chord = Factory::createChord(score->dummy()->segment());
+            Chord* chord = Factory::createChord(score->dummy());
             if (isgracenote) {             // grace notes
                 SetCapGraceDuration(chord, o);
                 chord->setTicks(chord->durationType().fraction());
@@ -1111,7 +1111,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                         LOGD("first and second anchor for hairpin identical (tick %d track %d first %p second %p)",
                              tick.ticks(), track, cr1, cr2);
                     } else {
-                        Hairpin* hp = Factory::createHairpin(score->dummy()->segment());
+                        Hairpin* hp = Factory::createHairpin(score->dummy());
                         if (wdgo->decresc) {
                             hp->setHairpinType(HairpinType::DIM_HAIRPIN);
                         } else {

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -582,7 +582,6 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                     tuplet->setBaseLen(d);
                     tuplet->setTrack(track);
                     tuplet->setTick(tick);
-                    tuplet->setOwnershipParent(m);
                     Fraction nn = ((o->tupletTicks.isZero()) ? (ticks * tupletNotesSpanned) : o->tupletTicks) / f;
                     tuplet->setTicks(nn);
                 }
@@ -672,7 +671,6 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                     tuplet->setBaseLen(d);
                     tuplet->setTrack(track);
                     tuplet->setTick(tick);
-                    tuplet->setOwnershipParent(m);
                     Fraction nn = ((o->tupletTicks.isZero()) ? (ticks * tupletNotesSpanned) : o->tupletTicks) / f;
                     tuplet->setTicks(nn);
                 }

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -752,7 +752,7 @@ void GPConverter::addTimeSig(const GPMasterBar* mB, Measure* measure)
     for (size_t staffIdx = 0; staffIdx < staves; ++staffIdx) {
         Staff* staff = _score->staff(staffIdx);
         if (staff->staffType()->genTimesig()) {
-            TimeSig* t = Factory::createTimeSig(_score->dummy()->segment());
+            TimeSig* t = Factory::createTimeSig(_score->dummy());
             track_idx_t curTrack = staffIdx * VOICES;
             t->setTrack(curTrack);
             t->setSig(scoreTimeSig);
@@ -864,7 +864,7 @@ void GPConverter::addSection(const GPMasterBar* mB, Measure* measure)
 
     if (!mB->section().first.isEmpty()) {
         Segment* s = measure->getSegment(SegmentType::ChordRest, measure->tick());
-        RehearsalMark* t = Factory::createRehearsalMark(_score->dummy()->segment());
+        RehearsalMark* t = Factory::createRehearsalMark(_score->dummy());
         t->setPlainText(mB->section().first);
         t->setType(RehearsalMark::Type::Main);
         t->setTrack(0);
@@ -872,7 +872,7 @@ void GPConverter::addSection(const GPMasterBar* mB, Measure* measure)
     }
     if (!mB->section().second.isEmpty()) {
         Segment* s = measure->getSegment(SegmentType::ChordRest, measure->tick());
-        RehearsalMark* t = Factory::createRehearsalMark(_score->dummy()->segment());
+        RehearsalMark* t = Factory::createRehearsalMark(_score->dummy());
         t->setPlainText(mB->section().second);
         t->setType(RehearsalMark::Type::Additional);
         t->setTrack(0);
@@ -985,7 +985,7 @@ void GPConverter::addKeySig(const GPMasterBar* mB, Measure* measure)
 
         Staff* staff = _score->staff(staffIdx);
         if (staff->staffType()->genTimesig()) {
-            KeySig* t = mu::engraving::Factory::createKeySig(_score->dummy()->segment());
+            KeySig* t = mu::engraving::Factory::createKeySig(_score->dummy());
             t->setTrack(staffIdx * VOICES);
             t->setKey(scoreKeySig);
             t->setMode(scoreMode);
@@ -1574,7 +1574,7 @@ void GPConverter::addInstrumentChanges()
                 instr.setDrumset(drumset::gpDrumset);
             }
 
-            InstrumentChange* instrCh =  Factory::createInstrumentChange(_score->dummy()->segment(), instr);
+            InstrumentChange* instrCh =  Factory::createInstrumentChange(_score->dummy(), instr);
             instrCh->setTrack(trackIdx * VOICES);
             instrCh->setXmlText(instrName);
 
@@ -1693,7 +1693,7 @@ void GPConverter::addClef(const GPBar* bar, int curTrack)
     }
 
     Segment* s = lastMeasure->getSegment(SegmentType::HeaderClef, tick);
-    Clef* cl = mu::engraving::Factory::createClef(_score->dummy()->segment());
+    Clef* cl = mu::engraving::Factory::createClef(_score->dummy());
     cl->setTrack(curTrack);
     cl->setClefType(clef);
 
@@ -1737,9 +1737,9 @@ ChordRest* GPConverter::addChordRest(const GPBeat* beat, const Context& ctx)
 
     ChordRest* cr{ nullptr };
     if (beat->isRest()) {
-        cr = Factory::createRest(_score->dummy()->segment());
+        cr = Factory::createRest(_score->dummy());
     } else {
-        cr = Factory::createChord(_score->dummy()->segment());
+        cr = Factory::createChord(_score->dummy());
     }
 
     cr->setTrack(ctx.curTrack);
@@ -1829,7 +1829,7 @@ void GPConverter::addOrnament(const GPNote* gpnote, Note* note)
         return SymId::ornamentUpPrall;
     };
 
-    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
     art->setSymId(scoreOrnament(gpnote->ornament()));
     if (!EditChord::toggleArticulation(_score, note, art)) {
         delete art;
@@ -1854,7 +1854,7 @@ Note* GPConverter::addHarmonic(const GPNote* gpnote, Note* note)
 
     Note* hnote = nullptr;
     if (gpnote->harmonic().type != GPNote::Harmonic::Type::Natural) {
-        hnote = mu::engraving::Factory::createNote(_score->dummy()->chord());
+        hnote = mu::engraving::Factory::createNote(_score->dummy());
         hnote->setTrack(note->track());
         hnote->setString(note->string());
         hnote->setPitch(note->pitch());
@@ -1919,7 +1919,7 @@ void GPConverter::addAccent(const GPNote* gpnote, Note* note)
 
     for (size_t flagIdx = 0; flagIdx < gpnote->accents().size(); flagIdx++) {
         if (gpnote->accents()[flagIdx] && symbolsIds.find(accentType(flagIdx)) == symbolsIds.end()) {
-            Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+            Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
             art->setSymId(accentType(flagIdx));
             note->chord()->add(art);
         }
@@ -1970,7 +1970,7 @@ void GPConverter::addSingleSlide(const GPNote* gpnote, Note* note)
 
     for (size_t flagIdx = 2; flagIdx < gpnote->slides().size(); flagIdx++) {
         if (gpnote->slides()[flagIdx]) {
-            ChordLine* cl = Factory::createChordLine(_score->dummy()->chord());
+            ChordLine* cl = Factory::createChordLine(_score->dummy());
             cl->setChordLineType(slideType(flagIdx));
             cl->setStraight(true);
             note->chord()->add(cl);
@@ -1993,7 +1993,7 @@ void GPConverter::addPickScrape(const GPNote* gpnote, Note* note)
 {
     if (gpnote->pickScrape() != GPNote::PickScrape::None && m_currentGPBeat) {
         if (engravingConfiguration()->guitarProImportExperimental()) {
-            ChordLine* cl = mu::engraving::Factory::createChordLine(_score->dummy()->chord());
+            ChordLine* cl = mu::engraving::Factory::createChordLine(_score->dummy());
             cl->setChordLineType(gpnote->pickScrape() == GPNote::PickScrape::Down ? ChordLineType::FALL : ChordLineType::DOIT);
             cl->setWavy(true);
             note->chord()->add(cl);
@@ -2205,7 +2205,7 @@ void GPConverter::addDynamic(const GPBeat* gpb, ChordRest* cr)
         return u"ppp";
     };
 
-    Dynamic* dynamic = Factory::createDynamic(_score->dummy()->segment());
+    Dynamic* dynamic = Factory::createDynamic(_score->dummy());
     dynamic->setTrack(cr->track());
     dynamic->setDynamicType(convertDynamic(gpb->dynamic()));
     cr->segment()->add(dynamic);
@@ -2246,7 +2246,7 @@ void GPConverter::addTie(const GPNote* gpnote, Note* note, TieMap& ties)
                 if (m_tremolosInChords.find(startChord) != m_tremolosInChords.end()) {
                     TremoloType type = m_tremolosInChords.at(startChord);
                     DO_ASSERT(!isTremoloTwoChord(type));
-                    TremoloSingleChord* t = Factory::createTremoloSingleChord(_score->dummy()->chord());
+                    TremoloSingleChord* t = Factory::createTremoloSingleChord(_score->dummy());
                     t->setTremoloType(type);
                     endChord->add(t);
                     muse::remove(m_tremolosInChords, startChord);
@@ -2472,7 +2472,7 @@ void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Cont
         return;
     }
 
-    FretDiagram* fretDiagram = mu::engraving::Factory::createFretDiagram(_score->dummy()->segment());
+    FretDiagram* fretDiagram = mu::engraving::Factory::createFretDiagram(_score->dummy());
     fretDiagram->setTrack(cr->track());
     fretDiagram->setStrings(diagram.stringCount);
     fretDiagram->setFretOffset(diagram.baseFret);
@@ -2511,7 +2511,7 @@ void GPConverter::addSlapped(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
     art->setTextType(ArticulationTextType::SLAP);
     cr->add(art);
 }
@@ -2522,7 +2522,7 @@ void GPConverter::addPopped(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
     art->setTextType(ArticulationTextType::POP);
     cr->add(art);
 }
@@ -2541,7 +2541,7 @@ void GPConverter::addBrush(const GPBeat* beat, ChordRest* cr)
         }
     };
 
-    Arpeggio* arp = mu::engraving::Factory::createArpeggio(_score->dummy()->chord());
+    Arpeggio* arp = mu::engraving::Factory::createArpeggio(_score->dummy());
     arp->setArpeggioType(brushType(beat->brush()));
     arp->setStretch(beat->arpeggioStretch());
 
@@ -2562,7 +2562,7 @@ void GPConverter::addArpeggio(const GPBeat* beat, ChordRest* cr)
         }
     };
 
-    Arpeggio* arp = mu::engraving::Factory::createArpeggio(_score->dummy()->chord());
+    Arpeggio* arp = mu::engraving::Factory::createArpeggio(_score->dummy());
     arp->setArpeggioType(arpeggioType(beat->arpeggio()));
     arp->setStretch(beat->arpeggioStretch());
     cr->add(arp);
@@ -2658,7 +2658,7 @@ void GPConverter::addTuplet(const GPBeat* beat, ChordRest* cr)
     m_nextTupletInfo.lowestBase = std::min(m_nextTupletInfo.lowestBase, cr->ticks().denominator());
 
     if (!m_nextTupletInfo.tuplet) {
-        m_nextTupletInfo.tuplet  = Factory::createTuplet(_score->dummy()->measure());
+        m_nextTupletInfo.tuplet  = Factory::createTuplet(_score->dummy());
         m_nextTupletInfo.tuplet->setRatio(currentTupletType);
         m_nextTupletInfo.ratio = currentTupletType;
         m_nextTupletInfo.measure = cr->measure();
@@ -2715,7 +2715,7 @@ void GPConverter::addFadding(const GPBeat* beat, ChordRest* cr)
         }
     };
 
-    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
     art->setSymId(scoreFadding(beat->fadding()));
     if (!EditChord::toggleArticulation(_score, toChord(cr)->upNote(), art)) {
         delete art;
@@ -2745,7 +2745,7 @@ void GPConverter::addPickStroke(const GPBeat* beat, ChordRest* cr)
         }
     };
 
-    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy());
     art->setSymId(scorePickStroke(beat->pickStroke()));
     if (!EditChord::toggleArticulation(_score, toChord(cr)->upNote(), art)) {
         delete art;
@@ -2769,7 +2769,7 @@ void GPConverter::addTremolo(const GPBeat* beat, ChordRest* cr)
         }
     };
 
-    TremoloSingleChord* t = Factory::createTremoloSingleChord(_score->dummy()->chord());
+    TremoloSingleChord* t = Factory::createTremoloSingleChord(_score->dummy());
     t->setTremoloType(scoreTremolo(beat->tremolo()));
     Chord* ch = toChord(cr);
     ch->add(t);
@@ -2792,7 +2792,7 @@ void GPConverter::addWah(const GPBeat* beat, ChordRest* cr)
         return SymId::brassMuteClosed;
     };
 
-    Articulation* art = Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = Factory::createArticulation(_score->dummy());
     art->setSymId(scoreWah(beat->wah()));
     if (!EditChord::toggleArticulation(_score, toChord(cr)->upNote(), art)) {
         delete art;
@@ -2808,7 +2808,7 @@ void GPConverter::addGolpe(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    Articulation* art = Factory::createArticulation(_score->dummy()->chord());
+    Articulation* art = Factory::createArticulation(_score->dummy());
     art->setSymId(SymId::guitarGolpe);
 
     if (beat->golpe() == GPBeat::Golpe::Thumb) {
@@ -2870,7 +2870,7 @@ void GPConverter::addLyrics(const GPBeat* beat, ChordRest* cr, const Context& ct
         return;
     }
 
-    Lyrics* lyr = Factory::createLyrics(_score->dummy()->chord());
+    Lyrics* lyr = Factory::createLyrics(_score->dummy());
 
     if (lyrStr.back() == '-') {
         lyr->setSyllabic(LyricsSyllabic::MIDDLE);
@@ -3077,7 +3077,7 @@ void GPConverter::addCapos()
             params.transposeMode = CapoParams::TransposeMode::TAB_ONLY;
             params.fretPosition = it->second;
 
-            Capo* capo = Factory::createCapo(_score->dummy()->segment());
+            Capo* capo = Factory::createCapo(_score->dummy());
             capo->setTrack(track);
             capo->setParams(params);
             segment->add(capo);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1526,7 +1526,7 @@ void GPConverter::addTempoMap()
             }
 
             if (tempIt->second.linear) {
-                GradualTempoChange* tempoChange = Factory::createGradualTempoChange(segment);
+                GradualTempoChange* tempoChange = Factory::createGradualTempoChange(_score->dummy());
                 tempoChange->setTick(tick);
                 tempoChange->setTrack(0);
                 _lastGradualTempoChange = tempoChange;

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2464,7 +2464,6 @@ void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Cont
     if (asHarmony) {
         Harmony* h = Factory::createHarmony(cr->segment());
         h->setTrack(cr->track());
-        h->setOwnershipParent(cr->segment());
         h->setHarmonyType(HarmonyType::STANDARD);
         h->setHarmony(diagram.name); // F#dim7
         h->setPlainText(h->harmonyName());
@@ -2581,7 +2580,6 @@ void GPConverter::addTimer(const GPBeat* beat, ChordRest* cr)
     st->setPlainText(String::number(minutes)
                      + u':'
                      + (seconds < 10 ? u'0' + String::number(seconds) : String::number(seconds)));
-    st->setOwnershipParent(cr->segment());
     st->setTrack(cr->track());
     cr->segment()->add(st);
 }
@@ -3053,7 +3051,6 @@ void GPConverter::addTuning()
             StringTunings* tun = Factory::createStringTunings(seg);
             tun->setStringData(sd);
             tun->setTrack(staff2track(s->idx()));
-            tun->setOwnershipParent(seg);
             seg->add(tun);
         }
     }

--- a/src/importexport/guitarpro/internal/guitarbendimport/bendbuilder.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/bendbuilder.cpp
@@ -166,7 +166,7 @@ static void reindexGraceNotes(Chord* chord)
 
 static Chord* createGraceAfterChord(Chord* parent)
 {
-    Chord* graceChord = Factory::createChord(parent->score()->dummy()->segment());
+    Chord* graceChord = Factory::createChord(parent->score()->dummy());
     graceChord->setTrack(parent->track());
     graceChord->setNoteType(NoteType::GRACE8_AFTER);
     graceChord->setNoStem(true);

--- a/src/importexport/guitarpro/internal/guitarbendimport/splitchord/benddataprocessorsplitchord.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/splitchord/benddataprocessorsplitchord.cpp
@@ -103,7 +103,7 @@ static void createSplitDurationBends(const BendDataContextSplitChord& bendDataCt
                     currentChord->setDurationType(currentChordDuration);
                 } else {
                     curSegment = currentMeasure->getSegment(SegmentType::ChordRest, currentActualTick);
-                    currentChord = Factory::createChord(score->dummy()->segment());
+                    currentChord = Factory::createChord(score->dummy());
                     currentChord->setTrack(track);
                     currentChord->setTicks(currentChordDuration);
                     currentChord->setDurationType(currentChordDuration);

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -149,7 +149,7 @@ int GuitarPro4::readBeatEffects(int track, Segment* segment)
         int strokeup = readUInt8();                // up stroke length
         int strokedown = readUInt8();                // down stroke length
 
-        Arpeggio* a = Factory::createArpeggio(score->dummy()->chord());
+        Arpeggio* a = Factory::createArpeggio(score->dummy());
         if (strokeup > 0) {
             a->setArpeggioType(ArpeggioType::UP_STRAIGHT);
             if (strokeup < 7) {
@@ -256,7 +256,7 @@ GuitarPro::ReadNoteResult GuitarPro4::readNote(int string, int staffIdx, Note* n
 
     // check if a note is supposed to be accented, and give it the sforzato type
     if (noteBits & NOTE_SFORZATO) {             // 0x40
-        Articulation* art = Factory::createArticulation(note->score()->dummy()->chord());
+        Articulation* art = Factory::createArticulation(note->score()->dummy());
         art->setSymId(SymId::articAccentAbove);
         if (!EditChord::toggleArticulation(note->score(), note, art)) {
             delete art;
@@ -330,7 +330,7 @@ GuitarPro::ReadNoteResult GuitarPro4::readNote(int string, int staffIdx, Note* n
             } else if (duration == 3) {
                 grace_len = Constants::DIVISION / 4;       //16th
             }
-            Note* gn = Factory::createNote(score->dummy()->chord());
+            Note* gn = Factory::createNote(score->dummy());
 
             if (fret == 255) {
                 gn->setHeadGroup(NoteHeadGroup::HEAD_CROSS);
@@ -345,7 +345,7 @@ GuitarPro::ReadNoteResult GuitarPro4::readNote(int string, int staffIdx, Note* n
             gn->setPitch(grace_pitch);
             gn->setTpcFromPitch();
 
-            Chord* gc = Factory::createChord(score->dummy()->segment());
+            Chord* gc = Factory::createChord(score->dummy());
             gc->setTrack(note->chord()->track());
             gc->add(gn);
             gc->setOwnershipParent(note->chord());
@@ -901,7 +901,7 @@ bool GuitarPro4::read(IODevice* io)
 
                 Lyrics* lyrics = 0;
                 if (beatBits & BEAT_LYRICS) {
-                    lyrics = Factory::createLyrics(score->dummy()->chord());
+                    lyrics = Factory::createLyrics(score->dummy());
                     auto str = readDelphiString();
                     //TODO-ws                   str.erase(std::remove_if(str.begin(), str.end(), [](char c){return c == '_'; }), str.end());
                     lyrics->setPlainText(str);
@@ -910,7 +910,7 @@ bool GuitarPro4::read(IODevice* io)
                 if (gpLyrics.beatCounter >= gpLyrics.fromBeat && static_cast<size_t>(gpLyrics.lyricTrack) == staffIdx + 1) {
                     size_t index = gpLyrics.beatCounter - gpLyrics.fromBeat;
                     if (index < gpLyrics.lyrics.size()) {
-                        lyrics = Factory::createLyrics(score->dummy()->chord());
+                        lyrics = Factory::createLyrics(score->dummy());
                         lyrics->setPlainText(gpLyrics.lyrics[index]);
                     }
                 }
@@ -935,10 +935,10 @@ bool GuitarPro4::read(IODevice* io)
                         delete cr;
                         cr = 0;
                     }
-                    cr = Factory::createRest(score->dummy()->segment());
+                    cr = Factory::createRest(score->dummy());
                 } else {
                     if (!segment->cr(track)) {
-                        cr = Factory::createChord(score->dummy()->segment());
+                        cr = Factory::createChord(score->dummy());
                     }
                 }
                 cr->setOwnershipParent(segment);

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -1004,7 +1004,6 @@ bool GuitarPro4::read(IODevice* io)
                             if (dotted) {
                                 // there is at most one dotted note in this guitar pro version
                                 NoteDot* dot = Factory::createNoteDot(note);
-                                dot->setOwnershipParent(note);
                                 dot->setTrack(track);                  // needed to know the staff it belongs to (and detect tablature)
                                 dot->setVisible(true);
                                 note->add(dot);
@@ -1105,7 +1104,6 @@ bool GuitarPro4::read(IODevice* io)
                                             s->setStartElement(n);
                                             s->setTick(seg->tick());
                                             s->setTrack(chord->track());
-                                            s->setOwnershipParent(n);
                                             s->setGlissandoType(GlissandoType::STRAIGHT);
                                             s->setEndElement(last);
                                             s->setTick2(chord->segment()->tick());
@@ -1184,7 +1182,6 @@ bool GuitarPro4::read(IODevice* io)
                         s->setStartElement(n);
                         s->setTick(n->chord()->segment()->tick());
                         s->setTrack(n->track());
-                        s->setOwnershipParent(n);
                         s->setGlissandoType(GlissandoType::STRAIGHT);
                         s->setEndElement(nt);
                         s->setTick2(nt->chord()->segment()->tick());

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -148,7 +148,7 @@ int GuitarPro5::readBeatEffects(int track, Segment* segment)
         int strokeup = readUInt8();                // up stroke length
         int strokedown = readUInt8();                // down stroke length
 
-        Arpeggio* a = Factory::createArpeggio(score->dummy()->chord());
+        Arpeggio* a = Factory::createArpeggio(score->dummy());
         // representation is different in guitar pro 5 - the up/down order below is correct
         if (strokeup > 0) {
             a->setArpeggioType(ArpeggioType::DOWN_STRAIGHT);
@@ -286,10 +286,10 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                 delete cr;
                 cr = 0;
             }
-            cr = Factory::createRest(score->dummy()->segment());
+            cr = Factory::createRest(score->dummy());
         } else {
             if (!cr) {
-                cr = Factory::createChord(score->dummy()->segment());
+                cr = Factory::createChord(score->dummy());
             }
         }
         cr->setOwnershipParent(segment);
@@ -738,7 +738,7 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
                 auto cr = seg->cr(gpLyrics.lyricTrack);
                 if (cr) {
                     if (str[0] != '-') {
-                        Lyrics* lyr = Factory::createLyrics(score->dummy()->chord());
+                        Lyrics* lyr = Factory::createLyrics(score->dummy());
 
                         std::string text;
                         auto pos = str.find('-');
@@ -1241,25 +1241,25 @@ GuitarPro::ReadNoteResult GuitarPro5::readNoteEffects(Note* note)
 
         if (slideKind & SLIDE_OUT_DOWN) {
             slideKind &= ~SLIDE_OUT_DOWN;
-            sld = Factory::createChordLine(score->dummy()->chord());
+            sld = Factory::createChordLine(score->dummy());
             slideType = ChordLineType::FALL;
         }
         // slide out upwards (doit)
         if (slideKind & SLIDE_OUT_UP) {
             slideKind &= ~SLIDE_OUT_UP;
-            sld = Factory::createChordLine(score->dummy()->chord());
+            sld = Factory::createChordLine(score->dummy());
             slideType = ChordLineType::DOIT;
         }
         // slide in from below (plop)
         if (slideKind & SLIDE_IN_BELOW) {
             slideKind &= ~SLIDE_IN_BELOW;
-            sld = Factory::createChordLine(score->dummy()->chord());
+            sld = Factory::createChordLine(score->dummy());
             slideType = ChordLineType::PLOP;
         }
         // slide in from above (scoop)
         if (slideKind & SLIDE_IN_ABOVE) {
             slideKind &= ~SLIDE_IN_ABOVE;
-            sld = Factory::createChordLine(score->dummy()->chord());
+            sld = Factory::createChordLine(score->dummy());
             slideType = ChordLineType::SCOOP;
         }
 
@@ -1504,7 +1504,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNote(int string, Note* note)
 
     // check if a note is supposed to be accented, and give it the marcato type
     if (noteBits & NOTE_MARCATO) {
-        Articulation* art = Factory::createArticulation(note->score()->dummy()->chord());
+        Articulation* art = Factory::createArticulation(note->score()->dummy());
         art->setSymId(SymId::articMarcatoAbove);
         if (!EditChord::toggleArticulation(note->score(), note, art)) {
             delete art;
@@ -1512,7 +1512,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNote(int string, Note* note)
     }
     // check if a note is supposed to be accented, and give it the sforzato type
     else if (noteBits & NOTE_SFORZATO) {
-        Articulation* art = Factory::createArticulation(note->score()->dummy()->chord());
+        Articulation* art = Factory::createArticulation(note->score()->dummy());
         art->setSymId(SymId::articAccentAbove);
         note->add(art);
         if (!EditChord::toggleArticulation(note->score(), note, art)) {
@@ -1593,7 +1593,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNote(int string, Note* note)
                         if (m_tremolosInChords.find(chord2) != m_tremolosInChords.end()) {
                             TremoloType type = m_tremolosInChords.at(chord2);
                             DO_ASSERT(!isTremoloTwoChord(type));
-                            TremoloSingleChord* t = Factory::createTremoloSingleChord(score->dummy()->chord());
+                            TremoloSingleChord* t = Factory::createTremoloSingleChord(score->dummy());
                             t->setTremoloType(type);
                             chord->add(t);
                             muse::remove(m_tremolosInChords, chord2);

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -309,7 +309,6 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                 tuplet = Factory::createTuplet(measure);
                 tuplets[track2] = tuplet;
                 setTuplet(tuplet, tuple);
-                tuplet->setOwnershipParent(measure);
             }
             tuplet->setTrack(cr->track());
             tuplet->setBaseLen(l);
@@ -343,7 +342,6 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                 if (dotted) {
                     // there is at most one dotted note in this guitar pro version
                     NoteDot* dot = Factory::createNoteDot(note);
-                    dot->setOwnershipParent(note);
                     dot->setTrack(track);            // needed to know the staff it belongs to (and detect tablature)
                     dot->setVisible(true);
                     note->add(dot);
@@ -1028,7 +1026,6 @@ bool GuitarPro5::read(IODevice* io)
             StringTunings* tun = Factory::createStringTunings(seg);
             tun->setStringData(sd);
             tun->setTrack(staff2track(s->idx()));
-            tun->setOwnershipParent(seg);
             seg->add(tun);
 
             auto tuning = utils::standardTuningFor(p->instrument()->channel(0)->program(), (int)sd.strings());
@@ -1091,7 +1088,6 @@ bool GuitarPro5::read(IODevice* io)
                     sym->setSym(SymId::segnoSerpent2);
                 }
 
-                sym->setOwnershipParent(measure);
                 sym->setTrack(0);
                 segment->add(sym);
                 auto iter = counter.find(articulations[i]);
@@ -1110,7 +1106,6 @@ bool GuitarPro5::read(IODevice* io)
                     "D.D.S. al Fine", "Da Coda", "Da Doppia Coda"
                 };
                 st->setPlainText(String::fromAscii(text[i - 4]));
-                st->setOwnershipParent(s);
                 st->setTrack(0);
                 auto iter = counter.find(articulations[i]);
                 if (iter == counter.end()) {
@@ -1733,7 +1728,6 @@ void GuitarPro5::addGlissandos()
         gliss->setStartElement(currentStart);
         gliss->setTick(currentStart->tick());
         gliss->setTrack(currentStart->track());
-        gliss->setOwnershipParent(currentStart);
         gliss->setGlissandoType(GlissandoType::STRAIGHT);
         gliss->setGlissandoShift(true);
         gliss->setEndElement(endNote);

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1335,7 +1335,6 @@ void GuitarPro::createSlur(bool hasSlur, staff_idx_t staffIdx, ChordRest* cr)
 {
     if (hasSlur && (slurs[staffIdx] == 0)) {
         Slur* slur = Factory::createSlur(score->dummy());
-        slur->setOwnershipParent(0);
         slur->setTrack(cr->track());
         slur->setTrack2(cr->track());
         slur->setTick(cr->tick());
@@ -1683,7 +1682,6 @@ bool GuitarPro2::read(IODevice* io)
                         tuplet->setTrack(cr->track());
                         tuplets[staffIdx] = tuplet;
                         setTuplet(tuplet, tuple);
-                        tuplet->setOwnershipParent(measure);
                     }
                     tuplet->setTrack(track);
                     tuplet->setBaseLen(l);
@@ -2459,7 +2457,6 @@ bool GuitarPro3::read(IODevice* io)
                         tuplet->setTrack(cr->track());
                         tuplets[staffIdx] = tuplet;
                         setTuplet(tuplet, tuple);
-                        tuplet->setOwnershipParent(measure);
                     }
                     tuplet->setTrack(track);
                     tuplet->setBaseLen(l);
@@ -2493,7 +2490,6 @@ bool GuitarPro3::read(IODevice* io)
                         if (dotted) {
                             NoteDot* dot = Factory::createNoteDot(note);
                             // there is at most one dotted note in this guitar pro version - set 0 index
-                            dot->setOwnershipParent(note);
                             dot->setTrack(track);                // needed to know the staff it belongs to (and detect tablature)
                             dot->setVisible(true);
                             note->add(dot);
@@ -2630,7 +2626,6 @@ bool GuitarPro3::read(IODevice* io)
                         s->setStartElement(n);
                         s->setTick(n->chord()->segment()->tick());
                         s->setTrack(n->track());
-                        s->setOwnershipParent(n);
                         s->setGlissandoType(GlissandoType::STRAIGHT);
                         s->setEndElement(nt);
                         s->setTick2(cr->segment()->tick());
@@ -2758,7 +2753,6 @@ void GuitarPro::addTunings()
             StringTunings* tun = Factory::createStringTunings(seg);
             tun->setStringData(sd);
             tun->setTrack(staff2track(s->idx()));
-            tun->setOwnershipParent(seg);
             seg->add(tun);
             // Instrument string data should be set to the standard
             tuning = utils::standardTuningFor(p->instrument()->channel(0)->program(), (int)sd.strings());

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -424,7 +424,7 @@ void GuitarPro::addTextArticulation(Note* note, ArticulationTextType type)
     }
 
     if (Chord* ch = toChord(note->parent())) {
-        Articulation* art = mu::engraving::Factory::createArticulation(score->dummy()->chord());
+        Articulation* art = mu::engraving::Factory::createArticulation(score->dummy());
         art->setTextType(type);
         ch->add(art);
     }
@@ -1140,7 +1140,7 @@ bool GuitarPro1::read(IODevice* io)
                 }
                 Lyrics* lyrics = 0;
                 if (beatBits & BEAT_LYRICS) {
-                    lyrics = Factory::createLyrics(score->dummy()->chord());
+                    lyrics = Factory::createLyrics(score->dummy());
                     lyrics->setPlainText(readDelphiString());
                 }
                 if (beatBits & BEAT_EFFECTS) {
@@ -1157,9 +1157,9 @@ bool GuitarPro1::read(IODevice* io)
                 Fraction l = len2fraction(len);
                 ChordRest* cr;
                 if (strings) {
-                    cr = Factory::createChord(score->dummy()->segment());
+                    cr = Factory::createChord(score->dummy());
                 } else {
-                    cr = Factory::createRest(score->dummy()->segment());
+                    cr = Factory::createRest(score->dummy());
                 }
                 cr->setTrack(track);
                 if (lyrics) {
@@ -1642,7 +1642,7 @@ bool GuitarPro2::read(IODevice* io)
                 Lyrics* lyrics = 0;
                 if (beatBits & BEAT_LYRICS) {
                     String txt = readDelphiString();
-                    lyrics = Factory::createLyrics(score->dummy()->chord());
+                    lyrics = Factory::createLyrics(score->dummy());
                     lyrics->setPlainText(txt);
                 }
                 if (beatBits & BEAT_EFFECTS) {
@@ -1659,9 +1659,9 @@ bool GuitarPro2::read(IODevice* io)
                 Fraction l = len2fraction(len);
                 ChordRest* cr;
                 if (strings) {
-                    cr = Factory::createChord(score->dummy()->segment());
+                    cr = Factory::createChord(score->dummy());
                 } else {
-                    cr = Factory::createRest(score->dummy()->segment());
+                    cr = Factory::createRest(score->dummy());
                 }
                 cr->setTrack(track);
                 if (lyrics) {
@@ -1831,7 +1831,7 @@ GuitarPro::ReadNoteResult GuitarPro1::readNote(int string, Note* note)
             } else if (duration == 3) {
                 grace_len = Constants::DIVISION / 4;       //16th
             }
-            Note* gn = Factory::createNote(score->dummy()->chord());
+            Note* gn = Factory::createNote(score->dummy());
 
             if (fret == 255) {
                 gn->setHeadGroup(NoteHeadGroup::HEAD_CROSS);
@@ -1851,7 +1851,7 @@ GuitarPro::ReadNoteResult GuitarPro1::readNote(int string, Note* note)
                 gc = note->chord()->graceNotes().front();
             }
             if (!gc) {
-                gc = Factory::createChord(score->dummy()->segment());
+                gc = Factory::createChord(score->dummy());
                 TDuration d;
                 d.setVal(grace_len);
                 if (grace_len == Constants::DIVISION / 6) {
@@ -2404,7 +2404,7 @@ bool GuitarPro3::read(IODevice* io)
                 Lyrics* lyrics = 0;
                 if (beatBits & BEAT_LYRICS) {
                     String txt = readDelphiString();
-                    Lyrics* lyrics2 = Factory::createLyrics(score->dummy()->chord());
+                    Lyrics* lyrics2 = Factory::createLyrics(score->dummy());
                     lyrics2->setPlainText(txt);
                 }
                 int beatEffects = 0;
@@ -2428,7 +2428,7 @@ bool GuitarPro3::read(IODevice* io)
                 // if (!pause || strings)
                 if (strings) {
                     if (!segment->cr(track)) {
-                        cr = Factory::createChord(score->dummy()->segment());
+                        cr = Factory::createChord(score->dummy());
                     }
                 } else {
                     if (segment->cr(track)) {
@@ -2436,7 +2436,7 @@ bool GuitarPro3::read(IODevice* io)
                         delete cr;
                         cr = 0;
                     }
-                    cr = Factory::createRest(score->dummy()->segment());
+                    cr = Factory::createRest(score->dummy());
                 }
 
                 cr->setTrack(track);
@@ -2669,7 +2669,7 @@ int GuitarPro3::readBeatEffects(int track, Segment* segment)
         int strokeup = readUInt8();                // up stroke length
         int strokedown = readUInt8();                // down stroke length
 
-        Arpeggio* a = Factory::createArpeggio(score->dummy()->chord());
+        Arpeggio* a = Factory::createArpeggio(score->dummy());
         if (strokeup > 0) {
             a->setArpeggioType(ArpeggioType::UP_STRAIGHT);
         } else if (strokedown > 0) {

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -741,7 +741,6 @@ void PowerTab::fillMeasure(tBeatList& elist, Measure* measure, int staff, std::v
 
         if (beat.tuplet && !tuple) {
             tuple = Factory::createTuplet(measure);
-            tuple->setOwnershipParent(measure);
             tuple->setTrack(cr->track());
             tuple->setTick(cr->tick());
             tuple->setBaseLen(l);

--- a/src/importexport/guitarpro/internal/utils.cpp
+++ b/src/importexport/guitarpro/internal/utils.cpp
@@ -150,7 +150,6 @@ static void addParenthesesToNotes(Chord* ch, const std::vector<Note*>& notes)
 {
     auto createParen = [ch](DirectionH dir) {
         Parenthesis* p = Factory::createParenthesis(ch);
-        p->setOwnershipParent(ch);
         p->setTrack(ch->track());
         p->setDirection(dir);
         return p;
@@ -203,7 +202,6 @@ void addPlayCountTexts(Score* score)
         }
         PlayCountText* pct = Factory::createPlayCountText(endBarSeg);
         pct->setTrack(0);
-        pct->setOwnershipParent(endBarSeg);
         score->addElement(pct);
     }
 }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -518,27 +518,28 @@ Spanner* MeiImporter::addSpanner(const libmei::Element& meiElement, Measure* mea
         return nullptr;
     }
 
-    Spanner* item = nullptr;
-    Segment* segment = pos.measure->getSegment(SegmentType::ChordRest, pos.tick);
+    // a spanner is not attached to anything: the score manages it
+    DummyParent* dummy = m_score->dummy();
 
+    Spanner* item = nullptr;
     if (meiElement.m_name == "dir") {
         ElementType elementType = Convert::elementTypeForDirWithExt(meiElement);
         switch (elementType) {
-        case (ElementType::HAIRPIN): item = Factory::createHairpin(segment);
+        case (ElementType::HAIRPIN): item = Factory::createHairpin(dummy);
             break;
         default:
-            item = Factory::createTextLine(segment);
+            item = Factory::createTextLine(dummy);
         }
     } else if (meiElement.m_name == "hairpin") {
-        item = Factory::createHairpin(segment);
+        item = Factory::createHairpin(dummy);
     } else if (meiElement.m_name == "octave") {
-        item = Factory::createOttava(segment);
+        item = Factory::createOttava(dummy);
     } else if (meiElement.m_name == "pedal") {
-        item = Factory::createPedal(segment);
+        item = Factory::createPedal(dummy);
     } else if (meiElement.m_name == "slur") {
-        item = Factory::createSlur(segment);
+        item = Factory::createSlur(dummy);
     } else if (meiElement.m_name == "trill") {
-        item = Factory::createTrill(segment);
+        item = Factory::createTrill(dummy);
     } else {
         return nullptr;
     }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -892,13 +892,11 @@ void MeiImporter::setOrnamentAccid(engraving::Ornament* ornament, const Convert:
     if (ornament->hasIntervalAbove() && (ornamSt.accidTypeAbove != AccidentalType::NONE)) {
         Accidental* accidental = Factory::createAccidental(ornament);
         accidental->setAccidentalType(ornamSt.accidTypeAbove);
-        accidental->setOwnershipParent(ornament);
         ornament->setAccidentalAbove(accidental);
     }
     if (ornament->hasIntervalBelow() && (ornamSt.accidTypeBelow != AccidentalType::NONE)) {
         Accidental* accidental = Factory::createAccidental(ornament);
         accidental->setAccidentalType(ornamSt.accidTypeBelow);
-        accidental->setOwnershipParent(ornament);
         ornament->setAccidentalBelow(accidental);
     }
 }
@@ -2222,7 +2220,6 @@ bool MeiImporter::readTuplet(pugi::xml_node tupletNode, Measure* measure, int tr
     }
 
     m_tuplet->setTrack(track);
-    m_tuplet->setOwnershipParent(measure);
 
     success = readElements(tupletNode, measure, track, ticks);
 
@@ -2744,7 +2741,6 @@ bool MeiImporter::readGliss(pugi::xml_node glissNode, Measure* measure)
     gliss->setTick(startNote->chord()->tick());
     gliss->setStartElement(startNote);
     gliss->setTrack(startNote->track());
-    gliss->setOwnershipParent(startNote);
     gliss->setGlissandoStyle(startNote->part()->instrument(startNote->tick())->glissandoStyle());
 
     const String glissText = String(glissNode.text().as_string());
@@ -2878,7 +2874,6 @@ bool MeiImporter::readLv(pugi::xml_node lvNode, Measure* measure)
     }
 
     LaissezVib* lv = Factory::createLaissezVib(note);
-    lv->setOwnershipParent(note);
     note->score()->undoAddElement(lv);
     m_uids->reg(lv, meiLv.m_xmlId);
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -277,19 +277,15 @@ ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int 
         duration.setDots(augmentDotsAtt->GetDots());
     }
 
-    Segment* segment = nullptr;
-    // For grace notes we use a dummy segment, otherwise a ChordRest segment with the appropriate ticks value
-    if (m_readingGraceNotes) {
-        segment = m_score->dummy()->segment();
-    } else {
-        segment = measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
-    }
+    // grace notes are added to the chord they precede, so they get no segment of their own
+    Segment* segment = m_readingGraceNotes ? nullptr : measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
+    const DummyParentOr<Segment> parent = parentOrDummy(segment, m_score->dummy());
 
     ChordRest* chordRest = nullptr;
     if (isRest) {
-        chordRest = Factory::createRest(segment);
+        chordRest = Factory::createRest(parent);
     } else {
-        chordRest = Factory::createChord(segment);
+        chordRest = Factory::createChord(parent);
     }
 
     // Do not use single note xml:id / EID for the ChordRest

--- a/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
@@ -251,7 +251,6 @@ void detectSwing(Staff* staff, MidiOperations::Swing swingType)
         Segment* seg = score->firstSegment(SegmentType::ChordRest);
         StaffText* st = new StaffText(seg, TextStyleType::STAFF);
         st->setPlainText(swingCaption(swingType));
-        st->setOwnershipParent(seg);
         st->setTrack(strack);       // voice == 0
         score->addElement(st);
     }

--- a/src/importexport/midi/internal/midiimport/importmidi_tuplet_tonotes.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tuplet_tonotes.cpp
@@ -88,7 +88,6 @@ void createTupletNotes(
         tuplet->setTrack(track);
         tuplet->setTick(tupletData.onTime.fraction());
         tuplet->setVoice(tupletData.voice);
-        tuplet->setOwnershipParent(measure);
 
         for (DurationElement* el: tupletData.elements) {
             tuplet->add(el);

--- a/src/importexport/mnx/internal/import/mnximporter.cpp
+++ b/src/importexport/mnx/internal/import/mnximporter.cpp
@@ -647,7 +647,6 @@ void MnxImporter::setBarline(engraving::Measure* measure, const mnx::global::Bar
         mensurStriche = mensurStriche && !localSpan && !localTick && !localShort;
 
         BarLine* bl = Factory::createBarLine(bls);
-        bl->setOwnershipParent(bls);
         bl->setTrack(staff2track(idx));
         bl->setVisible(mnxBlt != mnx::BarlineType::NoBarline);
         bl->setGenerated(false);
@@ -731,7 +730,6 @@ void MnxImporter::createJumpOrMarker(engraving::Measure* measure, const mnx::Fra
                                     : ElementType::MARKER;
 
     TextBase* item = toTextBase(Factory::createItem(elementType, measure));
-    item->setOwnershipParent(measure);
     item->setTrack(curTrackIdx);
 
     std::visit([&](const auto& v) {
@@ -787,7 +785,6 @@ void MnxImporter::createTempoMark(engraving::Measure* measure, const mnx::global
     Segment* s = measure->getChordRestOrTimeTickSegment(measure->tick() + rTick);
 
     TempoText* item = Factory::createTempoText(s);
-    item->setOwnershipParent(s);
     item->setTrack(curTrackIdx);
 
     Fraction noteValueInQuarters = toMuseScoreFraction(tempo.value()) / Fraction(1, 4);

--- a/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
+++ b/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
@@ -1230,7 +1230,7 @@ void MnxImporter::createHairpin(const mnx::part::DynamicGradual& mnxHairpin, Seg
         }
     }
 
-    Hairpin* hairpin = Factory::createHairpin(segment);
+    Hairpin* hairpin = Factory::createHairpin(m_score->dummy());
     hairpin->setHairpinType(mnxHairpin.wedgeType() == mnx::DynamicWedgeType::Increasing
                             ? HairpinType::CRESC_HAIRPIN
                             : HairpinType::DIM_HAIRPIN);

--- a/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
+++ b/src/importexport/mnx/internal/import/mnximportpartmeasures.cpp
@@ -256,7 +256,6 @@ void MnxImporter::createLyrics(const mnx::sequence::Event& mnxEvent, engraving::
                     }
                     Lyrics* lyric = Factory::createLyrics(cr);
                     lyric->setTrack(cr->track());
-                    lyric->setOwnershipParent(cr);
                     lyric->setVerse(verse);
                     lyric->setXmlText(String::fromStdString(it->second.text()));
                     lyric->setSyllabic(toMuseScoreLyricsSyllabic(it->second.type()));
@@ -272,7 +271,6 @@ void MnxImporter::createLyrics(const mnx::sequence::Event& mnxEvent, engraving::
                 }
                 Lyrics* lyric = Factory::createLyrics(cr);
                 lyric->setTrack(cr->track());
-                lyric->setOwnershipParent(cr);
                 int verse = 0;
                 if (staffIt != m_lyricLineToVerse.end()) {
                     const auto mapped = staffIt->second.find(lineId);
@@ -366,7 +364,6 @@ void MnxImporter::createTies(const mnx::Array<mnx::sequence::Tie>& ties, engravi
         tie->setStartNote(startNote);
         tie->setTick(startNote->tick());
         tie->setTrack(startNote->track());
-        tie->setOwnershipParent(startNote);
         startNote->setTieFor(tie);
         DirectionV tieDir = DirectionV::AUTO;
         if (const auto side = mnxTie.side()) {
@@ -432,7 +429,6 @@ void MnxImporter::createTies(const mnx::Array<mnx::sequence::Tie>& ties, engravi
             tie->setStartNote(startNote);
             tie->setTick(startNote->tick());
             tie->setTrack(startNote->track());
-            tie->setOwnershipParent(startNote);
             startNote->setTieFor(tie);
             startTie = tie;
             setAndStyleProperty(tie, Pid::SLUR_DIRECTION, tieDir);
@@ -550,7 +546,6 @@ Note* MnxImporter::createNote(const mnx::sequence::Note& mnxNote, Chord* chord, 
                               const Fraction& tick, int ottavaDisplacement, track_idx_t curTrackIdx)
 {
     Note* note = Factory::createNote(chord);
-    note->setOwnershipParent(chord);
     note->setTrack(curTrackIdx);
     auto pitch = mnxNote.pitch();
     NoteVal nval = toMuseScoreNoteVal(pitch, baseStaff->concertKey(tick), ottavaDisplacement);
@@ -582,7 +577,6 @@ Tuplet* MnxImporter::createTuplet(const mnx::sequence::Tuplet& mnxTuplet, Measur
 
     Tuplet* t = Factory::createTuplet(measure);
     t->setTrack(curTrackIdx);
-    t->setOwnershipParent(measure);
     t->setTick(measure->tick() + toMuseScoreFraction(startTick));
     t->setRatio(tupletRatio);
     t->setBaseLen(baseLen);
@@ -637,7 +631,6 @@ void MnxImporter::createTremolo(const mnx::sequence::MultiNoteTremolo& mnxTremol
     tremolo->setTremoloType(TremoloType(tremoloBeamsNum));
     tremolo->setTrack(curTrackIdx);
     tremolo->setVisible(c1->notes().front()->visible());
-    tremolo->setOwnershipParent(c1);
     tremolo->setChords(c1, c2);
     c1->setTremoloTwoChord(tremolo);
 }
@@ -724,7 +717,6 @@ ChordRest* MnxImporter::importEvent(const mnx::sequence::Event& event,
                         nval.headGroup = drumset->noteHead(midiPitch);
                     }
                     engraving::Note* note = Factory::createNote(chord);
-                    note->setOwnershipParent(chord);
                     note->setTrack(curTrackIdx);
                     note->setNval(nval);
                     chord->add(note);
@@ -1117,7 +1109,6 @@ void MnxImporter::createDynamic(const mnx::part::DynamicGroupBase& mnxDynamic, S
     }
 
     Dynamic* dyn = Factory::createDynamic(segment);
-    dyn->setOwnershipParent(segment);
     dyn->setTrack(curTrackIdx);
 
     // An accent spells itself out as accentPrefix + value + accentSuffix + residualValue.
@@ -1551,7 +1542,6 @@ void MnxImporter::createArpeggios(const mnx::part::Measure& mnxMeasure)
                 }
             }
         }
-        arpeggio->setOwnershipParent(chordTop);
         chordTop->setArpeggio(arpeggio);
     };
 

--- a/src/importexport/musedata/internal/musedata.cpp
+++ b/src/importexport/musedata/internal/musedata.cpp
@@ -315,7 +315,7 @@ void MuseData::readNote(Part* part, QStringView s)
         }
     }
 
-    Chord* chord = Factory::createChord(score->dummy()->segment());
+    Chord* chord = Factory::createChord(score->dummy());
     chordRest = chord;
     chord->setTrack(gstaff * VOICES);
     chord->setStemDirection(dir);
@@ -499,7 +499,7 @@ void MuseData::readRest(Part* part, QStringView s)
 
     TDuration d;
     d.setVal(ticks.ticks());
-    Rest* rest = Factory::createRest(score->dummy()->segment(), d);
+    Rest* rest = Factory::createRest(score->dummy(), d);
     rest->setTicks(d.fraction());
     chordRest  = rest;
     rest->setTrack(gstaff * VOICES);

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -7182,7 +7182,7 @@ void ExportMusicXml::keysigTimesig(const Measure* m, const Part* p)
         if (m->tick().isZero()) {
             //KeySigEvent kse;
             //kse.setKey(Key::C);
-            KeySig* ks = Factory::createKeySig(m_score->dummy()->segment());
+            KeySig* ks = Factory::createKeySig(m_score->dummy());
             if (p->staff(0)->isTabStaff(Fraction(0, 1))) {
                 ks->setVisible(false);
             }

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -610,7 +610,7 @@ static InstrumentChange* createInstrumentChange(Score* score, const MusicXmlInst
         return nullptr;
     }
 
-    InstrumentChange* instrChange = Factory::createInstrumentChange(score->dummy()->segment(), instr);
+    InstrumentChange* instrChange = Factory::createInstrumentChange(score->dummy(), instr);
     instrChange->setTrack(track);
 
     // for text use instrument name (if known) else use "Instrument change"
@@ -1261,7 +1261,7 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
     const SymId articSym = notation.symId();
     const String direction = notation.attribute(u"type");
     Segment* seg = cr->segment();
-    Fermata* fermata = Factory::createFermata(seg ? seg : cr->score()->dummy()->segment());
+    Fermata* fermata = Factory::createFermata(parentOrDummy(seg, cr->score()->dummy()));
     fermata->setSymIdAndTimeStretch(articSym);
     fermata->setTrack(cr->track());
     fermata->setVisible(notation.visible());
@@ -2052,7 +2052,7 @@ Err MusicXmlParserPass2::parse()
 static std::unique_ptr<BarLine> createBarline(const Score* score, const track_idx_t track, const BarLineType type, const bool visible,
                                               const String& barStyle, const bool spanStaff)
 {
-    std::unique_ptr<BarLine> barline(Factory::createBarLine(score->dummy()->segment()));
+    std::unique_ptr<BarLine> barline(Factory::createBarLine(score->dummy()));
     barline->setTrack(track);
     barline->setBarLineType(type);
     barline->setSpanStaff(spanStaff);
@@ -2820,7 +2820,7 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
 
                 if (canAddTempoText(m_score, tick.ticks())) {
                     double tpo = tempoString.toDouble() / 60;
-                    TempoText* t = Factory::createTempoText(m_score->dummy()->segment());
+                    TempoText* t = Factory::createTempoText(m_score->dummy());
                     t->setXmlText(String(u"%1 = %2").arg(TempoText::duration2tempoTextString(TDuration(DurationType::V_QUARTER)),
                                                          tempoString));
                     t->setVisible(false);
@@ -3523,7 +3523,7 @@ void MusicXmlParserDirection::direction(const String& partId,
         // Ignore (TBD: print to footer?)
         return;
     } else if (isLikelyTempoText(m_track)) {
-        TempoText* tt = Factory::createTempoText(m_score->dummy()->segment());
+        TempoText* tt = Factory::createTempoText(m_score->dummy());
         tt->setXmlText(m_wordsText + m_metroText);
         if (m_tpoSound > 0 && canAddTempoText(m_score, tick.ticks())) {
             double tpo = m_tpoSound / 60;
@@ -3542,13 +3542,13 @@ void MusicXmlParserDirection::direction(const String& partId,
 
         GradualTempoChangeType gtc = getTempoChangeTypeFromString(simplifiedText);
 
-        GradualTempoChange* tempoLine = Factory::createGradualTempoChange(m_score->dummy()->segment());
+        GradualTempoChange* tempoLine = Factory::createGradualTempoChange(m_score->dummy());
         tempoLine->setTempoChangeType(gtc);
         tempoLine->setBeginText(simplifiedText);
         tempoLine->setContinueText(u"");
         m_inferredTempoLineStart = tempoLine;
     } else if (isLikelySticking()) {
-        Sticking* sticking = Factory::createSticking(m_score->dummy()->segment());
+        Sticking* sticking = Factory::createSticking(m_score->dummy());
         sticking->setXmlText(m_wordsText);
         if (!RealIsNull(m_relativeX)) {
             PointF offset = sticking->offset();
@@ -3571,7 +3571,7 @@ void MusicXmlParserDirection::direction(const String& partId,
         if (m_tpoSound > 0.1) {
             if (canAddTempoText(m_score, tick.ticks())) {
                 m_tpoSound /= 60;
-                t = Factory::createTempoText(m_score->dummy()->segment());
+                t = Factory::createTempoText(m_score->dummy());
                 String rawWordsText = m_wordsText;
                 static const std::regex re("(<.*?>)");
                 rawWordsText.remove(re);
@@ -3594,17 +3594,17 @@ void MusicXmlParserDirection::direction(const String& partId,
                 }
                 isExpressionText = m_wordsText.contains(u"<i>") && m_metroText.empty() && placement() == u"below";
                 if (isExpressionText) {
-                    t = Factory::createExpression(m_score->dummy()->segment());
+                    t = Factory::createExpression(m_score->dummy());
                 } else if (m_systemDirection) {
-                    t = Factory::createSystemText(m_score->dummy()->segment());
+                    t = Factory::createSystemText(m_score->dummy());
                 } else if (technique != PlayingTechniqueType::Undefined) {
-                    t = Factory::createPlayTechAnnotation(m_score->dummy()->segment(), technique, TextStyleType::STAFF);
+                    t = Factory::createPlayTechAnnotation(m_score->dummy(), technique, TextStyleType::STAFF);
                 } else {
-                    t = Factory::createStaffText(m_score->dummy()->segment());
+                    t = Factory::createStaffText(m_score->dummy());
                 }
                 t->setXmlText(m_wordsText + m_metroText);
             } else {
-                t = Factory::createRehearsalMark(m_score->dummy()->segment());
+                t = Factory::createRehearsalMark(m_score->dummy());
                 if (!m_rehearsalText.contains(u"<b>")) {
                     m_rehearsalText = u"<b></b>" + m_rehearsalText;            // explicitly turn bold off
                 }
@@ -3686,7 +3686,7 @@ void MusicXmlParserDirection::direction(const String& partId,
 
         if (canAddTempoText(m_score, tick.ticks())) {
             double tpo = m_tpoSound / 60;
-            TempoText* t = Factory::createTempoText(m_score->dummy()->segment());
+            TempoText* t = Factory::createTempoText(m_score->dummy());
             t->setXmlText(String(u"%1 = %2").arg(TempoText::duration2tempoTextString(TDuration(DurationType::V_QUARTER))).arg(
                               m_tpoSound));
             t->setVisible(false);
@@ -3709,7 +3709,7 @@ void MusicXmlParserDirection::direction(const String& partId,
     // do dynamics
     // LVIFIX: check import/export of <other-dynamics>unknown_text</...>
     for (StringList::iterator it = m_dynamicsList.begin(); it != m_dynamicsList.end(); ++it) {
-        Dynamic* dynamic = Factory::createDynamic(m_score->dummy()->segment());
+        Dynamic* dynamic = Factory::createDynamic(m_score->dummy());
         dynamic->setDynamicType(*it);
         colorItem(dynamic, m_dynamicsColor);
 
@@ -4240,7 +4240,7 @@ void MusicXmlParserDirection::harpPedal()
     const std::vector <String> pedalSteps = { u"D", u"C", u"B", u"E", u"F", u"G", u"A" };
     const Color color = Color::fromString(m_e.attribute("color"));
 
-    HarpPedalDiagram* hpd = Factory::createHarpPedalDiagram(m_score->dummy()->segment());
+    HarpPedalDiagram* hpd = Factory::createHarpPedalDiagram(m_score->dummy());
     while (m_e.readNextStartElement()) {
         int stepIndex = 0;
         PedalPosition pedpos = PedalPosition::UNSET;
@@ -4554,7 +4554,7 @@ void MusicXmlParserDirection::textToCrescLine(String& text)
 
     // Create line
     text.clear();
-    Hairpin* line = Factory::createHairpin(m_score->dummy()->segment());
+    Hairpin* line = Factory::createHairpin(m_score->dummy());
 
     line->setHairpinType(cresc ? HairpinType::CRESC_LINE : HairpinType::DIM_LINE);
     line->setBeginText(simplifiedText);
@@ -4802,28 +4802,28 @@ Jump* MusicXmlParserDirection::findJump(const String& repeat) const
 {
     Jump* jp = nullptr;
     if (repeat == u"daCapo") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DC);
     } else if (repeat == u"daCapoAlCoda") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DC_AL_CODA);
         jp->setPlayUntil(jp->playUntil() + m_codaId);
         jp->setContinueAt(jp->continueAt() + m_codaId);
     } else if (repeat == u"daCapoAlFine") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DC_AL_FINE);
     } else if (repeat == u"dalSegno") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DS);
         jp->setJumpTo(jp->jumpTo() + m_segnoId);
     } else if (repeat == u"dalSegnoAlCoda") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DS_AL_CODA);
         jp->setJumpTo(jp->jumpTo() + m_segnoId);
         jp->setPlayUntil(jp->playUntil() + m_codaId);
         jp->setContinueAt(jp->continueAt() + m_codaId);
     } else if (repeat == u"dalSegnoAlFine") {
-        jp = Factory::createJump(m_score->dummy()->measure());
+        jp = Factory::createJump(m_score->dummy());
         jp->setJumpType(JumpType::DS_AL_FINE);
         jp->setJumpTo(jp->jumpTo() + m_segnoId);
     }
@@ -4845,7 +4845,7 @@ void MusicXmlParserDirection::handleNmiCmi(Measure* measure, const Fraction& tic
     if (!m_wordsText.contains(u"NmiCmi")) {
         return;
     }
-    Harmony* ha = new Harmony(m_score->dummy()->segment());
+    Harmony* ha = new Harmony(m_score->dummy());
     HarmonyInfo* info = new HarmonyInfo(m_score);
     info->setRootTpc(Tpc::TPC_INVALID);
     info->setId(-1);
@@ -4869,7 +4869,7 @@ void MusicXmlParserDirection::handleChordSym(const Fraction& tick, HarmonyMap& h
         return;
     }
 
-    Harmony* ha = Factory::createHarmony(m_score->dummy()->segment());
+    Harmony* ha = Factory::createHarmony(m_score->dummy());
     ha->setHarmony(m_wordsText);
     ha->setTrack(m_track);
     ha->setPlacement(placement() == u"above" ? PlacementV::ABOVE : PlacementV::BELOW);
@@ -5241,7 +5241,7 @@ void MusicXmlParserDirection::dashes(const String& type, const int number,
             // TextLine supports only limited formatting, remove all (compatible with 1.3)
             String simplifiedText = MScoreTextToMusicXml::toPlainText(m_wordsText).simplified();
             if (isLikelyTempoLine(m_track)) {
-                b = Factory::createGradualTempoChange(m_score->dummy()->segment());
+                b = Factory::createGradualTempoChange(m_score->dummy());
                 GradualTempoChangeType gtc = getTempoChangeTypeFromString(simplifiedText);
                 toGradualTempoChange(b)->setTempoChangeType(gtc);
             }
@@ -5479,7 +5479,7 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
             m_e.skipCurrentElement();
             return;
         }
-        Hairpin* h = spdesc.isStopped ? toHairpin(spdesc.sp) : Factory::createHairpin(m_score->dummy()->segment());
+        Hairpin* h = spdesc.isStopped ? toHairpin(spdesc.sp) : Factory::createHairpin(m_score->dummy());
         h->setHairpinType(type == "crescendo"
                           ? HairpinType::CRESC_HAIRPIN : HairpinType::DIM_HAIRPIN);
         if (niente == "yes") {
@@ -5504,7 +5504,7 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
             m_e.skipCurrentElement();
             return;
         }
-        Hairpin* h = spdesc.isStarted ? toHairpin(spdesc.sp) : Factory::createHairpin(m_score->dummy()->segment());
+        Hairpin* h = spdesc.isStarted ? toHairpin(spdesc.sp) : Factory::createHairpin(m_score->dummy());
         if (niente == "yes") {
             h->setHairpinCircledTip(true);
         }
@@ -6603,7 +6603,7 @@ NoteType graceNoteType(const TDuration duration, const bool slash)
 static Chord* createGraceChord(Score* score, const int track,
                                const TDuration duration, const bool slash, const bool small)
 {
-    Chord* c = Factory::createChord(score->dummy()->segment());
+    Chord* c = Factory::createChord(score->dummy());
     c->setNoteType(graceNoteType(duration, slash));
     c->setTrack(track);
     // Chord is initialized with the smallness of its first note.
@@ -7675,7 +7675,7 @@ FiguredBassItem* MusicXmlParserPass2::figure(const int idx, const bool paren, Fi
 
 FiguredBass* MusicXmlParserPass2::figuredBass()
 {
-    FiguredBass* fb = Factory::createFiguredBass(m_score->dummy()->segment());
+    FiguredBass* fb = Factory::createFiguredBass(m_score->dummy());
 
     const bool parentheses = m_e.asciiAttribute("parentheses") == "yes";
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
@@ -7740,7 +7740,7 @@ FiguredBass* MusicXmlParserPass2::figuredBass()
 
 FretDiagram* MusicXmlParserPass2::frame()
 {
-    FretDiagram* fd = Factory::createFretDiagram(m_score->dummy()->segment());
+    FretDiagram* fd = Factory::createFretDiagram(m_score->dummy());
 
     colorItem(fd, Color::fromString(m_e.asciiAttribute("color").ascii()));
 
@@ -7862,7 +7862,7 @@ void MusicXmlParserPass2::harmony(const String& partId, Measure* measure, const 
     std::vector<HDegree> degreeList;
 
     FretDiagram* fd = nullptr;
-    Harmony* ha = Factory::createHarmony(m_score->dummy()->segment());
+    Harmony* ha = Factory::createHarmony(m_score->dummy());
     HarmonyInfo* info = new HarmonyInfo(m_score);
     Fraction offset;
     if (!placement.empty()) {
@@ -8248,9 +8248,9 @@ void MusicXmlParserLyric::parse(bool visibility)
 
     TextBase* item = nullptr;
     if (isLikelySticking(formattedText, syllabic, hasExtend)) {
-        item = Factory::createSticking(m_score->dummy()->segment());
+        item = Factory::createSticking(m_score->dummy());
     } else {
-        item = Factory::createLyrics(m_score->dummy()->chord());
+        item = Factory::createLyrics(m_score->dummy());
     }
 
     //LOGD("formatted lyric '%s'", muPrintable(formattedText));
@@ -9537,7 +9537,7 @@ void MusicXmlParserNotations::addToScore(ChordRest* const cr, Note* const note, 
     // LVIFIX: check import/export of <other-dynamics>unknown_text</...>
     // TODO: remove duplicate code (see MusicXml::direction)
     for (const String& d : std::as_const(m_dynamicsList)) {
-        Dynamic* dynamic = Factory::createDynamic(m_score->dummy()->segment());
+        Dynamic* dynamic = Factory::createDynamic(m_score->dummy());
         dynamic->setDynamicType(d);
         colorItem(dynamic, m_dynamicsColor);
         m_pass2.addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), tick);

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -1145,7 +1145,6 @@ static void handleTupletStart(const ChordRest* const cr, Tuplet*& tuplet,
     tuplet->setBracketType(tupletDesc.bracket);
     tuplet->setNumberType(tupletDesc.shownumber);
     tuplet->setDirection(tupletDesc.direction);
-    tuplet->setOwnershipParent(cr->measure());
 }
 
 //---------------------------------------------------------
@@ -1907,7 +1906,6 @@ static void cleanupUnterminatedTie(Tie* tie, const Score* score, bool fixForCros
 
     // Add Laissez Vibrer instead
     LaissezVib* lvTie = Factory::createLaissezVib(unterminatedTieNote);
-    lvTie->setOwnershipParent(unterminatedTieNote);
     unterminatedTieNote->score()->undoAddElement(lvTie);
 }
 
@@ -8369,7 +8367,6 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, N
 
                 // Slur starts & ends on same chord - add lv instead
                 LaissezVib* lvTie = Factory::createLaissezVib(note);
-                lvTie->setOwnershipParent(note);
                 note->score()->undoAddElement(lvTie);
                 return;
             }
@@ -8427,7 +8424,6 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, N
 
                 // Slur starts & ends on same chord - add lv instead
                 LaissezVib* lvTie = Factory::createLaissezVib(note);
-                lvTie->setOwnershipParent(note);
                 note->score()->undoAddElement(lvTie);
                 return;
             }
@@ -8980,7 +8976,6 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
             gliss->setStartElement(note);
             gliss->setTick(tick);
             gliss->setTrack(track);
-            gliss->setOwnershipParent(note);
             gliss->setVisible(notation.visible());
             colorItem(gliss, Color::fromString(notation.attribute(u"color")));
             if (lineType == u"dashed") {
@@ -9171,7 +9166,6 @@ static void addTie(const Notation& notation, Note* note, const track_idx_t track
         }
     } else if (type == "let-ring") {
         LaissezVib* lvTie = Factory::createLaissezVib(note);
-        lvTie->setOwnershipParent(note);
         lvTie->setVisible(notation.visible());
         colorItem(lvTie, Color::fromString(notation.attribute(u"color")));
 

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -1772,7 +1772,6 @@ void OveToMScore::convertNotes(Measure* measure, int part, int staff, int track)
                     TDuration duration = OveNoteType_To_Duration(container->getNoteType());
                     tuplet->setBaseLen(duration);
                     tuplet->setTick(Fraction::fromTicks(tick));
-                    tuplet->setOwnershipParent(measure);
                     // measure->add(tuplet);
                 }
             }

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -1578,7 +1578,7 @@ void OveToMScore::convertNotes(Measure* measure, int part, int staff, int track)
 
             cr = measure->findChord(Fraction::fromTicks(tick), noteTrack);
             if (cr == 0) {
-                cr = Factory::createChord(m_score->dummy()->segment());
+                cr = Factory::createChord(m_score->dummy());
                 cr->setTrack(noteTrack);
 
                 // grace
@@ -2092,7 +2092,7 @@ void OveToMScore::convertLyrics(Measure* measure, int part, int staff, int track
         ovebase::Lyric* oveLyric = static_cast<ovebase::Lyric*>(lyrics[i]);
         int tick = m_mtt->getTick(measure->measureNumber(), oveLyric->getTick());
 
-        Lyrics* lyric = Factory::createLyrics(m_score->dummy()->chord());
+        Lyrics* lyric = Factory::createLyrics(m_score->dummy());
         lyric->setVerse(oveLyric->getVerse());
         lyric->setPlainText(oveLyric->getLyric());
         lyric->setTrack(track);
@@ -2129,7 +2129,7 @@ void OveToMScore::convertHarmonies(Measure* measure, int part, int staff, int tr
         ovebase::Harmony* harmonyPtr = static_cast<ovebase::Harmony*>(harmonies[i]);
         int absTick = m_mtt->getTick(measure->measureNumber(), harmonyPtr->getTick());
 
-        Harmony* harmony = Factory::createHarmony(m_score->dummy()->segment());
+        Harmony* harmony = Factory::createHarmony(m_score->dummy());
         HarmonyInfo* info = new HarmonyInfo(measure->score());
 
         // TODO - does this need to be key-aware?
@@ -2535,7 +2535,7 @@ void OveToMScore::convertWedges(Measure* measure, int part, int staff, int track
             MeasureToTick::unitToTick(wedgePtr->stop()->getOffset(), m_ove->getQuarter()));
 
         if (absTick2 > absTick) {
-            Hairpin* hp = Factory::createHairpin(m_score->dummy()->segment());
+            Hairpin* hp = Factory::createHairpin(m_score->dummy());
 
             hp->setHairpinType(OveWedgeType_To_Type(wedgePtr->getWedgeType()));
             // hp->setYoff(wedgePtr->getYOffset());

--- a/src/importexport/tabledit/internal/importtef.cpp
+++ b/src/importexport/tabledit/internal/importtef.cpp
@@ -297,7 +297,7 @@ static void addGraceNotesToChord(mu::engraving::Chord* chord, int pitch, int fre
     mu::engraving::TDuration durationType(mu::engraving::DurationType::V_INVALID);
     const int ticks { 240 };
     durationType.setVal(ticks);
-    mu::engraving::Chord* cr = Factory::createChord(chord->score()->dummy()->segment());
+    mu::engraving::Chord* cr = Factory::createChord(chord->score()->dummy());
     cr->setTrack(chord->track());
     cr->setNoteType(mu::engraving::NoteType::APPOGGIATURA);
     cr->setDurationType(mu::engraving::DurationType::V_EIGHTH);

--- a/src/importexport/tabledit/internal/tuplethandler.cpp
+++ b/src/importexport/tabledit/internal/tuplethandler.cpp
@@ -76,7 +76,6 @@ void TupletHandler::addCr(Measure* measure, ChordRest* cr)
     if (inTuplet && !tuplet) {
         tuplet = Factory::createTuplet(measure);
         LOGN("new tuplet %p cr ticks %d/%d", tuplet, cr->ticks().numerator(), cr->ticks().denominator());
-        tuplet->setOwnershipParent(measure);
         tuplet->setTrack(cr->track());
         tuplet->setTick(cr->tick());
         tuplet->setRatio({ 3, 2 });

--- a/src/importexport/tabledit/internal/tuplethandler.cpp
+++ b/src/importexport/tabledit/internal/tuplethandler.cpp
@@ -23,6 +23,7 @@
 #include "tuplethandler.h"
 
 #include "engraving/dom/factory.h"
+#include "engraving/dom/measure.h"
 #include "engraving/dom/tuplet.h"
 #include "engraving/types/fraction.h"
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -248,7 +248,7 @@ static void createMeasures(MasterScore* masterScore, const ScoreCreateOptions& s
         measure->adjustToLen(scoreOptions.withPickupMeasure ? scoreOptions.pickupTimesig : scoreOptions.globalTimesig);
 
         // Add timesigs...
-        TimeSig* timesig = Factory::createTimeSig(masterScore->dummy()->segment());
+        TimeSig* timesig = Factory::createTimeSig(masterScore->dummy());
         timesig->setSig(scoreOptions.globalTimesig, scoreOptions.timesigType);
         Transaction& tx = masterScore->transactionManager()->currentOrDummyTransaction();
         EditTimeSig::addTimeSig(tx, masterScore, measure, /*staffIdx*/ 0, timesig, /*local*/ false);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -51,7 +51,6 @@
 // TODO: Don't include from engraving/internal
 #include "engraving/internal/qmimedataadapter.h"
 
-#include "engraving/compat/dummyelement.h"
 #include "engraving/dom/accidental.h"
 #include "engraving/dom/actionicon.h"
 #include "engraving/dom/anchors.h"
@@ -61,6 +60,7 @@
 #include "engraving/dom/bracket.h"
 #include "engraving/dom/chord.h"
 #include "engraving/dom/drumset.h"
+#include "engraving/dom/dummyparent.h"
 #include "engraving/dom/dynamic.h"
 #include "engraving/dom/elementgroup.h"
 #include "engraving/dom/factory.h"

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5680,7 +5680,6 @@ void NotationInteraction::toggleDynamicPopup()
             Measure* measure = score()->tick2measure(tick);
             Segment* segment = measure->undoGetChordRestOrTimeTickSegment(tick);
             Dynamic* dynamic = Factory::createDynamic(segment);
-            dynamic->setOwnershipParent(segment);
             dynamic->setTrack(track);
             dynamic->setVoiceAssignment(voiceAssignment);
             score()->undoAddElement(dynamic);
@@ -6828,7 +6827,6 @@ void NotationInteraction::navigateToNextSyllable()
 
             Lyrics* toLyrics = Factory::createLyrics(initialCR);
             toLyrics->setTrack(track);
-            toLyrics->setOwnershipParent(initialCR);
             toLyrics->setVerse(verse);
             toLyrics->setTextStyleType(styleType);
             toLyrics->setPlacement(placement);
@@ -6904,7 +6902,6 @@ void NotationInteraction::navigateToNextSyllable()
 
         toLyrics = Factory::createLyrics(toLyricsChord);
         toLyrics->setTrack(track);
-        toLyrics->setOwnershipParent(toLyricsChord);
 
         toLyrics->setVerse(verse);
         toLyrics->setTextStyleType(styleType);
@@ -7007,7 +7004,6 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
     if (!lyrics) {
         lyrics = Factory::createLyrics(cr);
         lyrics->setTrack(track);
-        lyrics->setOwnershipParent(cr);
         lyrics->setVerse(verse);
         lyrics->setTextStyleType(styleType);
         lyrics->setPlacement(placement);
@@ -7743,8 +7739,6 @@ void NotationInteraction::addMelisma()
     if (!toLyrics) {
         toLyrics = Factory::createLyrics(nextCR);
         toLyrics->setTrack(track);
-        toLyrics->setOwnershipParent(nextCR);
-
         toLyrics->setVerse(verse);
         const TextStyleType styleType(toLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
         toLyrics->setTextStyleType(styleType);
@@ -7827,7 +7821,6 @@ void NotationInteraction::addLyricsVerse()
 
     mu::engraving::Lyrics* lyrics = Factory::createLyrics(oldLyrics->chordRest());
     lyrics->setTrack(oldLyrics->track());
-    lyrics->setOwnershipParent(oldLyrics->chordRest());
     lyrics->setPlacement(oldLyrics->placement());
     lyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, oldLyrics->propertyFlags(mu::engraving::Pid::PLACEMENT));
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -576,7 +576,7 @@ bool NotationInteraction::doShowShadowNote(ShadowNote& shadowNote, ShadowNotePar
 
     if (inputState.rest()) {
         Score* s = score()->paletteScore() ? score()->paletteScore() : score();
-        mu::engraving::Rest* rest = mu::engraving::Factory::createRest(s->dummy()->segment(), params.duration.type());
+        mu::engraving::Rest* rest = mu::engraving::Factory::createRest(s->dummy(), params.duration.type());
         rest->setTicks(params.duration.fraction());
         symNotehead = rest->getSymbol(params.duration.type(), 0, staff->lines(position.segment->tick()));
         shadowNote.setState(symNotehead, params.duration, true, params.position.beyondScore);
@@ -2500,14 +2500,14 @@ void NotationInteraction::applyPaletteElementToRange(EngravingItem* element, mu:
                 switch (elementType) {
                 case mu::engraving::ElementType::CLEF:
                 {
-                    mu::engraving::Clef* oclef = engraving::Factory::createClef(score->dummy()->segment());
+                    mu::engraving::Clef* oclef = engraving::Factory::createClef(score->dummy());
                     oclef->setClefType(staff->clef(tick2));
                     oelement = oclef;
                     break;
                 }
                 case mu::engraving::ElementType::KEYSIG:
                 {
-                    mu::engraving::KeySig* okeysig = engraving::Factory::createKeySig(score->dummy()->segment());
+                    mu::engraving::KeySig* okeysig = engraving::Factory::createKeySig(score->dummy());
                     okeysig->setKeySigEvent(staff->keySigEvent(tick2));
                     Key ck = okeysig->concertKey();
                     okeysig->setKey(ck);
@@ -2516,7 +2516,7 @@ void NotationInteraction::applyPaletteElementToRange(EngravingItem* element, mu:
                 }
                 case mu::engraving::ElementType::TIMESIG:
                 {
-                    mu::engraving::TimeSig* otimesig = engraving::Factory::createTimeSig(score->dummy()->segment());
+                    mu::engraving::TimeSig* otimesig = engraving::Factory::createTimeSig(score->dummy());
                     otimesig->setFrom(staff->timeSig(tick2));
                     oelement = otimesig;
                     break;
@@ -7937,7 +7937,7 @@ void NotationInteraction::addFretboardDiagram()
     std::vector<engraving::FretDiagram*> created;
 
     for (EngravingItem* element : filteredElements) {
-        engraving::FretDiagram* diagram = engraving::Factory::createFretDiagram(score->dummy()->segment());
+        engraving::FretDiagram* diagram = engraving::Factory::createFretDiagram(score->dummy());
         diagram->setTrack(element->track());
 
         Harmony* harmony = toHarmony(element);
@@ -8023,7 +8023,7 @@ mu::engraving::Harmony* NotationInteraction::findHarmonyInSegment(const mu::engr
 mu::engraving::Harmony* NotationInteraction::createHarmony(mu::engraving::Segment* segment, track_idx_t track,
                                                            mu::engraving::HarmonyType type) const
 {
-    mu::engraving::Harmony* harmony = Factory::createHarmony(score()->dummy()->segment());
+    mu::engraving::Harmony* harmony = Factory::createHarmony(score()->dummy());
     harmony->setScore(score());
     harmony->setOwnershipParent(segment);
     harmony->setTrack(track);

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -378,13 +378,11 @@ Note* NotationMidiInput::makePreviewNote(const muse::midi::Event& e)
     const engraving::DummyParentOr<Segment> seg = engraving::parentOrDummy(inputState.lastSegment(), score->dummy());
 
     Chord* chord = engraving::Factory::createChord(seg);
-    chord->setOwnershipParent(seg);
 
     const ChordRest* cr = inputState.cr();
     const staff_idx_t staffIdx = cr ? engraving::track2staff(cr->track()) : 0;
 
     Note* note = engraving::Factory::createNote(chord);
-    note->setOwnershipParent(chord);
     note->setStaffIdx(staffIdx);
 
     engraving::NoteVal nval = NoteInput::noteVal(score, e.note(), staffIdx, configuration()->midiUseWrittenPitch().val);

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -375,7 +375,7 @@ Note* NotationMidiInput::makePreviewNote(const muse::midi::Event& e)
 
     Score* score = this->score();
     const InputState& inputState = score->inputState();
-    Segment* seg = inputState.lastSegment() ? inputState.lastSegment() : score->dummy()->segment();
+    const engraving::DummyParentOr<Segment> seg = engraving::parentOrDummy(inputState.lastSegment(), score->dummy());
 
     Chord* chord = engraving::Factory::createChord(seg);
     chord->setOwnershipParent(seg);

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/dynamicpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/dynamicpopupmodel.cpp
@@ -211,7 +211,7 @@ void DynamicPopupModel::addHairpinToDynamic(ItemType itemType)
     }
 
     beginCommand(TranslatableString("undoableAction", "Add hairpin"));
-    Hairpin* hairpin = Factory::createHairpin(m_item->score()->dummy()->segment());
+    Hairpin* hairpin = Factory::createHairpin(m_item->score()->dummy());
     hairpin->setHairpinType(hairpinType);
     Transaction& tx = m_item->score()->transactionManager()->currentOrDummyTransaction();
     EditHairpin::addHairpinToDynamic(tx, m_item->score(), hairpin, dynamic);

--- a/src/notationscene/utilities/percussionutilities.cpp
+++ b/src/notationscene/utilities/percussionutilities.cpp
@@ -78,7 +78,6 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
 
     Note* note = Factory::createNote(chord.get());
     note->setMark(true);
-    note->setOwnershipParent(chord.get());
     note->setTrack(voice);
     note->setPitch(pitch);
     note->setTpcFromPitch();
@@ -97,7 +96,6 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
     chord->add(note);
 
     Stem* stem = Factory::createStem(chord.get());
-    stem->setOwnershipParent(chord.get());
     stem->setBaseLength(up ? -3.0_sp : 3.0_sp);
     engravingRender()->layoutItem(stem);
     chord->add(stem);

--- a/src/notationscene/utilities/percussionutilities.cpp
+++ b/src/notationscene/utilities/percussionutilities.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
         up = line > 4;
     }
 
-    auto chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy()->segment());
+    auto chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy());
     chord->setDurationType(DurationType::V_QUARTER);
     chord->setStemDirection(dir);
     chord->setIsUiItem(true);

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -220,9 +220,9 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
         } else if (s == "visible") {
             visible = e.readBool();
         } else if (s == "Tremolo") {
+            Score* paletteScore = paletteScoreProvider()->paletteScore();
             compat::TremoloCompat tc;
-            tc.parent = paletteScoreProvider()->paletteScore()->dummy()->chord();
-            rw::RWRegister::reader(paletteScoreProvider()->paletteScore()->mscVersion())->readTremoloCompat(&tc, e);
+            rw::RWRegister::reader(paletteScore->mscVersion())->readTremoloCompat(&tc, paletteScore, e);
             if (tc.single) {
                 element.reset(tc.single);
             } else if (tc.two) {

--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -126,7 +126,7 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
         }
 
         Articulation* oldOrnament = toArticulation(item);
-        Ornament* newOrnament = Factory::createOrnament((ChordRest*)(paletteScore->dummy()->chord()));
+        Ornament* newOrnament = Factory::createOrnament((ChordRest*)(paletteScore->dummy()));
         newOrnament->setSymId(oldOrnament->symId());
         cell->element.reset(newOrnament);
         return;
@@ -134,7 +134,7 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
 
     if (item->isStaffText() && toStaffText(item)->textStyleType() == TextStyleType::EXPRESSION) {
         StaffText* oldExpression = toStaffText(item);
-        Expression* newExpression = Factory::createExpression(paletteScore->dummy()->segment());
+        Expression* newExpression = Factory::createExpression(paletteScore->dummy());
         if (oldExpression->xmlText() == "Expression") {
             newExpression->setXmlText("expression");
         } else {
@@ -187,7 +187,7 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
             return;
         }
 
-        FretDiagram* newFretDiagram = Factory::createFretDiagram(paletteScore->dummy()->segment());
+        FretDiagram* newFretDiagram = Factory::createFretDiagram(paletteScore->dummy());
 
         if (harmonyName.empty()) {
             newFretDiagram->clear();
@@ -205,7 +205,7 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
     }
 
     if (item->isInstrumentChange()) {
-        InstrumentChange* newInstrumentChange = Factory::createInstrumentChange(paletteScore->dummy()->segment());
+        InstrumentChange* newInstrumentChange = Factory::createInstrumentChange(paletteScore->dummy());
         newInstrumentChange->setXmlText(QT_TRANSLATE_NOOP("palette", "Change instr."));
 
         cell->element.reset(newInstrumentChange);
@@ -298,7 +298,7 @@ void PaletteCompat::addNewGuitarItems(Palette& guitarPalette, Score* paletteScor
     }
 
     if (!containsWhammyBar) {
-        auto whammyBar = Factory::makeWhammyBar(paletteScore->dummy()->segment());
+        auto whammyBar = Factory::makeWhammyBar(paletteScore->dummy());
         int defaultPosition = std::min(3, guitarPalette.cellsCount());
         guitarPalette.insertElement(defaultPosition, whammyBar, QT_TRANSLATE_NOOP("palette", "Whammy bar"),
                                     0.8)->setElementTranslated(true);
@@ -322,11 +322,11 @@ void PaletteCompat::addNewGuitarItems(Palette& guitarPalette, Score* paletteScor
 
     if (!containsTapping) {
         int defaultPosition = std::min(30, guitarPalette.cellsCount());
-        auto lhTapping = Factory::makeTapping(paletteScore->dummy()->chord());
+        auto lhTapping = Factory::makeTapping(paletteScore->dummy());
         lhTapping->setHand(TappingHand::LEFT);
         guitarPalette.insertElement(defaultPosition, lhTapping, QT_TRANSLATE_NOOP("palette", "Left-hand tapping"), 1.0);
 
-        auto rhTapping = Factory::makeTapping(paletteScore->dummy()->chord());
+        auto rhTapping = Factory::makeTapping(paletteScore->dummy());
         rhTapping->setHand(TappingHand::RIGHT);
         guitarPalette.insertElement(defaultPosition + 1, rhTapping, QT_TRANSLATE_NOOP("palette", "Right-hand tapping"), 1.0);
     }
@@ -338,14 +338,14 @@ void PaletteCompat::addNewGuitarItems(Palette& guitarPalette, Score* paletteScor
     }
 
     if (!containsCapo) {
-        auto capo = Factory::makeCapo(paletteScore->dummy()->segment());
+        auto capo = Factory::makeCapo(paletteScore->dummy());
         capo->setXmlText(String::fromAscii(QT_TRANSLATE_NOOP("palette", "Capo")));
         int defaultPosition = std::min(40, guitarPalette.cellsCount());
         guitarPalette.insertElement(defaultPosition, capo, QT_TRANSLATE_NOOP("palette", "Capo"), 0.9)->setElementTranslated(true);
     }
 
     if (!containsStringTunings) {
-        auto stringTunings = Factory::makeStringTunings(paletteScore->dummy()->segment());
+        auto stringTunings = Factory::makeStringTunings(paletteScore->dummy());
         stringTunings->setXmlText(u"<sym>guitarString6</sym> - D");
         stringTunings->initTextStyleType(TextStyleType::STRING_TUNINGS);
         int defaultPosition = std::min(41, guitarPalette.cellsCount());
@@ -431,7 +431,7 @@ void PaletteCompat::addNewFretboardDiagramItems(Palette& fretboardDiagramPalette
     }
 
     if (!containsBlankItem) {
-        auto fret = Factory::makeFretDiagram(paletteScore->dummy()->segment());
+        auto fret = Factory::makeFretDiagram(paletteScore->dummy());
         fret->clear();
         fretboardDiagramPalette.insertElement(0, fret, muse::TranslatableString("palette", "Blank"));
     }
@@ -452,7 +452,7 @@ void PaletteCompat::addNewRepeatItems(Palette& repeatPalette, engraving::Score* 
     }
 
     if (!containsToCodaSym) {
-        auto marker = Factory::makeMarker(paletteScore->dummy()->measure());
+        auto marker = Factory::makeMarker(paletteScore->dummy());
         marker->setMarkerType(MarkerType::TOCODASYM);
         marker->styleChanged();
         repeatPalette.insertElement(5, marker, TConv::userName(MarkerType::TOCODASYM));
@@ -488,7 +488,7 @@ void PaletteCompat::addNewLayoutItems(Palette& layoutPalette, engraving::Score* 
 
     if (!containsNoBreak) {
         int defaultPosition = std::min(3, layoutPalette.cellsCount());
-        auto lb = Factory::makeLayoutBreak(paletteScore->dummy()->measure());
+        auto lb = Factory::makeLayoutBreak(paletteScore->dummy());
         lb->setLayoutBreakType(LayoutBreakType::NOBREAK);
         layoutPalette.insertElement(defaultPosition, lb, TConv::userName(LayoutBreakType::NOBREAK));
     }
@@ -520,7 +520,7 @@ void PaletteCompat::addChordBrackets(Palette& palette, engraving::Score* palette
                                      QT_TRANSLATE_NOOP("palette", "Chord bracket (play with right hand)") };
     for (int i = 0; i < 3; ++i) {
         DirectionV hookPos = DirectionV(i);
-        auto c = Factory::makeChordBracket(paletteScore->dummy()->chord());
+        auto c = Factory::makeChordBracket(paletteScore->dummy());
         c->setProperty(Pid::BRACKET_HOOK_POS, hookPos);
         if (position != muse::nidx) {
             palette.insertElement(position + i, c, names[i]);

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -120,23 +120,23 @@ struct makeElementImplWrapper {
         } \
     }; \
 
-IMPL_WRAPPER(Dynamic, score->dummy()->segment())
-IMPL_WRAPPER(MeasureRepeat, score->dummy()->segment())
-IMPL_WRAPPER(Hairpin, score->dummy()->segment())
-IMPL_WRAPPER(SystemText, score->dummy()->segment())
-IMPL_WRAPPER(TempoText, score->dummy()->segment())
-IMPL_WRAPPER(StaffText, score->dummy()->segment())
-IMPL_WRAPPER(Expression, score->dummy()->segment())
-IMPL_WRAPPER(PlayTechAnnotation, score->dummy()->segment())
-IMPL_WRAPPER(Capo, score->dummy()->segment())
-IMPL_WRAPPER(StringTunings, score->dummy()->segment())
-IMPL_WRAPPER(RehearsalMark, score->dummy()->segment())
+IMPL_WRAPPER(Dynamic, score->dummy())
+IMPL_WRAPPER(MeasureRepeat, score->dummy())
+IMPL_WRAPPER(Hairpin, score->dummy())
+IMPL_WRAPPER(SystemText, score->dummy())
+IMPL_WRAPPER(TempoText, score->dummy())
+IMPL_WRAPPER(StaffText, score->dummy())
+IMPL_WRAPPER(Expression, score->dummy())
+IMPL_WRAPPER(PlayTechAnnotation, score->dummy())
+IMPL_WRAPPER(Capo, score->dummy())
+IMPL_WRAPPER(StringTunings, score->dummy())
+IMPL_WRAPPER(RehearsalMark, score->dummy())
 
-IMPL_WRAPPER(Jump, score->dummy()->measure())
-IMPL_WRAPPER(MeasureNumber, score->dummy()->measure())
+IMPL_WRAPPER(Jump, score->dummy())
+IMPL_WRAPPER(MeasureNumber, score->dummy())
 
-IMPL_WRAPPER(Fingering, score->dummy()->note())
-IMPL_WRAPPER(NoteHead, score->dummy()->note())
+IMPL_WRAPPER(Fingering, score->dummy())
+IMPL_WRAPPER(NoteHead, score->dummy())
 
 // Dispatcher method ...
 template<class C, typename ... Args>
@@ -301,16 +301,16 @@ PalettePtr PaletteCreator::newKeySigPalette()
     sp->setYOffset(1.0);
 
     for (int i = 0; i < 7; ++i) {
-        auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
+        auto k = Factory::makeKeySig(paletteScore()->dummy());
         k->setKey(Key(i + 1));
         sp->appendElement(k, TConv::userName(Key(i + 1)));
     }
     for (int i = -7; i < 0; ++i) {
-        auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
+        auto k = Factory::makeKeySig(paletteScore()->dummy());
         k->setKey(Key(i));
         sp->appendElement(k, TConv::userName(Key(i)));
     }
-    auto k = Factory::makeKeySig(paletteScore()->dummy()->segment());
+    auto k = Factory::makeKeySig(paletteScore()->dummy());
     k->setKey(Key::C);
     sp->appendElement(k, TConv::userName(Key::C));
 
@@ -319,7 +319,7 @@ PalettePtr PaletteCreator::newKeySigPalette()
     nke.setConcertKey(Key::C);
     nke.setCustom(true);
     nke.setMode(KeyMode::NONE);
-    auto nk = Factory::makeKeySig(paletteScore()->dummy()->segment());
+    auto nk = Factory::makeKeySig(paletteScore()->dummy());
     nk->setKeySigEvent(nke);
     sp->appendElement(nk, TConv::userName(Key::C, true));
 
@@ -366,7 +366,7 @@ PalettePtr PaletteCreator::newBarLinePalette(bool defaultPalette)
 
     // bar line styles
     for (const BarLineTableItem& bti : BarLine::barLineTable) {
-        auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
+        auto b = Factory::makeBarLine(paletteScore()->dummy());
         b->setBarLineType(bti.type);
         sp->appendElement(b, bti.userName);
     }
@@ -383,7 +383,7 @@ PalettePtr PaletteCreator::newBarLinePalette(bool defaultPalette)
             { BARLINE_SPAN_SHORT2_FROM, BARLINE_SPAN_SHORT2_TO, muse::TranslatableString("engraving/sym", "Short barline 2") }, // Not in SMuFL
         };
         for (auto span : spans) {
-            auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
+            auto b = Factory::makeBarLine(paletteScore()->dummy());
             b->setBarLineType(BarLineType::NORMAL);
             b->setSpanFrom(span.from);
             b->setSpanTo(span.to);
@@ -478,7 +478,7 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
             continue;
         }
 
-        auto b = Factory::makeBarLine(paletteScore()->dummy()->segment());
+        auto b = Factory::makeBarLine(paletteScore()->dummy());
         b->setBarLineType(bti.type);
         PaletteCellPtr cell = sp->appendElement(b, bti.userName);
         cell->drawStaff = false;
@@ -544,7 +544,7 @@ PalettePtr PaletteCreator::newLayoutPalette()
         LayoutBreakType::NOBREAK
     };
     for (LayoutBreakType layoutBreakType : layoutBreaks) {
-        auto lb = Factory::makeLayoutBreak(paletteScore()->dummy()->measure());
+        auto lb = Factory::makeLayoutBreak(paletteScore()->dummy());
         lb->setLayoutBreakType(layoutBreakType);
         sp->appendElement(lb, TConv::userName(layoutBreakType));
     }
@@ -558,7 +558,7 @@ PalettePtr PaletteCreator::newLayoutPalette()
         SpacerType::FIXED
     };
     for (SpacerType spacerType : spacers) {
-        auto spacer = Factory::makeSpacer(paletteScore()->dummy()->measure());
+        auto spacer = Factory::makeSpacer(paletteScore()->dummy());
         spacer->setSpacerType(spacerType);
         spacer->setGap(3_sp);
         PaletteCellPtr cell = sp->appendElement(spacer, spacer->subtypeUserName());
@@ -624,7 +624,7 @@ PalettePtr PaletteCreator::newFingeringPalette(bool defaultPalette)
     };
     // include additional symbol-based fingerings (temporarily?) implemented as articulations
     for (auto i : defaultPalette ? defaultLute : masterLute) {
-        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
@@ -640,13 +640,13 @@ PalettePtr PaletteCreator::newTremoloPalette()
     sp->setVisible(false);
 
     for (int i = int(TremoloType::R8); i <= int(TremoloType::BUZZ_ROLL); ++i) {
-        auto tremolo = Factory::makeTremoloSingleChord(paletteScore()->dummy()->chord());
+        auto tremolo = Factory::makeTremoloSingleChord(paletteScore()->dummy());
         tremolo->setTremoloType(TremoloType(i));
         sp->appendElement(tremolo, tremolo->subtypeUserName());
     }
 
     for (int i = int(TremoloType::C8); i <= int(TremoloType::C256); ++i) {
-        auto tremolo = Factory::makeTremoloTwoChord(paletteScore()->dummy()->chord());
+        auto tremolo = Factory::makeTremoloTwoChord(paletteScore()->dummy());
         tremolo->setTremoloType(TremoloType(i));
         sp->appendElement(tremolo, tremolo->subtypeUserName());
     }
@@ -659,7 +659,7 @@ PalettePtr PaletteCreator::newTremoloPalette()
     };
     // include additional symbol-based tremolo articulations, implemented as articulations
     for (auto i : dots) {
-        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
@@ -767,7 +767,7 @@ PalettePtr PaletteCreator::newArticulationsPalette(bool defaultPalette)
     };
 
     for (SymId articulationType : defaultPalette ? defaultArticulations : masterArticulations) {
-        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy());
         artic->setSymId(articulationType);
         sp->appendElement(artic, artic->subtypeUserName());
     }
@@ -819,7 +819,7 @@ PalettePtr PaletteCreator::newOrnamentsPalette(bool defaultPalette)
     };
 
     for (auto ornamentType : defaultPalette ? defaultOrnaments : masterOrnaments) {
-        auto ornament = Factory::makeOrnament(paletteScore()->dummy()->chord());
+        auto ornament = Factory::makeOrnament(paletteScore()->dummy());
         ornament->setSymId(ornamentType);
         qreal mag = ornament->symId() == SymId::ornamentTrill ? 1.0 : 1.2;
         sp->appendElement(ornament, ornament->subtypeUserName(), mag);
@@ -987,7 +987,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
     // Breaths
 
     for (auto i : defaultPalette ? defaultFermatas : masterFermatas) {
-        auto f = Factory::makeFermata(paletteScore()->dummy()->segment());
+        auto f = Factory::makeFermata(paletteScore()->dummy());
         f->setSymIdAndTimeStretch(i);
         sp->appendElement(f, f->subtypeUserName());
     }
@@ -996,7 +996,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
         if ((breath.id == SymId::chantCaesura || breath.id == SymId::caesuraSingleStroke) && defaultPalette) {
             continue;
         }
-        auto a = Factory::makeBreath(paletteScore()->dummy()->segment());
+        auto a = Factory::makeBreath(paletteScore()->dummy());
         a->setSymId(breath.id);
         a->setPause(breath.pause);
         sp->appendElement(a, SymNames::userNameForSymId(breath.id));
@@ -1018,7 +1018,7 @@ PalettePtr PaletteCreator::newArpeggioPalette()
             // Deprecated, now handled by CHORD_BRACKET
             continue;
         }
-        auto a = Factory::makeArpeggio(paletteScore()->dummy()->chord());
+        auto a = Factory::makeArpeggio(paletteScore()->dummy());
         a->setArpeggioType(ArpeggioType(i));
         sp->appendElement(a, a->arpeggioTypeName());
     }
@@ -1042,20 +1042,20 @@ PalettePtr PaletteCreator::newArpeggioPalette()
     };
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy());
         cl->setChordLineType(chordLineType);
         sp->appendElement(cl, cl->chordLineTypeName());
     }
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy());
         cl->setChordLineType(chordLineType);
         cl->setStraight(true);
         sp->appendElement(cl, cl->chordLineTypeName());
     }
 
     for (ChordLineType chordLineType : chordLineTypes) {
-        auto cl = Factory::makeChordLine(paletteScore()->dummy()->chord());
+        auto cl = Factory::makeChordLine(paletteScore()->dummy());
         cl->setChordLineType(chordLineType);
         cl->setStraight(true);
         cl->setWavy(true);
@@ -1090,7 +1090,7 @@ PalettePtr PaletteCreator::newClefsPalette(bool defaultPalette)
     };
 
     for (ClefType clefType : defaultPalette ? clefsDefault : clefsMaster) {
-        auto clef = Factory::makeClef(paletteScore()->dummy()->segment());
+        auto clef = Factory::makeClef(paletteScore()->dummy());
         clef->setClefType(ClefTypeList(clefType, clefType));
         sp->appendElement(clef, TConv::userName(clefType));
     }
@@ -1314,7 +1314,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
 
     sp->appendActionIcon(ActionIconType::NOTE_ANCHORED_LINE, "add-noteline", 2);
 
-    auto a = Factory::makeAmbitus(paletteScore()->dummy()->segment());
+    auto a = Factory::makeAmbitus(paletteScore()->dummy());
     sp->appendElement(a, QT_TRANSLATE_NOOP("palette", "Ambitus"));
 
     auto letRing = makeElement<LetRing>(paletteScore());
@@ -1343,7 +1343,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
                                      QT_TRANSLATE_NOOP("palette", "Chord bracket (play with right hand)") };
     for (int i = 0; i < 3; ++i) {
         DirectionV hookPos = DirectionV(i);
-        auto c = Factory::makeChordBracket(paletteScore()->dummy()->chord());
+        auto c = Factory::makeChordBracket(paletteScore()->dummy());
         c->setProperty(Pid::BRACKET_HOOK_POS, hookPos);
         sp->appendElement(c, names[i]);
     }
@@ -1674,7 +1674,7 @@ PalettePtr PaletteCreator::newTimePalette(bool defaultPalette)
     };
 
     for (const TS& timeSignatureType : defaultPalette ? defaultTimeSignatureList : masterTimeSignatureList) {
-        auto timeSignature = Factory::makeTimeSig(paletteScore()->dummy()->segment());
+        auto timeSignature = Factory::makeTimeSig(paletteScore()->dummy());
         timeSignature->setSig(Fraction(timeSignatureType.numerator, timeSignatureType.denominator), timeSignatureType.type);
         sp->appendElement(timeSignature, timeSignatureType.name);
     }
@@ -1728,7 +1728,7 @@ PalettePtr PaletteCreator::newFretboardDiagramPalette(bool defaultPalette)
     };
 
     for (const FretDiagramInfo& fretboardDiagram : fretboardDiagrams) {
-        auto fret = Factory::makeFretDiagram(paletteScore()->dummy()->segment());
+        auto fret = Factory::makeFretDiagram(paletteScore()->dummy());
 
         if (fretboardDiagram.harmony.empty()) {
             fret->clear();
@@ -1813,11 +1813,11 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
         sp->appendElement(f, QT_TRANSLATE_NOOP("palette", "String number %1"));
     }
 
-    auto lhTapping = Factory::makeTapping(paletteScore()->dummy()->chord());
+    auto lhTapping = Factory::makeTapping(paletteScore()->dummy());
     lhTapping->setHand(TappingHand::LEFT);
     sp->appendElement(lhTapping, QT_TRANSLATE_NOOP("palette", "Left-hand tapping"), 1.0);
 
-    auto rhTapping = Factory::makeTapping(paletteScore()->dummy()->chord());
+    auto rhTapping = Factory::makeTapping(paletteScore()->dummy());
     rhTapping->setHand(TappingHand::RIGHT);
     sp->appendElement(rhTapping, QT_TRANSLATE_NOOP("palette", "Right-hand tapping"), 1.0);
 
@@ -1831,7 +1831,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
     };
 
     for (auto i : luteSymbols) {
-        auto s = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto s = Factory::makeArticulation(paletteScore()->dummy());
         s->setSymId(i);
         sp->appendElement(s, s->subtypeUserName());
     }
@@ -1929,7 +1929,7 @@ PalettePtr PaletteCreator::newKeyboardPalette()
                                      QT_TRANSLATE_NOOP("palette", "Chord bracket (play with right hand)") };
     for (int i = 0; i < 3; ++i) {
         DirectionV hookPos = DirectionV(i);
-        auto c = Factory::makeChordBracket(paletteScore()->dummy()->chord());
+        auto c = Factory::makeChordBracket(paletteScore()->dummy());
         c->setProperty(Pid::BRACKET_HOOK_POS, hookPos);
         sp->appendElement(c, names[i]);
     }
@@ -1969,7 +1969,7 @@ PalettePtr PaletteCreator::newPitchPalette(bool defaultPalette)
         sp->appendElement(ottava, ottava->subtypeUserName());
     }
 
-    auto a = Factory::makeAmbitus(paletteScore()->dummy()->segment());
+    auto a = Factory::makeAmbitus(paletteScore()->dummy());
     sp->appendElement(a, QT_TRANSLATE_NOOP("palette", "Ambitus"));
     return sp;
 }
@@ -1982,10 +1982,10 @@ PalettePtr PaletteCreator::newHarpPalette()
     sp->setDrawGrid(true);
     sp->setVisible(false);
 
-    auto pedalDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy()->segment());
+    auto pedalDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy());
     sp->appendElement(pedalDiagram, QT_TRANSLATE_NOOP("palette", "Harp pedal diagram"));
 
-    auto pedalTextDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy()->segment());
+    auto pedalTextDiagram = Factory::makeHarpPedalDiagram(paletteScore()->dummy());
     pedalTextDiagram->setIsDiagram(false);
 
     sp->appendElement(pedalTextDiagram, QT_TRANSLATE_NOOP("palette", "Harp pedal text diagram"));
@@ -2035,14 +2035,14 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
     };
 
     for (SymId symId : standardHandbellsArticSymbols) {
-        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy());
         artic->setSymId(symId);
         sp->appendElement(artic, artic->subtypeUserName(),
                           symId == SymId::handbellsGyro ? 0.7 : symId == SymId::handbellsMalletBellSuspended ? 1.4 : 1.0);
     }
 
     for (ArticulationTextType textType : handbellsTextTypes) {
-        auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
+        auto artic = Factory::makeArticulation(paletteScore()->dummy());
         artic->setTextType(textType);
         sp->appendElement(artic, artic->subtypeUserName(), 1.1);
     }
@@ -2064,7 +2064,7 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
         };
 
         for (SymId symId : additionalHandbellsArticSymbols) {
-            auto artic = Factory::makeArticulation(paletteScore()->dummy()->chord());
+            auto artic = Factory::makeArticulation(paletteScore()->dummy());
             artic->setSymId(symId);
             sp->appendElement(artic, artic->subtypeUserName());
         }

--- a/src/palette/widgets/customizekitdialog.cpp
+++ b/src/palette/widgets/customizekitdialog.cpp
@@ -580,7 +580,7 @@ void CustomizeKitDialog::updateExample()
     int v         = m_editedDrumset.voice(pitch);
     DirectionV dir = m_editedDrumset.stemDirection(pitch);
     bool up = (DirectionV::UP == dir) || (DirectionV::AUTO == dir && line > 4);
-    std::shared_ptr<Chord> chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy()->segment());
+    std::shared_ptr<Chord> chord = Factory::makeChord(paletteScoreProvider()->paletteScore()->dummy());
     chord->setDurationType(DurationType::V_QUARTER);
     chord->setStemDirection(dir);
     chord->setTrack(v);

--- a/src/palette/widgets/customizekitdialog.cpp
+++ b/src/palette/widgets/customizekitdialog.cpp
@@ -586,7 +586,6 @@ void CustomizeKitDialog::updateExample()
     chord->setTrack(v);
     chord->setIsUiItem(true);
     Note* note = Factory::createNote(chord.get());
-    note->setOwnershipParent(chord.get());
     note->setTrack(v);
     note->setPitch(pitch);
     note->setTpcFromPitch();
@@ -597,7 +596,6 @@ void CustomizeKitDialog::updateExample()
     note->mutldata()->cachedNoteheadSym.set_value(static_cast<SymId>(quarterCmb->currentData().toInt()));
     chord->add(note);
     Stem* stem = Factory::createStem(chord.get());
-    stem->setOwnershipParent(chord.get());
     stem->setBaseLength(up ? -3.0_sp : 3.0_sp);
     engravingRenderer()->layoutItem(stem);
     chord->add(stem);

--- a/src/palette/widgets/keyedit.cpp
+++ b/src/palette/widgets/keyedit.cpp
@@ -32,9 +32,9 @@
 #include "modularity/ioc.h"
 #include "translation.h"
 
-#include "engraving/compat/dummyelement.h"
 #include "engraving/dom/accidental.h"
 #include "engraving/dom/clef.h"
+#include "engraving/dom/dummyparent.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/keysig.h"
 #include "engraving/dom/masterscore.h"

--- a/src/palette/widgets/keyedit.cpp
+++ b/src/palette/widgets/keyedit.cpp
@@ -72,7 +72,7 @@ KeyCanvas::KeyCanvas(QWidget* parent)
     QAction* a = new QAction("delete", this);
     a->setShortcut(Qt::Key_Delete);
     addAction(a);
-    clef = Factory::createClef(paletteScoreProvider()->paletteScore()->dummy()->segment());
+    clef = Factory::createClef(paletteScoreProvider()->paletteScore()->dummy());
     clef->setClefType(ClefType::G);
     connect(a, &QAction::triggered, this, &KeyCanvas::deleteElement);
 }
@@ -408,7 +408,7 @@ void KeyEditor::addClicked()
         c.octAlt = static_cast<int>((line - (line >= 0 ? 0 : 6)) / 7);
         e.customKeyDefs().push_back(c);
     }
-    auto ks = Factory::makeKeySig(paletteScoreProvider()->paletteScore()->dummy()->segment());
+    auto ks = Factory::makeKeySig(paletteScoreProvider()->paletteScore()->dummy());
     ks->setKeySigEvent(e);
     m_keySigPaletteWidget->appendElement(ks, "custom");
     m_dirty = true;

--- a/src/palette/widgets/timedialog.cpp
+++ b/src/palette/widgets/timedialog.cpp
@@ -32,10 +32,10 @@
 #include "palettewidget.h"
 #include "internal/palettecreator.h"
 
+#include "engraving/dom/dummyparent.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/timesig.h"
-#include "engraving/compat/dummyelement.h"
 
 using namespace mu::palette;
 using namespace mu::engraving;

--- a/src/palette/widgets/timedialog.cpp
+++ b/src/palette/widgets/timedialog.cpp
@@ -111,7 +111,7 @@ bool TimeEditor::showTimePalette() const
 
 void TimeEditor::addClicked()
 {
-    auto ts = mu::engraving::Factory::makeTimeSig(paletteScoreProvider()->paletteScore()->dummy()->segment());
+    auto ts = mu::engraving::Factory::makeTimeSig(paletteScoreProvider()->paletteScore()->dummy());
     ts->setSig(Fraction(zNominal->value(), denominator()));
     ts->setGroups(groups->groups());
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -373,14 +373,12 @@ void PlaybackController::playNotes(const NoteValList& notes, staff_idx_t staffId
 {
     Segment* seg = const_cast<Segment*>(segment);
     Chord* chord = engraving::Factory::createChord(seg);
-    chord->setOwnershipParent(seg);
 
     std::vector<const EngravingItem*> elements;
     elements.reserve(notes.size());
 
     for (const NoteVal& nval : notes) {
         Note* note = engraving::Factory::createNote(chord);
-        note->setOwnershipParent(chord);
         note->setStaffIdx(staffIdx);
         note->setNval(nval);
         elements.push_back(note);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25519
Builds on https://github.com/musescore/MuseScore/pull/34606

This PR promotes the dummy parent element from a hack into a piece of anti-memory-leak infrastructure.

The first commit (disregarding the commits inherited from https://github.com/musescore/MuseScore/pull/34606) untangles the complicated relationship between DummyElement and RootItem; the RootItem used to own the dummy, which in turn owned another RootItem which created another DummyElement but broke the recursion by leaving that one uninitialised. Now, the dummy is owned directly by the score.

Then we rename DummyElement to DummyParent, to better reflect the purpose.

The third commit starts removing the dummy real element members from DummyParent, since "dummy real elements" is as contradictory as it sounds. We start with the BracketItem.

To unlock removing the other ones too, the fourth commit introduces a convenience type (or maybe rather an inconvenience type) for correctness, ensuring that constructors and `setOwnershipParent` overloads can take either the DummyParent or one of the specified real types.

As a result, the fifth commit is able to parent objects directly to the dummy instead of a "dummy real element", removing those members of DummyParent.

The sixth commit makes the DummyParent an EngravingObject rather than EngravingItem, since that feels more correct. It does mean introducing `DummyParentOr<EngravingItem>` in a number of places, but that's fine, because then we can easily track down usages of that and replace the `EngravingItem` with more specific types.

The seventh commit lets the EngravingObject constructor set the passed parent as the real parent unless it's the dummy. This finally removed the "has a parent but not explicitly set" state, allowing to eliminate `m_isParentExplicitlySet` in the eighth commit. 

What then follows, is cleanups that have now become possible; most notably, removing `setOwnershipParent` calls that repeat what was just passed to the constructor. 
Another one worth mentioning is an empirically motivated optimisation in `EngravingObject::removeChild`; it now searches from the back of the list, which in practice appears to be faster overall.
Finally there is a commit that should improve consistency of the accessibility tree. However, I must say that this whole accessibility tree and how it handles items with no layoutParent (and whether it should handle such items at all) could use a closer look from someone who has an idea of how it _should_ work and who is able to test it (accessibility is completely broken on macOS currently).

Reviewing commit-by-commit is again recommended.