### PR TITLE
Add sort functions for scores home page

### DIFF
--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -52,6 +52,7 @@ static const Settings::Key LAST_USED_SAVE_LOCATION_TYPE(module_name, "project/la
 static const Settings::Key SHOULD_WARN_BEFORE_PUBLISH(module_name, "project/shouldWarnBeforePublish");
 static const Settings::Key SHOULD_WARN_BEFORE_SAVING_PUBLICLY_TO_CLOUD(module_name, "project/shouldWarnBeforeSavingPubliclyToCloud");
 static const Settings::Key HOME_SCORES_PAGE_VIEW_TYPE(module_name, "project/homeScoresPageViewType");
+static const Settings::Key HOME_SCORES_PAGE_SORT_MODE(module_name, "project/homeScoresPageSortMode");
 static const Settings::Key PREFERRED_SCORE_CREATION_MODE_KEY(module_name, "project/preferredScoreCreationMode");
 static const Settings::Key MIGRATION_OPTIONS(module_name, "project/migration");
 static const Settings::Key AUTOSAVE_ENABLED_KEY(module_name, "project/autoSaveEnabled");
@@ -92,6 +93,7 @@ void ProjectConfiguration::init()
     settings()->setDefaultValue(PREFERRED_SCORE_CREATION_MODE_KEY, preferredScoreCreationMode);
 
     settings()->setDefaultValue(HOME_SCORES_PAGE_VIEW_TYPE, Val(HomeScoresPageViewType::Grid));
+    settings()->setDefaultValue(HOME_SCORES_PAGE_SORT_MODE, Val(HomeScoresPageSortMode::TimeModified));
 
     settings()->setDefaultValue(SHOULD_ASK_SAVE_LOCATION_TYPE, Val(true));
     settings()->setDefaultValue(LAST_USED_SAVE_LOCATION_TYPE, Val(SaveLocationType::Undefined));
@@ -433,6 +435,18 @@ void ProjectConfiguration::setHomeScoresPageViewType(HomeScoresPageViewType type
     // Intentionally not directly synced between instances
     // (it would be weird if you switch the view in one instance, and the others suddenly switch too)
     settings()->setLocalValue(HOME_SCORES_PAGE_VIEW_TYPE, Val(type));
+}
+
+IProjectConfiguration::HomeScoresPageSortMode ProjectConfiguration::homeScoresPageSortMode() const
+{
+    return settings()->value(HOME_SCORES_PAGE_SORT_MODE).toEnum<HomeScoresPageSortMode>();
+}
+
+void ProjectConfiguration::setHomeScoresPageSortMode(HomeScoresPageSortMode mode)
+{
+    // Intentionally not directly synced between instances
+    // (it would be weird if you switch the sort in one instance, and the others suddenly switch too)
+    settings()->setLocalValue(HOME_SCORES_PAGE_SORT_MODE, Val(mode));
 }
 
 QColor ProjectConfiguration::templatePreviewBackgroundColor() const

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -98,6 +98,9 @@ public:
     HomeScoresPageViewType homeScoresPageViewType() const override;
     void setHomeScoresPageViewType(HomeScoresPageViewType type) override;
 
+    HomeScoresPageSortMode homeScoresPageSortMode() const override;
+    void setHomeScoresPageSortMode(HomeScoresPageSortMode mode) override;
+
     QColor templatePreviewBackgroundColor() const override;
     muse::async::Notification templatePreviewBackgroundChanged() const override;
 

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -109,6 +109,14 @@ public:
         FromTemplate
     };
 
+    enum class HomeScoresPageSortMode {
+        TimeModified,
+        Name
+    };
+
+    virtual HomeScoresPageSortMode homeScoresPageSortMode() const = 0;
+    virtual void setHomeScoresPageSortMode(HomeScoresPageSortMode mode) = 0;
+
     virtual PreferredScoreCreationMode preferredScoreCreationMode() const = 0;
     virtual void setPreferredScoreCreationMode(PreferredScoreCreationMode mode) = 0;
 

--- a/src/project/qml/MuseScore/Project/ScoresPage.qml
+++ b/src/project/qml/MuseScore/Project/ScoresPage.qml
@@ -187,10 +187,47 @@ FocusScope {
             orientation: Qt.Horizontal
         }
 
