### PR TITLE
refactor cmdNextPrev...

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4025,6 +4025,7 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
     if (!currentMeasureBase) {
         return el;
     }
+    track_idx_t track = el->isChordRest() ? trackZeroVoice(el->track()) : 0;
 
     // Next Section of Score
     if (next) {
@@ -4032,7 +4033,7 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
         if (!destination) {
             return el;
         }
-        return getScoreElementOfMeasureBase(destination->next());
+        return getScoreElementOfMeasureBase(destination->next(), track);
     }
 
     // Previous Section of Score
@@ -4044,14 +4045,14 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
 
     if (currentSegment) {
         MeasureBase* firstBreak = destination;
-        el = getScoreElementOfMeasureBase(destination->next());
+        el = getScoreElementOfMeasureBase(destination->next(), track);
         if (el && el->isChordRest() && (toChordRest(el)->segment() == currentSegment)) {
             if (firstBreak == score()->first()) {
                 el = firstBreak;
             } else if ((destination = getNextPrevSectionBreak(destination, false))) {
                 bool isFallbackSentinel = (destination == score()->first());
                 bool isRealBreak = !destination->sectionBreak() && !isFallbackSentinel;
-                el = isRealBreak ? destination : getScoreElementOfMeasureBase(destination->next());
+                el = isRealBreak ? destination : getScoreElementOfMeasureBase(destination->next(), track);
             }
         }
     }
@@ -4060,14 +4061,14 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
     if (score()->first() == currentMeasureBase) {
         return el;
     }
-    el = getScoreElementOfMeasureBase(destination->next());
+    el = getScoreElementOfMeasureBase(destination->next(), track);
     if (!el) {
         return el;
     }
     if (el->findMeasureBase() == currentMeasureBase) {
         destination = getNextPrevSectionBreak(destination, false);
         if (destination) {
-            el = destination->sectionBreak() ? getScoreElementOfMeasureBase(destination->next()) : el;
+            el = destination->sectionBreak() ? getScoreElementOfMeasureBase(destination->next(), track) : el;
         }
     }
     return el;
@@ -4122,7 +4123,7 @@ MeasureBase* Score::getNextPrevSectionBreak(MeasureBase* mb, bool dir) const
 //    MeasureBase
 //---------------------------------------------------------
 
-EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
+EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb, track_idx_t track = 0) const
 {
     EngravingItem* el { nullptr };
     ChordRest* cr { nullptr };
@@ -4135,7 +4136,7 @@ EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
             if (style().styleB(Sid::createMultiMeasureRests) && currentMeasure->hasMMRest()) {
                 currentMeasure = currentMeasure->coveringMMRestOrThis();
             }
-            if ((cr = currentMeasure->first()->nextChordRest(0, false))) {
+            if ((cr = currentMeasure->first()->nextChordRest(track, false))) {
                 el = cr;
             }
         }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -48,6 +48,7 @@
 #include "editing/transpose.h"
 #include "editing/editstaffbrackets.h"
 
+#include "property.h"
 #include "rendering/iscorerenderer.h"
 
 #include "style/style.h"
@@ -3945,74 +3946,55 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
         return nullptr;
     }
 
-    auto newCR = cr;
-    auto currentMeasure = cr->measure();
-    auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->coveringMMRestOrThis()->system();
-    if (!currentSystem) {
-        return cr;
-    }
-    auto destinationMeasure = currentSystem->firstMeasure();
-    if (!destinationMeasure) {
-        return cr;
-    }
+    auto systemOf = [](Measure* m) -> System* {
+        return m->system() ? m->system() : m->coveringMMRestOrThis()->system();
+    };
+    auto firstChordRestOf = [track = trackZeroVoice(cr->track())](Measure* m) -> ChordRest* {
+        return m->first()->nextChordRest(track, false);
+    };
 
-    auto firstSegment = destinationMeasure->first(SegmentType::ChordRest);
+    Measure* currentMeasure = cr->measure();
+    System* currentSystem = systemOf(currentMeasure);
+    Measure* destinationMeasure = currentSystem->firstMeasure();
+    Segment* firstSegment = destinationMeasure->first(SegmentType::ChordRest);
 
