### PR TITLE
Expose score measures to plugins

### DIFF
--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -560,6 +560,24 @@ QQmlListProperty<System> Score::systems() const
     return wrapContainerProperty<System>(this, score()->systems());
 }
 
+/** Exposes the score's live measure-base list without a shared temporary container. */
+QQmlListProperty<MeasureBase> Score::measures()
+{
+    return QQmlListProperty<MeasureBase>(this, score()->measures(),
+                                         /** Returns the current number of measures and frames. */
+                                         [](QQmlListProperty<MeasureBase>* list) -> qsizetype {
+        return static_cast<engraving::MeasureBaseList*>(list->data)->size();
+    }, /** Returns the wrapped item at index, or null when the index is invalid. */
+                                         [](QQmlListProperty<MeasureBase>* list, qsizetype index) -> MeasureBase* {
+        const auto* measures = static_cast<engraving::MeasureBaseList*>(list->data);
+        if (index < 0 || index >= measures->size()) {
+            return nullptr;
+        }
+        engraving::MeasureBase* measure = measures->at(static_cast<size_t>(index));
+        return qobject_cast<MeasureBase*>(wrap(measure, Ownership::SCORE));
+    });
+}
+
 QQmlListProperty<EngravingItem> Score::brackets(int staffIdx)
 {
     return wrapContainerProperty<EngravingItem>(this, score()->brackets(static_cast<staff_idx_t>(staffIdx)));

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -153,6 +153,15 @@ class Score : public apiv1::ScoreElement, public muse::Contextable
     Q_PROPERTY(QQmlListProperty<apiv1::Page> pages READ pages)
 
     /** APIDOC
+     * List of measures and frames in score order, including individual measures
+     * within multimeasure rests. This list does not expand playback repeats.
+     * @readonly
+     * @q_property {Engraving.MeasureBase[]}
+     * @since 5.0
+     */
+    Q_PROPERTY(QQmlListProperty<apiv1::MeasureBase> measures READ measures)
+
+    /** APIDOC
      * Page numbering offset. The user-visible number of the given page is defined as
      * ```
      * page.pagenumber + 1 + score.pageNumberOffset
@@ -397,6 +406,8 @@ public:
 
     int npages() const { return static_cast<int>(score()->npages()); }
     QQmlListProperty<apiv1::Page> pages() const;
+    /** Returns read-only access to the score's measures and frames. */
+    QQmlListProperty<apiv1::MeasureBase> measures();
     int pageNumberOffset() const { return score()->pageNumberOffset(); }
     void setPageNumberOffset(int offset) { score()->undoChangePageNumberOffset(offset); }
 

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -754,8 +754,25 @@ MeasureBaseList::MeasureBaseList()
     m_size  = 0;
 }
 
