### PR TITLE
Preserve note-line endpoint placement in copies and score roundtrips

### DIFF
--- a/src/engraving/dom/noteline.cpp
+++ b/src/engraving/dom/noteline.cpp
@@ -111,7 +111,7 @@ NoteLine::NoteLine(EngravingItem* parent)
 }
 
 NoteLine::NoteLine(const NoteLine& nl)
-    : TextLineBase(nl)
+    : TextLineBase(nl), m_lineEndPlacement(nl.m_lineEndPlacement)
 {
 }
 

--- a/src/engraving/rw/read500/tread.cpp
+++ b/src/engraving/rw/read500/tread.cpp
@@ -433,6 +433,8 @@ PropertyValue TRead::readPropertyValue(Pid id, XmlReader& e, ReadContext& ctx)
 
     case P_TYPE::CLEF_TYPE:
         return PropertyValue(TConv::fromXml(e.readAsciiText(), ClefType::G));
+    case P_TYPE::NOTELINE_PLACEMENT_TYPE:
+        return NoteLineEndPlacement(e.readInt());
     case P_TYPE::CLEF_TO_BARLINE_POS:
         return ClefToBarlinePosition(e.readInt());
 
@@ -3514,7 +3516,16 @@ void TRead::read(NoteHead* h, XmlReader& xml, ReadContext& ctx)
 
 void TRead::read(NoteLine* nl, XmlReader& xml, ReadContext& ctx)
 {
-    TRead::read(toTextLineBase(nl), xml, ctx);
+    nl->eraseSpannerSegments();
+    while (xml.readNextStartElement()) {
+        if (!readProperty(nl, xml.name(), xml, ctx, Pid::NOTELINE_PLACEMENT)
+            && !readProperties(toTextLineBase(nl), xml, ctx)) {
+            xml.unknown();
+        }
+    }
+    if (ctx.mscVersion() < 470) {
+        compat::CompatUtils::setTextLineTextPositionFromAlign(nl);
+    }
 }
 
 void TRead::read(Ottava* o, XmlReader& e, ReadContext& ctx)

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2555,6 +2555,7 @@ void TWrite::write(const NoteLine* item, XmlWriter& xml, WriteContext& ctx)
         return;
     }
     xml.startElement(item);
+    writeProperty(item, xml, Pid::NOTELINE_PLACEMENT);
     writeProperties(static_cast<const TextLineBase*>(item), xml, ctx);
     xml.endElement();
 }

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -159,6 +159,9 @@ void XmlWriter::tagProperty(const AsciiStringView& name, P_TYPE type, const Prop
     case P_TYPE::SIZE_T:
         element(name, data.value<int>());
         break;
+    case P_TYPE::NOTELINE_PLACEMENT_TYPE:
+        element(name, data.toInt());
+        break;
     case P_TYPE::REAL:
         element(name, data.value<double>());
         break;

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -37,6 +37,7 @@
 #include "engraving/dom/measure.h"
 #include "engraving/dom/measurerepeat.h"
 #include "engraving/dom/note.h"
+#include "engraving/dom/noteline.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/segment.h"
 #include "engraving/dom/spanner.h"
@@ -1391,3 +1392,69 @@ TEST_F(Engraving_PartsTests, staffStyles)
 }
 
 #endif
