### PR TITLE
Fix empty rhythmic segments left in linked parts after deletion

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2654,7 +2654,7 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
         }
         doUndoRemoveElement(static_cast<EngravingItem*>(e));
         if (clearSegment) {
-            Segment* s = cr->segment();
+            Segment* s = static_cast<ChordRest*>(e)->segment();
             if (segments.find(s) == segments.end()) {
                 segments.insert(s);
             }

--- a/src/engraving/tests/parts_data/delete-linked-rests.mscx
+++ b/src/engraving/tests/parts_data/delete-linked-rests.mscx
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<museScore version="5.00">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <createMultiMeasureRests>0</createMultiMeasureRests>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+      </Staff>
+      <Instrument>
+        <trackName>Piano</trackName>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>quarter</durationType>
+          </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
+          </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
+          </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
+          </Rest>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <gtest/gtest.h>
+#include "engraving/dom/rest.h"
 
 #include "io/fileinfo.h"
 
@@ -1391,3 +1392,49 @@ TEST_F(Engraving_PartsTests, staffStyles)
 }
 
 #endif
+
+TEST_F(Engraving_PartsTests, deleteLinkedRestsRemovesEmptySegments)
+{
+    for (bool fromPart : { false, true }) {
+        SCOPED_TRACE(fromPart);
+        MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"delete-linked-rests.mscx");
+        ASSERT_TRUE(score);
+        Score* part = TestUtils::createPart(score);
+        ASSERT_TRUE(part);
+        auto check = [&](size_t expected) {
+            for (Score* s : { static_cast<Score*>(score), part }) {
+                size_t count = 0;
+                for (Segment* segment = s->firstMeasure()->first(SegmentType::ChordRest); segment;
+                     segment = segment->next(SegmentType::ChordRest)) {
+                    EXPECT_FALSE(segment->empty());
+                    EngravingItem* item = segment->element(0);
+                    EXPECT_TRUE(item && item->isRest());
+                    if (item && item->isRest()) {
+                        EXPECT_EQ(toRest(item)->ticks(), expected == 1 ? Fraction(1, 1) : Fraction(1, 4));
+                    }
+                    ++count;
+                }
+                EXPECT_EQ(count, expected);
+            }
+        };
+        check(4);
+        Score* owner = fromPart ? part : score;
+        score->startCmd(TranslatableString::untranslatable("Delete linked rests"));
+        owner->select(owner->firstMeasure(), SelectType::SINGLE, 0);
+        owner->cmdDeleteSelection();
+        score->endCmd();
+        check(1);
+        score->undoRedo(true, nullptr);
+        check(4);
+        score->undoRedo(false, nullptr);
+        check(1);
+        ASSERT_TRUE(ScoreRW::saveScore(score, u"delete-linked-rests-test.mscx"));
+        delete score;
+        score = ScoreRW::readScore(u"delete-linked-rests-test.mscx", true);
+        ASSERT_TRUE(score);
+        ASSERT_EQ(score->excerpts().size(), 1u);
+        part = score->excerpts().front()->excerptScore();
+        check(1);
+        delete score;
+    }
+}


### PR DESCRIPTION
Resolves: #34859

After range deletion, `removeChordRest` collected the initiating chord/rest's segment for every linked object. Collect each object's own segment so the existing emptiness check and undo commands also remove empty rhythmic segments from linked scores. Segments containing other content retain the existing protection.

The regression uses a minimal `parts_data` fixture and `TestUtils::createPart`. It checks rest durations and segment contents from both master and part entry points, after deletion, undo, redo and MSCX reopening. The same regression fails on main `8d6bbe95` and passes with this one-line correction; all 59 Parts tests pass. Production MSCZ reopening was also checked separately. Standalone compilation of the changed translation unit and upstream formatting checks pass.

This addresses retained score structure, with no claimed visual or playback difference. #30175 concerns creation-time cleanup in `cloneStaff2`, a different lifecycle.

AI was used to improve efficiency during development.

- [x] I signed the [CLA](https://musescore.org/en/cla), previously completed.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code follows the [coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine; the native reproduction and regression checks verify the intended result.
- [x] Prior related work and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created a unit test to verify the changes.
