### PR TITLE
Fix "FFmpeg libraries not found" on Arch Linux with AppImage caused by bundled libsystemd

### DIFF
--- a/buildscripts/ci/linux/tools/make_appimage.sh
+++ b/buildscripts/ci/linux/tools/make_appimage.sh
@@ -208,6 +208,9 @@ done
 fallback_libraries=(
   libjack.so.0 # https://github.com/LMMS/lmms/pull/3958
   libOpenGL.so.0 # https://bugreports.qt.io/browse/QTBUG-89754
+  # https://github.com/musescore/MuseScore/issues/33133
+  # old copy shadows system one, breaks dlopen of system FFmpeg via libmount
+  libsystemd.so.0
 )
 
 if $BUILD_PIPEWIRE; then
@@ -227,6 +230,11 @@ done
 # so we need to remove it as it is in the fallback mechanism
 if [[ -f "${appdir}/lib/libpipewire-0.3.so.0" ]]; then
   rm -f "${appdir}/lib/libpipewire-0.3.so.0"
+fi
+
+# Same for libsystemd.so.0
+if [[ -f "${appdir}/lib/libsystemd.so.0" ]]; then
+  rm -f "${appdir}/lib/libsystemd.so.0"
 fi
 
 # APPIMAGEUPDATETOOL


### PR DESCRIPTION
The appimage build process bundles libsystemd.so.0 as a transitive dependency of libdbus-1.so.3.

This breaks FFmpeg detection on rolling distributions. On Arch Linux, the system libavformat (ffmpeg) pulls in the system libmount.so.1, and libmount requires LIBSYSTEMD_251. The bundled copy of libsystemd (systemd 249, LIBSYSTEMD_209..LIBSYSTEMD_247) has precedence over the system one, so the load fails:

    libsystemd.so.0: version `LIBSYSTEMD_251' not found
    (required by /usr/lib/libmount.so.1)

Move libsystemd.so.0 to the fallback mechanism: the copy is removed from lib/ so the system library is used when present, and the bundled copy is only added to LD_LIBRARY_PATH by AppRun when the system has none (non-systemd distributions), the same way libpipewire is handled.

Right now, only the 4.7 branch is affected (ubuntu-22.04 builder in github actions). 
On master, this currently works by accident after builds moved to ubuntu-24.04 (systemd 255), which happens to define LIBSYSTEMD_251.  Either way, the bundled copy will break again as soon as a system library MuseScore loads at runtime requires a libsystemd version newer than the build host's.

**Please also backport to 4.7**
Resolves: #33133 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [X] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [X] The title of the PR describes the problem it addresses.
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [X] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [X] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [X] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [X] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).