### PR TITLE
Fix FX editor not opening for VST3 plugins on the Master channel

### DIFF
--- a/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerchannelitem.cpp
@@ -702,10 +702,7 @@ OutputResourceItem* MixerChannelItem::buildOutputResourceItem(const audio::Audio
 
         actions::ActionQuery aq(VSTFX_EDITOR_ACTION);
 
-        if (m_type != Type::Master) {
-            aq.addParam(TRACK_ID_KEY, Val(m_trackId));
-        }
-
+        aq.addParam(TRACK_ID_KEY, Val(m_trackId));
         aq.addParam(RESOURCE_ID_KEY, Val(newItem->params().resourceMeta.id));
         aq.addParam(CHAIN_ORDER_KEY, Val(newItem->params().chainOrder));
 

--- a/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
+++ b/src/playback/qml/MuseScore/Playback/mixerpanelmodel.cpp
@@ -595,7 +595,7 @@ MixerChannelItem* MixerPanelModel::buildAuxChannelItem(aux_channel_idx_t index, 
 
 MixerChannelItem* MixerPanelModel::buildMasterChannelItem()
 {
-    MixerChannelItem* item = new MixerChannelItem(this, MixerChannelItem::Type::Master, true /*outputOnly*/);
+    MixerChannelItem* item = new MixerChannelItem(this, MixerChannelItem::Type::Master, true /*outputOnly*/, MASTER_TRACK_ID);
     item->setPanelSection(m_navigationSection);
     item->setTitle(muse::qtrc("playback", "Master"));
 


### PR DESCRIPTION
Resolves: #33872

## Problem

Double-clicking a VST3 FX slot on the Master channel in the Mixer did nothing — the plugin's editor window never opened, even though the same double-click works fine for FX slots on instrument tracks.

## Root cause

The Master mixer channel item (`MixerChannelItem`) was constructed with the default `trackId` (`-1`), and `MixerChannelItem::buildOutputResourceItem()` deliberately omitted the `trackId` param from the `action://vst/fx_editor` query for the Master channel specifically.

However, the audio engine only ever creates/registers the Master channel's FX plugin instances through the generic per-track path (`AudioContext` → `AudioFactory::makeTrackFxChain(trackId, ...)`, called with `trackId = MASTER_TRACK_ID` (`0`) for the Master bus). The separate `-1`-keyed master-specific path (`AudioFactory::makeMasterFxChain` / `VstInstancesRegister::registerMasterFxPlugin`) is never actually invoked anywhere in the engine.

This left a mismatch: the plugin instance is registered under `trackId = 0`, but the editor-open request looks it up under `trackId = -1` — so `VstInstancesRegister::fxPlugin()` never finds it, and the "open editor" command silently fails.

## Fix

- Give the Master `MixerChannelItem` its real track id (`MASTER_TRACK_ID`) instead of the default `-1`.
- Always send the `trackId` param when requesting the FX editor, removing the Master-specific special case — this now matches every other channel type.

## Testing

Manually verified on macOS (Release build): added a VST3 FX plugin to the Master channel in the Mixer, double-clicked its slot — the plugin's editor window now opens and closes correctly, same as for instrument-track FX slots.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).