### PR TITLE
plugin api: restore scoreStateChanged 

### DIFF
--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -33,6 +33,11 @@
 
 #include "notation/inotation.h"
 #include "notation/inotationelements.h" // IWYU pragma: keep
+#include "notation/inotationinteraction.h"
+#include "notation/inotationundostack.h"
+#include "notation/inotationparts.h"
+#include "project/inotationproject.h"
+#include "notation/imasternotation.h"
 
 // api
 #include "engravingapiv1.h"
@@ -236,6 +241,8 @@ void PluginAPI::setup(QQmlEngine* e)
 
     engravingApi->setApi(this);
     m_engine = engravingApi->engine();
+
+    initScoreStateNotifications();
 }
 
 PluginAPI::PluginAPI(QQuickItem* parent)
@@ -495,6 +502,8 @@ apiv1::Fraction* PluginAPI::fractionFromTicks(int ticks) const
 
 void PluginAPI::quit()
 {
+    m_notationSubscriptions.async_disconnectAll();
+    async_disconnectAll();
     emit closeRequested();
     m_closeRequested.notify();
 }
@@ -661,4 +670,55 @@ IntervalWrapper* PluginAPI::interval(int diatonic, int chromatic) const
 IntervalWrapper* PluginAPI::intervalFromOrnamentInterval(OrnamentIntervalWrapper* o) const
 {
     return wrap(mu::engraving::Interval::fromOrnamentInterval(o->ornamentInterval()));
+}
+
+void PluginAPI::initScoreStateNotifications()
+{
+    context()->currentNotationChanged().onNotify(this, [this]() {
+        subscribeToNotationState(context()->currentNotation());
+    });
+
+    subscribeToNotationState(context()->currentNotation());
+}
+
+void PluginAPI::subscribeToNotationState(notation::INotationPtr n)
+{
+    m_notationSubscriptions.async_disconnectAll();
+
+    if (!n) {
+        return;
+    }
+
+    auto emitState = [this](bool selection, bool undoRedo, bool instruments, bool excerpts) {
+        QMap<QString, QVariant> state;
+        state["selectionChanged"] = selection;
+        state["undoRedo"] = undoRedo;
+        state["instrumentsChanged"] = instruments;
+        state["excerptsChanged"] = excerpts;
+        emit scoreStateChanged(state);
+    };
+
+    if (n->interaction()) {
+        n->interaction()->selectionChanged().onNotify(&m_notationSubscriptions, [emitState]() {
+            emitState(true, false, false, false);
+        });
+    }
+
+    if (n->undoStack()) {
+        n->undoStack()->stackChanged().onNotify(&m_notationSubscriptions, [emitState]() {
+            emitState(false, true, false, false);
+        });
+    }
+
+    if (n->parts()) {
+        n->parts()->partsChanged().onNotify(&m_notationSubscriptions, [emitState]() {
+            emitState(false, false, true, false);
+        });
+    }
+
+    if (n->project() && n->project()->masterNotation()) {
+        n->project()->masterNotation()->excerptsChanged().onNotify(&m_notationSubscriptions, [emitState]() {
+            emitState(false, false, false, true);
+        });
+    }
 }

--- a/src/engraving/api/v1/qmlpluginapi.h
+++ b/src/engraving/api/v1/qmlpluginapi.h
@@ -24,7 +24,7 @@
 #include <QQuickItem>
 
 #include "extensions/api/v1/ipluginapiv1.h"
-
+#include "async/asyncable.h"
 #include "global/api/apiutils.h"
 
 #include "modularity/ioc.h"
@@ -92,7 +92,7 @@ class Score;
 //   @P scores               array[mu::engraving::Score]  all currently open scores (read only)
 //---------------------------------------------------------
 
-class PluginAPI : public QQuickItem, public muse::extensions::apiv1::IPluginApiV1, public muse::Contextable
+class PluginAPI : public QQuickItem, public muse::extensions::apiv1::IPluginApiV1, public muse::Contextable, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -592,6 +592,11 @@ public:
 
 private:
     mu::engraving::Score* currentScore() const;
+    void initScoreStateNotifications();
+    void subscribeToNotationState(notation::INotationPtr notation);
+
+    struct NotationSubscriptions : public muse::async::Asyncable {};
+    NotationSubscriptions m_notationSubscriptions;
 
     muse::api::IApiEngine* m_engine = nullptr;
     QString m_pluginType;


### PR DESCRIPTION
Resolves: #20290

PluginAPI::scoreStateChanged(() already existed but nothing called endCmd() with real data, so the signal never fired. This wires it up to the actual notation notifications so MU3-style plugins using onScoreStateChanged work again in MU4.

I haven't been able to find where (or whether) the plugin window is torn down when it's closed via the window's X button. As a result, closing a plugin's dialog this way does not currently stop these signals from firing — the subscriptions stay live until quit() is called explicitly or the app closes. If a maintainer can point me to the relevant teardown code (if it exists), I can extend this fix to disconnect there too.

for testing:

```
import QtQuick 
import MuseScore
import Muse.UiComponents 

MuseScore{

    id: root
    title: "TEST  "        
    version: "1.1"
    pluginType: "dialog"
    thumbnailName: "test.jpg"
    requiresScore: true	
 
    MessageDialog {
        id: errorDialog
        title: "Caution"
        text: ""        
        onAccepted: errorDialog.close()	         
    }

    FlatButton {            
            accentButton: true
            text: "quit"
            onClicked: quit()			        
    }

    onScoreStateChanged: (state) => {
        if (state.selectionChanged) {
            var el = curScore ? curScore.selection.elements[0] : null
	    console.log(el ?  ("Selected: " + el.name) : "no selection")
            errorDialog.text = el ? ("Selected: " + el.name) : "no note selected"
            errorDialog.open()
        }
    }
}

```