### PR TITLE
UI: Allow removing individual recent scores via context menu

### DIFF
--- a/src/project/internal/recentfilescontroller.cpp
+++ b/src/project/internal/recentfilescontroller.cpp
@@ -115,6 +115,9 @@ void RecentFilesController::moveRecentFile(const muse::io::path_t& before, const
     }
 }
 
+/**
+ * @brief Remove @p path from the in-memory recent-files list and persist the result.
+ */
 void RecentFilesController::removeRecentFile(const muse::io::path_t& path)
 {
     if (path.empty()) {

--- a/src/project/internal/recentfilescontroller.cpp
+++ b/src/project/internal/recentfilescontroller.cpp
@@ -115,6 +115,28 @@ void RecentFilesController::moveRecentFile(const muse::io::path_t& before, const
     }
 }
 
+void RecentFilesController::removeRecentFile(const muse::io::path_t& path)
+{
+    if (path.empty()) {
+        return;
+    }
+
+    RecentFilesList newList;
+    newList.reserve(m_recentFilesList.size());
+
+    for (const RecentFile& file : m_recentFilesList) {
+        if (file.path != path) {
+            newList.push_back(file);
+        }
+    }
+
+    if (newList.size() == m_recentFilesList.size()) {
+        return;
+    }
+
+    setRecentFilesList(newList, true);
+}
+
 void RecentFilesController::clearRecentFiles()
 {
     setRecentFilesList({}, true);

--- a/src/project/internal/recentfilescontroller.h
+++ b/src/project/internal/recentfilescontroller.h
@@ -53,6 +53,7 @@ public:
 
     void prependRecentFile(const RecentFile& file) override;
     void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) override;
+    void removeRecentFile(const muse::io::path_t& path) override;
     void clearRecentFiles() override;
 
     muse::async::Promise<QPixmap> thumbnail(const muse::io::path_t& file) const override;

--- a/src/project/internal/recentfilescontroller.h
+++ b/src/project/internal/recentfilescontroller.h
@@ -53,6 +53,14 @@ public:
 
     void prependRecentFile(const RecentFile& file) override;
     void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) override;
+
+    /**
+     * @brief Remove a single entry from the persisted recent-files list.
+     * @param path Absolute path of the recent file to remove.
+     *
+     * No-op if @p path is empty or not present. When an entry is removed, the
+     * updated list is saved and @ref recentFilesListChanged() is notified.
+     */
     void removeRecentFile(const muse::io::path_t& path) override;
     void clearRecentFiles() override;
 

--- a/src/project/irecentfilescontroller.h
+++ b/src/project/irecentfilescontroller.h
@@ -44,6 +44,7 @@ public:
 
     virtual void prependRecentFile(const RecentFile& file) = 0;
     virtual void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) = 0;
+    virtual void removeRecentFile(const muse::io::path_t& path) = 0;
     virtual void clearRecentFiles() = 0;
 
     virtual muse::async::Promise<QPixmap> thumbnail(const muse::io::path_t& filePath) const = 0;

--- a/src/project/irecentfilescontroller.h
+++ b/src/project/irecentfilescontroller.h
@@ -44,6 +44,14 @@ public:
 
     virtual void prependRecentFile(const RecentFile& file) = 0;
     virtual void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) = 0;
+
+    /**
+     * @brief Remove a single entry from the recent-files list.
+     * @param path Absolute path of the recent file to remove.
+     *
+     * No-op if @p path is empty or not present in the list.
+     * Implementations persist the updated list and notify listeners when an entry is removed.
+     */
     virtual void removeRecentFile(const muse::io::path_t& path) = 0;
     virtual void clearRecentFiles() = 0;
 

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -49,6 +49,7 @@ ScoresView {
             searchText: root.searchText
 
             isNoResultsMessageAllowed: false // provided by the model instead
+            canRemoveFromRecent: true
 
             backgroundColor: root.backgroundColor
             sideMargin: root.sideMargin
@@ -64,6 +65,10 @@ ScoresView {
 
             onOpenScoreRequested: function(scorePath, displayName) {
                 root.openScoreRequested(scorePath, displayName)
+            }
+
+            onRemoveFromRecentRequested: function(scorePath) {
+                recentScoresModel.removeRecentScore(scorePath)
             }
         }
     }
