### PR TITLE
Display plugin errors to users

### DIFF
--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -23,7 +23,10 @@
 #include "qmlpluginapi.h"
 
 #include <QQmlEngine>
+#include <QQmlContext>
+#include <QQmlError>
 #include <QJSValueIterator>
+#include <QWindow>
 
 #include "engraving/compat/scoreaccess.h"
 #include "engraving/dom/factory.h"
@@ -33,6 +36,8 @@
 
 #include "notation/inotation.h"
 #include "notation/inotationelements.h" // IWYU pragma: keep
+
+#include "translation.h"
 
 // api
 #include "engravingapiv1.h"
@@ -238,6 +243,77 @@ void PluginAPI::setup(QQmlEngine* e)
     m_engine = engravingApi->engine();
 }
 
+//! Runs the plug-in and reports runtime QML errors to the user.
+void PluginAPI::runPlugin()
+{
+    QQmlEngine* engine = qmlEngine(this);
+    QQmlContext* context = QQmlEngine::contextForObject(this);
+    if (engine && context) {
+        const QUrl pluginUrl = context->baseUrl();
+        const QUrl pluginDirectory = pluginUrl.adjusted(QUrl::RemoveFilename | QUrl::NormalizePathSegments);
+
+        connect(engine, &QQmlEngine::warnings, this,
+                [this, context, pluginDirectory](const QList<QQmlError>& warnings) {
+            if (m_errorReported) {
+                return;
+            }
+
+            QStringList errorMessages;
+            QStringList errorDetails;
+            for (const QQmlError& warning : warnings) {
+                bool belongsToPlugin = pluginDirectory.isParentOf(warning.url().adjusted(QUrl::NormalizePathSegments));
+                if (QObject* object = warning.object()) {
+                    QQmlContext* warningContext = QQmlEngine::contextForObject(object);
+                    while (warningContext && warningContext != context) {
+                        warningContext = warningContext->parentContext();
+                    }
+                    belongsToPlugin = warningContext != nullptr;
+                }
+                if (belongsToPlugin) {
+                    errorMessages << warning.description();
+                    errorDetails << warning.toString();
+                    break;
+                }
+            }
+
+            if (errorMessages.empty()) {
+                return;
+            }
+
+            m_errorReported = true;
+            closePluginWindows();
+            quit();
+
+            const QString details = errorDetails.join('\n');
+            muse::IInteractive::Text text(
+                muse::qtrc("extensions", "An error occurred in the plug-in: %1. Please contact the developer.")
+                .arg(errorMessages.join('\n')).toStdString(),
+                muse::IInteractive::TextFormat::PlainText);
+            text.detailedText = details.toStdString();
+            interactive()->error(muse::trc("extensions", "Plug-in error"), text);
+        });
+    }
+
+    emit run();
+}
+
+//! Closes windows owned by this plug-in instance.
+void PluginAPI::closePluginWindows()
+{
+    const QList<QObject*> objects = findChildren<QObject*>();
+    for (QObject* object : objects) {
+        QWindow* window = qobject_cast<QWindow*>(object);
+        if (!window) {
+            window = object->property("window").value<QWindow*>();
+        }
+        if (window) {
+            window->hide();
+            window->close();
+        }
+    }
+}
+
+//! Creates a plug-in API object with the given visual parent.
 PluginAPI::PluginAPI(QQuickItem* parent)
     : QQuickItem(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {

--- a/src/engraving/api/v1/qmlpluginapi.h
+++ b/src/engraving/api/v1/qmlpluginapi.h
@@ -31,6 +31,7 @@
 #include "actions/iactionsdispatcher.h"
 #include "context/iglobalcontext.h"
 #include "global/iapplication.h"
+#include "interactive/iinteractive.h"
 
 #include "../../iengravingpluginapihelper.h"
 
@@ -139,6 +140,7 @@ private:
     muse::ContextInject<mu::context::IGlobalContext> context = { this };
     muse::GlobalInject<muse::IApplication> application;
     muse::ContextInject<mu::engraving::IEngravingPluginAPIHelper> helper = { this };
+    muse::ContextInject<muse::IInteractive> interactive = { this };
 
 public:
     // Should be initialized in qmlpluginapi.cpp
@@ -519,7 +521,8 @@ public:
     static void registerQmlTypes();
 
     void setup(QQmlEngine* e) override;
-    void runPlugin() override { emit run(); }
+    //! Runs the plug-in and reports runtime QML errors to the user.
+    void runPlugin() override;
     muse::async::Notification closeRequest() const override { return m_closeRequested; }
 
     void endCmd(const QMap<QString, QVariant>& stateInfo) { emit scoreStateChanged(stateInfo); }
@@ -592,6 +595,8 @@ public:
 
 private:
     mu::engraving::Score* currentScore() const;
+    //! Closes windows owned by this plug-in instance.
+    void closePluginWindows();
 
     muse::api::IApiEngine* m_engine = nullptr;
     QString m_pluginType;
@@ -602,6 +607,7 @@ private:
     QString m_thumbnailName;
     QString m_categoryCode;
     muse::async::Notification m_closeRequested;
+    bool m_errorReported = false;
 };
 
 #undef DECLARE_API_ENUM2


### PR DESCRIPTION
Resolves: #28545

Depends on https://github.com/musescore/muse_framework/pull/280

### Summary:

This PR provides a suggested way to more gracefully and usefully deal with QML errors encountered in plug-ins. Currently, when a plug-in error occurs, MuseScore writes the error to the log but does not notify the user; execution stops without any visible explanation, making the problem difficult for users to understand or report to the plug-in developer.

This PR now displays an error dialog for both plug-in loading and runtime QML errors. The dialog contains a concise message and a field for the technical details that can be copied by the user to send to the plug-in developer.

Errors reported are restricted to those originating only from the active plug-in. When one is detected, MuseScore stops the plug-in and closes its windows before displaying the dialog.

The strings will need localizing. I built mscore and tested that this works with several QML errors inside a plug-in.

<img width="639" height="289" alt="MuseScore plug-in error dialog" src="https://github.com/user-attachments/assets/2ec2eddc-2fcf-4d9e-944e-fc4ca65296e6" />

### Validation:

- `git diff --check` in MuseScore and `muse_framework`
- Uncrustify validation of the changed C++ implementation files and framework header
- Built and launched MuseScore Studio Development
- Tested with several deliberate QML plug-in errors
- Confirmed the error dialog contains copyable technical details
- Confirmed plug-in windows close when an error is handled
- Confirmed long details text wraps


- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user/michaelnorris).
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, they are described above.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).