### PR TITLE
fixed #34375: Playback speed doesn't update after changing Tempo

### DIFF
--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -24,6 +24,7 @@
 
 #include "mscoreview.h"
 #include "navigation.h"
+#include "transaction/transaction.h"
 #include "transaction/undostack.h"
 
 #include "iengravingfont.h"
@@ -31,6 +32,7 @@
 
 #include "../dom/fret.h"
 #include "../dom/lyrics.h"
+#include "../dom/masterscore.h"
 #include "../dom/score.h"
 #include "../dom/symbol.h"
 #include "../dom/utils.h"
@@ -180,7 +182,7 @@ void TextBase::endEdit(EditData& ed)
         LOGD("actual text is empty");
 
         if (newlyAdded) {
-            undo->reopen();
+            score()->masterScore()->transactionManager()->reopen();
             // Rollback the "AddElement" command, but don't delete the rolled-back element(s):
             score()->endCmd(true, false, /*keepRolledBackElements*/ true);
             // Defer deletion (to ~TextEditData):
@@ -188,7 +190,7 @@ void TextBase::endEdit(EditData& ed)
         } else {
             if (textWasEdited) {
                 // The text was just edited down to empty: the top transaction is this element's own edit:
-                undo->reopen();
+                score()->masterScore()->transactionManager()->reopen();
             } else {
                 /* The text was already empty before editing began (e.g. an empty text from a
                  * legacy/corrupt file). No undo command relevant to this text resides on undo
@@ -228,7 +230,7 @@ void TextBase::endEdit(EditData& ed)
 
     if (textWasEdited) {
         setXmlText(ted->oldXmlText); // reset text to value before editing
-        undo->reopen();
+        score()->masterScore()->transactionManager()->reopen();
         resetFormatting();
 
         // change property to set text to actual value again - this also changes text of linked elements

--- a/src/engraving/editing/transaction/transaction.cpp
+++ b/src/engraving/editing/transaction/transaction.cpp
@@ -228,6 +228,23 @@ void TransactionManager::endTransaction(bool rollback, bool layoutAllParts, bool
     }
 }
 
+void TransactionManager::reopen()
+{
+    UndoStack* stack = undoStack();
+
+    if (stack->isLocked()) {
+        return;
+    }
+
+    if (stack->hasActiveTransaction()) {
+        LOGD() << "cmd already active";
+        return;
+    }
+
+    stack->reopen();
+    m_currentTransaction = std::unique_ptr<Transaction>(new Transaction(stack->activeTransaction()));
+}
+
 Transaction* TransactionManager::currentTransaction() const
 {
     return m_currentTransaction.get();

--- a/src/engraving/editing/transaction/transaction.h
+++ b/src/engraving/editing/transaction/transaction.h
@@ -135,6 +135,8 @@ public:
     void beginTransaction(const muse::TranslatableString& description);
     void endTransaction(bool rollback = false, bool layoutAllParts = false, bool keepRolledBackElements = false);
 
+    void reopen();
+
     /// Returns the current transaction, if any is active.
     /// Where possible, prefer using `transaction()` instead of this method.
     Transaction* currentTransaction() const;


### PR DESCRIPTION
TextBase::endEdit() reopened the merged transaction via UndoStack::reopen(), which only activates the transaction at the UndoStack level and leaves TransactionManager::currentTransaction() null. The undoChangeProperty() calls that follow (Pid::TEXT, plus Pid::TEMPO via TempoText::commitText()) therefore hit Score::undo()'s "called outside of transaction" fallback: they were applied immediately but never recorded, so the transaction committed empty and no ScoreChanges were emitted.

Resolves: #34375