### PR TITLE
Fix lyric dashes not advancing across a repeat

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6947,12 +6947,14 @@ void NotationInteraction::navigateToNextSyllable()
         }
     }
 
-    bool newLyrics = (toLyrics == 0);
-    if (!toLyrics || hasPrecedingRepeat) {
+    const bool startIncomingPartialDash = hasPrecedingRepeat && !fromLyrics
+                                          && !prevPartialLyricsLine && lyrics->xmlText().empty();
+
+    const bool newLyrics = !toLyrics || startIncomingPartialDash;
+    if (newLyrics) {
         /* Don't advance the cursor when starting an incoming partial dash after a repeat,
          * i.e. when there is no adjacent preceding syllable to dash from: */
-        ChordRest* toLyricsChord = hasPrecedingRepeat && !fromLyrics && !prevPartialLyricsLine
-                                   && lyrics->xmlText().empty() ? initialCR : cr;
+        ChordRest* toLyricsChord = startIncomingPartialDash ? initialCR : cr;
 
         toLyrics = Factory::createLyrics(toLyricsChord);
         toLyrics->setTrack(track);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6949,8 +6949,10 @@ void NotationInteraction::navigateToNextSyllable()
 
     bool newLyrics = (toLyrics == 0);
     if (!toLyrics || hasPrecedingRepeat) {
-        // Don't advance cursor if we are after a repeat, there is no partial dash present and we are inputting a dash
-        ChordRest* toLyricsChord = hasPrecedingRepeat && !prevPartialLyricsLine && lyrics->xmlText().empty() ? initialCR : cr;
+        /* Don't advance the cursor when starting an incoming partial dash after a repeat,
+         * i.e. when there is no adjacent preceding syllable to dash from: */
+        ChordRest* toLyricsChord = hasPrecedingRepeat && !fromLyrics && !prevPartialLyricsLine
+                                   && lyrics->xmlText().empty() ? initialCR : cr;
 
         toLyrics = Factory::createLyrics(toLyricsChord);
         toLyrics->setTrack(track);


### PR DESCRIPTION
Ports: #34786
Resolves: #34784

In `navigateToNextSyllable()`, the "don't advance the cursor" path was guarded on `hasPrecedingJumpItem()`, which in itself does not mean that the previous measure is unreachable - the measures could still be adjacent in the play order. So on a start-repeat measure that is also entered normally on the first pass, the user got stuck on the first note when they arrived to it through adding dashes from the previous measure. The dash input created another lyric on the same note instead of moving on.

This PR:

* Adds `!fromLyrics` to the condition, to differentiate an incoming partial dash (e.g. 2nd volta, D.S. target) from a normal dash line coming from a valid, adjacent syllable. The former does not advance the cursor, the latter does.
* Recompute `newLyrics` from that same condition. It was previously evaluated before the create-branch, so entering via `hasPrecedingRepeat` with an existing `toLyrics` left it `false` - the newly created lyric was never passed to `undoAddElement()`, leaking it and opening the text input on an element that wasn't in the score (visible as an input box floating above the note).