### PR TITLE
Fix crash on opening pre-5.0 scores with an `InstrumentChange` inside a multimeasure rest

### DIFF
--- a/src/engraving/dom/part.cpp
+++ b/src/engraving/dom/part.cpp
@@ -374,11 +374,15 @@ void Part::setInstruments(const InstrumentList& instruments)
 //   removeInstrument
 //---------------------------------------------------------
 
-void Part::removeInstrument(const Fraction& tick)
+void Part::removeInstrument(Instrument* instr, const Fraction& tick)
 {
     auto i = m_instruments.find(tick.ticks());
     if (i == m_instruments.end()) {
         LOGD("Part::removeInstrument: not found at tick %d", tick.ticks());
+        return;
+    }
+    if (i->second != instr) {
+        LOGD("Part::removeInstrument: item at tick %d (%p) != instr (%p)", tick.ticks(), i->second, instr);
         return;
     }
     m_instruments.erase(i);

--- a/src/engraving/dom/part.h
+++ b/src/engraving/dom/part.h
@@ -146,7 +146,7 @@ public:
     void setInstrument(const Instrument&&, Fraction = { -1, 1 });
     void setInstrument(const Instrument&, Fraction = { -1, 1 });
     void setInstruments(const InstrumentList& instruments);
-    void removeInstrument(const Fraction&);
+    void removeInstrument(Instrument*, const Fraction&);
     void removeNonPrimaryInstruments();
     const InstrumentList& instruments() const;
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1148,8 +1148,6 @@ void Score::addElement(EngravingItem* element)
     break;
 
     case ElementType::INSTRUMENT_CHANGE: {
-        InstrumentChange* ic = toInstrumentChange(element);
-        ic->part()->setInstrument(ic->instrument(), ic->segment()->tick());
         addLayoutFlags(LayoutFlag::REBUILD_MIDI_MAPPING);
         cmdState().instrumentsChanged = true;
     }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -940,20 +940,14 @@ void Segment::remove(EngravingItem* el)
 
     case ElementType::STAFF_STATE:
         if (toStaffState(el)->staffStateType() == StaffStateType::INSTRUMENT) {
-            Part* part = el->part();
-            part->removeInstrument(tick());
+            el->part()->removeInstrument(toStaffState(el)->instrument(), tick());
         }
         removeAnnotation(el);
         break;
 
     case ElementType::INSTRUMENT_CHANGE:
-    {
-        if (!isMMRestSegment()) {
-            InstrumentChange* is = toInstrumentChange(el);
-            Part* part = is->part();
-            part->removeInstrument(tick());
-        }
-    }
+        // Ensure that the entry in the Part's InstrumentList for this segment's tick is the one this InstrumentChange owns:
+        el->part()->removeInstrument(toInstrumentChange(el)->instrument(), tick());
         removeAnnotation(el);
         break;
 

--- a/src/engraving/rendering/score/mmrestlayout.cpp
+++ b/src/engraving/rendering/score/mmrestlayout.cpp
@@ -380,6 +380,13 @@ void MMRestLayout::changeAnnotationsParent(Segment* oldParent, Segment* newParen
             continue;
         }
 
+        if (e->isInstrumentChange()) {
+            /* InstrumentChange items register their Instrument in Part::instruments(), keyed by the tick of
+             * the segment they belong to (see Segment::add/remove). Re-parenting one to a segment at a different
+             * tick would re-key that entry, making the instrument change take effect at the wrong time: */
+            DO_ASSERT_X(oldParent->tick() == newParent->tick(), "Changing InstrumentChange's parent to a different tick");
+        }
+
         e->score()->undoChangeParent(e, newParent, e->staffIdx(), false);
     }
 }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -31,6 +31,7 @@
 #include "dom/factory.h"
 #include "dom/harmony.h"
 #include "dom/image.h"
+#include "dom/instrchange.h"
 #include "dom/key.h"
 #include "dom/keylist.h"
 #include "dom/laissezvib.h"
@@ -45,6 +46,7 @@
 #include "dom/rest.h"
 #include "dom/score.h"
 #include "dom/staff.h"
