### PR TITLE
[4.7.6] Fix section break pauses with repeats and jumps for MIDI export

### DIFF
--- a/src/engraving/compat/midi/pausemap.cpp
+++ b/src/engraving/compat/midi/pausemap.cpp
@@ -87,6 +87,17 @@ void PauseMap::calculate(const Score* s)
                 }
             }
         }
+        if (!RealIsNull(rs->pause)) {
+            int utick = rs->utick + rs->len();
+
+            Fraction timeSig(sigmap->timesig(endTick).timesig());
+            double quarterNotesPerMeasure = (4.0 * timeSig.numerator()) / timeSig.denominator();
+            int ticksPerMeasure = quarterNotesPerMeasure * Constants::DIVISION;
+
+            m_tempomapWithPauses->setTempo(this->tickWithPauses(utick), quarterNotesPerMeasure / rs->pause);
+            this->insert(std::pair<const int, int>(utick, ticksPerMeasure + this->offsetAtUTick(utick)));
+            m_tempomapWithPauses->setTempo(this->tickWithPauses(utick), tempomap->tempo(endTick));
+        }
     }
 }
 

--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -240,11 +240,12 @@ void RepeatList::updateTempo()
     for (RepeatSegment* s : *this) {
         s->utick      = utick;
         s->utime      = t;
-        double ct      = tl->tick2time(s->tick);
+        double ct     = tl->tick2time(s->tick);
         s->timeOffset = t - ct;
         int len       = s->len();
         utick        += len;
         t            += tl->tick2time(s->tick + len) - ct;
+        t            += s->pause;
     }
 }
 

--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -317,10 +317,27 @@ int RepeatList::utime2utick(double secs) const
 {
     size_t repeatSegmentsCount = size();
     unsigned ii = (m_idx2 < repeatSegmentsCount) && (secs >= at(m_idx2)->utime) ? m_idx2 : 0;
+
     for (unsigned i = ii; i < repeatSegmentsCount; ++i) {
-        if ((secs >= at(i)->utime) && ((i + 1 == repeatSegmentsCount) || (secs < at(i + 1)->utime))) {
+        const RepeatSegment* segment = at(i);
+
+        if ((secs >= segment->utime)
+            && ((i + 1 == repeatSegmentsCount) || (secs < at(i + 1)->utime))) {
             m_idx2 = i;
-            return m_score->tempomap()->time2tick(secs - at(i)->timeOffset) + (at(i)->utick - at(i)->tick);
+
+            const double segmentEndTime
+                = segment->utime
+                  + m_score->tempomap()->tick2time(segment->endTick())
+                  - m_score->tempomap()->tick2time(segment->tick);
+
+            if (!muse::RealIsNull(segment->pause)
+                && secs >= segmentEndTime
+                && secs < segmentEndTime + segment->pause) {
+                return segment->utick + segment->len() - 1;
+            }
+
+            return m_score->tempomap()->time2tick(secs - segment->timeOffset)
+                   + (segment->utick - segment->tick);
         }
     }
 

--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -23,7 +23,6 @@
 #include "repeatlist.h"
 
 #include <list>
-#include <set>
 #include <utility> // std::pair
 
 #include "jump.h"
@@ -235,18 +234,6 @@ void RepeatList::updateTempo()
         return;
     }
 
-    // Collect the end-ticks of all segments that carry a section-break pause.
-    // tick2time() always includes the pause at the queried tick, so for repeated
-    // sections every segment ending at a section break would accumulate the pause
-    // once per iteration.  We subtract it from non-final segments so that it is
-    // counted only once (in the last segment, where s->pause > 0.0).
-    std::set<int> sectionBreakEndTicks;
-    for (RepeatSegment* s : *this) {
-        if (s->pause > 0.0) {
-            sectionBreakEndTicks.insert(s->tick + s->len());
-        }
-    }
-
     int utick = 0;
     double t  = 0;
 
@@ -257,13 +244,7 @@ void RepeatList::updateTempo()
         s->timeOffset = t - ct;
         int len       = s->len();
         utick        += len;
-        double delta  = tl->tick2time(s->tick + len) - ct;
-        // For a non-final segment that ends at a section break, remove the
-        // section-break pause from the delta so the pause is not double-counted.
-        if (s->pause == 0.0 && sectionBreakEndTicks.count(s->tick + len)) {
-            delta -= tl->pauseSecs(s->tick + len);
-        }
-        t            += delta;
+        t            += tl->tick2time(s->tick + len) - ct;
     }
 }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -520,13 +520,6 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure, std::optional<BeatsPerS
         const Fraction& startTick = measure->tick();
         resetTempoRange(startTick, measure->endTick());
 
