### PR TITLE
Implement option for oversized noteheads (#34797)

### DIFF
--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -4742,6 +4742,12 @@ enum class SymId {
     accidentalSharpParens = int(mu::engraving::SymId::accidentalSharpParens),
     accidentalDoubleSharpParens = int(mu::engraving::SymId::accidentalDoubleSharpParens),
 
+    noteheadBlackOversized = int(mu::engraving::SymId::noteheadBlackOversized),
+    noteheadHalfOversized = int(mu::engraving::SymId::noteheadHalfOversized),
+    noteheadWholeOversized = int(mu::engraving::SymId::noteheadWholeOversized),
+    noteheadDoubleWholeOversized = int(mu::engraving::SymId::noteheadDoubleWholeOversized),
+    noteheadDoubleWholeSquareOversized = int(mu::engraving::SymId::noteheadDoubleWholeSquareOversized),
+
     noteLongaUp = int(mu::engraving::SymId::noteLongaUp),
     noteLongaDown = int(mu::engraving::SymId::noteLongaDown),
     noteLongaSquareUp = int(mu::engraving::SymId::noteLongaSquareUp),

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -176,6 +176,7 @@ Score::Score(const modularity::ContextPtr& iocCtx)
     m_masterScore = nullptr;
 
     m_engravingFont = engravingFonts()->fontByName("Leland");
+    m_lastFontName.clear();
 
     m_fileDivision = Constants::DIVISION;
     m_style = DefaultStyle::defaultStyle();
@@ -4858,7 +4859,12 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
         end = std::max(et, spanner->tick2());
     }
 
-    m_engravingFont = engravingFonts()->fontByName(style().value(Sid::musicalSymbolFont).value<String>().toStdString());
+    std::string fontName = style().value(Sid::musicalSymbolFont).value<String>().toStdString();
+    if (!m_engravingFont || m_lastFontName != fontName) {
+        m_engravingFont = engravingFonts()->fontByName(fontName)->clone();
+        m_lastFontName = fontName;
+    }
+    m_engravingFont->setOversizedNoteheads(style().value(Sid::oversizedNoteheads).toBool());
     m_layoutOptions.noteHeadWidth = m_engravingFont->width(SymId::noteheadBlack, style().spatium() / style().defaultSpatium());
 
     if (this->cmdState().layoutFlags & LayoutFlag::REBUILD_MIDI_MAPPING) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -948,6 +948,7 @@ private:
     int m_mscoreRevision = 0;
 
     std::shared_ptr<IEngravingFont> m_engravingFont = nullptr;
+    std::string m_lastFontName;
 
     int m_pageNumberOffset = 0;          // Offset for page numbers.
 

--- a/src/engraving/iengravingfont.h
+++ b/src/engraving/iengravingfont.h
@@ -33,6 +33,9 @@ public:
     virtual String toString(SymId id) const = 0;
 
     virtual std::unordered_map<Sid, PropertyValue> engravingDefaults() const = 0;
+    virtual bool oversizedNoteheads() const = 0;
+    virtual void setOversizedNoteheads(bool enable) = 0;
+    virtual std::shared_ptr<IEngravingFont> clone() const = 0;
 
     // Metrics
     virtual double width(SymId id, double mag) const = 0;

--- a/src/engraving/internal/engravingfont.cpp
+++ b/src/engraving/internal/engravingfont.cpp
@@ -56,12 +56,15 @@ EngravingFont::EngravingFont(const std::string& name, const std::string& family,
 
 EngravingFont::EngravingFont(const EngravingFont& other)
 {
-    m_loaded = false;
-    m_symbols  = other.m_symbols;
-    m_name     = other.m_name;
-    m_family   = other.m_family;
-    m_fontPath = other.m_fontPath;
+    m_loaded       = false;
+    m_symbols      = other.m_symbols;
+    m_name         = other.m_name;
+    m_family       = other.m_family;
+    m_fontPath     = other.m_fontPath;
     m_metadataPath = other.m_metadataPath;
+    m_engravingDefaults      = other.m_engravingDefaults;
+    m_textEnclosureThickness = other.m_textEnclosureThickness;
+    m_oversizedNoteheads     = other.m_oversizedNoteheads;
 }
 
 // =============================================
@@ -86,6 +89,25 @@ std::unordered_map<Sid, PropertyValue> EngravingFont::engravingDefaults() const
 double EngravingFont::textEnclosureThickness()
 {
     return m_textEnclosureThickness;
+}
+
+bool EngravingFont::oversizedNoteheads() const
+{
+    return m_oversizedNoteheads;
+}
+
+void EngravingFont::setOversizedNoteheads(bool val)
+{
+    if (m_oversizedNoteheads != val) {
+        m_oversizedNoteheads = val;
+    }
+}
+
+std::shared_ptr<IEngravingFont> EngravingFont::clone() const
+{
+    auto clonedFont = std::make_shared<EngravingFont>(*this);
+    clonedFont->ensureLoad();
+    return clonedFont;
 }
 
 // =============================================
@@ -237,23 +259,23 @@ static const struct GlyphWithAlternates {
     },
     { std::string("noteheadBlack"),
       std::string("noteheadBlackOversized"),
-      SymId::noteheadBlack
+      SymId::noteheadBlackOversized
     },
     { std::string("noteheadHalf"),
       std::string("noteheadHalfOversized"),
-      SymId::noteheadHalf
+      SymId::noteheadHalfOversized
     },
     { std::string("noteheadWhole"),
       std::string("noteheadWholeOversized"),
-      SymId::noteheadWhole
+      SymId::noteheadWholeOversized
     },
     { std::string("noteheadDoubleWhole"),
       std::string("noteheadDoubleWholeOversized"),
-      SymId::noteheadDoubleWhole
+      SymId::noteheadDoubleWholeOversized
     },
     { std::string("noteheadDoubleWholeSquare"),
       std::string("noteheadDoubleWholeSquareOversized"),
-      SymId::noteheadDoubleWholeSquare
+      SymId::noteheadDoubleWholeSquareOversized
     },
     { std::string("noteheadDoubleWhole"),
       std::string("noteheadDoubleWholeAlt"),
@@ -838,6 +860,10 @@ void EngravingFont::loadEngravingDefaults(const JsonObject& engravingDefaultsObj
         applyEngravingDefault(key, engravingDefaultsObject.value(key).toDouble());
     }
 
+    bool defaultOversized = (m_family == "Bravura");
+    m_engravingDefaults.insert({ Sid::oversizedNoteheads, defaultOversized });
+    m_oversizedNoteheads = defaultOversized;
+
     m_engravingDefaults.insert({ Sid::musicalTextFont, String(u"%1 Text").arg(String::fromStdString(m_family)) });
 }
 
@@ -859,14 +885,32 @@ void EngravingFont::computeMetrics(EngravingFont::Sym& sym, const Smufl::Code& c
 // Symbol properties
 // =============================================
 
+SymId EngravingFont::resolveSymId(SymId id) const
+{
+    SymId oversizedId = id;
+    switch (id) {
+        case SymId::noteheadBlack:             oversizedId = SymId::noteheadBlackOversized; break;
+        case SymId::noteheadHalf:              oversizedId = SymId::noteheadHalfOversized; break;
+        case SymId::noteheadWhole:             oversizedId = SymId::noteheadWholeOversized; break;
+        case SymId::noteheadDoubleWhole:       oversizedId = SymId::noteheadDoubleWholeOversized; break;
+        case SymId::noteheadDoubleWholeSquare: oversizedId = SymId::noteheadDoubleWholeSquareOversized; break;
+        default:                               return id;
+    }
+    return m_symbols[static_cast<size_t>(oversizedId)].isValid() ? oversizedId : id;
+}
+
 EngravingFont::Sym& EngravingFont::sym(SymId id)
 {
-    return m_symbols[static_cast<size_t>(id)];
+    return m_oversizedNoteheads
+        ? m_symbols[static_cast<size_t>(resolveSymId(id))]
+        : m_symbols[static_cast<size_t>(id)];
 }
 
 const EngravingFont::Sym& EngravingFont::sym(SymId id) const
 {
-    return m_symbols.at(static_cast<size_t>(id));
+    return m_oversizedNoteheads
+        ? m_symbols.at(static_cast<size_t>(resolveSymId(id)))
+        : m_symbols.at(static_cast<size_t>(id));
 }
 
 char32_t EngravingFont::symCode(SymId id) const

--- a/src/engraving/internal/engravingfont.h
+++ b/src/engraving/internal/engravingfont.h
@@ -63,6 +63,10 @@ public:
     std::unordered_map<Sid, PropertyValue> engravingDefaults() const override;
     double textEnclosureThickness();
 
+    bool oversizedNoteheads() const;
+    void setOversizedNoteheads(bool enable);
+    std::shared_ptr<IEngravingFont> clone() const override;
+
     char32_t symCode(SymId id) const override;
     SymId fromCode(char32_t code) const override;
     String toString(SymId id) const override;
@@ -126,12 +130,14 @@ private:
 
     void constructShapeWithCutouts(Shape& shape, SymId id);
 
+    SymId resolveSymId(SymId id) const;
     Sym& sym(SymId id);
     const Sym& sym(SymId id) const;
 
     bool useFallbackFont(SymId id) const;
 
     bool m_loaded = false;
+    bool m_oversizedNoteheads = false;
     std::vector<Sym> m_symbols;
     mutable muse::draw::Font m_font;
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -270,6 +270,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     styleDef(barAccidentalDistance,                      0.65_sp),
     styleDef(noteBarDistance,                            1.5_sp),
+    styleDef(oversizedNoteheads,                         false),
     styleDef(spacingDensity,                             1.0),
     styleDef(measureSpacing,                             1.5),
     styleDef(measureRepeatNumberPos,                     -0.5_sp),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -277,6 +277,7 @@ enum class Sid : short {
     barNoteDistance,
     barAccidentalDistance,
     noteBarDistance,
+    oversizedNoteheads,
 
     spacingDensity,
     measureSpacing, // At some point we should rename this. This name is a legacy relic. This is now the spacing ratio.

--- a/src/engraving/types/symid_p.h
+++ b/src/engraving/types/symid_p.h
@@ -3102,6 +3102,12 @@ enum class SymId {
     accidentalSharpParens,
     accidentalDoubleSharpParens,
 
+    noteheadBlackOversized,
+    noteheadHalfOversized,
+    noteheadWholeOversized,
+    noteheadDoubleWholeOversized,
+    noteheadDoubleWholeSquareOversized,
+
     noteLongaUp,
     noteLongaDown,
     noteLongaSquareUp,

--- a/src/engraving/types/symnames.cpp
+++ b/src/engraving/types/symnames.cpp
@@ -3164,6 +3164,12 @@ constexpr const std::array<AsciiStringView, size_t(SymId::lastSym) + 1> SymNames
     "accidentalSharpParens",
     "accidentalDoubleSharpParens",
 
+    "noteheadBlackOversized",
+    "noteheadHalfOversized",
+    "noteheadWholeOversized",
+    "noteheadDoubleWholeOversized",
+    "noteheadDoubleWholeSquareOversized",
+
     "noteLongaUp",
     "noteLongaDown",
     "noteLongaSquareUp",
@@ -6251,6 +6257,12 @@ const std::array<muse::TranslatableString, size_t(SymId::lastSym) + 1> SymNames:
     muse::TranslatableString::untranslatable("Parenthesised natural accidental"),
     muse::TranslatableString::untranslatable("Parenthesised sharp accidental"),
     muse::TranslatableString::untranslatable("Parenthesised double sharp accidental"),
+
+    muse::TranslatableString::untranslatable("noteheadBlackOversized"),
+    muse::TranslatableString::untranslatable("noteheadHalfOversized"),
+    muse::TranslatableString::untranslatable("noteheadWholeOversized"),
+    muse::TranslatableString::untranslatable("noteheadDoubleWholeOversized"),
+    muse::TranslatableString::untranslatable("noteheadDoubleWholeSquareOversized"),
 
     muse::TranslatableString::untranslatable("noteLongaUp"),
     muse::TranslatableString::untranslatable("noteLongaDown"),

--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -605,6 +605,7 @@ void EditStyle::classBegin()
         // { StyleId::chordsXmlFile,            false, chordsXmlFile,                0 },
         { StyleId::dotMag,                   true,  dotMag,                       0 },
         { StyleId::articulationMag,          true,  articulationMag,              resetArticulationMag },
+        { StyleId::oversizedNoteheads,       false, oversizedNoteheads,           0 },
         { StyleId::shortenStem,              false, shortenStem,                  0 },
         { StyleId::showHeader,               false, showHeader,                   0 },
         { StyleId::headerFirstPage,          false, showHeaderFirstPage,          0 },

--- a/src/notationscene/widgets/editstyle.ui
+++ b/src/notationscene/widgets/editstyle.ui
@@ -5597,6 +5597,19 @@
              </property>
             </widget>
            </item>
+          <item row="9" column="0">
+            <widget class="QCheckBox" name="oversizedNoteheads">
+             <property name="toolTip">
+              <string>MuseScore will use available SMuFL metrics for oversized notehead alternatives for a bolder appearance</string>
+             </property>
+             <property name="text">
+              <string>Prefer oversized noteheads</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
            <item row="1" column="1">
             <widget class="QDoubleSpinBox" name="accidentalNoteDistance">
              <property name="sizePolicy">


### PR DESCRIPTION
Resolves: #34797

## Overview
This PR implements a new global style option (`Sid::oversizedNoteheads`) to support oversized noteheads. More specifically, it allows users to opt out, as external fonts are currently loaded with oversized noteheads by default. This ensures better usability across a wider range of fonts. To maintain backward compatibility, the option is disabled by default for all fonts except **Bravura**, which has it enabled by default when loading font defaults.

## Changes Made
* **Symbol Mapping:** Added new `SymId` enums and string mappings specifically for oversized noteheads.
* **UI & Styling:** Introduced the `Sid::oversizedNoteheads` style definition along with a corresponding checkbox in the `EditStyle` dialog.
* **Font Handling:** Updated `EngravingFont` to enable dynamic symbol resolution and cloning, which is necessary to isolate font instances and prevent state sharing.


https://github.com/user-attachments/assets/65c9519d-9ecf-4165-a240-7ab0aba95f02


- [x] I signed the [CLA](https://musescore.org/en/cla) as (https://musescore.org/en/user/6693412): musiculi
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).