### PR TITLE
Fix linked spanner serialization order after range edits

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -21,6 +21,8 @@
  */
 #include "twrite.h"
 
+#include <set>
+
 #include "../../iengravingconfiguration.h" // IWYU pragma: keep
 #include "../../iengravingfont.h"
 #include "../../types/typesconv.h"
@@ -514,13 +516,29 @@ void TWrite::writeScoreSpanners(const Score* score, XmlWriter& xml, WriteContext
     if (score->spannerMap().empty()) {
         return;
     }
-    xml.startElement("SpannerMap");
-    for (auto& i : score->spannerMap().map()) {
+    std::set<Spanner*> pending;
+    for (const auto& i : score->spannerMap().map()) {
         Spanner* s = i.second;
-        if (s->generated() || !ctx.canWrite(s)) {
+        if (!s->generated() && ctx.canWrite(s)) {
+            pending.insert(s);
+        }
+    }
+    xml.startElement("SpannerMap");
+    for (const auto& i : score->spannerMap().map()) {
+        Spanner* s = i.second;
+        if (!pending.count(s)) {
             continue;
         }
-        TWrite::writeItem(s, xml, ctx);
+        if (s->links()) {
+            // The reader resolves linkedTo immediately, so write the eligible main first.
+            Spanner* main = toSpanner(s->links()->mainElement());
+            if (pending.erase(main)) {
+                TWrite::writeItem(main, xml, ctx);
+            }
+        }
+        if (pending.erase(s)) {
+            TWrite::writeItem(s, xml, ctx);
+        }
     }
     xml.endElement();
 }

--- a/src/engraving/tests/spanners_data/linked-hairpin-range.mscx
+++ b/src/engraving/tests/spanners_data/linked-hairpin-range.mscx
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<museScore version="5.00">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <createMultiMeasureRests>0</createMultiMeasureRests>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+      </Staff>
+      <Instrument>
+        <trackName>Piano</trackName>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/spanners_tests.cpp
+++ b/src/engraving/tests/spanners_tests.cpp
@@ -21,6 +21,8 @@
  */
 
 #include <gtest/gtest.h>
+#include "engraving/dom/hairpin.h"
+#include "engraving/dom/linkedobjects.h"
 
 #include "engraving/dom/chord.h"
 #include "engraving/dom/excerpt.h"
@@ -47,6 +49,8 @@ static const String SPANNERS_DATA_DIR("spanners_data/");
 
 class Engraving_SpannersTests : public ::testing::Test
 {
+public:
+    void linkedHairpinRangeRoundTrip(bool existingIds);
 };
 
 //---------------------------------------------------------
@@ -596,4 +600,72 @@ TEST_F(Engraving_SpannersTests, spanners16)
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"smallstaff01.mscx", SPANNERS_DATA_DIR + u"smallstaff01-ref.mscx"));
     delete score;
