### PR TITLE
remove white space at beginning of measure

### DIFF
--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -49,6 +49,7 @@ class GuitarBend;
 
 struct ElementPattern {
     std::vector<EngravingItem*> el;
+    mu::engraving::ElementTypeSet types;
     int type = 0;
     int subtype = 0;
     staff_idx_t staffStart = 0;

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -2284,7 +2284,26 @@ void MeasureLayout::layoutTimeTickAnchors(Measure* m, LayoutContext& ctx)
         double relativeX = width * (relativeTick.toDouble() / refCRSeg->ticks().toDouble());
         double relativeWidth = width * (thisDuration.toDouble() / refSegDuration.toDouble());
 
-        segment.mutldata()->setPosX(refCRSeg->x() + relativeX);
+        double posX = refCRSeg->x() + relativeX;
+
+        if (segment.rtick().isZero()) {
+            bool hasStartingSignature = false;
+            for (const Segment* s = m->first(); s && s->rtick().isZero(); s = s->next()) {
+                if (s->enabled() && s->isType(SegmentType::HeaderClef | SegmentType::Clef
+                                            | SegmentType::KeySig | SegmentType::TimeSig
+                                            | SegmentType::StartRepeatBarLine)) {
+                    hasStartingSignature = true;
+                    break;
+                }
+            }
+
+            if (!hasStartingSignature) {
+                relativeWidth += posX;
+                posX = 0.0;
+            }
+        }
+
+        segment.mutldata()->setPosX(posX);
         segment.setWidth(relativeWidth);
 
         for (EngravingItem* item : segment.elist()) {

--- a/src/notation/utilities/scorerangeutilities.cpp
+++ b/src/notation/utilities/scorerangeutilities.cpp
@@ -79,8 +79,21 @@ std::vector<muse::RectF> ScoreRangeUtilities::boundingArea(const Score* score,
         const double y1 = topY + segmentFirstStaff->y() + section.startSegment->pagePos().y() - padding;
         const double y2 = bottomY + segmentLastStaff->y() + section.endSegment->pagePos().y() + padding;
 
-        if (section.startSegment->measure()->firstEnabled() == section.startSegment) {
-            x1 = section.startSegment->measure()->pagePos().x();
+        if (section.startSegment->rtick().isZero()) {
+            Measure* m = section.startSegment->measure();
+            bool hasStartingSignature = false;
+            for (const Segment* s = m->first(); s && s->rtick().isZero(); s = s->next()) {
+                if (s->enabled() && s->isType(SegmentType::HeaderClef | SegmentType::Clef
+                                              | SegmentType::KeySig | SegmentType::TimeSig
+                                              | SegmentType::StartRepeatBarLine)) {
+                    hasStartingSignature = true;
+                    break;
+                }
+            }
+
+            if (!hasStartingSignature) {
+                x1 = m->pagePos().x();
+            }
         }
 
         const RectF rect = RectF(PointF(x1, y1), PointF(x2, y2)).translated(section.system->page()->pos());


### PR DESCRIPTION
Resolves: #26880

Maintaned white offset in the case the measure had clef/keysig/timesig, but if it is preferred, we can let the marquee and blue anchors always start from the beginning of the measure.

Before:

https://github.com/user-attachments/assets/22380ed9-feec-47cf-9c93-4d624ab1a8f2



After:


https://github.com/user-attachments/assets/d7a0df59-f519-4552-9ab2-a874479bfdb3

