### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/score/stavesharinglayout.cpp
+++ b/src/engraving/rendering/score/stavesharinglayout.cpp
@@ -1430,8 +1430,8 @@ String StaveSharingLayout::formatInstrumentChangeLable(const InstrumentChange* o
 
     String prefix;
     std::vector<const Instrument*> originInstruments;
-    for (const EngravingItem* originChange : sharedChange->originItems()) {
-        const Part* originPart = originChange->part();
+    for (const EngravingItem* sharedOriginChange : sharedChange->originItems()) {
+        const Part* originPart = sharedOriginChange->part();
         originInstruments.push_back(originPart->instrument());
     }
     prefix = SystemHeaderLayout::formatSharedVoiceLabel(originInstruments, trailingDotSingle, trailingDotMultiple,

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1195,7 +1195,6 @@ GuitarPro::ReadNoteResult GuitarPro5::readNoteEffects(Note* note)
         gnote->chord()->setDurationType(Fraction { 1, 8 });
 
         gnote->setString(note->string());
-        auto sd = note->part()->instrument()->stringData();
         gnote->setFret(fret);
         if (transition == 0) {
             // no transition

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -2963,9 +2963,9 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
         delete inferredFingering;
     }
 
-    for (auto& harmony : delayedHarmony) {
-        HarmonyDesc harmonyDesc = harmony.second;
-        Fraction tick = Fraction::fromTicks(harmony.first);
+    for (auto& delHarmony : delayedHarmony) {
+        HarmonyDesc harmonyDesc = delHarmony.second;
+        Fraction tick = Fraction::fromTicks(delHarmony.first);
         if (FretDiagram* fd = harmonyDesc.m_fretDiagram) {
             fd->setTrack(harmonyDesc.m_track);
             Segment* s = measure->getSegment(SegmentType::ChordRest, tick);


### PR DESCRIPTION
* reg.: declaration of 'harmony' hides previous local declaration (C4456)
* reg.: 'sd': local variable is initialized but not referenced (C4189)
* reg.: declaration of 'originChange' hides function parameter (C4457)