### PR TITLE
Fix deadlock in multithreaded excerpt serialisation

### DIFF
--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -37,6 +37,7 @@
 #include "dom/imageStore.h"
 #include "dom/mscore.h"
 #include "dom/page.h"
+#include "dom/part.h"
 
 #include "engraving/automation/internal/automationrw.h"
 
@@ -75,6 +76,8 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
     if (ctx) {
         masterWriteOutData.ctx = *ctx;
     }
+
+    UnhidePartsForWrite unhideGuard(score);
 
     // Write MasterScore
     {
@@ -150,6 +153,8 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
         }
     }
 
+    unhideGuard.rollback();
+
     // Write ChordList
     {
         ChordList* chordList = score->chordList();
@@ -218,6 +223,8 @@ bool MscSaver::exportPart(Score* partScore, MscWriter& mscWriter)
 
     // Write excerpt as main score
     {
+        UnhidePartsForWrite unhideGuard(partScore);
+
         ByteArray excerptData;
         auto excerptBuf = Buffer::opened(IODevice::WriteOnly, &excerptData);
 
@@ -282,4 +289,72 @@ std::shared_ptr<muse::draw::Pixmap> MscSaver::createThumbnail(Score* score)
         score->doLayout();
     }
     return pixmap;
+}
+
+UnhidePartsForWrite::UnhidePartsForWrite(Score* score)
+    : m_score(nullptr)
+{
+    TRACEFUNC;
+
+    std::vector<Score*> scores = { score };
+    if (score->isMaster()) {
+        for (const Excerpt* excerpt : score->masterScore()->excerpts()) {
+            if (Score* excerptScore = excerpt->excerptScore()) {
+                scores.push_back(excerptScore);
+            }
+        }
+    }
+
+    std::vector<std::pair<Score*, std::vector<Part*> > > toUnhide;
+    for (Score* s : scores) {
+        if (!s->style().styleB(Sid::createMultiMeasureRests)) {
+            continue;
+        }
+
+        std::vector<Part*> hiddenParts;
+        for (Part* part : s->parts()) {
+            if (!part->show()) {
+                hiddenParts.push_back(part);
+            }
+        }
+
+        if (!hiddenParts.empty()) {
+            toUnhide.emplace_back(s, std::move(hiddenParts));
+        }
+    }
+
+    if (toUnhide.empty()) {
+        return;
+    }
+
+    /* The undo stack and transaction manager are shared between the master score and its excerpts.
+     * So all scores must be handled within a single transaction: */
+    score->startCmd(TranslatableString::untranslatable("Unhide instruments for save"));
+
+    for (const auto& [s, hiddenParts] : toUnhide) {
+        for (Part* part : hiddenParts) {
+            part->undoChangeProperty(Pid::VISIBLE, true);
+        }
+        s->doLayout();
+        for (Part* part : hiddenParts) {
+            part->setShow(false);
+        }
+    }
+
+    m_score = score;
+}
+
+UnhidePartsForWrite::~UnhidePartsForWrite()
+{
+    rollback();
+}
+
+void UnhidePartsForWrite::rollback()
+{
+    TRACEFUNC;
+
+    if (m_score) {
+        m_score->endCmd(/*rollback*/ true, /*layoutAllParts*/ true);
+        m_score = nullptr;
+    }
 }

--- a/src/engraving/rw/mscsaver.h
+++ b/src/engraving/rw/mscsaver.h
@@ -58,4 +58,25 @@ public:
 private:
     std::shared_ptr<muse::draw::Pixmap> createThumbnail(Score* score);
 };
+
+/* Multimeasure rest layout information is only generated for visible parts, so before
+ * serializing we must unhide every hidden part and relayout, then rollback the change
+ * once everything has been written. This RAII wrapper does that, then rolls back
+ * on destruction. Must be created and destroyed on the thread that owns the score
+ * because mutating and re-laying out a score is not thread safe, so it cannot happen
+ * while the excerpts are being serialised in parallel.
+ */
+class UnhidePartsForWrite
+{
+public:
+    UnhidePartsForWrite(Score* score);
+    UnhidePartsForWrite(const UnhidePartsForWrite&) = delete;
+    UnhidePartsForWrite& operator=(const UnhidePartsForWrite&) = delete;
+    ~UnhidePartsForWrite();
+
+    void rollback();
+
+private:
+    Score* m_score = nullptr;
+};
 }

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -89,31 +89,6 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::Writ
 {
     TRACEFUNC;
 
-    // if we have multi measure rests and some parts are hidden,
-    // then some layout information is missing:
-    // relayout with all parts set visible (but rollback at end)
-
-    std::vector<Part*> hiddenParts;
-    bool unhide = false;
-    if (score->style().styleB(Sid::createMultiMeasureRests)) {
-        for (Part* part : score->m_parts) {
-            if (!part->show()) {
-                if (!unhide) {
-                    score->startCmd(TranslatableString::untranslatable("Unhide instruments for save"));
-                    unhide = true;
-                }
-                part->undoChangeProperty(Pid::VISIBLE, true);
-                hiddenParts.push_back(part);
-            }
-        }
-    }
-    if (unhide) {
-        score->doLayout();
-        for (Part* p : hiddenParts) {
-            p->setShow(false);
-        }
-    }
-
     xml.startElement(score);
 
     TWrite::writeItemEid(score, xml);
@@ -271,10 +246,6 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::Writ
     TWrite::writeSystemDividers(score, xml, ctx);
 
     xml.endElement(); // score
-
-    if (unhide) {
-        score->endCmd(true);
-    }
 }
 
 void Writer::writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t strack, track_idx_t etrack,


### PR DESCRIPTION
The goal is to avoid side effects on the score during write/serialisation, so excerpt serialisation can safely run in separate threads.

There was a deadlock when saving scores (with "Save as...") that contained multi measure rests and some hidden parts. The save called layout in that case, which frees Systems/Pages, and the `EngravingItem` destructor calls `Score::onElementDestruction`  which ends with `score->elementDestroyed().send(e)`. This send was cross-thread, and that channel has a main-thread receiver for every score,  so the send must register a port on the main thread's slot (`QueuePool::regPort`), and this locks the same mutex that the main thread is holding while it's processing queued callbacks (in `QueuePool::processMessages`), and the save itself is one of the queued commands.

Apart from the freezing `doLayout()` call, the write was also modifying the score in other ways (`start/endCmd()`,  `undoChangeProperty(VISIBLE, true)`), and all this routes to the master score's single shared TransactionManager, whose `endTransaction` calls `m_masterScore->update()`, relaying out the master from a worker thread.

 I have moved the unhide and relayout out of the writer.