### PR TITLE
Fix crash and spurious notes when tying grace notes together

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -518,6 +518,27 @@ Note* searchTieNote(const Note* note, const Segment* nextSegment, const bool dis
     Note* note2  = nullptr;
     Chord* chord = note->chord();
     Segment* seg = chord->segment();
+    const bool explicitNextSegment = nextSegment != nullptr;
+
+    // Grace-after notes can tie directly to the next grace-after sibling regardless of whether
+    // a normal destination segment exists afterward (e.g. grace notes after the score's very
+    // last note) - check this first, before the normal-destination existence/adjacency gates
+    // below reject the search for unrelated reasons. Skipped when the caller passed an explicit
+    // nextSegment (e.g. probing a specific repeat/jump destination): the sibling is a fixed
+    // structural neighbor, not a per-repeat-destination candidate.
+    if (chord->isGraceAfter() && !explicitNextSegment) {
+        Chord* parentChord = toChord(chord->ownershipParent());
+        const GraceNotesGroup& gna = parentChord->graceNotesAfter();
+        for (size_t i = 0; i + 1 < gna.size(); ++i) {
+            if (gna[i] == chord) {
+                note2 = gna[i + 1]->findNote(note->pitch());
+                if (note2) {
+                    return note2;
+                }
+                break;
+            }
+        }
+    }
 
     if (!nextSegment) {
         nextSegment = seg->next1(SegmentType::ChordRest);
@@ -555,7 +576,7 @@ Note* searchTieNote(const Note* note, const Segment* nextSegment, const bool dis
             return note2;
         }
     } else if (chord->isGraceAfter()) {
-        // grace after
+        // grace after (the grace-after sibling lookup already happened above)
         // we will try to tie to note in next normal chord, below
         // meanwhile, set chord to parent chord so the endTick calculation will make sense
         chord = toChord(chord->ownershipParent());

--- a/src/engraving/editing/edittie.cpp
+++ b/src/engraving/editing/edittie.cpp
@@ -140,6 +140,8 @@ void EditTie::cmdAddTie(Score* score, bool addToChord)
             // tie grace note before to main note
             cr = toChord(c->ownershipParent());
             addToChord = true;
+            is.setTrack(cr->track());
+            is.setSegment(cr->segment());
         } else {
             is.setTrack(note->chord()->track());
             is.setSegment(note->chord()->segment());
@@ -261,7 +263,19 @@ Tie* EditTie::cmdToggleTie(Score* score)
 
     const bool shouldTieListSelection = noteList.size() >= 2 && !singleTick;
 
-    if (singleTick /* i.e. all notes are in the same tick */ && !allHaveExistingNextNoteToTieTo) {
+    // A same-tick list of 2+ notes (e.g. several grace notes anchored at the same main note)
+    // where only SOME of them already have a real note to tie to (typically because they can
+    // be tied directly to each other) must not be routed to cmdAddTie() as a whole: it treats
+    // every note in the list independently and unconditionally creates/reuses a note to tie
+    // each one forward - for the already-resolved notes this fabricates a spurious extra note,
+    // since cmdAddTie's own note creation for an earlier note in the list pollutes the chord
+    // that a later note's search then matches against. Let the main loop below tie the
+    // resolved notes directly instead (same "someHaveExistingNextNoteToTieTo && tieToNote"
+    // handling already used for non-singleTick lists), and only fall back to cmdAddTie when
+    // nothing in the list has any existing tie target at all.
+    const bool mixedSingleTickList = singleTick && someHaveExistingNextNoteToTieTo && !allHaveExistingNextNoteToTieTo;
+
+    if (singleTick /* i.e. all notes are in the same tick */ && !allHaveExistingNextNoteToTieTo && !mixedSingleTickList) {
         cmdAddTie(score);
         return nullptr;
     }


### PR DESCRIPTION
Resolves: #34751

## Description

This fixes both scenarios described in the issue.

**Scenario A (grace notes before the main note, crash):** selecting 2+ grace
notes and toggling a tie crashed immediately. `EditTie::cmdAddTie()`'s
`isGraceBefore()` branch never initialized the score's `InputState` before
`NoteInput::addPitch()` dereferenced its (null) `lastSegment()`.

Once the crash no longer masked it, a second issue surfaced: `cmdToggleTie()`
routed same-tick multi-note lists (e.g. several grace notes anchored at the
same main note) to `cmdAddTie()` whenever any note in the list lacked an
existing tie target - even when other notes in the list already had one
(typically each other). `cmdAddTie()` treats every note independently and
creates/reuses a note to tie it forward, so processing an already-resolved
note this way fabricated a spurious extra note: an earlier note's
newly-created note polluted the chord that a later note's own search then
matched against. Fixed by letting the existing tie-pairing logic handle
already-resolved notes directly, falling back to `cmdAddTie()` only for the
genuine remainder.

**Scenario B (grace notes after the main note, unexpected note creation):**
`searchTieNote()` had no sibling lookup at all for `isGraceAfter()` chords
(unlike `isGraceBefore()`, which already searches its siblings first), so two
grace-after notes of the same pitch never found each other and were both
independently routed to `cmdAddTie()`, each fabricating its own extra note.
Fixed by adding the missing sibling lookup, using `graceNotesAfter()`
(already correctly time-ordered) rather than raw stored grace indices, whose
storage order for the "after" group is reversed relative to insertion.

I could also reproduce both scenarios on MuseScore Studio 5.0.0, not just the
4.7.4 mentioned in the issue.

**Not a bug (existing MuseScore behavior, worth noting for reviewers):** if
both grace notes before a main note share the exact same pitch as that main
note (e.g. two grace C's before a normal C), tying the two grace notes also
ties the second grace note onward into the main note. This is not a side
effect of this fix - `searchTieNote()` already auto-extends a tie to the next
matching pitch for any note passed to it, the same way pressing Tie on a
single ordinary note auto-ties it forward when the next note shares its
pitch.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
