### PR TITLE
Fix trill line bug when ending on grace note at system break

### DIFF
--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -256,13 +256,11 @@ PointF Trill::trillLinePos(const SLine* line, Grip grip, System** system)
         return PointF(x, 0.0);
     }
 
-    Segment* graceNoteSeg = segment->preAppendedItem(line->track2()) ? segment : nullptr;
     Segment* clefSeg = segment->isClefType() ? segment : nullptr;
     Fraction curTick = segment->tick();
     while (true) {
         Segment* prevSeg = mmRest ? segment->prev1MM() : segment->prev1();
         if (prevSeg && prevSeg->tick() == curTick) {
-            graceNoteSeg = prevSeg->preAppendedItem(line->track2()) ? prevSeg : graceNoteSeg;
             clefSeg = prevSeg->isClefType() ? prevSeg : clefSeg;
             segment = prevSeg;
         } else {
@@ -282,19 +280,17 @@ PointF Trill::trillLinePos(const SLine* line, Grip grip, System** system)
     }
 
     // Stop line before grace notes
-    if (graceNoteSeg) {
-        const EngravingItem* preAppendedItem = graceNoteSeg->preAppendedItem(line->track2());
-        if (preAppendedItem && preAppendedItem->isGraceNotesGroup()) {
-            // get x position of leftmost grace note
-            const Chord* leftMostGraceChord = nullptr;
-            const GraceNotesGroup* graceGroup = toGraceNotesGroup(preAppendedItem);
-            for (const Chord* graceChord : *graceGroup) {
-                leftMostGraceChord = leftMostGraceChord
-                                     && leftMostGraceChord->x() < graceChord->x() ? leftMostGraceChord : graceChord;
-            }
-            if (leftMostGraceChord) {
-                graceOffset = segment->pageX() - leftMostGraceChord->pageX();
-            }
+    if (const EngravingItem* preAppendedItem = segment->preAppendedItem(line->track2());
+        preAppendedItem&& preAppendedItem->isGraceNotesGroup()) {
+        // get x position of leftmost grace note
+        const Chord* leftMostGraceChord = nullptr;
+        const GraceNotesGroup* graceGroup = toGraceNotesGroup(preAppendedItem);
+        for (const Chord* graceChord : *graceGroup) {
+            leftMostGraceChord = leftMostGraceChord
+                                 && leftMostGraceChord->x() < graceChord->x() ? leftMostGraceChord : graceChord;
+        }
+        if (leftMostGraceChord) {
+            graceOffset = segment->pageX() - leftMostGraceChord->pageX();
         }
     }
 


### PR DESCRIPTION
Resolves:

Write a trill like this, ending at a measure boundary and with a grace note at the start of the next measure
<img width="455" height="218" alt="image" src="https://github.com/user-attachments/assets/4c51e951-fd13-4375-800d-76b825663d7d" />
 Add a line break: trill line disappears
<img width="1146" height="426" alt="image" src="https://github.com/user-attachments/assets/7f81561e-09ee-46b8-84df-069334787809" />

After the fix:
<img width="1322" height="505" alt="image" src="https://github.com/user-attachments/assets/42887fe7-b2b2-420d-bc73-5c425527fa4b" />

