### PR TITLE
Fix offset spinboxes not updated

### DIFF
--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.h
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/appearance/appearancesettingsmodel.h
@@ -72,6 +72,9 @@ public:
 
     bool isVerticalOffsetAvailable() const;
 
+    void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
+                           const mu::engraving::StyleIdSet& changedStyleIdSet) override;
+
 public slots:
     void setIsSnappedToGrid(bool isSnapped);
     void setIsVerticalOffsetAvailable(bool isAvailable);
@@ -81,8 +84,6 @@ signals:
     void isVerticalOffsetAvailableChanged(bool isVerticalOffsetAvailable);
 
 private:
-    void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
-                           const mu::engraving::StyleIdSet& changedStyleIdSet) override;
     void loadProperties(const mu::engraving::PropertyIdSet& allowedPropertyIdSet);
 
     void updateIsVerticalOffsetAvailable();

--- a/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
+++ b/src/propertiespanel/qml/MuseScore/PropertiesPanel/general/generalsettingsmodel.cpp
@@ -118,9 +118,12 @@ void GeneralSettingsModel::loadProperties()
     updateAreGeneralPropertiesAvailable();
 }
 
-void GeneralSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
+void GeneralSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet& changedStyleIdSet)
 {
     loadProperties(changedPropertyIdSet);
+
+    m_appearanceSettingsModel->onNotationChanged(changedPropertyIdSet, changedStyleIdSet);
+    m_playbackProxyModel->onNotationChanged(changedPropertyIdSet, changedStyleIdSet);
 }
 
 void GeneralSettingsModel::loadProperties(const mu::engraving::PropertyIdSet& propertyIdSet)


### PR DESCRIPTION
Resolves: #34867

GeneralSettingsModel::onNotationChanged(), the hook that fires on every score/property change never forwards to AppearanceSettingsModel, so the Offset fields only ever refreshed when driven from their own widget.

Fixed by forwarding the notification to both m_appearanceSettingsModel and m_playbackProxyModel, matching the pattern already used in onCurrentNotationChanged() just below it.
This makes the Offset spinboxes update after dragging text on the canvas.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).