+#include "dom/staffstate.h"
 #include "dom/stafftext.h"
 #include "dom/stafftextbase.h"
 #include "dom/stem.h"
@@ -1140,12 +1142,39 @@ void CompatUtils::migrateOffsetPre302(EngravingItem* item, int mscVersion)
     item->setProperty(Pid::OFFSET, offset);
 }
 
+static void reregisterInstrumentChanges(Score* score)
+{
+    /* When reading the <5.0 InstrumentChange MMRest copy, it has overwritten the Part's InstrumentList
+     * entry for this segment's tick. Deleting the copies unregistered their Instruments from the
+     * InstrumentList. So we need to restore the InstrumentList entries with the originals. */
+    for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
+        if (!mb->isMeasure()) {
+            continue;
+        }
+        for (Segment& seg : toMeasure(mb)->segments()) {
+            for (EngravingItem* annotation : seg.annotations()) {
+                Instrument* instr = nullptr;
+                if (annotation->isInstrumentChange()) {
+                    instr = toInstrumentChange(annotation)->instrument();
+                } else if (annotation->isStaffState() && toStaffState(annotation)->staffStateType() == StaffStateType::INSTRUMENT) {
+                    instr = toStaffState(annotation)->instrument();
+                }
+                if (instr) {
+                    annotation->part()->setInstrument(instr, seg.tick());
+                }
+            }
+        }
+    }
+}
+
 void CompatUtils::removeMMRestElements(MasterScore* masterScore)
 {
     // <5.0 MMRests had copies of underlying elements. We now move the element when toggling the rests.
     // Remove redundant copies which are written to the file
 
     for (Score* score : masterScore->scoreList()) {
+        bool removedInstrumentChange = false;
+
         for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
             if (!mb->isMeasure()) {
                 continue;
@@ -1169,6 +1198,9 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
             for (Segment& seg : mmrest->segments()) {
                 std::vector<EngravingItem*> annotations = seg.annotations();
                 for (EngravingItem* annotation : annotations) {
+                    removedInstrumentChange |= annotation->isInstrumentChange()
+                                               || (annotation->isStaffState()
+                                                   && toStaffState(annotation)->staffStateType() == StaffStateType::INSTRUMENT);
                     annotation->unlink();
                     score->removeElement(annotation);
                     delete annotation;
@@ -1187,6 +1219,9 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
                     delete el;
                 }
             }
+        }
+        if (removedInstrumentChange) {
+            reregisterInstrumentChanges(score);
         }
     }
 }


### PR DESCRIPTION
#### The problem:

Pre-5.0 files store a linked copy of an `InstrumentChange` (or `StaffState`) inside the MMRest measure, at the same tick as the original and written after it. On read, the copy's `Segment::add` overwrites the `Part`'s `InstrumentList` entry for that tick. `CompatUtils::removeMMRestElements` then deletes those copies, and the destructor frees the copy's `Instrument` while leaving a dangling pointer in the `Part`, because https://github.com/musescore/MuseScore/pull/31992 stopped `Segment::remove` from unregistering instruments for MMRest segments.

`MasterScore::rebuildMidiMapping` only reads the freed instrument, so in the master score this seemed to be silently UAFing. `rebuildExcerptsMidiMapping` writes to it, which is why this only seemed to happen in scores with MMRests in parts (but the bug was present either way).

#### The fix:

* [#31992](https://github.com/musescore/MuseScore/pull/31992) is from before the [multimeasure rest refactor](https://github.com/musescore/MuseScore/pull/32900), which moves elements into the MMRest instead of copying them. There is no longer a copy to protect, so I allowed `Segment::remove` to unregister for MMRest segments again. It now erases the entry only if it is the one this item owns, so it can never unregister another item's instrument.
* Restored the `InstrumentList` entries from the originals after the compat removal of MMRest elements.
* Removed the duplicate registration in `Score::addElement` (`parent->add()` already does it).
* Added some asserts to make related problems easier to catch in future.

Note: it is definitely still worth a rethinking of the Intruments' ownership, as it's currently super fragile. I've left this for the future as it would take a larger refactor.