### PR TITLE
Expose system-object staves to plugins

### DIFF
--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -540,6 +540,12 @@ QQmlListProperty<Staff> Score::staves() const
     return wrapContainerProperty<Staff>(this, score()->staves());
 }
 
+/** Exposes the score's additional system-object staves as read-only API staff wrappers. */
+QQmlListProperty<Staff> Score::systemObjectStaves() const
+{
+    return wrapContainerProperty<Staff>(this, score()->systemObjectStaves());
+}
+
 QQmlListProperty<Part> Score::parts() const
 {
     return wrapContainerProperty<Part>(this, score()->parts());

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -183,6 +183,14 @@ class Score : public apiv1::ScoreElement, public muse::Contextable
     Q_PROPERTY(QQmlListProperty<apiv1::Staff> staves READ staves)
 
     /** APIDOC
+     * Additional staves configured to display system objects, excluding the top staff.
+     * @readonly
+     * @q_property {Engraving.Staff[]}
+     * @since 5.0
+     */
+    Q_PROPERTY(QQmlListProperty<apiv1::Staff> systemObjectStaves READ systemObjectStaves)
+
+    /** APIDOC
      * Number of tracks
      * @readonly
      * @q_property {Number}
@@ -418,6 +426,8 @@ public:
 
     int nstaves() const { return static_cast<int>(score()->nstaves()); }
     QQmlListProperty<apiv1::Staff> staves() const;
+    /** Returns the additional system-object staves, excluding the top staff. */
+    QQmlListProperty<apiv1::Staff> systemObjectStaves() const;
 
     int ntracks() const { return static_cast<int>(score()->ntracks()); }
 


### PR DESCRIPTION
Resolves: #30712

## Summary

Expose `curScore.systemObjectStaves` to QML plug-ins.

## Description

Plug-ins currently cannot directly access the staves configured by the user to display system objects.

This PR adds a read-only `systemObjectStaves` property, returning the existing score-level list as API `Staff` objects. The list contains the additional system-object staves and excludes the top staff, which MuseScore handles separately.

## Validation

The following commands completed successfully:

```sh
git diff --check
git diff --cached --check
git diff upstream/main...HEAD --check
_deps/uncrustify/bin/uncrustify -c muse/tools/codestyle/uncrustify_muse.cfg --check -l CPP src/engraving/api/v1/score.cpp src/engraving/api/v1/score.h
cmake --build builds/Mac-Qtopt-qt-Ninja-Release --target src/engraving/CMakeFiles/engraving.dir/api/v1/score.cpp.o -j 4
```

Uncrustify version: 0.74.0. The changed API source compiled successfully; the repeat build check was up to date. A full application build and manual plug-in test have not been performed for this change. No new test was added for this basic API exposure change. No prior PR referencing #30712 was found; the issue contains an earlier request from another contributor to be assigned.

## Checklist

- [x] I signed the [CLA](https://musescore.org/en/cla) as [michaelnorris](https://musescore.org/en/user/michaelnorris).
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [ ] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
