### PR TITLE
Avoid accidental collisions with beamed rests

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -424,6 +424,24 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
     // Relayout system to account for newly hidden/unhidden staves
     SystemLayout::layoutSystem(system, ctx, leadingHBoxesWidth);
 
+    // Update beamed rest positions now that the system has provisional geometry,
+    // so their shapes account for the displacement during horizontal spacing.
+    for (MeasureBase* mb : system->measures()) {
+        if (!mb->isMeasure()) {
+            continue;
+        }
+        for (Segment& segment : toMeasure(mb)->segments()) {
+            if (!segment.isChordRestType()) {
+                continue;
+            }
+            for (EngravingItem* item : segment.elist()) {
+                if (item && item->isChordRest()) {
+                    BeamLayout::layoutNonCrossBeams(toChordRest(item), ctx);
+                }
+            }
+        }
+    }
+
     // Create end barlines and system trailer if needed (cautionary time/key signatures etc)
     Measure* lm  = system->lastMeasure();
     if (lm) {


### PR DESCRIPTION
Resolves: #18628

When a rest within a beam is automatically moved vertically to avoid the beam, its updated position was not available when horizontal spacing was calculated. This could allow the displaced rest to collide with an accidental on the following note.

This change performs an additional beam-rest positioning pass after provisional system geometry is available but before horizontal spacing is finalized. The displaced rest's shape is therefore updated in time for the existing collision calculation to provide sufficient space before the following accidental.

I tested this fix on a previously colliding accidental score, and confirmed that the accidental now avoids the rest.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Validation

- `git diff --check`
- `uncrustify -c muse/tools/codestyle/uncrustify_muse.cfg --check src/engraving/rendering/score/systemlayout.cpp`
- Release/Ninja build: `QTDIR=/opt/homebrew/opt/qt cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja`
- Manually verified the issue reproduction score no longer has a collision between the displaced rest and following accidental.
- Manually checked narrow and wide systems, justified and unjustified systems, system reflow, differing beam slopes and directions, multiple rests, beams without rests, inset tremolos, repeated layout/reset operations, and cross-staff beams.