### PR TITLE
Fix slur loss when Explode moves a grace-noted note to another staff

### DIFF
--- a/src/engraving/editing/clonevoice.cpp
+++ b/src/engraving/editing/clonevoice.cpp
@@ -74,7 +74,6 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
             ChordRest* ncr = toChordRest(maybeLinkedClone(ocr));
             ncr->setScore(destScore);
             ncr->setTrack(dstTrack);
-            crMap.add(ocr, ncr);
 
             //Don't clone gaps to a first voice
             if (!(ncr->track() % VOICES) && ncr->isRest()) {
@@ -129,6 +128,10 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
                     continue;
                 }
             }
+
+            // Only map ChordRests that actually survive into the destination score - a skipped full-measure
+            // rest above must never be found as a spanner endpoint, since it is never added anywhere.
+            crMap.add(ocr, ncr);
 
             auto cloneChord = [&](Chord* oldChord, Chord* newChord) {
                 size_t n = oldChord->notes().size();

--- a/src/engraving/editing/clonevoice.cpp
+++ b/src/engraving/editing/clonevoice.cpp
@@ -34,6 +34,7 @@
 #include "../dom/segment.h"
 #include "../dom/spanner.h"
 #include "../dom/staff.h"
+#include "../dom/elementmap.h"
 #include "../dom/tiemap.h"
 #include "../dom/tremolotwochord.h"
 #include "../dom/tupletmap.h"
@@ -49,6 +50,7 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
     Fraction start = sourceSeg->tick();
     TieMap tieMap;
     TupletMap tupletMap;      // tuplets cannot cross measure boundaries
+    ElementMap crMap;         // old ChordRest/grace chord -> its clone, for spanner reconnection
     TremoloTwoChord* tremolo = nullptr;
 
     auto maybeLinkedClone = [link](EngravingItem* item) -> EngravingItem* {
@@ -72,6 +74,7 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
             ChordRest* ncr = toChordRest(maybeLinkedClone(ocr));
             ncr->setScore(destScore);
             ncr->setTrack(dstTrack);
+            crMap.add(ocr, ncr);
 
             //Don't clone gaps to a first voice
             if (!(ncr->track() % VOICES) && ncr->isRest()) {
@@ -205,6 +208,7 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
                     Chord* ogc = toChord(ocr)->graceNotes().at(i);
                     Chord* ngc = toChord(ncr)->graceNotes().at(i);
                     cloneChord(ogc, ngc);
+                    crMap.add(ogc, ngc);
                 }
             }
 
@@ -285,32 +289,32 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
             ChordRest* cr1 = sp->startCR();
             ChordRest* cr2 = sp->endCR();
 
-            ns->setStartElement(0);
-            ns->setEndElement(0);
-            if (cr1 && cr1->links()) {
-                for (EngravingObject* e : *cr1->links()) {
-                    ChordRest* cr = toChordRest(e);
-                    if (cr == cr1) {
-                        continue;
-                    }
-                    if ((cr->score() == destScore) && (cr->tick() == ns->tick()) && cr->track() == dstTrack) {
-                        ns->setStartElement(cr);
-                        break;
+            // Prefer the direct old-CR -> new-CR mapping built while cloning above: it also covers
+            // grace chords, which share their parent's tick and so can't be told apart by tick/track
+            // alone (the fallback below, kept for cross-staff endpoints not cloned here, cannot resolve them).
+            auto findNewCR = [&](ChordRest* cr, const Fraction& tick) -> ChordRest* {
+                if (!cr) {
+                    return nullptr;
+                }
+                if (EngravingItem* mapped = crMap.findNew(cr)) {
+                    return toChordRest(mapped);
+                }
+                if (cr->links()) {
+                    for (EngravingObject* e : *cr->links()) {
+                        ChordRest* linkedCr = toChordRest(e);
+                        if (linkedCr == cr) {
+                            continue;
+                        }
+                        if ((linkedCr->score() == destScore) && (linkedCr->tick() == tick) && linkedCr->track() == dstTrack) {
+                            return linkedCr;
+                        }
                     }
                 }
-            }
-            if (cr2 && cr2->links()) {
-                for (EngravingObject* e : *cr2->links()) {
-                    ChordRest* cr = toChordRest(e);
-                    if (cr == cr2) {
-                        continue;
-                    }
-                    if ((cr->score() == destScore) && (cr->tick() == ns->tick2()) && cr->track() == dstTrack) {
-                        ns->setEndElement(cr);
-                        break;
-                    }
-                }
-            }
+                return nullptr;
+            };
+
+            ns->setStartElement(findNewCR(cr1, ns->tick()));
+            ns->setEndElement(findNewCR(cr2, ns->tick2()));
             if (link) {
                 destScore->doUndoAddElement(ns);
             } else {


### PR DESCRIPTION
Resolves: #34809

## Description

When a staff has 2+ voices and each voice's note has a grace note tied to
it via a slur, running Tools > Explode moves each voice down to its own
staff but drops the slur between the grace note and its main note on any
staff that isn't the original top staff. The voice that stays in place
keeps its slur.

## Root cause

`ImplodeExplode::explode()` separates voices onto different staves via
`CloneVoice::cloneVoice(..., link=false)`. In `doCloneVoice()`
(`src/engraving/editing/clonevoice.cpp`), the code that reconnects a
cloned slur/hairpin/hammer-on-pull-off to its new start/end ChordRest
looked up the correspondence through the old element's `links()` list -
a mechanism that is only populated for *linked* clones (`linkedClone()`,
used by the "exchange voice" feature with `link=true`), never for the
plain `clone()` used by Explode/Implode (`link=false`). So this lookup
silently failed for Explode.

Ordinary (non-grace) notes were rescued anyway by a later fallback,
`Spanner::findStartCR()`/`findEndCR()`, which re-resolves a dangling
spanner endpoint via `Score::findCR(tick, track)`. That fallback can only
reach the ChordRest actually stored in a Segment's track slot - never a
grace chord, which shares its parent's tick and is a child of the main
Chord rather than that stored object. So a slur anchored on a grace note
had no way to be recovered, and was silently dropped.

## Fix

Added a `ChordRest -> clone` map in `doCloneVoice()` (reusing the
existing generic `ElementMap` type already used by `TieMap`/`TupletMap`
in the same function - no new class needed), populated for both main
chords and grace chords while cloning. The slur/hairpin/hammer-on-pull-off
reconnection code now looks up this map first, falling back to the
previous `links()`-based search only for endpoints outside the cloned
range. This fixes the reconnection uniformly for both link modes, rather
than special-casing grace notes.

## Testing

- All 7 existing `Engraving_ImplodeExplodeTests` unit tests pass (no
  regression).
- Manually built and installed the app; reproduced the reported scenario
  (2 voices, each with a slurred grace note, Explode) and confirmed both
  slurs are now preserved after Explode.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [tharosd](https://musescore.org/en/user)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