-        // Implement section break rest
-        for (MeasureBase* mb = measure->prev(); mb && mb->endTick() == startTick; mb = mb->prev()) {
-            if (mb->pause()) {
-                tempomap()->setPause(startTick.ticks(), mb->pause());
-            }
-        }
-
         // Add pauses from the end of the previous measure (at measure->tick()):
         for (Segment* s = measure->first(); s && s->tick() == startTick; s = s->prev1()) {
             if (!s->isBreathType()) {

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -41,46 +41,10 @@ inline int timestampToTick(const Score* score, const muse::mpe::timestamp_t time
     return score->repeatList().utime2utick(timestamp / 1000000.f);
 }
 
-// Returns the section-break pause at `tick` in microseconds, or 0.
-//
-// Section-break pauses should fire once — after the final repeat iteration —
-// but tick2time() includes the pause at every segment boundary.  To avoid
-// double-counting, we only return the pause for notes whose segment is the
-// one that carries it (i.e. the last segment in the repeat).
-//
-// Non-section-break pauses (caesuras, Fermata, etc.) are returned unconditionally.
-inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const int noteStartTick,
-                                     const int tickPositionOffset)
+inline muse::mpe::duration_t pauseUs(const Score* score, const int tick)
 {
     double secs = score->tempomap()->pauseSecs(tick);
-    if (muse::RealIsNull(secs)) {
-        return 0;
-    }
-
-    // Determine whether `tick` is a section-break boundary.
-    bool isSectionBreak = false;
-    for (const RepeatSegment* s : score->repeatList()) {
-        if (s->pause > 0.0 && s->tick + s->len() == tick) {
-            isSectionBreak = true;
-            break;
-        }
-    }
-
-    if (!isSectionBreak) {
-        return secs * 1000000;
-    }
-
-    // Section break: only subtract the pause if the note lives in the segment
-    // that carries it.  Other segments had the pause already removed from their
-    // time delta in updateTempo(), so subtracting again would double-count.
-    int utick = noteStartTick + tickPositionOffset;
-    for (const RepeatSegment* s : score->repeatList()) {
-        if (utick >= s->utick && utick < s->utick + s->len()) {
-            return s->pause > 0.0 ? secs * 1000000 : 0;
-        }
-    }
-
-    return 0;
+    return muse::RealIsNull(secs) ? 0 : secs* 1000000;
 }
 
 inline muse::mpe::duration_t durationFromStartAndEndTick(const Score* score, const int startTick, const int endTick,
@@ -88,7 +52,7 @@ inline muse::mpe::duration_t durationFromStartAndEndTick(const Score* score, con
 {
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTick + tickPositionOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, endTick + tickPositionOffset);
-    muse::mpe::duration_t pause = pauseUs(score, endTick, startTick, tickPositionOffset);
+    muse::mpe::duration_t pause = pauseUs(score, endTick);
 
     return endTimestamp - startTimestamp - pause;
 }
@@ -106,7 +70,7 @@ inline muse::mpe::TimestampAndDuration timestampAndDurationFromStartAndDurationT
     int startTickWithOffset = startTick + tickPositionOffset;
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTickWithOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, startTickWithOffset + durationTicks);
-    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks, startTick, tickPositionOffset);
+    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks);
     muse::mpe::duration_t duration = endTimestamp - startTimestamp - pause;
 
     return { startTimestamp, duration };

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -41,9 +41,18 @@ inline int timestampToTick(const Score* score, const muse::mpe::timestamp_t time
     return score->repeatList().utime2utick(timestamp / 1000000.f);
 }
 
-inline muse::mpe::duration_t pauseUs(const Score* score, const int tick)
+inline muse::mpe::duration_t pauseUs(const Score* score, const int tick, const int tickPositionOffset)
 {
     double secs = score->tempomap()->pauseSecs(tick);
+
+    const int utick = tick + tickPositionOffset;
+    for (const RepeatSegment* segment : score->repeatList()) {
+        if (segment->utick + segment->len() == utick) {
+            secs += segment->pause;
+            break;
+        }
+    }
+
     return muse::RealIsNull(secs) ? 0 : secs* 1000000;
 }
 