+
+TEST_F(Engraving_PartsTests, noteLinePlacement)
+{
+    auto noteLines = [](Score* score) {
+        std::vector<NoteLine*> lines;
+        for (Measure* measure = score->firstMeasure(); measure; measure = measure->nextMeasure()) {
+            for (Segment& segment : measure->segments()) {
+                for (EngravingItem* item : segment.elist()) {
+                    if (!item || !item->isChord()) {
+                        continue;
+                    }
+                    for (Note* note : toChord(item)->notes()) {
+                        for (Spanner* spanner : note->spannerFor()) {
+                            if (spanner->isNoteLine()) {
+                                lines.push_back(toNoteLine(spanner));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return lines;
+    };
+
+    for (bool resetPlacement : { false, true }) {
+        SCOPED_TRACE(resetPlacement);
+        MasterScore* score = ScoreRW::readScore(u"../../../vtest/scores/note-line.mscz");
+        ASSERT_TRUE(score);
+        const auto lines = noteLines(score);
+        ASSERT_EQ(lines.size(), 4);
+        const NoteLineEndPlacement expected = resetPlacement ? NoteLineEndPlacement::OFFSET_ENDS : NoteLineEndPlacement::LEFT_EDGE;
+        for (NoteLine* line : lines) {
+            ASSERT_EQ(line->lineEndPlacement(), NoteLineEndPlacement::LEFT_EDGE);
+            if (resetPlacement) {
+                line->resetProperty(Pid::NOTELINE_PLACEMENT);
+            }
+            EXPECT_EQ(line->lineEndPlacement(), expected);
+            NoteLine* cloned = line->clone();
+            EXPECT_EQ(cloned->lineEndPlacement(), expected);
+            delete cloned;
+        }
+
+        Score* part = TestUtils::createPart(score);
+        ASSERT_TRUE(part);
+        const auto partLines = noteLines(part);
+        ASSERT_EQ(partLines.size(), 4);
+        for (NoteLine* line : partLines) {
+            EXPECT_EQ(line->lineEndPlacement(), expected);
+        }
+
+        const String filename(u"noteLinePlacement.mscx");
+        ASSERT_TRUE(ScoreRW::saveScore(score, filename));
+        delete score;
+        score = ScoreRW::readScore(filename, true);
+        ASSERT_TRUE(score);
+        ASSERT_EQ(score->excerpts().size(), 1);
+        for (Score* restored : score->scoreList()) {
+            const auto restoredLines = noteLines(restored);
+            ASSERT_EQ(restoredLines.size(), 4);
+            for (NoteLine* line : restoredLines) {
+                EXPECT_EQ(line->lineEndPlacement(), expected);
+            }
+        }
+        delete score;
+    }
+}


### PR DESCRIPTION
Resolves: #34853

Older scores import note-anchored lines with `LEFT_EDGE` placement, but copying them into a part or saving/reopening the score loses that state and changes their appearance to `OFFSET_ENDS`.

Copy the existing member and serialize/read the existing `noteLinePlacement` property and its enum type. Preserve the current reader's spanner-segment cleanup and legacy text-position conversion. The default placement and legacy-import policy remain unchanged.

The native regression checks all four lines in the official `note-line.mscz` fixture: direct clones, actual part creation, master/part MSCX roundtrip, and the default state after explicit property reset. On official main `48dcc3d469d7b61d8fb371ba84edba0bc6ba1c06`, the same regression fails without the production change. All 59 `Engraving_PartsTests` pass with it; `engraving_tests` and the desktop application build successfully with Qt 6.10.2 / GCC 14 / Debug ASan.

Related history: #24992 deliberately retained pre-4.5 line appearance until reset; this fixes copying and persistence of that state. #33741 involves a different cross-staff editing scenario and is not claimed as resolved. Full-score roundtrip testing also covers the current endpoint serialization introduced in #34231.

Desktop verification below shows ordinary Flute part creation. Watch the line endpoints, especially the line and beginning text in measure 4. The independent MSCX roundtrip is tested natively, not shown in these recordings.

**Before**

https://github.com/user-attachments/assets/2b18c2de-2298-44cb-ae29-b99683f25527

**After**

https://github.com/user-attachments/assets/ab97bd7f-4c41-4daa-bd16-b046ec879063

- [x] I signed the [CLA](https://musescore.org/en/cla). Previously completed by the contributor; MuseScore.org account attribution remains to be added.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs; the intended behavior was manually verified in the desktop application with agent assistance.
- [x] Prior related attempts and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created a unit test to verify the changes.
