### PR TITLE
Fix Mixer: Master channel's mute button has no effect

### DIFF
--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -626,13 +626,7 @@ MixerChannelItem* MixerPanelModel::buildMasterChannelItem()
     });
 
     connect(item, &MixerChannelItem::soloMuteStateChanged, this, [this, item](const notation::INotationSoloMuteState::SoloMuteState&) {
-        AudioOutputParams playbackParams = item->outputParams();
-        playbackParams.forceMute = controller()->isMasterOutputForceMuted();
-        if (playbackParams.forceMute) {
-            playbackParams.muted = true;
-        }
-
-        playback()->setMasterControlParams(playbackParams.control());
+        playback()->setMasterControlParams(item->outputParams().control());
     });
 
     return item;

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -625,6 +625,16 @@ MixerChannelItem* MixerPanelModel::buildMasterChannelItem()
         playback()->setMasterAuxSendsParams(params.auxSends);
     });
 
+    connect(item, &MixerChannelItem::soloMuteStateChanged, this, [this, item](const notation::INotationSoloMuteState::SoloMuteState&) {
+        AudioOutputParams playbackParams = item->outputParams();
+        playbackParams.forceMute = controller()->isMasterOutputForceMuted();
+        if (playbackParams.forceMute) {
+            playbackParams.muted = true;
+        }
+
+        playback()->setMasterControlParams(playbackParams.control());
+    });
+
     return item;
 }
 


### PR DESCRIPTION
Resolves: #33239

The Mute button on the Mixer's Master channel updated the UI but never
actually silenced the audio.

`MixerChannelItem::setMuted()` only emits `soloMuteStateChanged` (never
`controlParamsChanged`). `MixerPanelModel::buildMasterChannelItem()` only
connected to `controlParamsChanged`/`fxChainParamsChanged`/`auxSendsParamsChanged`
— unlike every other channel builder (instrument, aux), which also
connect `soloMuteStateChanged`. So toggling Master mute never reached
`playback()->setMasterControlParams(...)`, and therefore never reached the
audio engine.

The audio engine side already works correctly when actually invoked
(`AudioContext::onControlParamsChanged()` → `ControlNode::setMuted()` →
node disabled), so the fix only adds the missing `soloMuteStateChanged`
connection in `buildMasterChannelItem()`, mirroring the `forceMute` logic
already used in the existing `controlParamsChanged` handler.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