@@ -52,7 +61,7 @@ inline muse::mpe::duration_t durationFromStartAndEndTick(const Score* score, con
 {
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTick + tickPositionOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, endTick + tickPositionOffset);
-    muse::mpe::duration_t pause = pauseUs(score, endTick);
+    muse::mpe::duration_t pause = pauseUs(score, endTick, tickPositionOffset);
 
     return endTimestamp - startTimestamp - pause;
 }
@@ -70,7 +79,7 @@ inline muse::mpe::TimestampAndDuration timestampAndDurationFromStartAndDurationT
     int startTickWithOffset = startTick + tickPositionOffset;
     muse::mpe::timestamp_t startTimestamp = timestampFromTicks(score, startTickWithOffset);
     muse::mpe::timestamp_t endTimestamp = timestampFromTicks(score, startTickWithOffset + durationTicks);
-    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks);
+    muse::mpe::duration_t pause = pauseUs(score, startTick + durationTicks, tickPositionOffset);
     muse::mpe::duration_t duration = endTimestamp - startTimestamp - pause;
 
     return { startTimestamp, duration };

--- a/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
+++ b/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
@@ -2924,7 +2924,7 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
     timestamp_t fourthMeasureTime = thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION
                                     + 3000000 + QUARTER_NOTE_DURATION;
 
-    timestamp_t fifthMeasureTime = fourthMeasureTime + (WHOLE_NOTE_DURATION + 5000000) * 2; // repeat
+    timestamp_t fifthMeasureTime = fourthMeasureTime + WHOLE_NOTE_DURATION * 2 + 5000000; // repeat: only final iteration carries the section-break pause
 
     std::vector<TimestampAndDuration> expectedTnDList {
         // 1st measure (no notes)
@@ -2939,8 +2939,8 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
         { thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION + 3000000, QUARTER_NOTE_DURATION },
 
         // 4th measure (whole note inside repeat + section break)
-        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // + 5s pause (section break)
-        { fourthMeasureTime + WHOLE_NOTE_DURATION + 5000000, WHOLE_NOTE_DURATION }, // repeat
+        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // no extra pause (non-final segment)
+        { fourthMeasureTime + WHOLE_NOTE_DURATION, WHOLE_NOTE_DURATION }, // final iteration carries the 5s section-break pause
 
         // 5th measure
         { fifthMeasureTime, HALF_NOTE_DURATION },

--- a/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
+++ b/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
@@ -2924,7 +2924,7 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
     timestamp_t fourthMeasureTime = thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION
                                     + 3000000 + QUARTER_NOTE_DURATION;
 
-    timestamp_t fifthMeasureTime = fourthMeasureTime + WHOLE_NOTE_DURATION * 2 + 5000000; // repeat: only final iteration carries the section-break pause
+    timestamp_t fifthMeasureTime = fourthMeasureTime + (WHOLE_NOTE_DURATION + 5000000) * 2; // repeat
 
     std::vector<TimestampAndDuration> expectedTnDList {
         // 1st measure (no notes)
@@ -2939,8 +2939,8 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Pauses)
         { thirdMeasureTime + HALF_NOTE_DURATION + QUARTER_NOTE_DURATION + 3000000, QUARTER_NOTE_DURATION },
 
         // 4th measure (whole note inside repeat + section break)
-        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // no extra pause (non-final segment)
-        { fourthMeasureTime + WHOLE_NOTE_DURATION, WHOLE_NOTE_DURATION }, // final iteration carries the 5s section-break pause
+        { fourthMeasureTime, WHOLE_NOTE_DURATION }, // + 5s pause (section break)
+        { fourthMeasureTime + WHOLE_NOTE_DURATION + 5000000, WHOLE_NOTE_DURATION }, // repeat
 
         // 5th measure
         { fifthMeasureTime, HALF_NOTE_DURATION },


### PR DESCRIPTION
(Forward) Port of (a part of) https://github.com/Jojo-Schmitz/MuseScore/pull/1276 (and more)
Resolves: #34871

* Reverts an [earlier fix](https://github.com/musescore/MuseScore/pull/34350), which only partially fixed it and was more complex than needed
* Fix section break pauses with repeats and jumps on playback
* Handle section break pauses in MIDI export.
* Partially fix unit test (with code from the reverted fix)
* Fixes the rest of the unit test
* Fixes the playback cursor, so it stops while playback pauses on a section break