### PR TITLE
Fix dragging slurs from grace notes

### DIFF
--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -276,6 +276,7 @@ void SlurSegment::changeAnchor(EditData& ed, EngravingItem* element)
     }
 }
 
+/// Handles grip dragging, including updating a slur endpoint's note anchor.
 void SlurSegment::dragGrip(EditData& ed)
 {
     Grip g = ed.curGrip;
@@ -293,13 +294,13 @@ void SlurSegment::dragGrip(EditData& ed)
             EngravingItem* e = ed.view()->elementNear(ed.pos);
             if (e && e->isNote()) {
                 Note* note = toNote(e);
-                Fraction tick = note->chord()->tick();
-                if ((g == Grip::END && tick > slr->tick()) || (g == Grip::START && tick < slr->tick2())) {
+                Chord* chord = note->chord();
+                if ((g == Grip::END && slr->startCR()->isBefore(chord))
+                    || (g == Grip::START && chord->isBefore(slr->endCR()))) {
                     if (km != (ShiftModifier | ControlModifier)) {
-                        Chord* c = note->chord();
                         ed.view()->setDropTarget(note);
-                        if (c->part() == slr->part() && c != slr->endCR()) {
-                            changeAnchor(ed, c);
+                        if (chord->part() == slr->part() && chord != slr->endCR()) {
+                            changeAnchor(ed, chord);
                         }
                     }
                 }


### PR DESCRIPTION
A slur endpoint couldn’t be dragged from a grace note to the immediately following normal note, because grace notes and their parent chord share the same tick. The existing comparison uses a tick comparison — therefore the normal note is ignored because it is not later than the grace note.

This change uses the existing call `ChordRest::isBefore()` to validate a new slur anchor. That method correctly figures out the correct structural ordering of grace notes and their parent chord already, so we should use that. It is tested, and it allows the slur to attach to the following normal note while continuing to prevent its endpoints from crossing.

Fixes #32915.

## Validation

- `git diff --check`
- Uncrustify check of `src/engraving/dom/slur.cpp`
- Release/Ninja build: `QTDIR=/opt/homebrew/opt/qt cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja`
- Manually reproduced the failure on an unmodified `upstream/main` build
- Manually confirmed that a slur endpoint can be dragged from grace notes to the immediately following normal note with this change