### PR TITLE
fix tie laissez-vibrer history

### DIFF
--- a/src/engraving/editing/edittie.cpp
+++ b/src/engraving/editing/edittie.cpp
@@ -114,7 +114,6 @@ void EditTie::cmdAddTie(Score* score, bool addToChord)
 
     std::vector<EngravingItem*> toSelect;
 
-    score->startCmd(TranslatableString("undoableAction", "Add tie"));
     Chord* lastAddedChord = nullptr;
 
     Transaction& tx = score->transactionManager()->currentOrDummyTransaction();
@@ -225,22 +224,18 @@ void EditTie::cmdAddTie(Score* score, bool addToChord)
             score->select(e, SelectType::ADD);
         }
     }
-    score->endCmd();
 }
 
-Tie* EditTie::cmdToggleTie(Score* score)
+EditTie::TieAnalysis EditTie::analyzeTieTargets(Score* score)
 {
-    std::vector<Note*> noteList = cmdTieNoteList(score->selection(), score->noteEntryMode());
-
-    if (noteList.empty()) {
-        LOGD("no notes selected");
-        return nullptr;
-    }
+    bool noteEntryMode = score->noteEntryMode();
+    std::vector<Note*> noteList = cmdTieNoteList(score->selection(), noteEntryMode);
 
     std::vector<Note*> tieNoteList(noteList.size());
     bool singleTick = true;
     bool someHaveExistingNextNoteToTieTo = false;
     bool allHaveExistingNextNoteToTieTo = true;
+
     for (size_t i = 0; i < noteList.size(); ++i) {
         Note* n = noteList[i];
         if (n->chord()->tick() != noteList.front()->tick()) {
@@ -259,88 +254,112 @@ Tie* EditTie::cmdToggleTie(Score* score)
         }
     }
 
-    const bool shouldTieListSelection = noteList.size() >= 2 && !singleTick;
+    TranslatableString actionName = (singleTick && !allHaveExistingNextNoteToTieTo) || someHaveExistingNextNoteToTieTo
+                                    ? TranslatableString("undoableAction", "Add tie")
+                                    : TranslatableString("undoableAction", "Remove tie");
 
-    if (singleTick /* i.e. all notes are in the same tick */ && !allHaveExistingNextNoteToTieTo) {
-        cmdAddTie(score);
+    return TieAnalysis {
+        std::move(noteList),
+        std::move(tieNoteList),
+        singleTick,
+        someHaveExistingNextNoteToTieTo,
+        allHaveExistingNextNoteToTieTo,
+        std::move(actionName)
+    };
+}
+
+Note* findTiePartnerInSelection(std::vector<Note*>& noteList, size_t i)
+{
+    Note* note = noteList[i];
+    for (size_t j = i + 1; j < noteList.size(); ++j) {
+        Note* candidate = noteList[j];
+        if (!candidate) {
+            continue;
+        }
+        const bool samePart = note->part() == candidate->part();
+        const bool samePitch = note->pitch() == candidate->pitch();
+        const bool sameUnisonIdx = note->unisonIndex() == candidate->unisonIndex();
+        const bool diffTick = note->tick() != candidate->tick();
+        if (samePart && samePitch && sameUnisonIdx && diffTick) {
+            noteList[j] = nullptr;
+            return candidate;
+        }
+    }
+    return nullptr;
+}
+
+bool toggleOffTie(Score* score, Note* note)
+{
+    Tie* oldTie = note->tieFor();
+    if (!oldTie) {
+        return false;
+    }
+    if (oldTie->tieJumpPoints()) {
+        oldTie->undoRemoveTiesFromJumpPoints();
+    }
+    score->undoRemoveElement(oldTie);
+    return true;
+}
+
+Tie* tieBetween(Note* a, Note* b)
+{
+    Note* startNote = a->tick() <= b->tick() ? a : b;
+    Note* endNote = startNote == b ? a : b;
+    return createAndAddTie(startNote, endNote);
+}
+
+Tie* EditTie::cmdToggleTie(Score* score)
+{
+    EditTie::TieAnalysis info = analyzeTieTargets(score);
+
+    if (info.noteList.empty()) {
+        LOGD("no notes selected");
         return nullptr;
     }
 
-    const TranslatableString actionName = someHaveExistingNextNoteToTieTo
-                                          ? TranslatableString("undoableAction", "Add tie")
-                                          : TranslatableString("undoableAction", "Remove tie");
-
-    score->startCmd(actionName);
+    if (info.singleTick /* i.e. all notes are in the same tick */ && !info.allHaveExistingNextNoteToTieTo) {
+        cmdAddTie(score);
+        return nullptr;
+    }
+    const bool shouldTieListSelection = info.noteList.size() >= 2 && !info.singleTick;
 
     Tie* tie = nullptr;
 
-    for (size_t i = 0; i < noteList.size(); ++i) {
-        Note* note = noteList[i];
-        Note* tieToNote = tieNoteList[i];
+    for (size_t i = 0; i < info.noteList.size(); ++i) {
+        Note* note = info.noteList[i];
 
         if (!note) {
             continue;
         }
 
         // Tie to adjacent unselected note
-        if (someHaveExistingNextNoteToTieTo && tieToNote) {
-            Note* startNote = note->tick() <= tieToNote->tick() ? note : tieToNote;
-            Note* endNote = startNote == tieToNote ? note : tieToNote;
-            tie = createAndAddTie(startNote, endNote);
+        if (info.someHaveExistingNextNoteToTieTo && info.tieNoteList[i]) {
+            tie = tieBetween(note, info.tieNoteList[i]);
             continue;
         }
 
-        Tie* oldTie = note->tieFor();
-        Chord* chord = note->chord();
-        if (oldTie) {
-            // Toggle existing tie off
-            if (oldTie->tieJumpPoints()) {
-                oldTie->undoRemoveTiesFromJumpPoints();
-            }
-            score->undoRemoveElement(oldTie);
+        if (toggleOffTie(score, note)) {
             continue;
         }
 
-        if (chord->hasFollowingJumpItem()) {
+        if (note->chord()->hasFollowingJumpItem()) {
             // Create partial tie
             tie = createAndAddTie(note, nullptr);
             continue;
         }
 
-        if (!shouldTieListSelection || i > noteList.size() - 2) {
+        if (!shouldTieListSelection || i > info.noteList.size() - 2) {
             continue;
         }
 
         // Tie to next appropriate note in selection
-        Note* note2 = nullptr;
-
-        for (size_t j = i + 1; j < noteList.size(); ++j) {
-            Note* candidateNote = noteList[j];
-            if (!candidateNote) {
-                continue;
-            }
-            const bool samePart = note->part() == candidateNote->part();
-            const bool samePitch = note->pitch() == candidateNote->pitch();
-            const bool sameUnisonIdx = note->unisonIndex() == candidateNote->unisonIndex();
-            const bool diffTick = note->tick() != candidateNote->tick();
-            if (samePart && samePitch && sameUnisonIdx && diffTick) {
-                note2 = candidateNote;
-                noteList[j] = nullptr;
-                break;
-            }
-        }
-
-        if (!(note && note2)) {
+        Note* partner = findTiePartnerInSelection(info.noteList, i);
+        if (!partner) {
             continue;
         }
 
-        Note* startNote = note->tick() <= note2->tick() ? note : note2;
-        Note* endNote = startNote == note2 ? note : note2;
-
-        tie = createAndAddTie(startNote, endNote);
+        tie = tieBetween(note, partner);
     }
-
-    score->endCmd();
 
     return tie;
 }
@@ -354,8 +373,6 @@ void EditTie::cmdToggleLaissezVib(Score* score)
         return;
     }
 
-    score->startCmd(TranslatableString("undoableAction", "Toggle laissez vibrer"));
-
     for (Note* note: noteList) {
         if (LaissezVib* lv = note->laissezVib()) {
             score->undoRemoveElement(lv);
@@ -367,6 +384,4 @@ void EditTie::cmdToggleLaissezVib(Score* score)
             score->undoAddElement(lvTie);
         }
     }
-
-    score->endCmd();
 }

--- a/src/engraving/editing/edittie.h
+++ b/src/engraving/editing/edittie.h
@@ -39,6 +39,15 @@ class TieJumpPointList;
 class EditTie
 {
 public:
+    struct TieAnalysis {
+        std::vector<Note*> noteList;
+        std::vector<Note*> tieNoteList;
+        bool singleTick = true;
+        bool someHaveExistingNextNoteToTieTo = false;
+        bool allHaveExistingNextNoteToTieTo = true;
+        TranslatableString actionName;
+    };
+    static TieAnalysis analyzeTieTargets(Score* score);
     static void cmdAddTie(Score* score, bool addToChord = false);
     static Tie* cmdToggleTie(Score* score);
     static void cmdToggleLaissezVib(Score* score);

--- a/src/engraving/tests/lv_tests.cpp
+++ b/src/engraving/tests/lv_tests.cpp
@@ -76,7 +76,9 @@ TEST_F(Engraving_LVTests, LV_Double_Notehead_test)
 
     // Add a Laissez-Vibrer tie to the First Note
     score->select(c->upNote());
+    score->startCmd(TranslatableString::untranslatable("Toggle Laissez-Vibrer"));
     EditTie::cmdToggleLaissezVib(score);
+    score->endCmd();
 
     EXPECT_TRUE(c->upNote()->tieFor()->isLaissezVib());
     score->doLayout();

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -316,10 +316,12 @@ TEST_F(Engraving_NoteTests, grace)
 
     // tie
     score->select(gn);
+    score->startCmd(TranslatableString::untranslatable("Add tie"));
     EditTie::cmdAddTie(score);
-//      n = toNote(ScoreRW::writeReadElement(gn));
-//      QVERIFY(n->tieFor() != 0);
-//      delete n;
+    score->endCmd();
+    //      n = toNote(ScoreRW::writeReadElement(gn));
+    //      QVERIFY(n->tieFor() != 0);
+    //      delete n;
 
     // tremolo
     score->startCmd(TranslatableString::untranslatable("Engraving note tests"));

--- a/src/engraving/tests/partialtie_tests.cpp
+++ b/src/engraving/tests/partialtie_tests.cpp
@@ -100,7 +100,9 @@ protected:
         // Add tie to start note
         // Expect tie to be added successfully and all jump points to have an incoming tie
         m_masterScore->select(m_startNote);
-        Tie* t = EditTie::cmdToggleTie(m_masterScore); // calls startCmd/endCmd internally
+        m_masterScore->startCmd(TranslatableString::untranslatable("Toggle tie"));
+        Tie* t = EditTie::cmdToggleTie(m_masterScore);
+        m_masterScore->endCmd();
         EXPECT_TRUE(t);
 
         for (const Note* note : m_jumpPoints) {
@@ -263,7 +265,9 @@ protected:
 
         Note* noteBeforeSegno = getNoteAtTick(tickBeforeSegno);
         m_masterScore->select(noteBeforeSegno);
-        Tie* tieBeforeSegno = EditTie::cmdToggleTie(m_masterScore); // calls startCmd/endCmd internally
+        m_masterScore->startCmd(TranslatableString::untranslatable("Toggle tie"));
+        Tie* tieBeforeSegno = EditTie::cmdToggleTie(m_masterScore);
+        m_masterScore->endCmd();
 
         bool newTieFound = false;
         for (TieJumpPoint* jumpPoint : *jumpPointList) {
@@ -297,7 +301,9 @@ protected:
         // Add a full tie to the note preceding a segno, then add a tie to the D.S which should add the previous tie to the list of jump points
         Note* noteBeforeSegno = getNoteAtTick(tickBeforeSegno);
         m_masterScore->select(noteBeforeSegno);
-        Tie* tieBeforeSegno = EditTie::cmdToggleTie(m_masterScore); // calls startCmd/endCmd internally
+        m_masterScore->startCmd(TranslatableString::untranslatable("Toggle tie"));
+        Tie* tieBeforeSegno = EditTie::cmdToggleTie(m_masterScore);
+        m_masterScore->endCmd();
         EXPECT_TRUE(tieBeforeSegno);
 
         Tie* startTie = addTie();
@@ -357,7 +363,9 @@ protected:
         // Expect tie to be added successfully and all jump points to have an incoming tie
         m_masterScore->select(m_startNote);
         m_masterScore->select(secondTieNote, SelectType::ADD);
-        Tie* t = EditTie::cmdToggleTie(m_masterScore); // calls startCmd/endCmd internally
+        m_masterScore->startCmd(TranslatableString::untranslatable("Toggle tie"));
+        Tie* t = EditTie::cmdToggleTie(m_masterScore);
+        m_masterScore->endCmd();
         EXPECT_TRUE(t);
 
         for (const Note* note : m_jumpPoints) {
@@ -555,7 +563,9 @@ TEST_F(Engraving_PartialTieTests, toggleTiePartialThenRestore)
 
     // Toggle tie at 4/4
     score->select(tieFromNote);
-    EditTie::cmdToggleTie(score); // calls startCmd/endCmd internally
+    score->startCmd(TranslatableString::untranslatable("Toggle tie"));
+    EditTie::cmdToggleTie(score);
+    score->endCmd();
 
     // Clear the second measure
 
@@ -593,7 +603,9 @@ TEST_F(Engraving_PartialTieTests, toggleTiePartialThenRestore)
 
     // Toggle tie again at 4/4
     score->select(tieFromNote);
-    EditTie::cmdToggleTie(score); // calls startCmd/endCmd internally
+    score->startCmd(TranslatableString::untranslatable("Toggle tie"));
+    EditTie::cmdToggleTie(score);
+    score->endCmd();
 
     // Verify the tie is now full
     Tie* newTie = tieFromNote->tieFor();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5251,8 +5251,13 @@ void NotationInteraction::mirrorNotes()
 
 void NotationInteraction::toggleTieForSelection()
 {
-    // Calls `startEdit` internally
+    mu::engraving::EditTie::TieAnalysis info = mu::engraving::EditTie::analyzeTieTargets(score());
+
+    startEdit(info.actionName);
+
     Tie* newTie = mu::engraving::EditTie::cmdToggleTie(score());
+
+    apply();
 
     notifyAboutNotationChanged();
     m_selection->selectionChanged().notify();
@@ -5264,8 +5269,11 @@ void NotationInteraction::toggleTieForSelection()
 
 void NotationInteraction::addLaissezVibToSelection()
 {
-    // Calls `startEdit` internally
+    startEdit(TranslatableString("undoableAction", "Toggle laissez-vibrer"));
+
     mu::engraving::EditTie::cmdToggleLaissezVib(score());
+
+    apply();
 
     notifyAboutNotationChanged();
     m_selection->selectionChanged().notify();

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -919,9 +919,10 @@ void NotationNoteInput::resetSlur()
 void NotationNoteInput::addTie()
 {
     TRACEFUNC;
+    startEdit(TranslatableString("undoableAction", "Add tie"));
 
-    // Calls `startEdit` internally
     EditTie::cmdAddTie(score());
+    apply();
 
     notifyAboutStateChanged();
     m_interaction->checkAndShowError();
@@ -931,8 +932,10 @@ void NotationNoteInput::addLaissezVib()
 {
     TRACEFUNC;
 
-    // Calls `startEdit` internally
+    startEdit(TranslatableString("undoableAction", "Toggle laissez vibrer"));
+
     EditTie::cmdToggleLaissezVib(score());
+    apply();
 
     notifyAboutStateChanged();
     m_interaction->checkAndShowError();


### PR DESCRIPTION
Resolves: #28538


Not sure why startCmd/endCmd wasn't registering action when adding ties and laissez-vibrer.
Wrapped the functions with startEdit()/apply() instead and that seemed to do the trick. 
Trade off is it now shows a generic "Toggle tie" for both cases when adding or removing ties instead of specifying the action. 


UPDATE:

- Pulled out the actionName logic into a separate function, analyzeTieTargets() which we can call from notationInteraction::toggleTieForSelection() and assign the action name before cmdToggleTie(). -- Now registers the right action name accordingly. 
- Wrapped direct calls for cmdToggleTie and cmdAddTie in test files with start/endCmd.
- while at it i refactored cmdToggleTie() into smaller helper functions
