### PR TITLE
Preserve linked bend continuation frets during excerpt layout

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -784,7 +784,7 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
         // use most convenient string as key
         if (!(skipDeadNotes && note->deadNote()) && !note->negativeFretUsed()
             && (string <= INVALID_STRING_INDEX || noteFret <= INVALID_FRET_INDEX
-                || (pitchIsValid(pitch) && pitch != note->pitch()))) {
+                || (pitchIsValid(pitch) && pitch != note->pitch() && !note->bendBack()))) {
             note->setString(INVALID_STRING_INDEX);
             note->setFret(INVALID_FRET_INDEX);
         }

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -639,69 +639,75 @@ TEST_F(Engraving_TabTransposeTests, sameStringTransposeKeepsStringsWithFretAbove
 
 TEST_F(Engraving_TabTransposeTests, bendFretsSurviveExcerptLayoutAndTranspose)
 {
-    std::unique_ptr<MasterScore> score(ScoreRW::readScore(u"../../../vtest/scores/vibrato-2.mscz"));
-    ASSERT_TRUE(score);
-    setFrettingFlags(false, false);
-    score->doLayout();
+    for (bool preferSameString : { false, true }) {
+        for (bool allowNegativeFrets : { false, true }) {
+            SCOPED_TRACE(preferSameString);
+            SCOPED_TRACE(allowNegativeFrets);
+            setFrettingFlags(preferSameString, allowNegativeFrets);
+            std::unique_ptr<MasterScore> score(ScoreRW::readScore(u"../../../vtest/scores/vibrato-2.mscz"));
+            ASSERT_TRUE(score);
+            score->doLayout();
 
-    Score* part = score->createScore();
-    Excerpt* excerpt = new Excerpt(score.get());
-    excerpt->setExcerptScore(part);
-    part->setExcerpt(excerpt);
-    score->excerpts().push_back(excerpt);
-    excerpt->setName(u"Guitar");
-    excerpt->setParts({ score->parts().front() });
-    Excerpt::createExcerpt(excerpt);
+            Score* part = score->createScore();
+            Excerpt* excerpt = new Excerpt(score.get());
+            excerpt->setExcerptScore(part);
+            part->setExcerpt(excerpt);
+            score->excerpts().push_back(excerpt);
+            excerpt->setName(u"Guitar");
+            excerpt->setParts({ score->parts().front() });
+            Excerpt::createExcerpt(excerpt);
 
-    std::array<std::array<Note*, 3>, 2> chains {};
-    const std::array<Score*, 2> scores { score.get(), part };
-    for (size_t i = 0; i < scores.size(); ++i) {
-        Note* end = nullptr;
-        for (Segment& segment : scores[i]->firstMeasure()->segments()) {
-            EngravingItem* item = segment.element(4);
-            if (item && item->isChord() && toChord(item)->upNote()->pitch() == 62) {
-                ASSERT_EQ(end, nullptr);
-                end = toChord(item)->upNote();
+            std::array<std::array<Note*, 3>, 2> chains {};
+            const std::array<Score*, 2> scores { score.get(), part };
+            for (size_t i = 0; i < scores.size(); ++i) {
+                Note* end = nullptr;
+                for (Segment& segment : scores[i]->firstMeasure()->segments()) {
+                    EngravingItem* item = segment.element(4);
+                    if (item && item->isChord() && toChord(item)->upNote()->pitch() == 62) {
+                        ASSERT_EQ(end, nullptr);
+                        end = toChord(item)->upNote();
+                    }
+                }
+                ASSERT_TRUE(end);
+                ASSERT_TRUE(end->bendBack());
+                Note* middle = end->bendBack()->startNote();
+                ASSERT_TRUE(middle);
+                ASSERT_TRUE(middle->bendBack());
+                Note* start = middle->bendBack()->startNote();
+                ASSERT_TRUE(start);
+                chains[i] = { start, middle, end };
             }
+
+            auto checkFrets = [&](int semitones) {
+                const std::array<int, 3> pitches { 59, 60, 62 };
+                for (const auto& chain : chains) {
+                    for (size_t i = 0; i < chain.size(); ++i) {
+                        EXPECT_EQ(chain[i]->pitch(), pitches[i] + semitones);
+                        EXPECT_EQ(chain[i]->string(), 1);
+                        EXPECT_EQ(chain[i]->fret(), semitones);
+                    }
+                }
+            };
+
+            score->doLayout();
+            part->doLayout();
+            checkFrets(0);
+
+            // Bend starts must still refret when transposed; continuation notes share that fret.
+            transposeScore(score.get(), 2);
+            part->doLayout();
+            checkFrets(2);
+
+            EditData editData;
+            score->transactionManager()->undoRedo(true, &editData);
+            score->doLayout();
+            part->doLayout();
+            checkFrets(0);
+
+            score->transactionManager()->undoRedo(false, &editData);
+            score->doLayout();
+            part->doLayout();
+            checkFrets(2);
         }
-        ASSERT_TRUE(end);
-        ASSERT_TRUE(end->bendBack());
-        Note* middle = end->bendBack()->startNote();
-        ASSERT_TRUE(middle);
-        ASSERT_TRUE(middle->bendBack());
-        Note* start = middle->bendBack()->startNote();
-        ASSERT_TRUE(start);
-        chains[i] = { start, middle, end };
     }
-
-    auto checkFrets = [&](int semitones) {
-        const std::array<int, 3> pitches { 59, 60, 62 };
-        for (const auto& chain : chains) {
-            for (size_t i = 0; i < chain.size(); ++i) {
-                EXPECT_EQ(chain[i]->pitch(), pitches[i] + semitones);
-                EXPECT_EQ(chain[i]->string(), 1);
-                EXPECT_EQ(chain[i]->fret(), semitones);
-            }
-        }
-    };
-
-    score->doLayout();
-    part->doLayout();
-    checkFrets(0);
-
-    // Bend starts must still refret when transposed; continuation notes share that fret.
-    transposeScore(score.get(), 2);
-    part->doLayout();
-    checkFrets(2);
-
-    EditData editData;
-    score->transactionManager()->undoRedo(true, &editData);
-    score->doLayout();
-    part->doLayout();
-    checkFrets(0);
-
-    score->transactionManager()->undoRedo(false, &editData);
-    score->doLayout();
-    part->doLayout();
-    checkFrets(2);
 }

--- a/src/engraving/tests/tab_transpose_tests.cpp
+++ b/src/engraving/tests/tab_transpose_tests.cpp
@@ -23,8 +23,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
+#include <memory>
 
 #include "engraving/dom/chord.h"
+#include "engraving/dom/excerpt.h"
+#include "engraving/dom/guitarbend.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/measure.h"
 #include "engraving/dom/note.h"
@@ -631,4 +635,73 @@ TEST_F(Engraving_TabTransposeTests, sameStringTransposeKeepsStringsWithFretAbove
     EXPECT_EQ(n1->fret, 29);
 
     delete score;
+}
+
+TEST_F(Engraving_TabTransposeTests, bendFretsSurviveExcerptLayoutAndTranspose)
+{
+    std::unique_ptr<MasterScore> score(ScoreRW::readScore(u"../../../vtest/scores/vibrato-2.mscz"));
+    ASSERT_TRUE(score);
+    setFrettingFlags(false, false);
+    score->doLayout();
+
+    Score* part = score->createScore();
+    Excerpt* excerpt = new Excerpt(score.get());
+    excerpt->setExcerptScore(part);
+    part->setExcerpt(excerpt);
+    score->excerpts().push_back(excerpt);
+    excerpt->setName(u"Guitar");
+    excerpt->setParts({ score->parts().front() });
+    Excerpt::createExcerpt(excerpt);
+
+    std::array<std::array<Note*, 3>, 2> chains {};
+    const std::array<Score*, 2> scores { score.get(), part };
+    for (size_t i = 0; i < scores.size(); ++i) {
+        Note* end = nullptr;
+        for (Segment& segment : scores[i]->firstMeasure()->segments()) {
+            EngravingItem* item = segment.element(4);
+            if (item && item->isChord() && toChord(item)->upNote()->pitch() == 62) {
+                ASSERT_EQ(end, nullptr);
+                end = toChord(item)->upNote();
+            }
+        }
+        ASSERT_TRUE(end);
+        ASSERT_TRUE(end->bendBack());
+        Note* middle = end->bendBack()->startNote();
+        ASSERT_TRUE(middle);
+        ASSERT_TRUE(middle->bendBack());
+        Note* start = middle->bendBack()->startNote();
+        ASSERT_TRUE(start);
+        chains[i] = { start, middle, end };
+    }
+
+    auto checkFrets = [&](int semitones) {
+        const std::array<int, 3> pitches { 59, 60, 62 };
+        for (const auto& chain : chains) {
+            for (size_t i = 0; i < chain.size(); ++i) {
+                EXPECT_EQ(chain[i]->pitch(), pitches[i] + semitones);
+                EXPECT_EQ(chain[i]->string(), 1);
+                EXPECT_EQ(chain[i]->fret(), semitones);
+            }
+        }
+    };
+
+    score->doLayout();
+    part->doLayout();
+    checkFrets(0);
+
+    // Bend starts must still refret when transposed; continuation notes share that fret.
+    transposeScore(score.get(), 2);
+    part->doLayout();
+    checkFrets(2);
+
+    EditData editData;
+    score->transactionManager()->undoRedo(true, &editData);
+    score->doLayout();
+    part->doLayout();
+    checkFrets(0);
+
+    score->transactionManager()->undoRedo(false, &editData);
+    score->doLayout();
+    part->doLayout();
+    checkFrets(2);
 }


### PR DESCRIPTION
Resolves: #34855

Laying out an excerpt from `vtest/scores/vibrato-2.mscz` temporarily overwrites the linked master's bend-continuation frets with their sounding-pitch frets. The native master → excerpt layout sequence changes the continuation frets from 0 to 1 and 3 before the master is laid out again.

Exclude incoming bend notes from the valid pitch/fret mismatch invalidation in `StringData::sortChordNotes`. Invalid string/fret handling remains active, and bend-start notes still refret normally. No new state, broad bend-note skip, or score-wide scan is introduced.

Validation on official main `48dcc3d469d7b61d8fb371ba84edba0bc6ba1c06`:

- The same added native regression fails without the one-line production change and passes with it.
- All 73 `Engraving_PartsTests` and `Engraving_TabTransposeTests` pass.
- The new regression checks both linked scores and the actual 59 → grace 60 → 62 bend chain, then transposes it up two semitones, checks fret 2, undoes, redoes, and lays out both scores again. It now runs all four combinations of same-string transposition and negative-fret preferences, configured before score loading. All four pass; this additional coverage required no production change.
- `engraving_tests` and `mscore` build with Qt 6.10.2 / GCC 14 / Debug ASan.

Prior work matters here: #29465 addressed #29075 by skipping all bend notes during sorting. Commit `671ee95072c7d0c6c877103fd153cdcd74180a3d` in #31292 removed that skip to restore transposition. This narrower guard preserves start-note transposition, and the regression exercises the real bend chain rather than relying only on ordinary TAB transpose tests.

**Scope:** the confirmed defect is intermediate native score state. Returning to the master in the desktop UI appears to relayout and restore its displayed frets; a visible desktop reproduction is not confirmed. No persistent file corruption or user-visible undo failure is claimed. This remains a draft while its practical UI impact and contribution attestations are reviewed.

- [x] I signed the [CLA](https://musescore.org/en/cla). Previously completed by the contributor; MuseScore.org account attribution remains to be added.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose. (Build and native tests pass; a visible desktop reproduction remains unconfirmed.)
- [x] Prior related attempts and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created a unit test to verify the changes.