+/** Returns a score-order item in constant time after lazily rebuilding the index. */
+MeasureBase* MeasureBaseList::at(size_t index) const
+{
+    if (index >= static_cast<size_t>(m_size)) {
+        return nullptr;
+    }
+    if (m_index.empty()) {
+        m_index.reserve(m_size);
+        for (MeasureBase* measure = m_first; measure; measure = measure->next()) {
+            m_index.push_back(measure);
+        }
+    }
+    return m_index.at(index);
+}
+
+/** Empties the list and invalidates its lookup indexes without deleting its items. */
 void MeasureBaseList::clear()
 {
+    m_index.clear();
     m_first = nullptr;
     m_last = nullptr;
     m_size = 0;
@@ -766,8 +783,10 @@ void MeasureBaseList::clear()
 //   push_back
 //---------------------------------------------------------
 
+/** Links an item at the end and invalidates indexed access. */
 void MeasureBaseList::push_back(MeasureBase* m)
 {
+    m_index.clear();
     ++m_size;
     if (m_last) {
         m_last->setNext(m);
@@ -785,8 +804,10 @@ void MeasureBaseList::push_back(MeasureBase* m)
 //   push_front
 //---------------------------------------------------------
 
+/** Links an item at the beginning and invalidates indexed access. */
 void MeasureBaseList::push_front(MeasureBase* m)
 {
+    m_index.clear();
     ++m_size;
     if (m_first) {
         m_first->setPrev(m);
@@ -805,8 +826,10 @@ void MeasureBaseList::push_front(MeasureBase* m)
 //    insert m before m->next()
 //---------------------------------------------------------
 
+/** Inserts an item before its next item and invalidates indexed access. */
 void MeasureBaseList::add(MeasureBase* m)
 {
+    m_index.clear();
     MeasureBase* el = m->next();
     if (el == 0) {
         append(m);
@@ -826,8 +849,10 @@ void MeasureBaseList::add(MeasureBase* m)
 //   remove
 //---------------------------------------------------------
 
+/** Unlinks one item and invalidates indexed access without deleting the item. */
 void MeasureBaseList::remove(MeasureBase* m)
 {
+    m_index.clear();
     --m_size;
     if (m->prev()) {
         m->prev()->setNext(m->next());
@@ -845,8 +870,10 @@ void MeasureBaseList::remove(MeasureBase* m)
 //   insert
 //---------------------------------------------------------
 
+/** Inserts an inclusive linked range and invalidates indexed access. */
 void MeasureBaseList::insert(MeasureBase* fm, MeasureBase* lm)
 {
+    m_index.clear();
     for (MeasureBase* m = fm; m != lm; m = m->next()) {
         ++m_size;
     }
@@ -869,8 +896,10 @@ void MeasureBaseList::insert(MeasureBase* fm, MeasureBase* lm)
 //   remove
 //---------------------------------------------------------
 
+/** Unlinks an inclusive range and invalidates indexed access without deleting its items. */
 void MeasureBaseList::remove(MeasureBase* fm, MeasureBase* lm)
 {
+    m_index.clear();
     for (MeasureBase* m = fm; m != lm; m = m->next()) {
         --m_size;
     }
@@ -893,8 +922,10 @@ void MeasureBaseList::remove(MeasureBase* fm, MeasureBase* lm)
 //   change
 //---------------------------------------------------------
 
+/** Replaces an item in place and invalidates indexed access even when the size is unchanged. */
 void MeasureBaseList::change(MeasureBase* ob, MeasureBase* nb)
 {
+    m_index.clear();
     nb->setPrev(ob->prev());
     nb->setNext(ob->next());
     if (ob->prev()) {

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -208,6 +208,8 @@ public:
     MeasureBaseList();
     MeasureBase* first() const { return m_first; }
     MeasureBase* last()  const { return m_last; }
+    /** Returns the item at index, or null if out of bounds; rebuilds the index after list changes. */
+    MeasureBase* at(size_t index) const;
     void clear();
     void add(MeasureBase*);
     void remove(MeasureBase*);
@@ -232,6 +234,9 @@ private:
     int m_size = 0;
     MeasureBase* m_first = nullptr;
     MeasureBase* m_last = nullptr;
+
+    // Non-owning index, cleared by every structural mutation and rebuilt on demand.
+    mutable std::vector<MeasureBase*> m_index;
 
     // At a tick there can be any number of MeasureBases
     // There can only be one Measure


### PR DESCRIPTION
Resolves: #32536

## Summary

Expose the score’s measures and frames to QML plug-ins through `curScore.measures`.

## Description

Plug-ins that process a whole score currently need to build their own list of measures either by getting curScore.systems then iterating through system.measures, or by getting curScore.firstMeasure then repeatedly calling nextMeasure().

This PR adds a read-only `measures` property to curScore that provides direct access to measures and frames in score order, making measure loops in plugins a lot more straightforward.

Indexed access uses a lazily rebuilt, non-owning index in the score's measure-base list. Structural mutations clear the index, preserving live score order while making subsequent indexed lookups O(1).

## Validation

The following commands completed successfully:

```sh
git diff --check
git diff --cached --check
git diff upstream/main...HEAD --check
_deps/uncrustify/bin/uncrustify -c muse/tools/codestyle/uncrustify_muse.cfg --check -l CPP src/engraving/api/v1/score.cpp src/engraving/api/v1/score.h src/engraving/dom/measurebase.cpp src/engraving/dom/measurebase.h src/engraving/tests/measure_tests.cpp
cmake --build builds/Mac-Qtopt-qt-Ninja-Release --target engraving_tests -j 8
QT_QPA_PLATFORM=offscreen builds/Mac-Qtopt-qt-Ninja-Release/src/engraving/tests/engraving_tests --gtest_filter='Engraving_MeasureTests.*'
```

Before removing the added regression test, all 25 measure tests passed, including the cache ordering, bounds and invalidation test. That test has now been removed; no new test is included in this PR. The implementation is unchanged. Uncrustify version: 0.74.0. The build emitted dependency deployment-target warnings; the tests emitted logging/fixture warnings but exited successfully.

Before the indexed-access follow-up, the following build/install commands also passed:

```sh
cmake --build builds/Mac-Qtopt-qt-Ninja-Release --target src/engraving/CMakeFiles/engraving.dir/api/v1/score.cpp.o -j 4
cmake --build builds/Mac-Qtopt-qt-Ninja-Release --target mscore -j 6
cmake --install builds/Mac-Qtopt-qt-Ninja-Release
```

I opened the development app and tested `curScore.measures`; initial manual testing worked. The indexed-access follow-up was build- and unit-tested, but not manually retested in the app. No other PR referencing #32536 was found when preparing this submission.

## Checklist

- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user/michaelnorris).
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
