### PR TITLE
Fix retained page locks when expanding multimeasure rests

### DIFF
--- a/src/engraving/editing/editpagelocks.cpp
+++ b/src/engraving/editing/editpagelocks.cpp
@@ -471,6 +471,11 @@ void EditPageLocks::removePageLocksContainingMMRests(Transaction& tx, Score* sco
 {
     std::vector<const RangeLock*> allLocks = score->pageLocks()->allLocks(); // copy
     for (const RangeLock* lock : allLocks) {
+        if ((lock->startMB()->isMeasure() && toMeasure(lock->startMB())->isMMRest())
+            || (lock->endMB()->isMeasure() && toMeasure(lock->endMB())->isMMRest())) {
+            undoRemovePageLock(tx, lock);
+            continue;
+        }
         for (MeasureBase* mb = lock->startMB(); mb; mb = mb->next()) {
             if (mb->isMeasure() && toMeasure(mb)->mmRest()) {
                 undoRemovePageLock(tx, lock);

--- a/src/engraving/tests/page_locks_tests.cpp
+++ b/src/engraving/tests/page_locks_tests.cpp
@@ -212,3 +212,31 @@ TEST_F(Engraving_PageLocksTests, togglePageLock)
 
     delete score;
 }
+
+TEST_F(Engraving_PageLocksTests, removePageLockOnExpandMMRest)
+{
+    MasterScore* score = ScoreRW::readScore(PAGE_LOCKS_DATA_DIR + u"page_locks-1.mscx");
+    ASSERT_TRUE(score);
+    score->startCmd(TranslatableString::untranslatable("Enable MM rests"));
+    score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
+    score->endCmd();
+    score->transactionManager()->transaction(TranslatableString::untranslatable("Unlock pages"), [&](auto& tx) {
+        EditPageLocks::undoRemoveAllLocks(tx, score);
+    });
+    score->transactionManager()->transaction(TranslatableString::untranslatable("Lock compressed layout"), [&](auto& tx) {
+        EditPageLocks::toggleScoreLock(tx, score);
+    });
+    ASSERT_FALSE(score->pageLocks()->allLocks().empty());
+    const RangeLock* firstLock = score->pageLocks()->allLocks().front();
+    ASSERT_TRUE(firstLock->endMB()->isMeasure());
+    ASSERT_TRUE(toMeasure(firstLock->endMB())->isMMRest());
+    score->startCmd(TranslatableString::untranslatable("Expand MM rests"));
+    score->undoChangeStyleVal(Sid::createMultiMeasureRests, false);
+    score->endCmd();
+    bool retained = false;
+    for (const RangeLock* lock : score->pageLocks()->allLocks()) {
+        retained = retained || lock == firstLock;
+    }
+    EXPECT_FALSE(retained);
+    delete score;
+}


### PR DESCRIPTION
Resolves: #34841

Disabling multimeasure rests can retain a page lock whose endpoint is a generated MMRest. The ordinary-measure traversal misses that endpoint, leaving an obsolete lock in memory and an unresolved `endMeasure` EID in the saved score.

Check generated start/end measures before the existing traversal and remove affected locks through `undoRemovePageLock`. The existing ordinary-measure cleanup remains unchanged. The added work is constant per page lock, with no additional scans or allocations.

Add `Engraving_PageLocksTests.removePageLockOnExpandMMRest` using the existing page-lock fixture. It confirms that the lock ends on a generated MMRest before expansion, then checks that the old lock is removed.

### Before and after recordings

**Before fix:**

https://github.com/user-attachments/assets/b0d83f5c-c57b-43e1-bb3b-97425f6f7cbb

**After candidate fix:**

https://github.com/user-attachments/assets/b290298c-039e-46b5-b949-2609039b1938

The layout alone does not establish the page-lock defect; the saved-score endpoint checks in #34841 establish the difference.

### Validation

- On unchanged native source, the original five page-lock tests pass and the additional reproduction fails because the lock remains. With endpoint cleanup, all six pass. The final candidate, including the explicit endpoint precondition, was built and all six tests passed on official main `ce7067126406142e51eb7772b11fac239a1dc873`.
- APP Debug desktop executable builds. Equivalent before/after GUI recordings and saved files are attached through [the issue's evidence links](https://github.com/musescore/MuseScore/issues/34841).
- Native desktop workflow: disable Multimeasure rests, save, undo/save, redo/save, exit, reopen, and Save As. Before: one lock with a missing endpoint EID. After: zero locks; undo restores one valid lock; redo and reopen/resave preserve zero locks.
- Both changed files pass upstream Uncrustify and `git diff --check`.

Environment: Ubuntu 24.04.2, Qt 6.10.2/GCC 14, ASan. Tests used `QT_QPA_PLATFORM=minimal:enable_fonts` and `ASAN_OPTIONS=detect_leaks=0:new_delete_type_mismatch=0`. Desktop interactions were agent-operated through Xvfb/xdotool. No Windows/macOS validation is claimed.

### Prior work and scope

#33737 introduced page locks; #34505 fixed frame-ending locks. #27473 establishes removal behavior for affected system locks when multimeasure rests expand. This correction follows the existing page-lock cleanup intent; it does not remap endpoints or change unrelated layout behavior. No exact duplicate was found in the current search, which is not a claim of first discovery.

This contribution was prepared with AI assistance.

### Checklist

- [x] I signed the [CLA](https://musescore.org/en/cla): contributor confirms it is already signed; MuseScore.org username to be added.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. This PR links the upstream report above.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested. Pending contributor confirmation.
- [x] The code compiles and runs on my machine. Manual GUI operations and saved results were verified through the agent-operated desktop session described above.
- [x] I listed prior attempts and described how this change avoids repeating their problems.
- [x] There are no unnecessary changes.
- [x] I created a unit test to verify the changes.
