### PR TITLE
Fix cross-measure upward glissandos missing from parts

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1045,6 +1045,7 @@ static MeasureBase* cloneMeasure(MeasureBase* mb, Score* score, const Score* osc
                                     // 'on' is the old spanner end note and 'nn' is the new spanner end note
                                     for (Spanner* oldSp : on->spannerBack()) {
                                         if (oldSp->startElement() && oldSp->endElement()
+                                            && oldSp->startElement()->findMeasure() == oldSp->endElement()->findMeasure()
                                             && oldSp->startElement()->track() > oldSp->endElement()->track()) {
                                             continue;
                                         }
@@ -1059,7 +1060,8 @@ static MeasureBase* cloneMeasure(MeasureBase* mb, Score* score, const Score* osc
                                     }
                                     for (Spanner* oldSp : on->spannerFor()) {
                                         if (oldSp->startElement() && oldSp->endElement()
-                                            && oldSp->startElement()->track() <= oldSp->endElement()->track()) {
+                                            && (oldSp->startElement()->findMeasure() != oldSp->endElement()->findMeasure()
+                                                || oldSp->startElement()->track() <= oldSp->endElement()->track())) {
                                             continue;
                                         }
                                         Note* newEnd = Spanner::endElementFromSpanner(oldSp, nn);

--- a/src/engraving/tests/parts_data/cross-measure-gliss.mscx
+++ b/src/engraving/tests/parts_data/cross-measure-gliss.mscx
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+      </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+        <defaultClef>F</defaultClef>
+      </Staff>
+      <Instrument id="harp">
+        <trackName>Harp</trackName>
+        <instrumentId>pluck.harp</instrumentId>
+        <clef staff="2">F</clef>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>84</pitch>
+              <tpc>14</tpc>
+              <Spanner type="Glissando">
+                <prev>
+                  <location>
+                    <staves>1</staves>
+                    <measures>-1</measures>
+                  </location>
+                </prev>
+              </Spanner>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+    </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              <Spanner type="Glissando">
+                <Glissando>
+                  <text>gliss.</text>
+                  <diagonal>1</diagonal>
+                  <anchor>3</anchor>
+                </Glissando>
+                <next>
+                  <location>
+                    <staves>-1</staves>
+                    <measures>1</measures>
+                  </location>
+                </next>
+              </Spanner>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1394,7 +1394,7 @@ TEST_F(Engraving_PartsTests, staffStyles)
 
 TEST_F(Engraving_PartsTests, crossMeasureUpwardGlissExcerpt)
 {
-    MasterScore* master = ScoreRW::readScore(u"../../../vtest/scores/gliss-6.mscz");
+    MasterScore* master = ScoreRW::readScore(PARTS_DATA_DIR + u"cross-measure-gliss.mscx");
     ASSERT_TRUE(master);
     const Note* original = toChord(master->firstMeasure()->firstChordRest(4))->upNote();
     ASSERT_EQ(original->pitch(), 48);
@@ -1402,14 +1402,8 @@ TEST_F(Engraving_PartsTests, crossMeasureUpwardGlissExcerpt)
     ASSERT_EQ(toNote(original->spannerFor().front()->endElement())->pitch(), 84);
     ASSERT_EQ(original->spannerFor().front()->endElement()->findMeasure(), master->firstMeasure()->nextMeasure());
     ASSERT_EQ(original->spannerFor().front()->endElement()->track(), 0u);
-    Score* part = master->createScore();
-    Excerpt* excerpt = new Excerpt(master);
-    excerpt->setExcerptScore(part);
-    part->setExcerpt(excerpt);
-    master->excerpts().push_back(excerpt);
-    excerpt->setName(u"Harp");
-    excerpt->setParts({ master->parts().front() });
-    Excerpt::createExcerpt(excerpt);
+    Score* part = TestUtils::createPart(master, 0);
+    ASSERT_TRUE(part);
     part->doLayout();
     const Note* cloned = toChord(part->firstMeasure()->firstChordRest(4))->upNote();
     ASSERT_EQ(cloned->spannerFor().size(), 1u);

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1391,3 +1391,33 @@ TEST_F(Engraving_PartsTests, staffStyles)
 }
 
 #endif
+
+TEST_F(Engraving_PartsTests, crossMeasureUpwardGlissExcerpt)
+{
+    MasterScore* master = ScoreRW::readScore(u"../../../vtest/scores/gliss-6.mscz");
+    ASSERT_TRUE(master);
+    const Note* original = toChord(master->firstMeasure()->firstChordRest(4))->upNote();
+    ASSERT_EQ(original->pitch(), 48);
+    ASSERT_EQ(original->spannerFor().size(), 1u);
+    ASSERT_EQ(toNote(original->spannerFor().front()->endElement())->pitch(), 84);
+    ASSERT_EQ(original->spannerFor().front()->endElement()->findMeasure(), master->firstMeasure()->nextMeasure());
+    ASSERT_EQ(original->spannerFor().front()->endElement()->track(), 0u);
+    Score* part = master->createScore();
+    Excerpt* excerpt = new Excerpt(master);
+    excerpt->setExcerptScore(part);
+    part->setExcerpt(excerpt);
+    master->excerpts().push_back(excerpt);
+    excerpt->setName(u"Harp");
+    excerpt->setParts({ master->parts().front() });
+    Excerpt::createExcerpt(excerpt);
+    part->doLayout();
+    const Note* cloned = toChord(part->firstMeasure()->firstChordRest(4))->upNote();
+    ASSERT_EQ(cloned->spannerFor().size(), 1u);
+    EXPECT_EQ(cloned->spannerFor().front()->endElement()->track(), 0u);
+    EXPECT_EQ(cloned->pitch(), 48);
+    EXPECT_EQ(cloned->spannerFor().front()->startElement(), cloned);
+    EXPECT_EQ(cloned->spannerFor().front()->endElement()->score(), part);
+    EXPECT_EQ(cloned->spannerFor().front()->endElement()->findMeasure(), part->firstMeasure()->nextMeasure());
+    EXPECT_EQ(toNote(cloned->spannerFor().front()->endElement())->pitch(), 84);
+    delete master;
+}


### PR DESCRIPTION
Resolves: #34851

Creating an ordinary Harp part from `vtest/scores/gliss-6.mscz` drops the upward cross-staff glissando connecting measures 1 and 2. `cloneMeasure` attempts to clone it before the later endpoint exists, then skips it at the endpoint.

Use measure order before track order when choosing which endpoint clones the spanner. The existing start-side path remains for upward spanners within one measure. The regression uses the dedicated minimal `parts_data/cross-measure-gliss.mscx` fixture and `TestUtils::createPart(master, 0)`. It checks that the new part owns the glissando and both corresponding endpoints.

Validation on main `48dcc3d469d7b61d8fb371ba84edba0bc6ba1c06`: the revised regression fails without the production change because the part has no glissando; all 59 `Engraving_PartsTests` pass with the fix. This was rechecked after replacing the vtest dependency and manual excerpt setup. Built `engraving_tests` and `mscore` with GCC 14 / Qt 6.10.2 / Debug ASan, and verified the same ordinary-part workflow in the desktop application.

Related work: #30061 and #23412 concern custom-part staff cloning through `cloneStaff2`. This change addresses `cloneMeasure` and does not claim to fix that separate path. See #34851 for the precise before/after build revisions and reproduction score.

**Before**

https://github.com/user-attachments/assets/12331aac-918f-468b-ba47-7bb877e308af

**After**

https://github.com/user-attachments/assets/d731dcbf-2b9f-4c7b-b24b-51c5f023cf74

- [x] I signed the [CLA](https://musescore.org/en/cla). Previously completed by the contributor; MuseScore.org account attribution remains to be added.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs; the intended behavior was manually verified in the desktop application with agent assistance.
- [x] Prior related attempts and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created a unit test to verify the changes.
