### PR TITLE
Add pluralization for strings in convertfiletoscore files

### DIFF
--- a/src/project/internal/convertfiletoscorescenario.cpp
+++ b/src/project/internal/convertfiletoscorescenario.cpp
@@ -364,16 +364,16 @@ void ConvertFileToScoreScenario::showMultiplePdfFilesError()
 
 void ConvertFileToScoreScenario::showTooManyAudioFilesError(int maxFiles)
 {
-    std::string text = muse::qtrc("project/convert", "You can convert up to %1 audio files at a time. Remove some files and try again.")
-                       .arg(maxFiles).toStdString();
+    std::string text = muse::qtrc("project/convert", "You can convert up to %n audio file(s) at a time. Remove some files and try again.",
+                                  nullptr, maxFiles).toStdString();
     interactive()->warning(muse::trc("project/convert", "Too many files selected"), text,
                            { interactive()->buttonData(IInteractive::Button::Ok) });
 }
 
 void ConvertFileToScoreScenario::showTooManyImagesError(int maxImages)
 {
-    std::string text = muse::qtrc("project/convert", "You can convert up to %1 images at a time. Remove some images and try again.")
-                       .arg(maxImages).toStdString();
+    std::string text = muse::qtrc("project/convert", "You can convert up to %n image(s) at a time. Remove some images and try again.",
+                                  nullptr, maxImages).toStdString();
     interactive()->warning(muse::trc("project/convert", "Too many images selected"), text,
                            { interactive()->buttonData(IInteractive::Button::Ok) });
 }

--- a/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/MultipleFilesPanel.qml
+++ b/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/MultipleFilesPanel.qml
@@ -230,7 +230,7 @@ Rectangle {
 
                     //: %1 is the number of files currently selected, %2 is the maximum allowed, e.g. "3/5 max files"
                     text: root.filesModel.maxFileCount > 0 && root.filesModel.count > 1
-                          ? qsTrc("project/convert", "%1/%2 max files").arg(root.filesModel.count).arg(root.filesModel.maxFileCount)
+                          ? qsTrc("project/convert", "%1/%n file(s) max.", root.filesModel.maxFileCount).arg(root.filesModel.count)
                           : ""
                     horizontalAlignment: Text.AlignLeft
                     color: ui.theme.fontSecondaryColor

--- a/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/convertfiletoscoremodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/convertfiletoscoremodel.cpp
@@ -220,14 +220,12 @@ QVariantList ConvertFileToScoreModel::fileRequirements() const
         }
 
         if (omr.pdf.maxPages > 0) {
-            //: %1 is the maximum number of pages; shown as a short label/badge, e.g. "20 pages max"
-            pdfItems << muse::qtrc("project/convert", "%1 pages max").arg(omr.pdf.maxPages);
+            //: %n is the maximum number of pages; shown as a short label/badge, e.g. "20 pages max"
+            pdfItems << muse::qtrc("project/convert", "%n page(s) max.", nullptr, omr.pdf.maxPages);
         }
 
-        if (omr.pdf.maxFiles == 1) {
-            pdfItems << muse::qtrc("project/convert", "1 file per conversion");
-        } else if (omr.pdf.maxFiles > 1) {
-            pdfItems << muse::qtrc("project/convert", "%1 files per conversion").arg(omr.pdf.maxFiles);
+        if (omr.pdf.maxFiles > 0) {
+            pdfItems << muse::qtrc("project/convert", "%n file(s) per conversion", nullptr, omr.pdf.maxFiles);
         }
 
         result << requirementsSection(muse::qtrc("project/convert", "PDF"), pdfItems);
@@ -253,7 +251,7 @@ QVariantList ConvertFileToScoreModel::fileRequirements() const
         }
 
         if (omr.images.maxFiles > 0) {
-            imageItems << muse::qtrc("project/convert", "Max %1 images").arg(omr.images.maxFiles);
+            imageItems << muse::qtrc("project/convert", "Max. %n image(s)", nullptr, omr.images.maxFiles);
         }
 
         if (!imageItems.isEmpty()) {
@@ -273,10 +271,8 @@ QVariantList ConvertFileToScoreModel::fileRequirements() const
             a2sItems << maxFileSizeText(a2s.file.maxFileSizeBytes);
         }
 
-        if (a2s.file.maxFiles == 1) {
-            a2sItems << muse::qtrc("project/convert", "1 file per conversion");
-        } else if (a2s.file.maxFiles > 1) {
-            a2sItems << muse::qtrc("project/convert", "%1 files per conversion").arg(a2s.file.maxFiles);
+        if (a2s.file.maxFiles > 0) {
+            a2sItems << muse::qtrc("project/convert", "%n file(s) per conversion", nullptr, a2s.file.maxFiles);
         }
 
         if (!a2sItems.empty()) {

--- a/src/project/tests/convertfiletoscorescenario_tests.cpp
+++ b/src/project/tests/convertfiletoscorescenario_tests.cpp
@@ -557,8 +557,8 @@ TEST_F(Project_ConvertFileToScoreScenarioTest, ValidateFiles_TooManyAudioFiles_S
     // [GIVEN] A configured maximum audio file count
     m_config.audio2score.file.maxFiles = 3;
     const std::string text = muse::qtrc("project/convert",
-                                        "You can convert up to %1 audio files at a time. Remove some files and try again.")
-                             .arg(m_config.audio2score.file.maxFiles).toStdString();
+                                        "You can convert up to %n audio file(s) at a time. Remove some files and try again.",
+                                        nullptr, m_config.audio2score.file.maxFiles).toStdString();
 
     expectValidateFilesShowsError(Err::ConvertTooManyAudioFiles, muse::trc("project/convert", "Too many files selected"), text);
 }
@@ -567,8 +567,8 @@ TEST_F(Project_ConvertFileToScoreScenarioTest, ValidateFiles_TooManyImages_Shows
 {
     // [GIVEN] A configured maximum image count
     m_config.omr.images.maxFiles = 15;
-    const std::string text = muse::qtrc("project/convert", "You can convert up to %1 images at a time. Remove some images and try again.")
-                             .arg(m_config.omr.images.maxFiles).toStdString();
+    const std::string text = muse::qtrc("project/convert", "You can convert up to %n image(s) at a time. Remove some images and try again.",
+                                        nullptr, m_config.omr.images.maxFiles).toStdString();
 
     expectValidateFilesShowsError(Err::ConvertTooManyImages, muse::trc("project/convert", "Too many images selected"), text);
 }


### PR DESCRIPTION
Strings that needed separate plural forms were not defined as such.
Redefine as pluralized strings.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).