+}
+
+void Engraving_SpannersTests::linkedHairpinRangeRoundTrip(bool existingIds)
+{
+    MasterScore* score = ScoreRW::readScore(SPANNERS_DATA_DIR + u"linked-hairpin-range.mscx");
+    ASSERT_TRUE(score);
+    Hairpin* hairpin = Factory::createHairpin(score->dummy());
+    hairpin->setTrack(0);
+    hairpin->setTrack2(0);
+    hairpin->setTick(Fraction(0, 1));
+    hairpin->setTicks(Fraction(2, 1));
+    score->addSpanner(hairpin);
+    Staff* staff = score->staff(0);
+    Staff* linkedStaff = Factory::createStaff(staff->part());
+    linkedStaff->initFromStaffType(staff->staffType(Fraction(0, 1)));
+    score->undoInsertStaff(linkedStaff, 1, false);
+    Excerpt::cloneStaff(staff, linkedStaff);
+    score->doLayout();
+
+    auto deleteRange = [&](Measure* measure) {
+        score->startCmd(TranslatableString::untranslatable("Shorten linked hairpins"));
+        score->select(measure, SelectType::SINGLE, 0);
+        score->select(measure, SelectType::RANGE, 1);
+        score->cmdDeleteSelection();
+        score->endCmd();
+    };
+    deleteRange(score->firstMeasure());
+    score->undoRedo(true, nullptr);
+    score->undoRedo(false, nullptr);
+    score->undoRedo(true, nullptr);
+    deleteRange(score->firstMeasure()->nextMeasure());
+    score->undoRedo(true, nullptr);
+    score->undoRedo(false, nullptr);
+
+    ASSERT_EQ(score->spannerMap().map().size(), 2u);
+    Spanner* first = score->spannerMap().map().begin()->second;
+    ASSERT_TRUE(first->links());
+    EXPECT_NE(first->links()->mainElement(), first);
+    if (existingIds) {
+        for (const auto& entry : score->spannerMap().map()) {
+            entry.second->assignNewEID();
+        }
+    }
+    ASSERT_TRUE(ScoreRW::saveScore(score, u"linked-hairpin-range-test.mscx"));
+    MasterScore* reopened = ScoreRW::readScore(u"linked-hairpin-range-test.mscx", true);
+    ASSERT_TRUE(reopened);
+    ASSERT_EQ(reopened->spannerMap().map().size(), 2u);
+    for (const auto& entry : reopened->spannerMap().map()) {
+        Spanner* spanner = entry.second;
+        EXPECT_EQ(spanner->type(), ElementType::HAIRPIN);
+        EXPECT_EQ(spanner->tick(), Fraction(0, 1));
+        EXPECT_EQ(spanner->ticks(), Fraction(1, 1));
+        ASSERT_TRUE(spanner->links());
+        EXPECT_EQ(spanner->links()->size(), 2u);
+        EXPECT_EQ(spanner->links(), reopened->spannerMap().map().begin()->second->links());
+    }
+    delete reopened;
+    delete score;
+}
+
+TEST_F(Engraving_SpannersTests, linkedHairpinRangeFirstSave)
+{
+    linkedHairpinRangeRoundTrip(false);
+}
+
+TEST_F(Engraving_SpannersTests, linkedHairpinRangeExistingIds)
+{
+    linkedHairpinRangeRoundTrip(true);
 }


### PR DESCRIPTION
Resolves: #34861

Range edits can leave a linked hairpin before its main element in `SpannerMap`. The writer then emits a forward `linkedTo` reference, although the reader resolves that reference immediately. Missing IDs cause a save assertion; existing IDs move the failure to reopening.

Write an eligible main before its dependent and remove each emitted spanner from the pending set. This preserves the current filters, excludes mains belonging to another score, and writes each eligible spanner once. The clipboard writer is unchanged because it omits links.

Two regressions reuse one edit/reopen helper with a minimal fixture: first-save IDs and existing IDs. Both check reversed map order before saving, then actual reopened link identity and endpoints. Both fail on unpatched main; all 14 enabled Spanners tests pass with this change. Production MSCZ reopening, standalone compilation and upstream formatting checks also pass.

The recordings use the same clean input and commands: official main `8d6bbe95` before, and the same base with this PR's changes (`35ffe8c782`) after. On the Debug build, the before recording stops at the reopen assertion; the after recording reopens the shortened hairpins successfully.

**Before**

https://github.com/user-attachments/assets/15a3aea4-5b1d-4179-a93b-ecaf768c3cad

**After**

https://github.com/user-attachments/assets/6d6660a9-30d9-4371-b581-4c44d1f02c12

Related work: #34231 introduced score-map serialization. #33618 fixed EID thread safety; #34446 concerns external main elements when exporting a part. This change addresses ordering of eligible spanners inside one score.

AI was used to improve efficiency during development.

- [x] I signed the [CLA](https://musescore.org/en/cla), previously completed.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code follows the [coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine; the desktop workflow and native regression checks verify the intended result.
- [x] Prior related work and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created unit tests to verify the changes.
