### PR TITLE
Disable 2 MusicXML tests on mac & windows

### DIFF
--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -804,10 +804,10 @@ TEST_F(MusicXml_Tests, incorrectStaffNumber1) {
 TEST_F(MusicXml_Tests, incorrectStaffNumber2) {
     musicXmlIoTestRef("testIncorrectStaffNumber2");
 }
-TEST_F(MusicXml_Tests, inferredCredits1) {
+TEST_F(MusicXml_Tests, DISABLED_EXCEPT_ON_LINUX(inferredCredits1)) {
     musicXmlImportTestRef("testInferredCredits1");
 }
-TEST_F(MusicXml_Tests, inferredCredits2) {
+TEST_F(MusicXml_Tests, DISABLED_EXCEPT_ON_LINUX(inferredCredits2)) {
     musicXmlImportTestRef("testInferredCredits2");
 }
 TEST_F(MusicXml_Tests, inferCodaII) {


### PR DESCRIPTION
These tests are failing on Mac due to differences in text layout between platforms