### PR TITLE
Fix ties missing endpoints in linked parts after Explode

### DIFF
--- a/src/engraving/editing/clonevoice.cpp
+++ b/src/engraving/editing/clonevoice.cpp
@@ -34,6 +34,7 @@
 #include "../dom/segment.h"
 #include "../dom/spanner.h"
 #include "../dom/staff.h"
+#include "../dom/tie.h"
 #include "../dom/tiemap.h"
 #include "../dom/tremolotwochord.h"
 #include "../dom/tupletmap.h"
@@ -143,7 +144,14 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
                         nn->setTpc2(Transpose::transposeTpc(nn->tpc1(), v, true));
                     }
 
-                    if (on->tieFor()) {
+                    if (!link && on->tieForNonPartial()) {
+                        // Keep ordinary ties out of chords while undoAddCR creates linked copies.
+                        Tie* tie = nn->tieFor();
+                        nn->setTieFor(nullptr);
+                        tie->setScore(destScore);
+                        tie->setTrack(nn->track());
+                        tieMap.add(on->tieFor(), tie);
+                    } else if (link && on->tieFor()) {
                         Tie* tie = toTie(maybeLinkedClone(on->tieFor()));
                         tie->setScore(destScore);
                         nn->setTieFor(tie);
@@ -155,7 +163,9 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
                     if (on->tieBack()) {
                         Tie* tie = tieMap.findNew(on->tieBack());
                         if (tie) {
-                            nn->setTieBack(tie);
+                            if (link) {
+                                nn->setTieBack(tie);
+                            }
                             tie->setEndNote(nn);
                         } else {
                             LOGD("cloneVoices: cannot find tie");
@@ -258,6 +268,19 @@ static void doCloneVoice(Score* destScore, track_idx_t srcTrack, track_idx_t dst
             } else {
                 // To all linked staves (implode/explode)
                 destScore->undoAddElement(newAnnotation);
+            }
+        }
+    }
+
+    if (!link) {
+        for (const auto& entry : tieMap) {
+            Tie* tie = toTie(entry.second);
+            if (tie->endNote()) {
+                // Both chords and their linked copies now exist.
+                destScore->undoAddElement(tie);
+            } else {
+                // As in paste, a tie without its copied endpoint is not included.
+                delete tie;
             }
         }
     }

--- a/src/engraving/tests/implode_explode_data/explode-linked-ties.mscx
+++ b/src/engraving/tests/implode_explode_data/explode-linked-ties.mscx
@@ -1,0 +1,166 @@
+<?xml version='1.0' encoding='utf-8'?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <createMultiMeasureRests>0</createMultiMeasureRests>
+    </Style>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+      </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+      </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <instrumentId>keyboard.piano</instrumentId>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie />
+                <next>
+                  <location>
+                    <fractions>1/2</fractions>
+                  </location>
+                </next>
+              </Spanner>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+            </Note>
+          </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/2</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              <Spanner type="Tie">
+                <Tie />
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    <fractions>-1/2</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            </Note>
+          </Chord>
+        </voice>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie />
+                <next>
+                  <location>
+                    <fractions>1/2</fractions>
+                  </location>
+                </next>
+              </Spanner>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+            </Note>
+          </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/2</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <Spanner type="Tie">
+                <Tie />
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    <fractions>-1/2</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    <fractions>1/2</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+            </Note>
+          </Chord>
+        </voice>
+        <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    <fractions>1/2</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+    </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+          </Rest>
+        </voice>
+      </Measure>
+    </Staff>
+  </Score>
+</museScore>

--- a/src/engraving/tests/implodeexplode_tests.cpp
+++ b/src/engraving/tests/implodeexplode_tests.cpp
@@ -21,6 +21,13 @@
  */
 
 #include <gtest/gtest.h>
+#include "engraving/dom/chord.h"
+#include "engraving/dom/excerpt.h"
+#include "engraving/dom/measure.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/segment.h"
+#include "engraving/dom/tie.h"
+#include "utils/testutils.h"
 
 #include "engraving/dom/masterscore.h"
 #include "engraving/editing/implodeexplode.h"
@@ -135,4 +142,94 @@ TEST_F(Engraving_ImplodeExplodeTests, implodeDynamics)
 TEST_F(Engraving_ImplodeExplodeTests, implodeArticulations)
 {
     testUndoImplode(u"implodeArticulations");
+}
+
+TEST_F(Engraving_ImplodeExplodeTests, explodeLinkedTies)
+{
+    for (bool fromPart : { false, true }) {
+        SCOPED_TRACE(fromPart);
+        MasterScore* score = ScoreRW::readScore(IMPLODEEXP_DATA_DIR + u"explode-linked-ties.mscx");
+        ASSERT_TRUE(score);
+        Score* part = TestUtils::createPart(score);
+        ASSERT_TRUE(part);
+        auto check = [&](bool exploded) {
+            for (Score* s : { static_cast<Score*>(score), part }) {
+                for (track_idx_t track : { 0, exploded ? 4 : 1 }) {
+                    Segment* start = s->tick2segment(Fraction(0, 1));
+                    Segment* end = s->tick2segment(Fraction(1, 2));
+                    ASSERT_TRUE(start && end);
+                    ASSERT_TRUE(start->element(track) && start->element(track)->isChord());
+                    ASSERT_TRUE(end->element(track) && end->element(track)->isChord());
+                    Note* startNote = toChord(start->element(track))->upNote();
+                    Note* endNote = toChord(end->element(track))->upNote();
+                    ASSERT_TRUE(startNote->tieFor());
+                    EXPECT_EQ(startNote->tieFor()->startNote(), startNote);
+                    EXPECT_EQ(startNote->tieFor()->endNote(), endNote);
+                    EXPECT_EQ(endNote->tieBack(), startNote->tieFor());
+                    EXPECT_EQ(startNote->tieFor()->score(), s);
+                    Segment* nextMeasure = s->tick2segment(Fraction(1, 1));
+                    ASSERT_TRUE(nextMeasure && nextMeasure->element(track) && nextMeasure->element(track)->isChord());
+                    Note* nextNote = toChord(nextMeasure->element(track))->upNote();
+                    ASSERT_TRUE(endNote->tieFor());
+                    EXPECT_EQ(endNote->tieFor()->endNote(), nextNote);
+                    EXPECT_EQ(nextNote->tieBack(), endNote->tieFor());
+                }
+            }
+        };
+        check(false);
+        Score* owner = fromPart ? part : score;
+        owner->cmdSelectAll();
+        score->startCmd(TranslatableString::untranslatable("Explode linked ties"));
+        ASSERT_TRUE(ImplodeExplode::explode(owner));
+        score->endCmd();
+        check(true);
+        score->undoRedo(true, nullptr);
+        check(false);
+        score->undoRedo(false, nullptr);
+        check(true);
+        ASSERT_FALSE(HasFailure());
+        ASSERT_TRUE(ScoreRW::saveScore(score, u"explode-linked-ties-test.mscx"));
+        delete score;
+        score = ScoreRW::readScore(u"explode-linked-ties-test.mscx", true);
+        ASSERT_TRUE(score);
+        ASSERT_EQ(score->excerpts().size(), 1u);
+        part = score->excerpts().front()->excerptScore();
+        check(true);
+        delete score;
+    }
+}
+
+TEST_F(Engraving_ImplodeExplodeTests, explodeLinkedTiesAtRangeEnd)
+{
+    MasterScore* score = ScoreRW::readScore(IMPLODEEXP_DATA_DIR + u"explode-linked-ties.mscx");
+    ASSERT_TRUE(score);
+    Score* part = TestUtils::createPart(score);
+    ASSERT_TRUE(part);
+    score->select(score->firstMeasure(), SelectType::SINGLE, 0);
+    score->select(score->firstMeasure(), SelectType::RANGE, 1);
+    score->startCmd(TranslatableString::untranslatable("Explode one measure"));
+    ASSERT_TRUE(ImplodeExplode::explode(score));
+    score->endCmd();
+    auto check = [&]() {
+        for (Score* s : { static_cast<Score*>(score), part }) {
+            Note* start = toChord(s->tick2segment(Fraction(0, 1))->element(4))->upNote();
+            Note* end = toChord(s->tick2segment(Fraction(1, 2))->element(4))->upNote();
+            ASSERT_TRUE(start->tieFor());
+            EXPECT_EQ(start->tieFor()->endNote(), end);
+            EXPECT_EQ(end->tieBack(), start->tieFor());
+            EXPECT_FALSE(end->tieFor());
+        }
+    };
+    check();
+    score->undoRedo(true, nullptr);
+    for (Score* s : { static_cast<Score*>(score), part }) {
+        Note* start = toChord(s->tick2segment(Fraction(1, 2))->element(1))->upNote();
+        Note* end = toChord(s->tick2segment(Fraction(1, 1))->element(1))->upNote();
+        ASSERT_TRUE(start->tieFor());
+        EXPECT_EQ(start->tieFor()->endNote(), end);
+        EXPECT_EQ(end->tieBack(), start->tieFor());
+    }
+    score->undoRedo(false, nullptr);
+    check();
+    delete score;
 }


### PR DESCRIPTION
Resolves: #31825

Exploding multiple voices into staves can leave existing parts with ties that have no end note. `Note` copying already creates an outgoing tie, and `undoAddCR` copies that incomplete tie again into linked staves before the destination end chord exists.

For the unlinked cloning used by Explode/Implode, detach and reuse the constructor's ordinary tie copy. Keep it in the existing `TieMap`, connect copied endpoints, then add it once through `undoAddElement` after the linked chords exist. Discard incomplete ordinary copies at the range boundary, following the existing paste policy. Partial/LV ties retain their constructor handling; the linked voice-exchange path keeps its existing behavior.

The regression reuses `TestUtils::createPart` and a dedicated two-voice, two-measure fixture. It checks exact start/end notes and reciprocal ties in the master and part, both command entry points, undo, redo, MSCX reopening, and an end outside the selected range. The same tests fail on official main `8d6bbe95` and pass with this change.

Validation: 74 relevant Parts, Implode/Explode, Exchange Voices and boundary-paste tests pass on this independent branch. The original #31825 attachment was also checked natively: it fails on unpatched main and passes with this patch, including undo, redo and production MSCZ reopening. Standalone compilation and upstream formatting checks pass.

[Minimal desktop reproduction](https://github.com/0xMashiro/MuseScore/raw/3f868232438d9a019c35b9436b3e47d068308d5e/linked-editing/explode-linked-ties.zip). The recordings use identical input and commands: select all in the full score, Tools > Explode, open the existing Piano part, undo and redo. Watch the ties on the part's lower staff.

**Before — official main `8d6bbe95`**

https://github.com/user-attachments/assets/bba1af51-c0e2-45d0-9e4a-0449e9196129

**After — the same base with this PR's changes (`a6b2c26c67`)**

https://github.com/user-attachments/assets/f35f0651-dcf2-4ee6-9f02-db43b0b80b77

Related work: #32850 refactored this cloning path; #33631 guards playback against cyclic ties; #34810 addresses grace-note slur mapping. This patch fixes ordinary tie construction and propagation rather than changing Explode's voice-distribution policy.

AI was used to improve efficiency during development.

- [x] I signed the [CLA](https://musescore.org/en/cla), previously completed.
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code follows the [coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine; the desktop workflow and native regression checks verify the intended result.
- [x] Prior related work and the distinction are described above.
- [x] There are no unnecessary changes.
- [x] I created unit tests to verify the changes.
