### PR TITLE
Avoid null dereference in Score::addPitch (#34751) [4.7]

### DIFF
--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -173,12 +173,15 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
     InputState& is = externalInputState ? (*externalInputState) : m_is;
 
     if (addFlag) {
-        ChordRest* c = toChordRest(is.lastSegment()->element(is.track()));
+        const Segment* lastSegment = is.lastSegment();
+        IF_ASSERT_FAILED(lastSegment) {
+            return nullptr;
+        }
+        ChordRest* c = toChordRest(lastSegment->element(is.track()));
         if (!c || !c->isChord()) {
             LOGD("Score::addPitch: cr %s", c ? c->typeName() : "zero");
             return nullptr;
         }
-
         return addPitchToChord(nval, toChord(c), externalInputState);
     }
 


### PR DESCRIPTION
Resolves crash from #34751

The root cause and other buggy behaviour will be resolved separately.