-    // Case: Go to next system
     if (next) {
-        if ((destinationMeasure = currentSystem->lastMeasure()->nextMeasure())) {
-            // There is a next system present: get it and accommodate for MMRest
-            currentSystem = destinationMeasure->system()
-                            ? destinationMeasure->system()
-                            : destinationMeasure->coveringMMRestOrThis()->system();
-            if (!currentSystem) {
-                return cr;
-            }
-            if ((destinationMeasure = currentSystem->firstMeasure())) {
-                if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
-                    cr = newCR;
-                }
-            }
-        } else if (currentMeasure != lastMeasure()) {
-            // There is no next system present: go to last measure of current system
-            if ((destinationMeasure = lastMeasure())) {
-                if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
-                    if (!destinationMeasure->isMMRest()) {
-                        cr = newCR;
-                    }
-                    // Last visual measure is a MMRest: go to very last measure within that MMRest
-                    else if ((destinationMeasure = lastMeasureMM())
-                             && (newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
-                        cr = newCR;
-                    }
-                }
-            }
+        if (Measure* nextSystemMeasure = currentSystem->lastMeasure()->nextMeasure()) {
+            // Next system exists: get it and accommodate for MMRest
+            System* nextSystem = systemOf(nextSystemMeasure);
+            destinationMeasure = nextSystem->firstMeasure();
+            ChordRest* newCR = firstChordRestOf(destinationMeasure);
+            return newCR ? newCR : cr;
         }
+        if (currentMeasure == lastMeasure()) {
+            return cr;
+        }
+
+        // No next system: go to the last measure of the score
+        destinationMeasure = lastMeasure();
+        if (Measure* lastMM = lastMeasureMM()) {
+            ChordRest* mmCR = firstChordRestOf(lastMM);
+            return mmCR;
+        }
+        ChordRest* newCR = firstChordRestOf(destinationMeasure);
+        return newCR;
     }
-    // Case: Go to previous system
-    else {
-        auto currentSegment = cr->segment();
-        // Only go to previous system's beginning if user is already at the absolute beginning of current system
-        // and not in first measure of entire score
-        if ((destinationMeasure != firstMeasure() && destinationMeasure != firstMeasureMM())
-            && (currentSegment == firstSegment || (currentMeasure->mmRest() && currentMeasure->mmRest()->isFirstInSystem()))) {
-            if (!(destinationMeasure = destinationMeasure->prevMeasureMM())) {
-                return cr;
-            }
-            if (!(currentSystem = destinationMeasure->system()
-                                  ? destinationMeasure->system()
-                                  : destinationMeasure->coveringMMRestOrThis()->system())) {
-                return cr;
-            }
-            destinationMeasure = currentSystem->firstMeasure();
-        }
-        if (destinationMeasure) {
-            if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
-                cr = newCR;
-            }
-        }
+
+    // Go to previous system
+    Segment* currentSegment = cr->segment();
+    bool atSystemStart = (currentSegment == firstSegment) || (currentMeasure->mmRest() && currentMeasure->mmRest()->isFirstInSystem());
+    bool notAtScoreStart = (destinationMeasure != firstMeasure() && destinationMeasure != firstMeasureMM());
+
+    // Only jump to previous system's start if we're at the absolute start
+    // of the current system and not in the score's first measure
+    if (notAtScoreStart && atSystemStart) {
+        destinationMeasure = destinationMeasure->prevMeasureMM();
+        currentSystem = systemOf(destinationMeasure);
+        destinationMeasure = currentSystem->firstMeasure();
     }
-    return cr;
+
+    ChordRest* newCR = firstChordRestOf(destinationMeasure);
+    return newCR ? newCR : cr;
 }
 
 //---------------------------------------------------------
@@ -4037,41 +4019,54 @@ Box* Score::cmdNextPrevFrame(MeasureBase* currentMeasureBase, bool next) const
 //    Return [Box* or ChordRest*] of next/previous section
 //---------------------------------------------------------
 
-EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool dir) const
+EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
 {
-    auto currentMeasureBase = el->findMeasureBase();
-    auto destination = currentMeasureBase;
-    if (currentMeasureBase) {
-        // -----------------------
-        // Next Section of Score
-        // -----------------------
-        if (dir) {
-            if ((destination = getNextPrevSectionBreak(currentMeasureBase, true))) {
-                el = getScoreElementOfMeasureBase(destination->next());
+    MeasureBase* currentMeasureBase = el->findMeasureBase();
+    if (!currentMeasureBase) {
+        return el;
+    }
+
+    // Next Section of Score
+    if (next) {
+        MeasureBase* destination = getNextPrevSectionBreak(currentMeasureBase, true);
+        if (!destination) {
+            return el;
+        }
+        return getScoreElementOfMeasureBase(destination->next());
+    }
+
+    // Previous Section of Score
+    Segment* currentSegment = el->isChordRest() ? toChordRest(el)->segment() : nullptr;
+    MeasureBase* destination = getNextPrevSectionBreak(currentMeasureBase, false);
+    if (!destination) {
+        return el;
+    }
+
+    if (currentSegment) {
+        MeasureBase* firstBreak = destination;
+        el = getScoreElementOfMeasureBase(destination->next());
+        if (el && el->isChordRest() && (toChordRest(el)->segment() == currentSegment)) {
+            if (firstBreak == score()->first()) {
+                el = firstBreak;
+            } else if ((destination = getNextPrevSectionBreak(destination, false))) {
+                bool isFallbackSentinel = (destination == score()->first());
+                el = (!destination->sectionBreak() && !isFallbackSentinel) ? destination : getScoreElementOfMeasureBase(destination->next());
             }
         }
-        // -------------------------
-        // Previous Section of Score
-        // -------------------------
-        else {
-            auto currentSegment = el->isChordRest() ? toChordRest(el)->segment() : nullptr;
-            if ((destination = getNextPrevSectionBreak(currentMeasureBase, false))) {
-                if (currentSegment) {
-                    if ((el = getScoreElementOfMeasureBase((score()->first() == destination) ? destination : destination->next()))) {
-                        if (el->isChordRest() && (toChordRest(el)->segment() == currentSegment)) {
-                            if ((destination = getNextPrevSectionBreak(destination, false))) {
-                                el = !(destination->sectionBreak()) ? destination : getScoreElementOfMeasureBase(destination->next());
-                            }
-                        }
-                    }
-                } else if ((score()->first() != currentMeasureBase) && (el = getScoreElementOfMeasureBase(destination->next()))) {
-                    if (el->findMeasureBase() == currentMeasureBase) {
-                        if ((destination = getNextPrevSectionBreak(destination, false))) {
-                            el = !(destination->sectionBreak()) ? el : getScoreElementOfMeasureBase(destination->next());
-                        }
-                    }
-                }
-            }
+    }
+
+    // el is not a ChordRest
+    if (score()->first() == currentMeasureBase) {
+        return el;
+    }
+    el = getScoreElementOfMeasureBase(destination->next());
+    if (!el) {
+        return el;
+    }
+    if (el->findMeasureBase() == currentMeasureBase) {
+        destination = getNextPrevSectionBreak(destination, false);
+        if (destination) {
+            el = destination->sectionBreak() ? getScoreElementOfMeasureBase(destination->next()) : el;
         }
     }
     return el;
@@ -4086,7 +4081,7 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool dir) const
 
 MeasureBase* Score::getNextPrevSectionBreak(MeasureBase* mb, bool dir) const
 {
-    auto destination = mb;
+    MeasureBase* destination = mb;
     if (destination) {
         if (dir) {
             // Find next section break
@@ -4167,7 +4162,7 @@ size_t Score::nmeasures() const
 Measure* Score::firstTrailingMeasure(ChordRest** cr)
 {
     Measure* firstMeasure = nullptr;
-    auto m = lastMeasure();
+    Measure* m = lastMeasure();
 
     if (!cr) {
         // No active selection: prepare first empty trailing measure of entire score

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4050,7 +4050,8 @@ EngravingItem* Score::cmdNextPrevSection(EngravingItem* el, bool next) const
                 el = firstBreak;
             } else if ((destination = getNextPrevSectionBreak(destination, false))) {
                 bool isFallbackSentinel = (destination == score()->first());
-                el = (!destination->sectionBreak() && !isFallbackSentinel) ? destination : getScoreElementOfMeasureBase(destination->next());
+                bool isRealBreak = !destination->sectionBreak() && !isFallbackSentinel;
+                el = isRealBreak ? destination : getScoreElementOfMeasureBase(destination->next());
             }
         }
     }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -558,7 +558,7 @@ public:
     Box* cmdNextPrevFrame(MeasureBase*, bool) const;
     EngravingItem* cmdNextPrevSection(EngravingItem*, bool) const;
     MeasureBase* getNextPrevSectionBreak(MeasureBase*, bool) const;
-    EngravingItem* getScoreElementOfMeasureBase(MeasureBase*) const;
+    EngravingItem* getScoreElementOfMeasureBase(MeasureBase*, track_idx_t) const;
 
     int fileDivision(int t) const { return static_cast<int>(((int64_t)t * Constants::DIVISION + m_fileDivision / 2) / m_fileDivision); }
     void setFileDivision(int t) { m_fileDivision = t; }

--- a/src/notation/internal/notationselection.cpp
+++ b/src/notation/internal/notationselection.cpp
@@ -244,6 +244,12 @@ void NotationSelection::select(SelectionTarget target)
     case SelectionTarget::PrevSystem:
         moveSelection(MoveDirection::Left, MoveSelectionType::System);
         break;
+    case SelectionTarget::NextSection:
+        moveSelection(MoveDirection::Right, MoveSelectionType::Section);
+        break;
+    case SelectionTarget::PrevSection:
+        moveSelection(MoveDirection::Left, MoveSelectionType::Section);
+        break;
     case SelectionTarget::AboveStaff:
         moveSelection(MoveDirection::Up, MoveSelectionType::Track);
         break;
@@ -486,6 +492,7 @@ void NotationSelection::moveSelection(MoveDirection d, MoveSelectionType type)
         case MoveSelectionType::Track:     return QString("track");
         case MoveSelectionType::Frame:     return QString("frame");
         case MoveSelectionType::System:    return QString("system");
+        case MoveSelectionType::Section:   return QString("section");
         case MoveSelectionType::String:   return QString();
         }
         return QString();

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -129,6 +129,8 @@ enum class SelectionTarget : unsigned char
     PrevFrame,
     NextSystem,
     PrevSystem,
+    NextSection,
+    PrevSection,
     AboveStaff,
     BelowStaff,
     UpNoteInChord,
@@ -225,6 +227,7 @@ enum class MoveSelectionType : unsigned char
     Track,
     Frame,
     System,
+    Section,
     String // TAB Staff
 };
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -131,6 +131,8 @@ void NotationActionController::init()
     registerCommand(GOTO_PREV_FRAME_COMMAND, [this]() { select(SelectionTarget::PrevFrame); });
     registerCommand(GOTO_NEXT_SYSTEM_COMMAND, [this]() { select(SelectionTarget::NextSystem); });
     registerCommand(GOTO_PREV_SYSTEM_COMMAND, [this]() { select(SelectionTarget::PrevSystem); });
+    registerCommand(GOTO_NEXT_SECTION_COMMAND, [this]() { select(SelectionTarget::NextSection); });
+    registerCommand(GOTO_PREV_SECTION_COMMAND, [this]() { select(SelectionTarget::PrevSection); });
     registerCommand(GOTO_UPNOTE_IN_CHORD_COMMAND, [this]() { select(SelectionTarget::UpNoteInChord); });
     registerCommand(GOTO_DOWNNOTE_IN_CHORD_COMMAND, [this]() { select(SelectionTarget::DownNoteInChord); });
     registerCommand(GOTO_TOPNOTE_IN_CHORD_COMMAND, [this]() { select(SelectionTarget::TopNoteInChord); });
@@ -811,6 +813,8 @@ void NotationActionController::init()
             { "prev-frame", GOTO_PREV_FRAME_COMMAND, {} },
             { "next-system", GOTO_NEXT_SYSTEM_COMMAND, {} },
             { "prev-system", GOTO_PREV_SYSTEM_COMMAND, {} },
+            { "next-section", GOTO_NEXT_SECTION_COMMAND, {} },
+            { "prev-section", GOTO_PREV_SECTION_COMMAND, {} },
             { "up-chord", GOTO_UPNOTE_IN_CHORD_COMMAND, {} },
             { "down-chord", GOTO_DOWNNOTE_IN_CHORD_COMMAND, {} },
             { "top-chord", GOTO_TOPNOTE_IN_CHORD_COMMAND, {} },

--- a/src/notationscene/internal/notationcommandsregister.cpp
+++ b/src/notationscene/internal/notationcommandsregister.cpp
@@ -1052,6 +1052,20 @@ static const std::vector<CommandInfo> s_commandInfos = {
         Decoration()
     },
     CommandInfo{
+        GOTO_NEXT_SECTION_COMMAND,
+        TranslatableString("action", "Next section"),
+        TranslatableString("action", "Go to next section"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
+        GOTO_PREV_SECTION_COMMAND,
+        TranslatableString("action", "Previous section"),
+        TranslatableString("action", "Go to previous section"),
+        InputSchema(),
+        Decoration()
+    },
+    CommandInfo{
         GOTO_UPNOTE_IN_CHORD_COMMAND,
         TranslatableString("action", "Up note in chord"),
         TranslatableString("action", "Select note/rest above"),

--- a/src/notationscene/internal/notationcommandsstate.cpp
+++ b/src/notationscene/internal/notationcommandsstate.cpp
@@ -224,7 +224,9 @@ static const std::map<Command, MoveSelectionType> MOVE_SELECTION_COMMANDS = {
     { GOTO_NEXT_FRAME_COMMAND, MoveSelectionType::Frame },
     { GOTO_PREV_FRAME_COMMAND, MoveSelectionType::Frame },
     { GOTO_NEXT_SYSTEM_COMMAND, MoveSelectionType::System },
-    { GOTO_PREV_SYSTEM_COMMAND, MoveSelectionType::System }
+    { GOTO_PREV_SYSTEM_COMMAND, MoveSelectionType::System },
+    { GOTO_NEXT_SECTION_COMMAND, MoveSelectionType::Section },
+    { GOTO_PREV_SECTION_COMMAND, MoveSelectionType::Section }
 };
 
 static const std::vector<Command> LAYOUT_BREAK_COMMANDS = {

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -299,6 +299,18 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "Previous system"),
              TranslatableString("action", "Go to previous system")
              ),
+    UiAction("next-section",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
+             TranslatableString("action", "Next section"),
+             TranslatableString("action", "Go to next section")
+             ),
+    UiAction("prev-section",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
+             TranslatableString("action", "Previous section"),
+             TranslatableString("action", "Go to previous section")
+             ),
     UiAction("select-next-chord",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notationscene/notationcommands.h
+++ b/src/notationscene/notationcommands.h
@@ -46,6 +46,8 @@ inline static const muse::rcommand::Command GOTO_NEXT_FRAME_COMMAND("command://n
 inline static const muse::rcommand::Command GOTO_PREV_FRAME_COMMAND("command://notation/goto-prev-frame");
 inline static const muse::rcommand::Command GOTO_NEXT_SYSTEM_COMMAND("command://notation/goto-next-system");
 inline static const muse::rcommand::Command GOTO_PREV_SYSTEM_COMMAND("command://notation/goto-prev-system");
+inline static const muse::rcommand::Command GOTO_NEXT_SECTION_COMMAND("command://notation/goto-next-section");
+inline static const muse::rcommand::Command GOTO_PREV_SECTION_COMMAND("command://notation/goto-prev-section");
 inline static const muse::rcommand::Command GOTO_UPNOTE_IN_CHORD_COMMAND("command://notation/goto-upnote-in-chord");
 inline static const muse::rcommand::Command GOTO_DOWNNOTE_IN_CHORD_COMMAND("command://notation/goto-downnote-in-chord");
 inline static const muse::rcommand::Command GOTO_TOPNOTE_IN_CHORD_COMMAND("command://notation/goto-topnote-in-chord");


### PR DESCRIPTION
Resolves: #17082 

I wasn't able to find an action that triggered "next/prev-section" so i wasn't able to test it out. 

"Next/prev-system" actions are present in the shorctus menu and were tested. A slight improvement: Applying "next-system"  on a lastMeasureMM  now maintains their selection. 

Update:

Resolves #23012
Restored "next/prev-section"  actions. 
A slight update in behaviour: instead of prev-section going to title frame it now goes to first measure. 
Track is now maintained (mirroring the behaviour of nextprevSystem) instead of defaulting to zero.