### PR TITLE
Fix manually edited Chordlines disappearing in parts

### DIFF
--- a/src/engraving/dom/chordline.cpp
+++ b/src/engraving/dom/chordline.cpp
@@ -58,6 +58,12 @@ ChordLine::ChordLine(const ChordLine& cl)
     m_lengthX = cl.m_lengthX;
     m_lengthY = cl.m_lengthY;
     m_note = cl.m_note;
+
+    /* The manually edited shape is "given" data which happens to live in the layout
+     * data, and EngravingItem's copy constructor doesn't copy that. Without this, an edited
+     * chordline is invisible in newly created parts: m_modified is true, so the layout won't
+     * regenerate the path, but the path itself is empty. */
+    mutldata()->path = cl.ldata()->path;
 }
 
 //---------------------------------------------------------
@@ -317,6 +323,7 @@ bool ChordLine::setProperty(Pid propertyId, const PropertyValue& val)
     switch (propertyId) {
     case Pid::PATH:
         mutldata()->path = val.value<PainterPath>();
+        setModified(true);
         break;
     case Pid::CHORD_LINE_TYPE:
         setChordLineType(ChordLineType(val.toInt()));


### PR DESCRIPTION
Resolves: #34590

Manually edited `ChordLine`s were either missing entirely from a part or shown without the edit.

`ChordLine` keeps its user-edited shape in `ChordLine::LayoutData::path` together with a `m_modified` flag that tells the layout not to regenerate it. Since `EngravingItem`'s copy constructor does not copy layout data, a part cloning an edited `ChordLine` got `m_modified == true` with an empty path, so the layout left it alone and nothing was drawn; and a part that already existed received the new path through property propagation but had `m_modified == false`, so the next layout pass overwrote it with the default shape.

This PR restores the copy in `ChordLine`'s copy constructor and marks the element as modified when `Pid::PATH` is set.

This restores 4.7.1 behaviour with a minimal patch, but we may want to refactor this for 5.0 to match the design in other parts of the code, e.g. in `SlurTieSegment`. This would involve storing the grip offsets as real properties instead of having durable user data stored in layout data and guarded by a flag that suppresses layout.