### PR TITLE
Fix score corruption after undoing local time signature deletion

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -836,6 +836,13 @@ void Measure::add(EngravingItem* e)
         }
         seg->setOwnershipParent(this);
         m_segments.insert(seg, s);
+        if (seg->isTimeSigType()) {
+            for (EngravingItem* item : seg->elist()) {
+                if (item && item->isTimeSig()) {
+                    item->staff()->addTimeSig(toTimeSig(item));
+                }
+            }
+        }
         //
         // update measure flags
         //
@@ -946,6 +953,13 @@ void Measure::remove(EngravingItem* e)
     case ElementType::SEGMENT:
     {
         Segment* s = toSegment(e);
+        if (s->isTimeSigType()) {
+            for (EngravingItem* item : s->elist()) {
+                if (item && item->isTimeSig()) {
+                    item->staff()->removeTimeSig(toTimeSig(item));
+                }
+            }
+        }
         m_segments.remove(s);
         //
         // update measure flags

--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -22,16 +22,24 @@
 
 #include <gtest/gtest.h>
 
+#include "global/defer.h"
+#include "global/io/buffer.h"
+#include "global/io/file.h"
+
 #include "engraving/dom/barline.h"
 #include "engraving/dom/excerpt.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/measure.h"
+#include "engraving/dom/mscore.h"
 #include "engraving/dom/note.h"
+#include "engraving/dom/staff.h"
 #include "engraving/dom/timesig.h"
 #include "engraving/editing/edittimesig.h"
 #include "engraving/editing/transaction/transaction.h"
 #include "engraving/editing/transaction/undostack.h"
+
+#include "engraving/rw/mscsaver.h"
 
 #include "utils/scorerw.h"
 #include "utils/scorecomp.h"
@@ -614,5 +622,76 @@ TEST_F(Engraving_TimesigTests, deleteMMRTimeSig)
         Measure* tsMeasure2 = score->lastMeasureMM();
         EXPECT_FALSE(tsMeasure2 == endMeasure);
         EXPECT_EQ(tsMeasure2->timesig(), Fraction(4, 4));
+    }
+}
+
+TEST_F(Engraving_TimesigTests, localMeterDeletionUndo)
+{
+    for (bool fromExcerpt : { false, true }) {
+        for (bool redo : { false, true }) {
+            SCOPED_TRACE(fromExcerpt);
+            SCOPED_TRACE(redo);
+            MasterScore* score = ScoreRW::readScore(TIMESIG_DATA_DIR + u"timeSig-11.mscz");
+            ASSERT_TRUE(score);
+            Measure* second = score->firstMeasure()->nextMeasure();
+            Measure* third = second->nextMeasure();
+            const std::array<std::pair<Measure*, Fraction>, 2> meters = { { { second, Fraction(7, 8) }, { third, Fraction(5, 4) } } };
+            for (const auto& entry : meters) {
+                TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
+                ts->setSig(entry.second);
+                score->startCmd(TranslatableString::untranslatable("Add local time signature"));
+                EditTimeSig::addTimeSig(score->transactionManager()->currentOrDummyTransaction(), score, entry.first, 2, ts, true);
+                score->endCmd();
+            }
+            const Fraction tick = third->tick();
+            Score* part = score->excerpts().at(2)->excerptScore();
+            Score* owner = fromExcerpt ? part : score;
+            TimeSig* ts = toTimeSig(owner->tick2measure(tick)->findSegment(SegmentType::TimeSig, tick)->element(fromExcerpt ? 0 : 8));
+            score->startCmd(TranslatableString::untranslatable("Remove local time signature"));
+            EditTimeSig::removeTimeSig(score->transactionManager()->currentOrDummyTransaction(), owner, ts);
+            score->endCmd();
+            EXPECT_EQ(score->staff(2)->timeStretch(tick), Fraction(7, 8));
+            EXPECT_EQ(part->staff(0)->timeStretch(tick), Fraction(7, 8));
+            score->undoRedo(true, nullptr);
+            EXPECT_EQ(toTimeSig(score->tick2measure(tick)->findSegment(SegmentType::TimeSig, tick)->element(8))->sig(), Fraction(5, 4));
+            EXPECT_EQ(score->staff(2)->timeStretch(tick), Fraction(5, 4));
+            EXPECT_EQ(part->staff(0)->timeStretch(tick), Fraction(5, 4));
+            if (redo) {
+                score->undoRedo(false, nullptr);
+            }
+            const Fraction expected = redo ? Fraction(7, 8) : Fraction(5, 4);
+            EXPECT_EQ(score->staff(2)->timeStretch(tick), expected);
+            EXPECT_EQ(part->staff(0)->timeStretch(tick), expected);
+            const muse::Ret integrity = score->sanityCheck();
+            ASSERT_TRUE(integrity) << integrity.text();
+
+            const String fileName = String(u"localMeterDeletionUndo-%1-%2.mscz").arg(fromExcerpt).arg(redo);
+            auto buffer = muse::io::Buffer::opened(muse::io::IODevice::WriteOnly);
+            MscWriter::Params params;
+            params.device = &buffer;
+            params.filePath = fileName;
+            params.mode = MscIoMode::Zip;
+            MscWriter writer(params);
+            ASSERT_TRUE(writer.open());
+            {
+                // Production MSCZ files store excerpts separately, not inline as test-mode MSCX does.
+                const bool testMode = MScore::testMode;
+                DEFER { MScore::testMode = testMode;
+                };
+                MScore::testMode = false;
+                ASSERT_TRUE(MscSaver(score->iocContext()).writeMscz(score, writer, false));
+            }
+            writer.close();
+            ASSERT_FALSE(writer.hasError());
+            ASSERT_TRUE(muse::io::File::writeFile(fileName, buffer.data()));
+            delete score;
+
+            MasterScore* reopened = ScoreRW::readScore(fileName, true);
+            ASSERT_TRUE(reopened);
+            EXPECT_TRUE(reopened->sanityCheck());
+            EXPECT_EQ(reopened->staff(2)->timeStretch(tick), expected);
+            EXPECT_EQ(reopened->excerpts().at(2)->excerptScore()->staff(0)->timeStretch(tick), expected);
+            delete reopened;
+        }
     }
 }


