### PR TITLE
Add Ornament.cueNoteChord to plugin API

### DIFF
--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -2271,6 +2271,9 @@ class Ornament : public EngravingItem
     Q_PROPERTY(bool hasIntervalBelow READ hasIntervalBelow)
     /// Whether this ornament displays a cue note.
     Q_PROPERTY(bool showCueNote READ showCueNote)
+    /// The chord containing this ornament's displayed cue note, if one exists.
+    /// \since MuseScore 5.0
+    Q_PROPERTY(apiv1::Chord * cueNoteChord READ cueNoteChord)
     /// The accidental for the interval above the attached note.
     Q_PROPERTY(apiv1::EngravingItem * accidentalAbove READ accidentalAbove)
     /// The accidental for the interval below the attached note.
@@ -2287,6 +2290,7 @@ public:
     bool hasIntervalAbove() const { return ornament()->hasIntervalAbove(); }
     bool hasIntervalBelow() const { return ornament()->hasIntervalBelow(); }
     bool showCueNote() { return ornament()->showCueNote(); }
+    Chord* cueNoteChord() const { return wrap<Chord>(ornament()->cueNoteChord()); }
     EngravingItem* accidentalAbove() const { return wrap<EngravingItem>(ornament()->accidentalAbove()); }
     EngravingItem* accidentalBelow() const { return wrap<EngravingItem>(ornament()->accidentalBelow()); }
     /// \endcond


### PR DESCRIPTION
Resolves: #33931

MuseScore plugins could determine whether an ornament displays a cue note, but could not access the displayed cue-note chord itself.

This change adds the read-only `Ornament.cueNoteChord` QML API property. It returns a wrapped API `Chord` when the ornament has a displayed cue-note chord, or `null` when none exists.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Validation

- `git diff --check`
- Release/Ninja build: `QTDIR=/opt/homebrew/opt/qt cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja`
- Manually verified from a QML plugin that `Ornament.cueNoteChord` returns the displayed cue-note chord, or `null` when none exists.
- Uncrustify 0.83 produces no changes in the modified `Ornament` region; its whole-file comparison reports only pre-existing macro indentation differences elsewhere in `src/engraving/api/v1/elements.h`.
