### PR TITLE
Handle range articulations on tied notes

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2658,7 +2658,8 @@ void NotationInteraction::applyPaletteElementToRange(EngravingItem* element, mu:
         const size_t totalNotesInChord = chord->notes().size();
         for (size_t noteIdx = 0; noteIdx < totalNotesInChord; ++noteIdx) {
             Note* note = chord->notes().at(noteIdx);
-            if (!note || !score->selectionFilter().canSelectNoteIdx(noteIdx, totalNotesInChord, rangeContainsMultiNoteChords)) {
+            if (!note || (element->isArticulation() && toArticulation(element)->symId() != SymId::stringsHarmonic && note->tieBack())
+                || !score->selectionFilter().canSelectNoteIdx(noteIdx, totalNotesInChord, rangeContainsMultiNoteChords)) {
                 continue;
             }
             applyDropPaletteElement(score, note, element, modifiers);
@@ -5483,6 +5484,15 @@ void NotationInteraction::toggleArticulationForSelection(SymbolId articulationSy
             if (c) {
                 notes.insert(notes.begin(), c->notes().begin(), c->notes().end());
             }
+        }
+    }
+
+    if (selection()->isRange() && articulationSymbolId != SymbolId::stringsHarmonic) {
+        muse::remove_if(notes, [](const Note* note) {
+            return note->tieBack();
+        });
+        if (notes.empty()) {
+            return;
         }
     }
 


### PR DESCRIPTION
When a range includes tied notes, and an articulation is applied to the range, MuseScore currently adds it to every note in each tie rather than only the first. This often produces incorrect notation, such as having accents in the middle of a tied note. The user would then have to go through and delete all the incorrect accents.

This PR fixes this by filtering out tied-back notes, so that ordinary articulations are added only to the first note of a tie. Harmonic circles, however, are an exception to this rule — they continue to appear on every note in the tie chain. Applying an articulation to an individually selected tied continuation remains unaffected.

Fixes #22594.

## Validation

- `git diff --check`
- `uncrustify -c muse/tools/codestyle/uncrustify_muse.cfg --check src/notation/internal/notationinteraction.cpp`
- Release/Ninja build: `QTDIR=/opt/homebrew/opt/qt cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja`
