### PR TITLE
Fix use-after-free in `UndoableTransaction::unwind`

### DIFF
--- a/src/engraving/editing/transaction/undostack.cpp
+++ b/src/engraving/editing/transaction/undostack.cpp
@@ -262,10 +262,18 @@ void UndoableTransaction::cleanup(bool wasDone)
 
 void UndoableTransaction::unwind(bool cleanUp)
 {
+    // Undo everything first, without freeing: commands pushed later (e.g. AddElement for a part's linked
+    // clone) may still be referenced by earlier commands' undo() (e.g. Link::undo()):
+    std::vector<UndoableCommand*> undoneCommands;
+    undoneCommands.reserve(m_commands.size());
     while (!m_commands.empty()) {
         UndoableCommand* command = muse::takeLast(m_commands);
         LOG_UNDO() << "unwind: " << command->name();
         command->undo();
+        undoneCommands.push_back(command);
+    }
+    // Now we can free everything:
+    for (UndoableCommand* command : undoneCommands) {
         if (cleanUp) {
             command->cleanup(false);
         }


### PR DESCRIPTION
Resolves: #34717

The issue reported a crash when clicking "cancel" from the instrument change dialog inside a part. This happened because: 

* `EngravingItem::linkedClone()` adds a `Link` command _before_ the linked clone's `AddElement`
* Then, `UndoableTransaction::unwind()` rolled back the cancelled transaction one command at a time, undoing and freeing each.
* `unwind` freed the `AddElement` and its items, and the `~EngravingObject` destructor freed the `LinkedObjects` list pointer once it was empty.
*  Lastly, by the time `Link::undo()` was called, it called `unlink()` on the freed object and on a `LinkedObjects` list its destructor had already deleted.

`unwind()` now undoes every command first and only frees them once all the undos are done.