### PR DESCRIPTION
Resolves: #29789

Deleting a local time signature and undoing restores the visible signature but can leave the full-score staff time-signature map at the preceding meter. Saving then reports an incomplete measure and score corruption.

Register and unregister time signatures when `Measure` adds or removes a complete time-signature segment. Restoring a segment during undo does not pass through the individual-item registration in `Segment::add`, so this keeps both mutation paths consistent.

The regression uses the existing `timeSig-11.mscz` fixture: Clarinet measure 2 has local 7/8 and measure 3 has local 5/4. It covers deletion from the full score and linked part, undo, redo, integrity validation, and MSCZ save/reopen including excerpts.

### Validation

- Unmodified official main `a64e0d0c8725a89af2b4b9f8e058a75be20c01d3`: the new regression fails. The restored object is 5/4, while the full-score staff lookup remains 7/8; the save integrity check reports incomplete measures.
- Candidate: all **16 native time signature tests pass** (`Engraving_TimesigTests.*`).
- Linux desktop, Qt 6.10.2, GCC 14, Debug/ASan: agent-operated delete → undo → save reproduces the corruption warning before the fix and saves successfully after it.
- Official Uncrustify configuration and `git diff --check` pass.

[Reproduction instructions, scores and native logs](https://github.com/0xMashiro/MuseScore/blob/e8027265234712f11162b2dda2136a39e972bd38/README.md)

**Before video:**

https://github.com/user-attachments/assets/fa78758e-93af-4b4b-9aa4-185d8bfdba28

**After video:**

https://github.com/user-attachments/assets/d95978f0-2072-46e8-b4c4-9e1170b90783

### Related work

This addresses the existing report #29789, rather than claiming a newly discovered issue. #26100 provides related local-meter work and the reused fixture. #17418 concerns deleting a whole measure, and #11941 concerns an initial time signature. No matching active fix PR was found in the issue timeline and repository searches; this is not an exhaustive claim about all prior work.

### Contributor checklist

- [x] I signed the [CLA](https://musescore.org/en/cla). The contributor confirmed signing; the MuseScore.org username remains to be supplied.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose. (Desktop verification was operated by the coding agent.)
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes. (Search scope and related work are described above.)
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