+        StyledTextLabel {
+            visible: sortModeRadioButtons.visible
+
+            text: qsTrc("project", "Sort by:")
+        }
+
+        RadioButtonGroup {
+            id: sortModeRadioButtons
+
+            visible: tabBar.currentIndex === 0
+
+            implicitHeight: ui.theme.defaultButtonSize
+
+            model: [
+                { "title": qsTrc("project", "Date modified"), "value": ScoresPageModel.SortByTimeModified },
+                { "title": qsTrc("project", "Name"), "value": ScoresPageModel.SortByName }
+            ]
+
+            delegate: FlatRadioButton {
+                implicitHeight: ui.theme.defaultButtonSize
+
+                checked: scoresPageModel.sortMode === modelData.value
+
+                text: modelData.title
+                transparent: true
+                checkedColor: ui.theme.buttonColor
+
+                navigation.name: "SortMode_" + modelData.title
+                navigation.panel: viewButtonsNavPanel
+                navigation.order: model.index
+
+                onToggled: {
+                    scoresPageModel.sortMode = modelData.value
+                }
+            }
+        }
+
         RadioButtonGroup {
             id: viewTypeRadioButtons
 
-            property int navigationOrderStart: refreshButton.navigation.order + 1
+            property int navigationOrderStart: refreshButton.navigation.order + 3
 
             implicitHeight: ui.theme.defaultButtonSize
 
@@ -246,6 +283,7 @@ FocusScope {
             anchors.fill: parent
 
             viewType: scoresPageModel.viewType
+            sortMode: scoresPageModel.sortMode
             searchText: searchField.searchText
 
             backgroundColor: background.color

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -29,8 +29,11 @@ import MuseScore.Project
 ScoresView {
     id: root
 
+    property int sortMode: RecentScoresModel.SortByTimeModified
+
     RecentScoresModel {
         id: recentScoresModel
+        sortMode: root.sortMode
     }
 
     Component.onCompleted: {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
@@ -29,6 +29,9 @@
 
 #include "log.h"
 
+#include <algorithm>
+#include <QCollator>
+
 using namespace muse;
 using namespace mu::project;
 
@@ -61,15 +64,13 @@ void RecentScoresModel::updateRecentScores()
 {
     const RecentFilesList& recentScores = recentFilesController()->recentFilesList();
 
-    std::vector<QVariantMap> items;
-    items.reserve(recentScores.size());
+    struct ScoreEntry {
+        QVariantMap obj;
+        muse::DateTime lastModified;
+    };
 
-    QVariantMap addItem;
-    addItem[NAME_KEY] = muse::qtrc("project", "New score");
-    addItem[IS_CREATE_NEW_KEY] = true;
-    addItem[IS_NO_RESULTS_FOUND_KEY] = false;
-    addItem[IS_CLOUD_KEY] = false;
-    items.push_back(addItem);
+    std::vector<ScoreEntry> scoreEntries;
+    scoreEntries.reserve(recentScores.size());
 
     for (const RecentFile& file : recentScores) {
         QVariantMap obj;
@@ -80,17 +81,49 @@ void RecentScoresModel::updateRecentScores()
         RetVal<uint64_t> fileSize = fileSystem()->fileSize(file.path);
         QString fileSizeString = (fileSize.ret && fileSize.val > 0) ? DataFormatter::formatFileSize(fileSize.val).toQString() : QString();
 
+        muse::DateTime lastModified = io::FileInfo(file.path).lastModified();
+
         obj[NAME_KEY] = file.displayName(isSuffixInteresting);
         obj[PATH_KEY] = file.path.toQString();
         obj[SUFFIX_KEY] = QString::fromStdString(suffix);
         obj[FILE_SIZE_KEY] = fileSizeString;
         obj[IS_CLOUD_KEY] = configuration()->isCloudProject(file.path);
         obj[CLOUD_SCORE_ID_KEY] = configuration()->cloudScoreIdFromPath(file.path);
-        obj[TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(io::FileInfo(file.path).lastModified().date()).toQString();
+        obj[TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(lastModified.date()).toQString();
         obj[IS_CREATE_NEW_KEY] = false;
         obj[IS_NO_RESULTS_FOUND_KEY] = false;
 
-        items.push_back(obj);
+        scoreEntries.push_back({ obj, lastModified });
+    }
+
+    if (m_sortMode == SortByName) {
+        QCollator collator;
+        collator.setNumericMode(true);
+        collator.setCaseSensitivity(Qt::CaseInsensitive);
+
+        std::stable_sort(scoreEntries.begin(), scoreEntries.end(), [&collator](const ScoreEntry& a, const ScoreEntry& b) {
+            return collator.compare(a.obj[NAME_KEY].toString(), b.obj[NAME_KEY].toString()) < 0;
+        });
+    } else {
+        // SortByTimeModified: sort by actual file mtime, not recent-files usage order,
+        // so it matches what the "Modified" column displays (open+close alone shouldn't reorder).
+        std::stable_sort(scoreEntries.begin(), scoreEntries.end(), [](const ScoreEntry& a, const ScoreEntry& b) {
+            return a.lastModified.toQDateTime() > b.lastModified.toQDateTime();
+        });
+    }
+
+    std::vector<QVariantMap> items;
+    items.reserve(scoreEntries.size() + 2);
+
+    QVariantMap addItem;
+    addItem[NAME_KEY] = muse::qtrc("project", "New score");
+    addItem[IS_CREATE_NEW_KEY] = true;
+    addItem[IS_NO_RESULTS_FOUND_KEY] = false;
+    addItem[IS_CLOUD_KEY] = false;
+    items.push_back(addItem);
+
+    for (const ScoreEntry& entry : scoreEntries) {
+        items.push_back(entry.obj);
     }
 
     QVariantMap noResultsFoundItem;
@@ -101,6 +134,23 @@ void RecentScoresModel::updateRecentScores()
     items.push_back(noResultsFoundItem);
 
     setRecentScores(items);
+}
+
+RecentScoresModel::SortMode RecentScoresModel::sortMode() const
+{
+    return m_sortMode;
+}
+
+void RecentScoresModel::setSortMode(SortMode mode)
+{
+    if (m_sortMode == mode) {
+        return;
+    }
+
+    m_sortMode = mode;
+    emit sortModeChanged();
+
+    updateRecentScores();
 }
 
 QList<int> RecentScoresModel::nonScoreItemIndices() const

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
@@ -41,6 +41,7 @@ class RecentScoresModel : public AbstractScoresModel, public muse::async::Asynca
     muse::GlobalInject<IProjectConfiguration> configuration;
     muse::ContextInject<IRecentFilesController> recentFilesController = { this };
     muse::GlobalInject<muse::io::IFileSystem> fileSystem;
+    Q_PROPERTY(SortMode sortMode READ sortMode WRITE setSortMode NOTIFY sortModeChanged)
 
 public:
     RecentScoresModel(QObject* parent = nullptr);
@@ -49,8 +50,22 @@ public:
 
     QList<int> nonScoreItemIndices() const override;
 
+    enum SortMode {
+        SortByTimeModified,
+        SortByName
+    };
+    Q_ENUM(SortMode)
+
+    SortMode sortMode() const;
+    void setSortMode(SortMode mode);
+
+signals:
+    void sortModeChanged();
+
 private:
     void updateRecentScores();
     void setRecentScores(const std::vector<QVariantMap>& items);
+
+    SortMode m_sortMode = SortByTimeModified;
 };
 }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/scorespagemodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/scorespagemodel.cpp
@@ -83,3 +83,18 @@ void ScoresPageModel::setViewType(ViewType type)
     configuration()->setHomeScoresPageViewType(IProjectConfiguration::HomeScoresPageViewType(type));
     emit viewTypeChanged();
 }
+
+ScoresPageModel::SortMode ScoresPageModel::sortMode() const
+{
+    return static_cast<SortMode>(configuration()->homeScoresPageSortMode());
+}
+
+void ScoresPageModel::setSortMode(SortMode mode)
+{
+    if (sortMode() == mode) {
+        return;
+    }
+
+    configuration()->setHomeScoresPageSortMode(IProjectConfiguration::HomeScoresPageSortMode(mode));
+    emit sortModeChanged();
+}

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/scorespagemodel.h
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/scorespagemodel.h
@@ -40,6 +40,7 @@ class ScoresPageModel : public QObject, public muse::Contextable
 
     Q_PROPERTY(int tabIndex READ tabIndex WRITE setTabIndex NOTIFY tabIndexChanged)
     Q_PROPERTY(ViewType viewType READ viewType WRITE setViewType NOTIFY viewTypeChanged)
+    Q_PROPERTY(SortMode sortMode READ sortMode WRITE setSortMode NOTIFY sortModeChanged)
 
     QML_ELEMENT
 
@@ -63,6 +64,15 @@ public:
     ViewType viewType() const;
     void setViewType(ViewType type);
 
+    enum SortMode {
+        SortByTimeModified = int(IProjectConfiguration::HomeScoresPageSortMode::TimeModified),
+        SortByName = int(IProjectConfiguration::HomeScoresPageSortMode::Name),
+    };
+    Q_ENUM(SortMode);
+
+    SortMode sortMode() const;
+    void setSortMode(SortMode mode);
+
     Q_INVOKABLE void createNewScore();
     Q_INVOKABLE void openOther();
     Q_INVOKABLE void openScore(const QString& scorePath, const QString& displayNameOverride);
@@ -71,5 +81,6 @@ public:
 signals:
     void tabIndexChanged();
     void viewTypeChanged();
+    void sortModeChanged();
 };
 }

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -77,6 +77,9 @@ public:
     MOCK_METHOD(HomeScoresPageViewType, homeScoresPageViewType, (), (const, override));
     MOCK_METHOD(void, setHomeScoresPageViewType, (HomeScoresPageViewType), (override));
 
+    MOCK_METHOD(HomeScoresPageSortMode, homeScoresPageSortMode, (), (const, override));
+    MOCK_METHOD(void, setHomeScoresPageSortMode, (HomeScoresPageSortMode), (override));
+
     MOCK_METHOD(int, homeScoresPageTabIndex, (), (const, override));
     MOCK_METHOD(void, setHomeScoresPageTabIndex, (int), (override));
 


### PR DESCRIPTION
Although this has come up several times on discord and forums, I couldnt find an open issue on this. 

Added sort by *name* and by *date modified* funtions to score page.

https://github.com/user-attachments/assets/bfef5c0f-1adb-436a-954f-16a2f1ed84a8

