### PR TITLE
Fix wrong plural form from #34821

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/MultipleFilesPanel.qml
+++ b/src/project/qml/MuseScore/Project/internal/ConvertFileToScore/MultipleFilesPanel.qml
@@ -228,9 +228,9 @@ Rectangle {
 
                     visible: Boolean(maxCountReachedLabel.text)
 
-                    //: %1 is the number of files currently selected, %2 is the maximum allowed, e.g. "3/5 max files"
+                    //: %1 is the number of files currently selected, %n is the maximum allowed, e.g. "3/5 max files"
                     text: root.filesModel.maxFileCount > 0 && root.filesModel.count > 1
-                          ? qsTrc("project/convert", "%1/%n file(s) max.", root.filesModel.maxFileCount).arg(root.filesModel.count)
+                          ? qsTrc("project/convert", "%1/%n file(s) max.", "", root.filesModel.maxFileCount).arg(root.filesModel.count)
                           : ""
                     horizontalAlignment: Text.AlignLeft
                     color: ui.theme.fontSecondaryColor


### PR DESCRIPTION

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).