### PR TITLE
Disconnect shared items from origin when removed from the score

### DIFF
--- a/src/engraving/editing/addremoveelement.cpp
+++ b/src/engraving/editing/addremoveelement.cpp
@@ -116,6 +116,8 @@ void AddElement::undo()
         score->removeElement(element);
     }
 
+    EngravingItem::disconnectAllOriginItems(element);
+
     endUndoRedo(true);
 }
 
@@ -285,6 +287,8 @@ void RemoveElement::redo()
     } else if (element->isKeySig()) {
         score->setLayout(element->staff()->nextKeyTick(element->tick()), element->staffIdx());
     }
+
+    EngravingItem::disconnectAllOriginItems(element);
 }
 
 const char* RemoveElement::name() const

--- a/src/engraving/tests/stavesharing_data/staveSharing_01.mscx
+++ b/src/engraving/tests/stavesharing_data/staveSharing_01.mscx
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="5.00">
+  <programVersion>5.0.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>TLOq/eQ/2vO_ZZSd2SRyYWN</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2026-09-02</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <eid>5CsY7dIULTH_vJP4CziSxJG</eid>
+      <Staff>
+        <eid>ewFjetf5apK_iJDkpNLSskG</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <BracketItem>
+          <type>Normal</type>
+          <bracketSpan>2</bracketSpan>
+          <level>0</level>
+          </BracketItem>
+        <BracketItem>
+          <type>Square</type>
+          <bracketSpan>2</bracketSpan>
+          <level>1</level>
+          </BracketItem>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Instrument id="flute">
+        <InstrumentLabel>
+          <longName>Flute</longName>
+          <shortName>Fl.</shortName>
+          <number>1</number>
+          </InstrumentLabel>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <eid>bFeqmHXJdwG_MS/u+FCNsoD</eid>
+      <Staff>
+        <eid>k10sWxgCl+K_9Atn3eVv+3G</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <Instrument id="flute">
+        <InstrumentLabel>
+          <longName>Flute</longName>
+          <shortName>Fl.</shortName>
+          <number>2</number>
+          </InstrumentLabel>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>RdtStuOv5XE_hOfX7mgReXK</eid>
+        <Text>
+          <eid>qP6HaWfovkP_x05dyxCaLHP</eid>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <eid>Vs3E7cI0l8_N8mwuDiyYSM</eid>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <eid>esFKqDmulLJ_0C0xYlVuWnN</eid>
+        <voice>
+          <KeySig>
+            <eid>+XQ85zdjbcB_WOHeu6ODVFB</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>+NSw/I/ZtUP_9oq3Bcv6jSM</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <eid>mGlEisN0yEL_IFVMnM8mamH</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <KeySig>
+            <eid>BBCOcYQpvWJ_1SG3wdDeLPF</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>bG/TlkA7c8O_HpSBKLphUGG</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <eid>rx/+2zGIypO_7qUY+6Fal3N</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/stavesharing_tests.cpp
+++ b/src/engraving/tests/stavesharing_tests.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include "engraving/dom/measure.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/sharedpart.h"
 
@@ -196,6 +197,59 @@ TEST_F(Engraving_StaveSharingTests, testSaveReloadStaveSharing)
     collectSharedAndOriginParts(score, &sharedPart, originParts);
 
     EXPECT_TRUE(checkSharedPartExist(sharedPart, originParts));
+
+    delete score;
+}
+
+TEST_F(Engraving_StaveSharingTests, testChangeDurationAfterUndoingStaveSharing)
+{
+    // [GIVEN] A score of 1 measure with 2 staves and stave sharing disabled
+    MasterScore* score = ScoreRW::readScore(STAVE_SHARING_DIR + u"staveSharing_01.mscx");
+    EXPECT_TRUE(score);
+
+    // [THEN] Check rest has no shared item yet
+    Measure* m1 = score->firstMeasure();
+    ChordRest* cr1 = m1->findChordRest(Fraction(0, 1), 0);
+    EXPECT_TRUE(cr1 && cr1->isRest());
+    ASSERT_FALSE(cr1->sharedItem());
+
+    // [WHEN] Stave sharing is enabled
+    score->transactionManager()->transaction(muse::TranslatableString("staveSharingTest", "Enable stave sharing"), [&](Transaction& tx) {
+        EditStaveSharing::toggleStaveSharing(tx, score, true);
+    });
+
+    // [THEN] Rest should have a shared item now
+    ASSERT_TRUE(cr1->sharedItem());
+
+    // [WHEN] Stave sharing is disabled
+    score->transactionManager()->transaction(muse::TranslatableString("staveSharingTest", "Disable stave sharing"), [&](Transaction& tx) {
+        EditStaveSharing::toggleStaveSharing(tx, score, false);
+    });
+
+    // [THEN] Rest should stll have a shared item, as the shared parts still exist
+    ASSERT_TRUE(cr1->sharedItem());
+
+    // [WHEN] Undo twice
+    // Undo "Disable stave sharing"
+    score->undoRedo(true, nullptr);
+    // Undo "Enable stave sharing" - creation of the stave sharing groups is now undone
+    score->undoRedo(true, nullptr);
+
+    // [THEN] The shared item should have been removed from the score and disconnected from the origin rest
+    ASSERT_FALSE(cr1->sharedItem());
+
+    // [THEN] Shared parts should have been removed
+    SharedPart* sharedPart = nullptr;
+    std::vector<Part*> originParts;
+    collectSharedAndOriginParts(score, &sharedPart, originParts);
+    EXPECT_TRUE(checkSharedPartNotExist(sharedPart, originParts));
+
+    // [WHEN] The rest's duration is changed
+    score->startCmd(muse::TranslatableString("staveSharingTest", "Change rest duration"));
+    score->changeCRlen(cr1, TDuration(DurationType::V_QUARTER));
+    score->endCmd();
+
+    // [THEN] We should not crash
 
     delete score;
 }


### PR DESCRIPTION
Resolves: #34648

Prior to this PR, shared items were only disconnected from their origin items during shared stave layout. Connecting/disconnecting origin items and shared items is not an undoable command. During stave sharing layout, items are always disconnected THEN removed. However, when undoing the creation of shared parts, no stave sharing layout happens. This means that shared items are removed (via undo) but not disconnected from their origin items. 

There are two possible solutions here:
1. Make connecting/disconnecting undoable
2. Disconnect origin items when shared items are removed from the score

I have opted for the latter, as making these commands undoable would fill the undo stack with disconnection and connection of _every_ item in the score on every layout. 