### PR TITLE
Fix automation curves misaligning after switching Page/Continuous view

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
@@ -794,6 +794,20 @@ void NotationAutomationController::onCurrentNotationChanged()
             scheduleUpdate();
         }, Asyncable::Mode::SetReplace /* FIXME */);
     }
+
+    if (const INotationPtr notation = currentNotation()) {
+        // Switching between Page/Continuous view completely re-flows the systems and does not
+        // go through changesChannel() - without this, the cached polylines keep referencing
+        // stale System* objects, so they end up misaligned with the staves and stop tracking
+        // the notation on scroll.
+        mu::notation::INotation* thisNotation = notation.get();
+        notation->viewModeChanged().onNotify(this, [this, thisNotation]() {
+            if (thisNotation != currentNotation().get()) {
+                return;
+            }
+            rebuildAllPolylines();
+        }, Asyncable::Mode::SetReplace /* FIXME */);
+    }
 }
 
 void NotationAutomationController::mergePendingScoreChanges(const mu::engraving::ScoreChanges& changes)

--- a/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/notationautomationcontroller.cpp
@@ -795,16 +795,8 @@ void NotationAutomationController::onCurrentNotationChanged()
         }, Asyncable::Mode::SetReplace /* FIXME */);
     }
 
-    if (const INotationPtr notation = currentNotation()) {
-        // Switching between Page/Continuous view completely re-flows the systems and does not
-        // go through changesChannel() - without this, the cached polylines keep referencing
-        // stale System* objects, so they end up misaligned with the staves and stop tracking
-        // the notation on scroll.
-        mu::notation::INotation* thisNotation = notation.get();
-        notation->viewModeChanged().onNotify(this, [this, thisNotation]() {
-            if (thisNotation != currentNotation().get()) {
-                return;
-            }
+    if (currentNotation()) {
+        currentNotation()->viewModeChanged().onNotify(this, [this]() {
             rebuildAllPolylines();
         }, Asyncable::Mode::SetReplace /* FIXME */);
     }


### PR DESCRIPTION
Resolves: #34776

## Description

When Automation view is enabled (e.g. showing the Dynamics curve) and the
view mode is switched between Page View and Continuous View, the curves
become completely misaligned with the staves and stop following the score
when scrolling.

Switching view mode (`NotationPainting::setViewMode()`) fully re-flows the
score's `System`s (`Score::doLayout()`), but this change never goes through
`changesChannel()` (reserved for edit transactions). `NotationAutomationController`
had no other way to detect it, so its cached polylines (`m_stavesToLinesMap`,
keyed by `System*`) kept referencing stale `System` pointers instead of being
rebuilt - leaving the curves misaligned, and un-corrected on subsequent scroll
since no rebuild was ever triggered.

The fix subscribes `NotationAutomationController` to `INotation::viewModeChanged()`
and calls the existing `rebuildAllPolylines()` when it fires, matching the same
pattern already used elsewhere in this controller for other whole-score state
changes (e.g. `currentAutomationTypeChanged()`).

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