@@ -83,6 +88,7 @@ ScoresView {
             sideMargin: root.sideMargin
 
             showNewScoreItem: true
+            canRemoveFromRecent: true
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrder
@@ -95,6 +101,10 @@ ScoresView {
 
             onOpenScoreRequested: function(scorePath, displayName) {
                 root.openScoreRequested(scorePath, displayName)
+            }
+
+            onRemoveFromRecentRequested: function(scorePath) {
+                recentScoresModel.removeRecentScore(scorePath)
             }
 
             columns: [

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -37,6 +37,13 @@ ScoresView {
         recentScoresModel.load()
     }
 
+    function requestRemoveFromRecent(scorePath) {
+        if (!scorePath) {
+            return
+        }
+        recentScoresModel.removeRecentScore(scorePath)
+    }
+
     sourceComponent: root.viewType === ScoresPageModel.List ? listComp : gridComp
 
     Component {
@@ -68,7 +75,7 @@ ScoresView {
             }
 
             onRemoveFromRecentRequested: function(scorePath) {
-                recentScoresModel.removeRecentScore(scorePath)
+                root.requestRemoveFromRecent(scorePath)
             }
         }
     }
@@ -104,7 +111,7 @@ ScoresView {
             }
 
             onRemoveFromRecentRequested: function(scorePath) {
-                recentScoresModel.removeRecentScore(scorePath)
+                root.requestRemoveFromRecent(scorePath)
             }
 
             columns: [

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
@@ -93,7 +93,7 @@ FocusScope {
             ]
 
             onHandleMenuItem: function(itemId) {
-                if (itemId === "remove-from-recent") {
+                if (itemId === "remove-from-recent" && root.canRemoveFromRecent) {
                     root.removeFromRecentRequested()
                 }
             }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
@@ -39,10 +39,12 @@ FocusScope {
     property bool isNoResultsFound: false
     property bool isCloud: false
     property int cloudScoreId: 0
+    property bool canRemoveFromRecent: false
 
     property alias navigation: navCtrl
 
     signal clicked()
+    signal removeFromRecentRequested()
 
     NavigationControl {
         id: navCtrl
@@ -67,9 +69,34 @@ FocusScope {
 
         enabled: root.enabled
         hoverEnabled: true
+        acceptedButtons: root.canRemoveFromRecent
+                         ? (Qt.LeftButton | Qt.RightButton)
+                         : Qt.LeftButton
 
-        onClicked: {
+        onClicked: function(mouse) {
+            if (mouse.button === Qt.RightButton) {
+                contextMenuLoader.show(Qt.point(mouse.x, mouse.y))
+                return
+            }
+
             root.clicked()
+        }
+
+        ContextMenuLoader {
+            id: contextMenuLoader
+
+            items: [
+                {
+                    id: "remove-from-recent",
+                    title: qsTrc("project", "Remove from recent")
+                }
+            ]
+
+            onHandleMenuItem: function(itemId) {
+                if (itemId === "remove-from-recent") {
+                    root.removeFromRecentRequested()
+                }
+            }
         }
     }
 

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreListItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreListItem.qml
@@ -72,7 +72,7 @@ ListItemBlank {
         ]
 
         onHandleMenuItem: function(itemId) {
-            if (itemId === "remove-from-recent") {
+            if (itemId === "remove-from-recent" && root.canRemoveFromRecent) {
                 root.removeFromRecentRequested()
             }
         }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreListItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreListItem.qml
@@ -38,6 +38,9 @@ ListItemBlank {
     property real itemInset: 12
     property real columnSpacing: 44
     property alias showBottomBorder: bottomBorder.visible
+    property bool canRemoveFromRecent: false
+
+    signal removeFromRecentRequested()
 
     implicitHeight: 64
 
@@ -45,6 +48,33 @@ ListItemBlank {
     navigation.onActiveChanged: {
         if (navigation.active) {
             root.scrollIntoView()
+        }
+    }
+
+    mouseArea.acceptedButtons: root.canRemoveFromRecent
+                               ? (Qt.LeftButton | Qt.RightButton)
+                               : Qt.LeftButton
+
+    onClicked: function(mouse) {
+        if (root.canRemoveFromRecent && mouse && mouse.button === Qt.RightButton) {
+            contextMenuLoader.show(Qt.point(mouse.x, mouse.y))
+        }
+    }
+
+    ContextMenuLoader {
+        id: contextMenuLoader
+
+        items: [
+            {
+                id: "remove-from-recent",
+                title: qsTrc("project", "Remove from recent")
+            }
+        ]
+
+        onHandleMenuItem: function(itemId) {
+            if (itemId === "remove-from-recent") {
+                root.removeFromRecentRequested()
+            }
         }
     }
 

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
@@ -33,6 +33,7 @@ Item {
     property string searchText
 
     property bool isNoResultsMessageAllowed: true
+    property bool canRemoveFromRecent: false
 
     property color backgroundColor: ui.theme.backgroundSecondaryColor
     property real sideMargin: 46
@@ -43,6 +44,7 @@ Item {
 
     signal createNewScoreRequested()
     signal openScoreRequested(var scorePath, var displayName)
+    signal removeFromRecentRequested(var scorePath)
 
     clip: true
 
@@ -161,6 +163,7 @@ Item {
                 isCloud: score.isCloud
                 cloudScoreId: score.scoreId ?? 0
                 timeSinceModified: score.timeSinceModified ?? ""
+                canRemoveFromRecent: root.canRemoveFromRecent && !score.isCreateNew && !score.isNoResultsFound
 
                 onClicked: {
                     if (isCreateNew) {
@@ -168,6 +171,10 @@ Item {
                     } else if (!isNoResultsFound) {
                         root.openScoreRequested(score.path, score.name)
                     }
+                }
+
+                onRemoveFromRecentRequested: {
+                    root.removeFromRecentRequested(score.path)
                 }
             }
         }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
@@ -163,7 +163,7 @@ Item {
                 isCloud: score.isCloud
                 cloudScoreId: score.scoreId ?? 0
                 timeSinceModified: score.timeSinceModified ?? ""
-                canRemoveFromRecent: root.canRemoveFromRecent && !score.isCreateNew && !score.isNoResultsFound
+                canRemoveFromRecent: root.canRemoveFromRecent && !score.isCreateNew && !score.isNoResultsFound && !score.isCloud
 
                 onClicked: {
                     if (isCreateNew) {
@@ -174,6 +174,9 @@ Item {
                 }
 
                 onRemoveFromRecentRequested: {
+                    if (isCreateNew || isNoResultsFound || isCloud) {
+                        return
+                    }
                     root.removeFromRecentRequested(score.path)
                 }
             }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresListView.qml
@@ -120,6 +120,8 @@ Item {
                 }
             }
 
+            canRemoveFromRecent: false
+
             onClicked: root.createNewScoreRequested()
         }
 
@@ -214,6 +216,9 @@ Item {
                         implicitHeight: view.rowHeight
                         columnSpacing: view.columnSpacing
                         canRemoveFromRecent: root.canRemoveFromRecent
+                                             && !(score.isCreateNew ?? false)
+                                             && !(score.isNoResultsFound ?? false)
+                                             && !(score.isCloud ?? false)
 
                         navigation.panel: navPanel
                         navigation.row: index + 1
@@ -228,6 +233,9 @@ Item {
                         }
 
                         onRemoveFromRecentRequested: {
+                            if ((score.isCreateNew ?? false) || (score.isNoResultsFound ?? false) || (score.isCloud ?? false)) {
+                                return
+                            }
                             root.removeFromRecentRequested(score.path)
                         }
                     }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresListView.qml
@@ -35,6 +35,8 @@ Item {
     property alias showNewScoreItem: newScoreItem.visible
     property string searchText
 
+    property bool canRemoveFromRecent: false
+
     property color backgroundColor: ui.theme.backgroundSecondaryColor
     property real sideMargin: 46
 
@@ -44,6 +46,7 @@ Item {
 
     signal createNewScoreRequested()
     signal openScoreRequested(var scorePath, var displayName)
+    signal removeFromRecentRequested(var scorePath)
 
     component ColumnItem : QtObject {
         property string header
@@ -210,13 +213,22 @@ Item {
                         itemInset: view.itemInset
                         implicitHeight: view.rowHeight
                         columnSpacing: view.columnSpacing
+                        canRemoveFromRecent: root.canRemoveFromRecent
 
                         navigation.panel: navPanel
                         navigation.row: index + 1
                         navigation.column: 0
 
-                        onClicked: {
+                        onClicked: function(mouse) {
+                            if (mouse && mouse.button === Qt.RightButton) {
+                                return
+                            }
+
                             root.openScoreRequested(score.path, score.name)
+                        }
+
+                        onRemoveFromRecentRequested: {
+                            root.removeFromRecentRequested(score.path)
                         }
                     }
                 }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
@@ -46,9 +46,21 @@ void RecentScoresModel::load()
     });
 }
 
+/**
+ * @brief QML entry point for “Remove from recent”; ignores empty and cloud paths.
+ */
 void RecentScoresModel::removeRecentScore(const QString& scorePath)
 {
-    recentFilesController()->removeRecentFile(muse::io::path_t(scorePath));
+    if (scorePath.isEmpty()) {
+        return;
+    }
+
+    const muse::io::path_t path(scorePath);
+    if (configuration()->isCloudProject(path)) {
+        return;
+    }
+
+    recentFilesController()->removeRecentFile(path);
 }
 
 void RecentScoresModel::setRecentScores(const std::vector<QVariantMap>& items)

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.cpp
@@ -46,6 +46,11 @@ void RecentScoresModel::load()
     });
 }
 
+void RecentScoresModel::removeRecentScore(const QString& scorePath)
+{
+    recentFilesController()->removeRecentFile(muse::io::path_t(scorePath));
+}
+
 void RecentScoresModel::setRecentScores(const std::vector<QVariantMap>& items)
 {
     if (m_items == items) {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
@@ -47,6 +47,8 @@ public:
 
     void load() override;
 
+    Q_INVOKABLE void removeRecentScore(const QString& scorePath);
+
     QList<int> nonScoreItemIndices() const override;
 
 private:

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/recentscoresmodel.h
@@ -47,6 +47,13 @@ public:
 
     void load() override;
 
+    /**
+     * @brief Remove a recent score from the Home “New & recent” list.
+     * @param scorePath Absolute path of the score, as provided by the QML item.
+     *
+     * No-op if @p scorePath is empty or identifies a cloud project.
+     * Local recent files are forwarded to @ref IRecentFilesController::removeRecentFile().
+     */
     Q_INVOKABLE void removeRecentScore(const QString& scorePath);
 
     QList<int> nonScoreItemIndices() const override;

--- a/src/stubs/project/recentfilescontrollerstub.cpp
+++ b/src/stubs/project/recentfilescontrollerstub.cpp
@@ -43,6 +43,9 @@ void RecentFilesControllerStub::moveRecentFile(const muse::io::path_t&, const Re
 {
 }
 
+/**
+ * @brief Stub; recent-file removal is a no-op in this build configuration.
+ */
 void RecentFilesControllerStub::removeRecentFile(const muse::io::path_t&)
 {
 }

--- a/src/stubs/project/recentfilescontrollerstub.cpp
+++ b/src/stubs/project/recentfilescontrollerstub.cpp
@@ -43,6 +43,10 @@ void RecentFilesControllerStub::moveRecentFile(const muse::io::path_t&, const Re
 {
 }
 
+void RecentFilesControllerStub::removeRecentFile(const muse::io::path_t&)
+{
+}
+
 void RecentFilesControllerStub::clearRecentFiles()
 {
 }

--- a/src/stubs/project/recentfilescontrollerstub.h
+++ b/src/stubs/project/recentfilescontrollerstub.h
@@ -35,6 +35,11 @@ public:
 
     void prependRecentFile(const RecentFile& file) override;
     void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) override;
+
+    /**
+     * @brief Stub implementation of recent-file removal; does nothing.
+     * @param path Absolute path of the recent file that would be removed.
+     */
     void removeRecentFile(const muse::io::path_t& path) override;
     void clearRecentFiles() override;
 

--- a/src/stubs/project/recentfilescontrollerstub.h
+++ b/src/stubs/project/recentfilescontrollerstub.h
@@ -35,6 +35,7 @@ public:
 
     void prependRecentFile(const RecentFile& file) override;
     void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) override;
+    void removeRecentFile(const muse::io::path_t& path) override;
     void clearRecentFiles() override;
 
     muse::async::Promise<QPixmap> thumbnail(const muse::io::path_t& filePath) const override;


### PR DESCRIPTION
Resolves: N/A (no existing issue)
## Summary
- Adds the ability to remove a single score from the Home screen **New & recent** list via a right-click context menu (**Remove from recent**).
- Extends `IRecentFilesController` / `RecentFilesController` with `removeRecentFile(path)`, which updates the in-memory list, persists JSON, and notifies listeners (same path as clear-all).
- Wires a MuseScore `ContextMenuLoader` into recent score grid and list delegates; cloud scores and the New score tile are unchanged.

## Test plan
- [x] Open Home → New & recent (grid view)
- [x] Right-click a recent score → **Remove from recent** → item disappears
- [x] Restart the app → removed score stays gone
- [x] Confirm New score tile has no remove menu
- [x] Repeat in list view
- [x] File → Clear recent files still clears the full list

Made with [Cursor](https://cursor.com)