### PR TITLE
Clear the barline drag offset on release

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -633,11 +633,9 @@ void BarLine::endDragGrip(EditData& ed)
 {
     calcY();
     BarLineEditData* bed = static_cast<BarLineEditData*>(ed.getData(this).get());
-    mutldata()->y1 += bed->yoff1;
-    mutldata()->y2 += bed->yoff2;
 
     double ay0      = pagePos().y();
-    double ay2      = ay0 + mutldata()->y2;                       // absolute (page-relative) bar line bottom coord
+    double ay2      = ay0 + ldata()->y2 + bed->yoff2;             // absolute (page-relative) bar line bottom coord
     staff_idx_t staffIdx1 = staffIdx();
     System* syst   = segment()->measure()->system();
     double systTopY = syst->pagePos().y();


### PR DESCRIPTION
Resolves: #34819

AI generated fix; please review critically.

Barlines now snap to their expected position when the grab handle is released, avoiding partial segments continuing to draw while the barline remains selected.

https://github.com/user-attachments/assets/1b9b7012-0f61-4bfc-901b-9ded1cda2014