### PR TITLE
Make beamPos values readable by QML plugins

### DIFF
--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -99,6 +99,7 @@ qreal ScoreElement::spatium() const
 
 //---------------------------------------------------------
 //   ScoreElement::get
+///   Returns an engraving property converted to a plugin-readable value.
 //---------------------------------------------------------
 
 QVariant ScoreElement::get(mu::engraving::Pid pid) const
@@ -118,6 +119,10 @@ QVariant ScoreElement::get(mu::engraving::Pid pid) const
     }
     case P_TYPE::POINT:
         return val.value<PointF>().toQPointF() / spatium();
+    case P_TYPE::PAIR_REAL: {
+        const PairF pair = val.value<PairF>();
+        return QVariantList { pair.first, pair.second };
+    }
     case P_TYPE::ABSOLUTE:
         return val.toReal() / spatium();
     case P_TYPE::SPATIUM:


### PR DESCRIPTION
Resolves: #33026

## Summary

Make `beamPos` values directly readable by QML plug-ins.

## Description

For plugins, the `beamPos` property currently returns a pair (QPair) whose individual values cannot be accessed directly from a QML plug-in, requiring developers to extract them by using a ‘hack’ (parsing its string representation).

This PR proposes converting any `PAIR_REAL` property values to a two-element array so that plug-ins can then use (e.g.) `beamPos[0]` and `beamPos[1]` to read the vertical positions of the two beam ends.

## Validation

The following checks passed locally:

```sh
git diff --check upstream/main...HEAD
_deps/uncrustify/bin/uncrustify -c muse/tools/codestyle/uncrustify_muse.cfg --check -l CPP src/engraving/api/v1/scoreelement.cpp
cmake --build builds/Mac-Qtopt-qt-Ninja-Release --target src/engraving/CMakeFiles/engraving.dir/api/v1/scoreelement.cpp.o -j 4
/private/tmp/beampos-api-check
```

Uncrustify version: 0.74.0. The temporary standalone Qt check uses `QJSEngine` to verify that the converted list has two numeric entries accessible with `[0]` and `[1]`, preserving order and values for `(-1.25, 2.75)` and `(0.0, 0.0)`. It is not included in the commit and does not replace an end-to-end score test. Manual testing in MuseScore has not been repeated after rebasing onto current `main`.

No other PR referencing #33026 was found when preparing this submission.

## Checklist

- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user/michaelnorris).
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [ ] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
