### PR TITLE
Quick-swap popup for basic articulations

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
+++ b/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
@@ -42,6 +42,8 @@ qt_add_qml_module(notationscene_qml
         editgridsizedialogmodel.h
         editpercussionshortcutmodel.cpp
         editpercussionshortcutmodel.h
+        elementpopups/articulationpopupmodel.cpp
+        elementpopups/articulationpopupmodel.h
         elementpopups/caposettingsmodel.cpp
         elementpopups/caposettingsmodel.h
         elementpopups/dynamicpopupmodel.cpp
@@ -169,6 +171,7 @@ qt_add_qml_module(notationscene_qml
         ConcertPitchControl.qml
         EditGridSizeDialog.qml
         EditPercussionShortcutDialog.qml
+        elementpopups/ArticulationPopup.qml
         elementpopups/CapoPopup.qml
         elementpopups/DynamicPopup.qml
         elementpopups/ElementPopupLoader.qml

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.cpp
@@ -31,6 +31,7 @@
 #include "notation/inotationundostack.h"
 #include "notation/inotationviewstate.h"
 
+#include "elementpopups/articulationpopupmodel.h"
 #include "elementpopups/partialtiepopupmodel.h"
 #include "elementpopups/shadownotepopupmodel.h"
 
@@ -61,6 +62,7 @@ static const QMap<mu::engraving::ElementType, PopupModelType> ELEMENT_POPUP_TYPE
     { mu::engraving::ElementType::TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
     { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
     { mu::engraving::ElementType::SHADOW_NOTE, PopupModelType::TYPE_SHADOW_NOTE },
+    { mu::engraving::ElementType::ARTICULATION, PopupModelType::TYPE_ARTICULATION },
 };
 
 static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDENT_ELEMENT_TYPES = {
@@ -85,6 +87,7 @@ static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDEN
         mu::engraving::ElementType::TEMPO_TEXT,
         mu::engraving::ElementType::PLAY_COUNT_TEXT } },
     { PopupModelType::TYPE_PARTIAL_TIE, { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, mu::engraving::ElementType::TIE_SEGMENT } },
+    { PopupModelType::TYPE_ARTICULATION, { mu::engraving::ElementType::ARTICULATION } },
 };
 
 AbstractElementPopupModel::AbstractElementPopupModel(PopupModelType modelType, QObject* parent)
@@ -123,6 +126,8 @@ bool AbstractElementPopupModel::hasElementEditPopup(const EngravingItem* element
         return PartialTiePopupModel::canOpen(element);
     case PopupModelType::TYPE_SHADOW_NOTE:
         return ShadowNotePopupModel::canOpen(element);
+    case PopupModelType::TYPE_ARTICULATION:
+        return ArticulationPopupModel::canOpen(element);
     default:
         return true;
     }

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractelementpopupmodel.h
@@ -57,7 +57,8 @@ public:
         TYPE_DYNAMIC,
         TYPE_TEXT,
         TYPE_PARTIAL_TIE,
-        TYPE_SHADOW_NOTE
+        TYPE_SHADOW_NOTE,
+        TYPE_ARTICULATION
     };
     Q_ENUM(PopupModelType)
 

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ArticulationPopup.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ArticulationPopup.qml
@@ -1,0 +1,182 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+import MuseScore.NotationScene
+
+AbstractElementPopup {
+    id: root
+
+    property NavigationSection notationViewNavigationSection: null
+    property int navigationOrderStart: 0
+    property int navigationOrderEnd: articulationsNavPanel.order
+
+    property int buttonWidth: 32
+    property int buttonHeight: 30
+
+    // Page 0 (default) is the base page (the 5 basic articulation types) - its left chevron
+    // pages left into page 1, the 4 Accent/Marcato combos, whose right chevron pages back.
+    property int currentPage: 0
+
+    margins: 4
+
+    contentWidth: content.width
+    contentHeight: content.height
+
+    showArrow: false
+
+    focusPolicies: PopupView.DefaultFocus & ~PopupView.ClickFocus
+    // Always below, regardless of the articulation's own placement: matches DynamicPopup's
+    // real-world behavior, and an above-placed articulation sits close enough to its note that
+    // a popup opening above it tends to cover the mark itself.
+    placementPolicies: PopupView.PreferBelow
+
+    model: ArticulationPopupModel {
+        id: articulationModel
+    }
+
+    RowLayout {
+        id: content
+
+        // Fixed to fit the widest page (the 5-item base page) with no slack, so the popup's
+        // width stays constant across pages; the fillWidth Items around the Repeater absorb
+        // the leftover space on the narrower combo page, keeping its buttons centered. Only one
+        // chevron is visible at a time, so it doesn't factor into this beyond its own 16px.
+        width: 183
+        spacing: 1
+
+        NavigationPanel {
+            id: articulationsNavPanel
+            name: "ArticulationsPopup"
+            direction: NavigationPanel.Horizontal
+            section: root.notationViewNavigationSection
+            order: root.navigationOrderStart
+            accessible.name: qsTrc("notation", "Articulations popup")
+
+            onNavigationEvent: function(event) {
+                if (event.type === NavigationEvent.Escape) {
+                    root.close()
+                }
+            }
+        }
+
+        function togglePage() {
+            const newPage = (root.currentPage + 1) % articulationModel.pages.length
+            root.currentPage = newPage
+
+            // Arriving on the combo page (1) via the left chevron/key should focus its last
+            // item (the one spatially adjacent to where the user came from); arriving back on
+            // the base page (0) via the right chevron/key should focus its first item.
+            Qt.callLater(requestNavigationActive, newPage === 1 ? -1 : 0)
+        }
+
+        function requestNavigationActive(index) {
+            (articulationRepeater.itemAt(index < 0 ? articulationRepeater.count - 1 : index) as FlatButton).navigation.requestActive()
+        }
+
+        FlatButton {
+            id: leftButton
+
+            implicitWidth: 16
+            transparent: true
+            visible: root.currentPage === 0
+
+            contentItem: StyledIconLabel {
+                iconCode: IconCode.CHEVRON_LEFT
+                font.pixelSize: 16
+            }
+
+            onClicked: {
+                content.togglePage()
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Repeater {
+            id: articulationRepeater
+
+            model: articulationModel.pages[root.currentPage]
+
+            delegate: FlatButton {
+                id: articulationButton
+
+                required property var modelData
+                required property int index
+
+                implicitWidth: root.buttonWidth
+                implicitHeight: root.buttonHeight
+                transparent: true
+
+                navigation.panel: articulationsNavPanel
+                navigation.order: index
+                accessible.name: modelData.accessibleName
+                toolTipTitle: modelData.accessibleName
+
+                navigation.onNavigationEvent: function(event) {
+                    switch (event.type) {
+                    case NavigationEvent.Up:
+                    case NavigationEvent.Left: {
+                        if (index == 0 && root.currentPage === 0) {
+                            content.togglePage()
+
+                            event.accepted = true
+                        }
+
+                        break
+                    }
+
+                    case NavigationEvent.Right:
+                    case NavigationEvent.Down: {
+                        if (index == articulationRepeater.count - 1 && root.currentPage === 1) {
+                            content.togglePage()
+
+                            event.accepted = true
+                        }
+
+                        break
+                    }
+                    }
+                }
+
+                contentItem: StyledTextLabel {
+                    text: articulationButton.modelData.text
+                    font.family: articulationModel.fontFamily
+                    font.pixelSize: 30
+
+                    anchors.centerIn: parent
+                }
+
+                onClicked: {
+                    articulationModel.changeArticulation(root.currentPage, index)
+                }
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        FlatButton {
+            id: rightButton
+
+            implicitWidth: 16
+            transparent: true
+            visible: root.currentPage === 1
+
+            contentItem: StyledIconLabel {
+                iconCode: IconCode.CHEVRON_RIGHT
+                font.pixelSize: 16
+            }
+
+            onClicked: {
+                content.togglePage()
+            }
+        }
+    }
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ElementPopupLoader.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ElementPopupLoader.qml
@@ -57,6 +57,7 @@ Item {
             case AbstractElementPopupModel.TYPE_TEXT: return textStyleComp
             case AbstractElementPopupModel.TYPE_PARTIAL_TIE: return partialTieComp
             case AbstractElementPopupModel.TYPE_SHADOW_NOTE: return shadowNoteComp
+            case AbstractElementPopupModel.TYPE_ARTICULATION: return articulationComp
             }
 
             return null
@@ -198,6 +199,12 @@ Item {
     Component {
         id: shadowNoteComp
         ShadowNotePopup {
+        }
+    }
+
+    Component {
+        id: articulationComp
+        ArticulationPopup {
         }
     }
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/articulationpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/articulationpopupmodel.cpp
@@ -1,0 +1,317 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "articulationpopupmodel.h"
+
+#include <array>
+#include <span>
+#include <vector>
+
+#include "containers.h"
+
+#include "engraving/dom/articulation.h"
+#include "engraving/dom/chord.h"
+#include "engraving/dom/score.h"
+
+#include "log.h"
+
+using namespace mu::notation;
+using namespace mu::engraving;
+
+namespace {
+struct ArticulationTypeItem {
+    SymId above;
+    SymId below;
+    muse::TranslatableString name;
+    // Mirrors Articulation::computeCategories() for exactly this popup's 9 supported types, so
+    // a target type can be checked for semantic overlap against a chord's OTHER (real, already
+    // laid out) articulations via their own isStaccato()/isAccent()/etc. accessors, without
+    // needing to construct a throwaway Articulation just to query categories for a hypothetical
+    // SymId. Note Staccatissimo intentionally carries no STACCATO overlap - computeCategories()
+    // doesn't consider it part of that category either.
+    ArticulationCategories categories;
+};
+
+// `name` is the plain type name, independent of the above/below placement (which this popup
+// never changes), reusing the same translated strings as the add-staccato/add-tenuto/etc.
+// actions where they already exist.
+
+// Page 0 (default): the 5 basic articulation types, in this fixed order.
+const std::array<ArticulationTypeItem, 5> BASE_PAGE_TYPES = { {
+    { SymId::articMarcatoAbove, SymId::articMarcatoBelow, muse::TranslatableString("action", "Marcato"), ArticulationCategory::MARCATO },
+    { SymId::articAccentAbove, SymId::articAccentBelow, muse::TranslatableString("action", "Accent"), ArticulationCategory::ACCENT },
+    { SymId::articTenutoAbove, SymId::articTenutoBelow, muse::TranslatableString("action", "Tenuto"), ArticulationCategory::TENUTO },
+    { SymId::articStaccatoAbove, SymId::articStaccatoBelow, muse::TranslatableString("action", "Staccato"),
+      ArticulationCategory::STACCATO },
+    { SymId::articStaccatissimoAbove, SymId::articStaccatissimoBelow, muse::TranslatableString("engraving/sym", "Staccatissimo"),
+      ArticulationCategory::NONE },
+} };
+
+// Page 1: the 5 "double" combos, reached by paginating left from the base page.
+const std::array<ArticulationTypeItem, 5> COMBO_PAGE_TYPES = { {
+    { SymId::articAccentStaccatoAbove, SymId::articAccentStaccatoBelow, muse::TranslatableString("engraving/sym", "Accent-staccato"),
+      ArticulationCategory::ACCENT | ArticulationCategory::STACCATO },
+    { SymId::articTenutoAccentAbove, SymId::articTenutoAccentBelow, muse::TranslatableString("engraving/sym", "Tenuto-accent"),
+      ArticulationCategory::TENUTO | ArticulationCategory::ACCENT },
+    { SymId::articTenutoStaccatoAbove, SymId::articTenutoStaccatoBelow, muse::TranslatableString("engraving/sym", "Tenuto-staccato"),
+      ArticulationCategory::TENUTO | ArticulationCategory::STACCATO },
+    { SymId::articMarcatoStaccatoAbove, SymId::articMarcatoStaccatoBelow, muse::TranslatableString("engraving/sym", "Marcato-staccato"),
+      ArticulationCategory::MARCATO | ArticulationCategory::STACCATO },
+    { SymId::articMarcatoTenutoAbove, SymId::articMarcatoTenutoBelow, muse::TranslatableString("engraving/sym", "Marcato-tenuto"),
+      ArticulationCategory::MARCATO | ArticulationCategory::TENUTO },
+} };
+
+bool containsAbove(std::span<const ArticulationTypeItem> types, SymId symId)
+{
+    for (const ArticulationTypeItem& item : types) {
+        if (item.above == symId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool containsEither(std::span<const ArticulationTypeItem> types, SymId symId)
+{
+    for (const ArticulationTypeItem& item : types) {
+        if (item.above == symId || item.below == symId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool isAboveSymId(SymId symId)
+{
+    return containsAbove(BASE_PAGE_TYPES, symId) || containsAbove(COMBO_PAGE_TYPES, symId);
+}
+
+ArticulationCategories categoriesFor(SymId symId)
+{
+    for (const ArticulationTypeItem& item : BASE_PAGE_TYPES) {
+        if (item.above == symId || item.below == symId) {
+            return item.categories;
+        }
+    }
+    for (const ArticulationTypeItem& item : COMBO_PAGE_TYPES) {
+        if (item.above == symId || item.below == symId) {
+            return item.categories;
+        }
+    }
+    return ArticulationCategory::NONE;
+}
+
+ArticulationCategories categoriesOf(const Articulation* item)
+{
+    ArticulationCategories result = ArticulationCategory::NONE;
+    if (item->isStaccato()) {
+        result |= ArticulationCategory::STACCATO;
+    }
+    if (item->isAccent()) {
+        result |= ArticulationCategory::ACCENT;
+    }
+    if (item->isMarcato()) {
+        result |= ArticulationCategory::MARCATO;
+    }
+    if (item->isTenuto()) {
+        result |= ArticulationCategory::TENUTO;
+    }
+    return result;
+}
+
+// True if two marks with these categories shouldn't coexist on the same chord: either they share
+// a base category (e.g. both imply staccato - an existing plain Staccato conflicts with a target
+// of Accent-Staccato, which already implies staccato), or one is accent-flavored and the other
+// marcato-flavored. The latter isn't a shared-category case (ACCENT and MARCATO are disjoint in
+// computeCategories()) - it mirrors Chord::updateArticulations(), which hardcodes accent and
+// marcato as always mutually exclusive on a chord, independent of the category system.
+bool categoriesConflict(ArticulationCategories a, ArticulationCategories b)
+{
+    if (a & b) {
+        return true;
+    }
+    return (a & ArticulationCategory::ACCENT && b & ArticulationCategory::MARCATO)
+           || (a & ArticulationCategory::MARCATO && b & ArticulationCategory::ACCENT);
+}
+
+QVariantList buildPage(std::span<const ArticulationTypeItem> types, bool above, const IEngravingFontPtr& engravingFont)
+{
+    QVariantList page;
+    for (const ArticulationTypeItem& item : types) {
+        SymId symId = above ? item.above : item.below;
+        page.append(QVariantMap {
+                { "symId", static_cast<int>(symId) },
+                { "text", engravingFont->toString(symId).toQString() },
+                { "accessibleName", item.name.translated().toQString() },
+            });
+    }
+    return page;
+}
+} // namespace
+
+ArticulationPopupModel::ArticulationPopupModel(QObject* parent)
+    : AbstractElementPopupModel(PopupModelType::TYPE_ARTICULATION, parent)
+{
+}
+
+bool ArticulationPopupModel::canOpen(const EngravingItem* element)
+{
+    if (!element || !element->isArticulation()) {
+        return false;
+    }
+
+    SymId symId = toArticulation(element)->symId();
+    return containsEither(BASE_PAGE_TYPES, symId) || containsEither(COMBO_PAGE_TYPES, symId);
+}
+
+QString ArticulationPopupModel::fontFamily() const
+{
+    IF_ASSERT_FAILED(m_item) {
+        return QString();
+    }
+
+    return QString::fromStdString(m_item->score()->engravingFont()->family());
+}
+
+QVariantList ArticulationPopupModel::pages() const
+{
+    return m_pages;
+}
+
+void ArticulationPopupModel::init()
+{
+    AbstractElementPopupModel::init();
+
+    connect(this, &AbstractElementPopupModel::dataChanged, this, [this]() {
+        load();
+    });
+
+    load();
+}
+
+void ArticulationPopupModel::load()
+{
+    if (!m_item || !m_item->isArticulation()) {
+        if (!m_pages.isEmpty()) {
+            m_pages.clear();
+            emit pagesChanged();
+        }
+        return;
+    }
+
+    bool above = isAboveSymId(toArticulation(m_item)->symId());
+
+    // dataChanged fires for any ARTICULATION change in the score, not just this popup's own
+    // item, so most reloads are redundant - skip rebuilding (and re-emitting, which would force
+    // the QML Repeater to tear down and recreate its delegates) when nothing actually changed.
+    if (!m_pages.isEmpty() && above == m_pagesAbove) {
+        return;
+    }
+    m_pagesAbove = above;
+
+    m_pages.clear();
+    IEngravingFontPtr engravingFont = m_item->score()->engravingFont();
+
+    // QVariant::fromValue is required here: QVariantList::append(const QVariantList&) resolves
+    // to QList's "concatenate" overload and would flatten each page into m_pages instead of
+    // nesting it, since a plain QVariantList argument is an exact-type match for that overload.
+    m_pages.append(QVariant::fromValue(buildPage(BASE_PAGE_TYPES, above, engravingFont)));
+    m_pages.append(QVariant::fromValue(buildPage(COMBO_PAGE_TYPES, above, engravingFont)));
+
+    emit pagesChanged();
+}
+
+void ArticulationPopupModel::changeArticulation(int page, int index)
+{
+    IF_ASSERT_FAILED(m_item && m_item->isArticulation() && page >= 0 && page < m_pages.size()) {
+        return;
+    }
+
+    QVariantList pageItems = m_pages[page].toList();
+
+    IF_ASSERT_FAILED(index >= 0 && index < pageItems.size()) {
+        return;
+    }
+
+    SymId newSymId = static_cast<SymId>(pageItems[index].toMap().value("symId").toInt());
+    Articulation* articulation = toArticulation(m_item);
+
+    // Guard against operating on an item this popup already removed from its chord: after
+    // undoRemoveElement below, the C++ object stays alive (owned by the pending undo command)
+    // and m_item keeps pointing at it, so a stale reload or a second click on the same button
+    // could otherwise reach undoRemoveElement a second time on the same pointer.
+    ChordRest* ownerChordRest = articulation->chordRest();
+    if (!ownerChordRest || !ownerChordRest->isChord()
+        || !muse::contains(toChord(ownerChordRest)->articulations(), articulation)) {
+        return;
+    }
+
+    Chord* chord = toChord(ownerChordRest);
+
+    if (newSymId == articulation->symId()) {
+        // Clicking the type that's already applied removes it, matching the toolbar/shortcut
+        // toggle behavior instead of silently doing nothing.
+        beginCommand(TranslatableString("undoableAction", "Remove articulation"));
+        articulation->score()->undoRemoveElement(articulation);
+        endCommand();
+
+        // Nothing in this popup still applies to the chord it was opened on - select it instead
+        // of leaving the popup open over a removed item, whether or not other marks remain.
+        if (interaction()) {
+            interaction()->select({ chord });
+        }
+
+        updateNotation();
+        return;
+    }
+
+    // Resolve conflicts with the chord's OTHER marks instead of silently refusing the click, the
+    // same way Chord::updateArticulations() replaces (rather than blocks) a conflicting existing
+    // mark when the toolbar/shortcut path adds a new one - e.g. picking Accent-Staccato while a
+    // separate plain Staccato is already present removes that redundant Staccato; picking Accent
+    // while a separate Marcato is present removes the Marcato (they're always mutually exclusive).
+    std::vector<Articulation*> conflicting;
+    ArticulationCategories targetCategories = categoriesFor(newSymId);
+    for (Articulation* other : chord->articulations()) {
+        if (other != articulation && categoriesConflict(categoriesOf(other), targetCategories)) {
+            conflicting.push_back(other);
+        }
+    }
+
+    // setSymId() (called by the property change below) unconditionally resets the anchor to its
+    // style default, so a manually-overridden placement needs to be captured and reapplied.
+    ArticulationAnchor oldAnchor = articulation->anchor();
+    PropertyFlags oldAnchorFlags = articulation->propertyFlags(Pid::ARTICULATION_ANCHOR);
+    bool anchorWasOverridden = oldAnchorFlags == PropertyFlags::UNSTYLED;
+
+    beginCommand(TranslatableString("undoableAction", "Change articulation"));
+    for (Articulation* other : conflicting) {
+        articulation->score()->undoRemoveElement(other);
+    }
+    articulation->undoChangeProperty(Pid::SYMBOL, PropertyValue::fromValue(newSymId));
+    if (anchorWasOverridden) {
+        articulation->undoChangeProperty(Pid::ARTICULATION_ANCHOR, int(oldAnchor), oldAnchorFlags);
+    }
+    endCommand();
+
+    updateNotation();
+}

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/articulationpopupmodel.h
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/articulationpopupmodel.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QVariantList>
+#include <qqmlintegration.h>
+
+#include "engraving/iengravingfont.h"
+
+#include "../abstractelementpopupmodel.h"
+
+namespace mu::notation {
+class ArticulationPopupModel : public AbstractElementPopupModel
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QString fontFamily READ fontFamily CONSTANT)
+    Q_PROPERTY(QVariantList pages READ pages NOTIFY pagesChanged)
+
+public:
+    explicit ArticulationPopupModel(QObject* parent = nullptr);
+
+    static bool canOpen(const engraving::EngravingItem* element);
+
+    Q_INVOKABLE void init() override;
+    Q_INVOKABLE void changeArticulation(int page, int index);
+
+    QString fontFamily() const;
+    QVariantList pages() const;
+
+signals:
+    void pagesChanged();
+
+private:
+    void load();
+
+    // Page 0: the 5 basic articulation types (default page)
+    // Page 1: the 5 "double" combos (paginated left of the base page)
+    QVariantList m_pages;
+    bool m_pagesAbove = true;
+};
+}


### PR DESCRIPTION
Resolves: #34701

Adds a small popup for the basic articulations - Staccato, Staccatissimo, Accent, Marcato, Tenuto - following the same interaction pattern as the existing Dynamics popup: clicking an articulation already placed on a note opens a compact popup showing the other basic types, letting you switch the type with a single click instead of deleting and reapplying. The 5 "double" combinations (Accent-Staccato, Tenuto-Accent, Tenuto-Staccato, Marcato-Staccato, Marcato-Tenuto) are reachable via a single pagination arrow, keeping the default popup small.

Clicking the type that's already applied removes it, matching the toolbar/shortcut toggle behavior. Conflict handling (e.g. picking a type that would coexist redundantly with another mark already on the chord) follows the same rules `Chord::updateArticulations()` already uses elsewhere in the app - Accent and Marcato are always mutually exclusive, and a conflicting mark is replaced rather than silently blocking the click. A manually-overridden placement anchor is preserved across a type swap. The popup always opens below the note, matching Dynamics' own real-world behavior.

## Implementation

Follows the existing `elementpopups/` pattern: `ArticulationPopupModel` + `ArticulationPopup.qml`, registered as a new `AbstractElementPopupModel::PopupModelType::TYPE_ARTICULATION`, wired into `ElementPopupLoader.qml` and the dispatch tables in `abstractelementpopupmodel.cpp`.

## Testing

- Manually built and tested locally (macOS).
- Verified type-swap, toggle-off-to-remove, conflict resolution (Accent/Marcato exclusivity, redundant-mark replacement), placement-anchor preservation across a swap, and pagination for both above- and below-placed articulations.
- Ran `checkcodestyle.cmake` against `src/` - no style issues.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).